### PR TITLE
fix: resilient CVM deploy (SSH keepalive + background build)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,7 @@ jobs:
   deploy:
     name: Build on CVM and deploy
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     environment: production
     env:
       SSH_HOST: ${{ secrets.TENCENT_CLOUD_IP || secrets.DEPLOY_HOST }}
@@ -44,18 +45,29 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
 
-      - name: Prepare SSH key
+      - name: Prepare SSH
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh
           echo "${{ secrets.TENCENT_CLOUD_SSH_KEY || secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
+          cat >> ~/.ssh/config <<EOF
+          Host deploy-cvm
+            HostName ${{ env.SSH_HOST }}
+            User ${{ env.SSH_USER }}
+            IdentityFile ~/.ssh/deploy_key
+            StrictHostKeyChecking no
+            ServerAliveInterval 30
+            ServerAliveCountMax 120
+            TCPKeepAlive yes
+          EOF
+          chmod 600 ~/.ssh/config
 
-      - name: Sync source and build on CVM
+      - name: Sync source to CVM
         run: |
           set -euo pipefail
-          HOST="${{ env.SSH_USER }}@${{ env.SSH_HOST }}"
           DEPLOY_DIR="${{ env.DEPLOY_DIR }}"
+          IMAGE_TAG="${{ env.IMAGE_TAG }}"
 
           tar --exclude='.git' \
               --exclude='node_modules' \
@@ -65,9 +77,9 @@ jobs:
               --exclude='docs' \
               -czf /tmp/lnkpi-src.tgz .
 
-          scp -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key /tmp/lnkpi-src.tgz "$HOST:/tmp/lnkpi-src.tgz"
+          scp /tmp/lnkpi-src.tgz deploy-cvm:/tmp/lnkpi-src.tgz
 
-          ssh -o StrictHostKeyChecking=no -i ~/.ssh/deploy_key "$HOST" << EOF
+          ssh deploy-cvm <<EOF
           set -euo pipefail
           sudo mkdir -p ${DEPLOY_DIR}
           if [[ -f ${DEPLOY_DIR}/.env ]]; then
@@ -85,12 +97,53 @@ jobs:
           fi
           sudo chmod +x ${DEPLOY_DIR}/deploy/deploy-remote-build.sh
           sudo chmod +x ${DEPLOY_DIR}/deploy/deploy-remote.sh
-          cd ${DEPLOY_DIR}
-          sudo -E env IMAGE_TAG="${{ env.IMAGE_TAG }}" bash deploy/deploy-remote-build.sh
+          sudo rm -f /tmp/lnkpi-deploy-${IMAGE_TAG}.status /tmp/lnkpi-deploy-${IMAGE_TAG}.log
           rm -f /tmp/lnkpi-src.tgz
           EOF
 
-          rm -f /tmp/lnkpi-src.tgz ~/.ssh/deploy_key
+          rm -f /tmp/lnkpi-src.tgz
+
+      - name: Launch background build on CVM
+        run: |
+          set -euo pipefail
+          DEPLOY_DIR="${{ env.DEPLOY_DIR }}"
+          IMAGE_TAG="${{ env.IMAGE_TAG }}"
+
+          ssh deploy-cvm "sudo bash -c 'cd ${DEPLOY_DIR} && nohup env IMAGE_TAG=${IMAGE_TAG} STATUS_FILE=/tmp/lnkpi-deploy-${IMAGE_TAG}.status LOG_FILE=/tmp/lnkpi-deploy-${IMAGE_TAG}.log bash deploy/deploy-remote-build.sh >> /tmp/lnkpi-deploy-${IMAGE_TAG}.log 2>&1 & echo \$! > /tmp/lnkpi-deploy-${IMAGE_TAG}.pid'"
+          echo "Build started on CVM (pid file: /tmp/lnkpi-deploy-${IMAGE_TAG}.pid)"
+
+      - name: Wait for CVM build
+        run: |
+          set -euo pipefail
+          IMAGE_TAG="${{ env.IMAGE_TAG }}"
+          STATUS_FILE="/tmp/lnkpi-deploy-${IMAGE_TAG}.status"
+          LOG_FILE="/tmp/lnkpi-deploy-${IMAGE_TAG}.log"
+          OK=0
+
+          for i in $(seq 1 120); do
+            STATUS=$(ssh deploy-cvm "sudo cat ${STATUS_FILE} 2>/dev/null || echo pending")
+            echo "Attempt $i: status=${STATUS}"
+            case "$STATUS" in
+              success)
+                OK=1
+                break
+                ;;
+              failed)
+                echo "=== CVM build log (tail) ==="
+                ssh deploy-cvm "sudo tail -80 ${LOG_FILE} 2>/dev/null || true"
+                exit 1
+                ;;
+            esac
+            sleep 30
+          done
+
+          if [[ "$OK" != "1" ]]; then
+            echo "Build timed out after 60 minutes"
+            ssh deploy-cvm "sudo tail -80 ${LOG_FILE} 2>/dev/null || true"
+            exit 1
+          fi
+
+          echo "CVM build succeeded"
 
       - name: Verify deployment
         run: |
