### PR TITLE
perf: slim Docker image and speed up deploy pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Git / IDE
+.git
+.github
+.cursor
+.vscode
+*.md
+docs/
+
+# 前端与本地开发（API 镜像不需要）
+apps/web/
+apps/server/dist/
+apps/server/data/
+apps/server/uploads/
+apps/server/.env
+
+# 依赖与构建产物（容器内重新 install / build）
+node_modules/
+**/node_modules/
+**/dist/
+coverage/
+.turbo/
+
+# 测试与临时文件
+**/*.test.ts
+**/*.spec.ts
+**/__tests__/
+*.log
+.DS_Store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
 
   docker-build:
     name: Build API Docker image
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -67,6 +68,8 @@ jobs:
           context: .
           file: deploy/docker/Dockerfile.api
           push: false
+          provenance: false
+          sbom: false
           tags: lnkpi-api:ci
           cache-from: type=gha,scope=lnkpi-api
           cache-to: type=gha,scope=lnkpi-api,mode=max,ignore-error=true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,9 +3,15 @@ name: Deploy API to Tencent Cloud
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
+    paths:
+      - "apps/server/**"
+      - "packages/**"
+      - "deploy/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".dockerignore"
+      - ".github/workflows/deploy.yml"
   workflow_dispatch:
     inputs:
       branch:
@@ -57,6 +63,8 @@ jobs:
           context: .
           file: deploy/docker/Dockerfile.api
           push: true
+          provenance: false
+          sbom: false
           tags: |
             ${{ env.TCR_REGISTRY }}/${{ env.TCR_NAMESPACE }}/lnkpi-api:${{ env.IMAGE_TAG }}
             ${{ env.TCR_REGISTRY }}/${{ env.TCR_NAMESPACE }}/lnkpi-api:latest

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -19,6 +19,7 @@
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/platform-express": "^10.4.15",
     "@prisma/client": "^6.2.1",
+    "prisma": "^6.2.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "multer": "^2.2.0",
@@ -29,7 +30,6 @@
     "@types/express": "^5.0.0",
     "@types/multer": "^2.2.0",
     "@types/node": "^22.10.5",
-    "prisma": "^6.2.1",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3"
   }

--- a/deploy/docker/Dockerfile.api
+++ b/deploy/docker/Dockerfile.api
@@ -1,5 +1,8 @@
 # lnkpi API（NestJS + Prisma SQLite）
 FROM node:22-bookworm-slim AS build
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 WORKDIR /app
 
@@ -18,8 +21,11 @@ RUN node -e "\
     fs.writeFileSync(p, JSON.stringify(j,null,2));\
   }"
 
-# 只安装 server 及其 workspace 依赖，跳过 apps/web
-RUN pnpm install --frozen-lockfile --filter @lnkpi/server...
+# 只安装 API 相关 workspace（含 devDeps 供 tsc/prisma build），跳过 apps/web
+RUN pnpm install --frozen-lockfile \
+  --filter @lnkpi/server \
+  --filter @lnkpi/agent \
+  --filter @lnkpi/shared
 RUN pnpm --filter @lnkpi/shared build
 RUN pnpm --filter @lnkpi/agent build
 RUN node deploy/docker/patch-workspace-packages.cjs

--- a/deploy/docker/Dockerfile.api
+++ b/deploy/docker/Dockerfile.api
@@ -21,11 +21,8 @@ RUN node -e "\
     fs.writeFileSync(p, JSON.stringify(j,null,2));\
   }"
 
-# 只安装 API 相关 workspace（含 devDeps 供 tsc/prisma build），跳过 apps/web
-RUN pnpm install --frozen-lockfile \
-  --filter @lnkpi/server \
-  --filter @lnkpi/agent \
-  --filter @lnkpi/shared
+# 安装除 apps/web 外全部 workspace（保留 agent/shared 的 devDeps 供 tsc build）
+RUN pnpm install --frozen-lockfile --filter '!@lnkpi/web'
 RUN pnpm --filter @lnkpi/shared build
 RUN pnpm --filter @lnkpi/agent build
 RUN node deploy/docker/patch-workspace-packages.cjs

