### PR TITLE
feat: CVM local Docker build (skip TCR cross-border push)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,52 +28,12 @@ concurrency:
 
 env:
   IMAGE_TAG: ${{ github.sha }}
-  TCR_REGISTRY: ${{ vars.TCR_REGISTRY || 'ccr.ccs.tencentyun.com' }}
-  TCR_NAMESPACE: ${{ vars.TCR_NAMESPACE || 'lnkpi' }}
   DEPLOY_DIR: /opt/lnkpi
   API_PORT: "5100"
 
 jobs:
-  build-push:
-    name: Build and push lnkpi-api
-    runs-on: ubuntu-latest
-    environment: production
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.branch || github.ref }}
-
-      - name: Validate TCR credentials
-        run: |
-          if [[ -z "${{ secrets.TCR_USERNAME }}" || -z "${{ secrets.TCR_PASSWORD }}" ]]; then
-            echo "::error::Missing TCR_USERNAME or TCR_PASSWORD in environment production."
-            exit 1
-          fi
-
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Login to TCR
-        run: |
-          echo "${{ secrets.TCR_PASSWORD }}" | docker login "${{ env.TCR_REGISTRY }}" \
-            -u "${{ secrets.TCR_USERNAME }}" --password-stdin
-
-      - name: Build and push API image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: deploy/docker/Dockerfile.api
-          push: true
-          provenance: false
-          sbom: false
-          tags: |
-            ${{ env.TCR_REGISTRY }}/${{ env.TCR_NAMESPACE }}/lnkpi-api:${{ env.IMAGE_TAG }}
-            ${{ env.TCR_REGISTRY }}/${{ env.TCR_NAMESPACE }}/lnkpi-api:latest
-          cache-from: type=gha,scope=lnkpi-api
-          cache-to: type=gha,scope=lnkpi-api,mode=max,ignore-error=true
-
   deploy:
-    name: Deploy to Tencent Cloud CVM
-    needs: build-push
+    name: Build on CVM and deploy
     runs-on: ubuntu-latest
     environment: production
     env:
@@ -91,39 +51,46 @@ jobs:
           echo "${{ secrets.TENCENT_CLOUD_SSH_KEY || secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
 
-      - name: Sync deploy files and run remote deploy
+      - name: Sync source and build on CVM
         run: |
           set -euo pipefail
           HOST="${{ env.SSH_USER }}@${{ env.SSH_HOST }}"
-          ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key "$HOST" "mkdir -p /tmp/lnkpi-deploy"
-          scp -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key -r \
-            deploy/docker-compose.prod.yml \
-            deploy/docker-compose.prod.images.yml \
-            deploy/.env.production.example \
-            deploy/deploy-remote.sh \
-            deploy/bootstrap-server.sh \
-            "$HOST:/tmp/lnkpi-deploy/"
+          DEPLOY_DIR="${{ env.DEPLOY_DIR }}"
+
+          tar --exclude='.git' \
+              --exclude='node_modules' \
+              --exclude='apps/web' \
+              --exclude='**/dist' \
+              --exclude='.cursor' \
+              --exclude='docs' \
+              -czf /tmp/lnkpi-src.tgz .
+
+          scp -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key /tmp/lnkpi-src.tgz "$HOST:/tmp/lnkpi-src.tgz"
 
           ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key "$HOST" << EOF
           set -euo pipefail