@@ -101,6 +154,8 @@ jobs:
             CODE=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 --max-time 10 "${API_BASE}/api/health" 2>/dev/null || echo "000")
             if [ "$CODE" = "200" ]; then
               echo "Health OK: ${API_BASE}/api/health"
+              curl -fsS "${API_BASE}/api/health" | head -c 200
+              echo ""
               OK=1
               break
             fi
@@ -108,6 +163,10 @@ jobs:
             sleep $((i <= 5 ? 5 : 10))
           done
           [ "$OK" = "1" ] || exit 1
+
+      - name: Cleanup SSH key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key
 
       - name: Deployment summary
         if: always()

--- a/deploy/deploy-remote-build.sh
+++ b/deploy/deploy-remote-build.sh
@@ -4,41 +4,64 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 IMAGE_TAG="${IMAGE_TAG:?set IMAGE_TAG to git commit sha}"
+STATUS_FILE="${STATUS_FILE:-/tmp/lnkpi-deploy-${IMAGE_TAG}.status}"
+LOG_FILE="${LOG_FILE:-/tmp/lnkpi-deploy-${IMAGE_TAG}.log}"
 export LNKPI_API_IMAGE="lnkpi-api:${IMAGE_TAG}"
 export DOCKER_BUILDKIT=1
 export COMPOSE_DOCKER_CLI_BUILD=1
 
 COMPOSE="docker compose -f deploy/docker-compose.prod.yml"
 
-echo "=== Disk before build (${LNKPI_API_IMAGE}) ==="
+log() {
+  echo "[$(date -u +%H:%M:%S)] $*"
+}
+
+set_status() {
+  echo "$1" > "$STATUS_FILE"
+  log "status=$1"
+}
+
+on_fail() {
+  set_status failed
+  docker logs lnkpi-api --tail 40 2>&1 || true
+  exit 1
+}
+
+set_status running
+
+log "=== Disk before build (${LNKPI_API_IMAGE}) ==="
 df -h / /var/lib/docker 2>/dev/null || df -h /
 
-set +euo
-docker image prune -f >/dev/null 2>&1
+log "=== Prune unused Docker data ==="
+docker image prune -f >/dev/null 2>&1 || true
+docker builder prune -f --filter 'until=24h' >/dev/null 2>&1 || true
 docker images lnkpi-api --format '{{.Tag}}' 2>/dev/null | while read -r tag; do
   [[ -z "$tag" || "$tag" == "<none>" ]] && continue
   [[ "$tag" == "$IMAGE_TAG" || "$tag" == "latest" ]] && continue
   docker rmi "lnkpi-api:${tag}" 2>/dev/null || true
 done
-set -euo pipefail
 
-echo "=== Building ${LNKPI_API_IMAGE} on CVM ==="
-$COMPOSE build api
+log "=== Building ${LNKPI_API_IMAGE} on CVM ==="
+if ! $COMPOSE build --progress=plain api 2>&1 | tee -a "$LOG_FILE"; then
+  on_fail
+fi
 docker tag "${LNKPI_API_IMAGE}" lnkpi-api:latest
 
+log "=== Starting container ==="
 $COMPOSE up -d --no-build
 
-echo "等待健康检查..."
-for i in 1 2 3 4 5 6 7 8 9 10; do
+log "=== Waiting for health ==="
+for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
   if curl -fsS "http://127.0.0.1:5100/api/health" >/dev/null 2>&1; then
     curl -fsS "http://127.0.0.1:5100/api/health" | head -c 200
     echo ""
-    echo "部署完成 (IMAGE=${LNKPI_API_IMAGE})"
+    set_status success
+    log "部署完成 (IMAGE=${LNKPI_API_IMAGE})"
     exit 0
   fi
-  echo "health attempt $i failed, retry..."
-  sleep $((i <= 3 ? 5 : 10))
+  log "health attempt $i failed, retry..."
+  sleep $((i <= 5 ? 5 : 10))
 done
-echo "health check failed after retries"
-docker logs lnkpi-api --tail 30 2>&1 || true
-exit 1
+
+log "health check failed after retries"
+on_fail


### PR DESCRIPTION
## Summary
- SSH 配置 `ServerAliveInterval=30` / `ServerAliveCountMax=120`，避免长 build 断连 (exit 255)
- 拆分为：同步源码 → **nohup 后台 build** → 短 SSH 轮询 status（最多 60 min）
- `deploy-remote-build.sh` 写入 status/log 文件，build 前 prune 镜像与 builder 缓存

## Test plan
- [ ] CI 通过
- [ ] Merge 后 Deploy workflow 在 10–20 min 内完成
- [ ] `curl http://119.29.173.89:5100/api/health` 返回 200


Made with [Cursor](https://cursor.com)