--- a/deploy/docker/Dockerfile.api
+++ b/deploy/docker/Dockerfile.api
@@ -18,13 +18,16 @@ RUN node -e "\
     fs.writeFileSync(p, JSON.stringify(j,null,2));\
   }"
 
-RUN pnpm install --frozen-lockfile
+# 只安装 server 及其 workspace 依赖，跳过 apps/web
+RUN pnpm install --frozen-lockfile --filter @lnkpi/server...
 RUN pnpm --filter @lnkpi/shared build
 RUN pnpm --filter @lnkpi/agent build
 RUN node deploy/docker/patch-workspace-packages.cjs
 WORKDIR /app/apps/server
 RUN pnpm exec prisma generate
 RUN pnpm run build
+WORKDIR /app
+RUN pnpm prune --prod
 
 FROM node:22-bookworm-slim AS runner
 WORKDIR /app
@@ -39,8 +42,11 @@ RUN apt-get update \
 
 COPY --from=build /app/node_modules /app/node_modules
 COPY --from=build /app/package.json /app/pnpm-workspace.yaml ./
-COPY --from=build /app/packages /app/packages
-COPY --from=build /app/apps/server /app/apps/server
+COPY --from=build /app/packages/shared/package.json /app/packages/shared/dist ./packages/shared/
+COPY --from=build /app/packages/agent/package.json /app/packages/agent/dist ./packages/agent/
+COPY --from=build /app/apps/server/dist ./apps/server/dist
+COPY --from=build /app/apps/server/prisma ./apps/server/prisma
+COPY --from=build /app/apps/server/package.json ./apps/server/
 COPY --from=build /app/deploy/docker/docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -17,6 +17,7 @@
     "@lnkpi/shared": "workspace:*"
   },
   "devDependencies": {
+    "@types/node": "^22.10.5",
     "typescript": "^5.7.3",
     "vitest": "^3.2.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       multer:
         specifier: ^2.2.0
         version: 2.2.0
+      prisma:
+        specifier: ^6.2.1
+        version: 6.19.3(typescript@5.9.3)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -56,9 +59,6 @@ importers:
       '@types/node':
         specifier: ^22.10.5
         version: 22.20.1
-      prisma:
-        specifier: ^6.2.1
-        version: 6.19.3(typescript@5.9.3)
       tsx:
         specifier: ^4.19.2
         version: 4.23.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
         specifier: workspace:*
         version: link:../shared
     devDependencies:
+      '@types/node':
+        specifier: ^22.10.5
+        version: 22.20.1
       typescript:
         specifier: ^5.7.3
         version: 5.9.3


### PR DESCRIPTION
## Summary
- 添加 `.dockerignore`，排除 `apps/web`、docs、本地 node_modules 等无关内容
- Dockerfile 改为 `--filter @lnkpi/server...` 只装 API 依赖，build 后 `pnpm prune --prod` 瘦身镜像
- runner 阶段只 COPY dist/prisma/package.json，不再整包复制源码
- `prisma` 移至 production dependencies（entrypoint 需要 `db push`）
- main 上 CI 不再重复 docker build（仅 PR 验证）；Deploy 改为精确 path 触发
- build-push 关闭 provenance/sbom，减少 push 体积

## Expected impact
| 阶段 | 优化前 | 预期 |
|------|--------|------|
| Docker build | ~10 min（全量 install） | ~3–5 min |
| Push 到 TCR | ~15–20 min（大镜像） | ~5–10 min |
| main CI | build + docker 重复 | 仅 build |

## Test plan
- [ ] PR CI：Build monorepo + Build API Docker image 通过
- [ ] Merge 后 Deploy workflow 耗时对比（应明显低于 ~28 min）
- [ ] `curl http://119.29.173.89:5100/api/health` 正常


Made with [Cursor](https://cursor.com)