### PR TITLE
fix: Prisma OpenSSL 3.0 binary target for Docker deploy

### DIFF
--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 datasource db {

--- a/deploy/deploy-remote.sh
+++ b/deploy/deploy-remote.sh
@@ -33,7 +33,16 @@ done
 TCR_REGISTRY="$TCR_REGISTRY" TCR_NAMESPACE="$TCR_NAMESPACE" IMAGE_TAG="$IMAGE_TAG" $COMPOSE up -d --no-build
 
 echo "等待健康检查..."
-sleep 8
-curl -fsS "http://127.0.0.1:5100/api/health" | head -c 200
-echo ""
-echo "部署完成 (IMAGE_TAG=$IMAGE_TAG, registry=${IMAGE_REPO})"
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  if curl -fsS "http://127.0.0.1:5100/api/health" >/dev/null 2>&1; then
+    curl -fsS "http://127.0.0.1:5100/api/health" | head -c 200
+    echo ""
+    echo "部署完成 (IMAGE_TAG=$IMAGE_TAG, registry=${IMAGE_REPO})"
+    exit 0
+  fi
+  echo "health attempt $i failed, retry..."
+  sleep $((i <= 3 ? 5 : 10))
+done
+echo "health check failed after retries"
+docker logs lnkpi-api --tail 30 2>&1 || true
+exit 1


### PR DESCRIPTION
## Summary
- 为 Prisma Client 增加 `debian-openssl-3.0.x` binary target，修复 API 容器在 `node:22-bookworm-slim` 上因 Query Engine 不匹配导致的 crash loop
- 部署脚本 health 检查改为最多 10 次重试，失败时输出 `lnkpi-api` 容器日志便于排查

## Context
Deploy workflow 的 deploy job 失败根因：
```
PrismaClientInitializationError: Generated for "debian-openssl-1.1.x", but deployment requires "debian-openssl-3.0.x"
```
仅 re-run deploy job 无法修复，因为旧镜像在 build 阶段未包含正确的 Query Engine。

## Test plan
- [ ] PR 触发 CI workflow，build + Docker build 通过
- [ ] Merge 到 main 后 Deploy workflow 自动触发（build 新镜像 + SSH 部署）
- [ ] 验证 `curl http://119.29.173.89:5100/api/health` 返回 `{"ok":true,...}`
- [ ] https://lnkpi-web.vercel.app 登录/创建画布联调


Made with [Cursor](https://cursor.com)