-          sudo mkdir -p ${{ env.DEPLOY_DIR }}/deploy
-          sudo cp /tmp/lnkpi-deploy/* ${{ env.DEPLOY_DIR }}/deploy/
-          sudo chmod +x ${{ env.DEPLOY_DIR }}/deploy/deploy-remote.sh
-          if [[ ! -f ${{ env.DEPLOY_DIR }}/.env ]]; then
-            sudo cp ${{ env.DEPLOY_DIR }}/deploy/.env.production.example ${{ env.DEPLOY_DIR }}/.env
+          sudo mkdir -p ${DEPLOY_DIR}
+          if [[ -f ${DEPLOY_DIR}/.env ]]; then
+            sudo cp ${DEPLOY_DIR}/.env /tmp/lnkpi.env.bak
+          fi
+          sudo tar -xzf /tmp/lnkpi-src.tgz -C ${DEPLOY_DIR}
+          if [[ -f /tmp/lnkpi.env.bak ]]; then
+            sudo mv /tmp/lnkpi.env.bak ${DEPLOY_DIR}/.env
+          elif [[ ! -f ${DEPLOY_DIR}/.env ]]; then
+            sudo cp ${DEPLOY_DIR}/deploy/.env.production.example ${DEPLOY_DIR}/.env
             if command -v openssl >/dev/null 2>&1; then
               SECRET=\$(openssl rand -hex 24)
-              sudo sed -i "s/请替换为随机长字符串/\${SECRET}/" ${{ env.DEPLOY_DIR }}/.env
+              sudo sed -i "s/请替换为随机长字符串/\${SECRET}/" ${DEPLOY_DIR}/.env
             fi
           fi
-          echo "${{ secrets.TCR_PASSWORD }}" | sudo docker login "${{ env.TCR_REGISTRY }}" \
-            -u "${{ secrets.TCR_USERNAME }}" --password-stdin
-          cd ${{ env.DEPLOY_DIR }}
-          sudo -E env IMAGE_TAG="${{ env.IMAGE_TAG }}" TCR_REGISTRY="${{ env.TCR_REGISTRY }}" TCR_NAMESPACE="${{ env.TCR_NAMESPACE }}" \
-            bash deploy/deploy-remote.sh
+          sudo chmod +x ${DEPLOY_DIR}/deploy/deploy-remote-build.sh
+          sudo chmod +x ${DEPLOY_DIR}/deploy/deploy-remote.sh
+          cd ${DEPLOY_DIR}
+          sudo -E env IMAGE_TAG="${{ env.IMAGE_TAG }}" bash deploy/deploy-remote-build.sh
+          rm -f /tmp/lnkpi-src.tgz
           EOF
 
-          rm -f ~/.ssh/deploy_key
+          rm -f /tmp/lnkpi-src.tgz ~/.ssh/deploy_key
 
       - name: Verify deployment
         run: |
@@ -146,11 +113,11 @@ jobs:
         if: always()
         run: |
           {
-            echo "## lnkpi API Deployment"
+            echo "## lnkpi API Deployment (CVM local build)"
             echo "| Item | Value |"
             echo "|------|-------|"
             echo "| Status | ${{ job.status }} |"
-            echo "| Image | \`${{ env.TCR_REGISTRY }}/${{ env.TCR_NAMESPACE }}/lnkpi-api:${{ env.IMAGE_TAG }}\` |"
+            echo "| Image | \`lnkpi-api:${{ env.IMAGE_TAG }}\` (built on CVM) |"
             echo "| Server | \`${{ env.SSH_HOST }}:${{ env.API_PORT }}\` |"
             echo "| Health | \`http://${{ env.SSH_HOST }}:${{ env.API_PORT }}/api/health\` |"
             echo ""

--- a/deploy/bootstrap-server.sh
+++ b/deploy/bootstrap-server.sh
@@ -10,7 +10,9 @@ sudo cp "$REPO_ROOT/deploy/docker-compose.prod.yml" "$DEPLOY_DIR/deploy/"
 sudo cp "$REPO_ROOT/deploy/docker-compose.prod.images.yml" "$DEPLOY_DIR/deploy/"
 sudo cp "$REPO_ROOT/deploy/.env.production.example" "$DEPLOY_DIR/deploy/"
 sudo cp "$REPO_ROOT/deploy/deploy-remote.sh" "$DEPLOY_DIR/deploy/"
+sudo cp "$REPO_ROOT/deploy/deploy-remote-build.sh" "$DEPLOY_DIR/deploy/"
 sudo chmod +x "$DEPLOY_DIR/deploy/deploy-remote.sh"
+sudo chmod +x "$DEPLOY_DIR/deploy/deploy-remote-build.sh"
 
 if [[ ! -f "$DEPLOY_DIR/.env" ]]; then
   sudo cp "$DEPLOY_DIR/deploy/.env.production.example" "$DEPLOY_DIR/.env"
@@ -23,5 +25,5 @@ if [[ ! -f "$DEPLOY_DIR/.env" ]]; then
 fi
 
 echo "初始化完成: $DEPLOY_DIR"
-echo "下一步: 配置 GitHub Secrets 后 push main 触发 deploy，或手动:"
-echo "  cd $DEPLOY_DIR && IMAGE_TAG=latest TCR_REGISTRY=... TCR_NAMESPACE=lnkpi bash deploy/deploy-remote.sh"
+echo "下一步: push main 触发 GHA deploy，或手动:"
+echo "  cd $DEPLOY_DIR && IMAGE_TAG=<git-sha> bash deploy/deploy-remote-build.sh"

--- a/deploy/deploy-remote-build.sh
+++ b/deploy/deploy-remote-build.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# 在服务器 /opt/lnkpi 执行：本地 docker build + compose up（无 TCR 跨境 push）
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+IMAGE_TAG="${IMAGE_TAG:?set IMAGE_TAG to git commit sha}"
+export LNKPI_API_IMAGE="lnkpi-api:${IMAGE_TAG}"
+export DOCKER_BUILDKIT=1
+export COMPOSE_DOCKER_CLI_BUILD=1
+
+COMPOSE="docker compose -f deploy/docker-compose.prod.yml"
+
+echo "=== Disk before build (${LNKPI_API_IMAGE}) ==="
+df -h / /var/lib/docker 2>/dev/null || df -h /
+
+set +euo
+docker image prune -f >/dev/null 2>&1
+docker images lnkpi-api --format '{{.Tag}}' 2>/dev/null | while read -r tag; do
+  [[ -z "$tag" || "$tag" == "<none>" ]] && continue
+  [[ "$tag" == "$IMAGE_TAG" || "$tag" == "latest" ]] && continue
+  docker rmi "lnkpi-api:${tag}" 2>/dev/null || true
+done
+set -euo pipefail
+
+echo "=== Building ${LNKPI_API_IMAGE} on CVM ==="
+$COMPOSE build api
+docker tag "${LNKPI_API_IMAGE}" lnkpi-api:latest
+
+$COMPOSE up -d --no-build
+
+echo "等待健康检查..."
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  if curl -fsS "http://127.0.0.1:5100/api/health" >/dev/null 2>&1; then
+    curl -fsS "http://127.0.0.1:5100/api/health" | head -c 200
+    echo ""
+    echo "部署完成 (IMAGE=${LNKPI_API_IMAGE})"
+    exit 0
+  fi
+  echo "health attempt $i failed, retry..."
+  sleep $((i <= 3 ? 5 : 10))
+done
+echo "health check failed after retries"
+docker logs lnkpi-api --tail 30 2>&1 || true
+exit 1

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -2,7 +2,11 @@
 # 本地调试:
 #   cp deploy/.env.production.example .env
 #   docker compose -f deploy/docker-compose.prod.yml up -d --build
-# 服务器（TCR 镜像）:
+# 服务器（CVM 本地 build，推荐）:
+#   export IMAGE_TAG=<git-sha> LNKPI_API_IMAGE=lnkpi-api:<git-sha>
+#   docker compose -f deploy/docker-compose.prod.yml build api
+#   docker compose -f deploy/docker-compose.prod.yml up -d --no-build
+# 服务器（TCR 镜像，备选）:
 #   export IMAGE_TAG=<git-sha> TCR_REGISTRY=ccr.ccs.tencentyun.com TCR_NAMESPACE=lnkpi
 #   docker compose -f deploy/docker-compose.prod.yml -f deploy/docker-compose.prod.images.yml pull
 #   docker compose -f deploy/docker-compose.prod.yml -f deploy/docker-compose.prod.images.yml up -d --no-build

--- a/deploy/init-remote.sh
+++ b/deploy/init-remote.sh
@@ -16,6 +16,7 @@ scp -i "$SSH_KEY" -o StrictHostKeyChecking=no \
   "$REPO_ROOT/deploy/docker-compose.prod.yml" \
   "$REPO_ROOT/deploy/docker-compose.prod.images.yml" \
   "$REPO_ROOT/deploy/deploy-remote.sh" \
+  "$REPO_ROOT/deploy/deploy-remote-build.sh" \
   "$REPO_ROOT/deploy/bootstrap-server.sh" \
   "${SSH_USER}@${SSH_HOST}:/tmp/lnkpi-deploy/"
 
@@ -29,6 +30,7 @@ mkdir -p /opt/lnkpi/deploy
 cp /tmp/lnkpi-deploy/* /opt/lnkpi/deploy/
 cp /tmp/lnkpi-deploy/.env.production.example /opt/lnkpi/deploy/
 chmod +x /opt/lnkpi/deploy/deploy-remote.sh
+chmod +x /opt/lnkpi/deploy/deploy-remote-build.sh
 if [ ! -f /opt/lnkpi/.env ]; then
   cp /opt/lnkpi/deploy/.env.production.example /opt/lnkpi/.env
   SECRET=$(openssl rand -hex 24)
@@ -44,5 +46,5 @@ REMOTE
 
 echo ""
 echo "✅ 服务器 /opt/lnkpi 已就绪"
-echo "下一步: 配置 GitHub Secrets + TCR 命名空间 lnkpi + Vercel"
-echo "详见 docs/DEPLOY_SETUP_WALKTHROUGH.md"
+echo "下一步: 配置 GitHub Secrets 后 push main 触发 deploy（CVM 本地 build），或手动:"
+echo "  cd /opt/lnkpi && IMAGE_TAG=<sha> bash deploy/deploy-remote-build.sh"


### PR DESCRIPTION
## Summary
- 移除 GHA `build-push` job（GitHub US → TCR 跨境 push 耗时 ~51 分钟）
- 改为单 job：tar 同步源码到 `/opt/lnkpi` → CVM 上 `docker compose build` → `up -d`
- 新增 `deploy/deploy-remote-build.sh`，保留 `deploy-remote.sh` 作 TCR 备选

## Expected timing
| 阶段 | 优化前 | 优化后（预期） |
|------|--------|----------------|
| 同步源码 | — | ~10–30s |
| CVM docker build | — | ~3–8 min |
| compose up + health | ~1 min | ~1 min |
| **总计** | **~52 min** | **~5–10 min** |

## Test plan
- [ ] Merge 后 Deploy workflow 单 job 完成
- [ ] `curl http://119.29.173.89:5100/api/health` 返回 200
- [ ] https://lnkpi-web.vercel.app 联调


Made with [Cursor](https://cursor.com)