### PR TITLE
feat: videoComposition C-1 — Dock panel and inbound track list

### DIFF
--- a/apps/web/src/components/canvas/CanvasNodeVideoComposition.vue
+++ b/apps/web/src/components/canvas/CanvasNodeVideoComposition.vue
@@ -1,10 +1,24 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import NeoBaseNode from '@/components/canvas/NeoBaseNode.vue'
 
-defineProps<{
+const props = defineProps<{
   selected?: boolean
-  data: { title?: string; status?: string; clipCount?: number; label?: string }
+  data: {
+    title?: string
+    status?: string
+    clipCount?: number
+    tracks?: Array<{ type?: string }>
+    label?: string
+  }
 }>()
+
+const videoCount = computed(
+  () => props.data.tracks?.filter((track) => track.type === 'video').length ?? 0,
+)
+const audioCount = computed(
+  () => props.data.tracks?.filter((track) => track.type === 'audio').length ?? 0,
+)
 </script>
 
 <template>
@@ -24,7 +38,9 @@ defineProps<{
             <line x1="12" y1="17" x2="12" y2="21" />
           </svg>
           <span class="neo-placeholder-text">{{ data.title || '多轨合成' }}</span>
-          <span class="text-[11px] text-white/40">{{ data.clipCount ?? 0 }} 个片段</span>
+          <span class="text-[11px] text-indigo-200/70">
+            {{ data.clipCount ?? 0 }} 轨 · 视频 {{ videoCount }} · 音频 {{ audioCount }}
+          </span>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/canvas/DockStudioToolbar.vue
+++ b/apps/web/src/components/canvas/DockStudioToolbar.vue
@@ -6,10 +6,12 @@ import DockStudioRouter from '@/components/canvas/dock-studio/DockStudioRouter.v
 import { EDITABLE_NODE_TYPES } from '@/composables/useSelectedNodeEditor'
 import { computed } from 'vue'
 import { isNodeGenerating } from '@/constants/dockStudio'
+import type { CompositionTrack } from '@/utils/compositionUpstream'
 
 const props = defineProps<{
   node: EditableFlowNode | null
   upstream: UpstreamNodeContext
+  compositionTracks?: CompositionTrack[]
   mentions?: MentionOption[]
   generating?: boolean
   scale?: number
@@ -59,6 +61,7 @@ const dockLocked = computed(() => {
         <DockStudioRouter
           :node="node"
           :upstream="upstream"
+          :composition-tracks="compositionTracks"
           :mentions="mentions"
           :generating="generating"
           @patch="emit('patch', $event)"

--- a/apps/web/src/components/canvas/dock-studio/DockStudioRouter.vue
+++ b/apps/web/src/components/canvas/dock-studio/DockStudioRouter.vue
@@ -10,12 +10,15 @@ import AudioDockPanel from '@/components/canvas/dock-studio/panels/AudioDockPane
 import ShotDockPanel from '@/components/canvas/dock-studio/panels/ShotDockPanel.vue'
 import MediaInputDockPanel from '@/components/canvas/dock-studio/panels/MediaInputDockPanel.vue'
 import SceneComposerDockPanel from '@/components/canvas/dock-studio/panels/SceneComposerDockPanel.vue'
+import VideoCompositionDockPanel from '@/components/canvas/dock-studio/panels/VideoCompositionDockPanel.vue'
 import LegacyDockPanel from '@/components/canvas/dock-studio/panels/LegacyDockPanel.vue'
 import { isNodeGenerating } from '@/constants/dockStudio'
+import type { CompositionTrack } from '@/utils/compositionUpstream'
 
 const props = defineProps<{
   node: EditableFlowNode | null
   upstream: UpstreamNodeContext
+  compositionTracks?: CompositionTrack[]
   mentions?: MentionOption[]
   generating?: boolean
 }>()
@@ -125,6 +128,16 @@ const panelBindings = {
     @save="emit('save')"
     @expand="emit('expand')"
     @batch-generate="emit('batchGenerate')"
+    @close="panelBindings.close"
+  />
+  <VideoCompositionDockPanel
+    v-else-if="node && nodeType === 'videoComposition'"
+    :node="node"
+    :upstream="upstream"
+    :tracks="compositionTracks ?? []"
+    :generating="generating"
+    :readonly="dockReadonly"
+    @patch="panelBindings.patch"
     @close="panelBindings.close"
   />
   <LegacyDockPanel

--- a/apps/web/src/components/canvas/dock-studio/panels/VideoCompositionDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/VideoCompositionDockPanel.vue
@@ -1,0 +1,160 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
+import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
+import type { CompositionTrack } from '@/utils/compositionUpstream'
+import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
+import { isNodeGenerating } from '@/constants/dockStudio'
+
+const props = defineProps<{
+  node: EditableFlowNode
+  upstream: UpstreamNodeContext
+  tracks: CompositionTrack[]
+  generating?: boolean
+  readonly?: boolean
+}>()
+
+const emit = defineEmits<{
+  patch: [patch: Record<string, unknown>]
+  close: []
+}>()
+
+const title = ref('')
+
+const locked = computed(
+  () => !!props.readonly || isNodeGenerating(props.node.data?.status) || !!props.generating,
+)
+
+const videoTrackCount = computed(() => props.tracks.filter((track) => track.type === 'video').length)
+const audioTrackCount = computed(() => props.tracks.filter((track) => track.type === 'audio').length)
+
+function syncFromNode() {
+  title.value = String(props.node.data?.title ?? '视频合成')
+}
+
+watch(() => props.node, syncFromNode, { immediate: true, deep: true })
+
+function onTitleInput(value: string) {
+  title.value = value
+  emit('patch', { title: value })
+}
+</script>
+
+<template>
+  <DockToolbarShell
+    type-label="视频合成"
+    show-title
+    :title="title"
+    title-placeholder="合成项目名"
+    :readonly="locked"
+    @update:title="onTitleInput"
+    @close="emit('close')"
+  >
+    <div class="mb-2 flex flex-wrap items-center gap-2 px-1 text-[10px] text-white/45">
+      <span>{{ tracks.length }} 轨</span>
+      <span>视频 {{ videoTrackCount }}</span>
+      <span>音频 {{ audioTrackCount }}</span>
+      <span v-if="!tracks.length" class="text-amber-300/80">请连接 video / audio 节点到本节点</span>
+    </div>
+
+    <div class="composition-track-list">
+      <div v-if="!tracks.length" class="composition-empty">
+        <p>暂无入边素材</p>
+        <p class="text-white/35">从画布将视频或音频节点连线到「视频合成」节点</p>
+      </div>
+      <div v-for="(track, index) in tracks" :key="track.nodeId" class="composition-track-row">
+        <span class="composition-track-index">{{ index + 1 }}</span>
+        <span class="composition-track-type" :class="track.type">{{ track.label }}</span>
+        <div class="min-w-0 flex-1">
+          <p class="truncate text-[11px] text-white/80">{{ track.title }}</p>
+          <p class="truncate text-[10px] text-white/35">{{ track.url || '尚无媒体 URL' }}</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="composition-timeline-placeholder">
+      <span>时间轴预览</span>
+      <span class="text-white/35">（C-3 开发中）</span>
+    </div>
+
+    <div class="bottom-toolbar-actions flex-wrap">
+      <button
+        type="button"
+        class="rounded-lg border border-white/10 px-3 py-1.5 text-xs text-white/40"
+        disabled
+        title="C-4 合成/export API 开发中"
+      >
+        导出合成（即将推出）
+      </button>
+    </div>
+  </DockToolbarShell>
+</template>
+
+<style scoped>
+.composition-track-list {
+  max-height: 160px;
+  margin-bottom: 8px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 0 4px;
+}
+
+.composition-empty {
+  padding: 16px 12px;
+  border-radius: 12px;
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+  text-align: center;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.composition-track-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(0, 0, 0, 0.18);
+}
+
+.composition-track-index {
+  width: 18px;
+  text-align: center;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.composition-track-type {
+  flex-shrink: 0;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 10px;
+}
+
+.composition-track-type.video {
+  background: rgba(99, 102, 241, 0.2);
+  color: #a5b4fc;
+}
+
+.composition-track-type.audio {
+  background: rgba(16, 185, 129, 0.18);
+  color: #6ee7b7;
+}
+
+.composition-timeline-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 52px;
+  margin-bottom: 4px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.55);
+}
+</style>

--- a/apps/web/src/constants/dockStudio.ts
+++ b/apps/web/src/constants/dockStudio.ts
@@ -9,6 +9,7 @@ export const EDITABLE_NODE_TYPES = new Set([
   'shot',
   'prompt',
   'mediaInput',
+  'videoComposition',
 ])
 
 /** 使用独立 Dock Panel 的节点 */
@@ -20,6 +21,7 @@ export const DOCK_PANEL_NODE_TYPES = {
   shot: 'shot',
   mediaInput: 'mediaInput',
   sceneComposer: 'sceneComposer',
+  videoComposition: 'videoComposition',
 } as const
 
 export type DockPanelNodeType = keyof typeof DOCK_PANEL_NODE_TYPES

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -16,6 +16,7 @@ import { useShotPolling } from '@/composables/useShotPolling'
 import { useGenerationPolling, parseRecordUrl, type GenerationPollTask } from '@/composables/useGenerationPolling'
 import { useNodeGeneration } from '@/composables/useNodeGeneration'
 import { createInitialSceneComposerNodeData } from '@/utils/sceneComposer'
+import { resolveCompositionTracks, compositionTracksToNodePatch } from '@/utils/compositionUpstream'
 import { resolveUpstreamContext } from '@/composables/useUpstreamNodeContext'
 import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
 import CanvasNodePrompt from '@/components/canvas/CanvasNodePrompt.vue'
@@ -311,6 +312,12 @@ const editorUpstream = computed(() => {
   return resolveUpstreamContext(node.id, nodes.value, edges.value)
 })
 
+const editorCompositionTracks = computed(() => {
+  const node = editorNode.value
+  if (!node || node.type !== 'videoComposition') return []
+  return resolveCompositionTracks(node.id, nodes.value, edges.value)
+})
+
 const multiSelectCanUngroup = computed(() => {
   if (multiSelectedIds.value.length !== 1) return false
   const node = findNodeById(multiSelectedIds.value[0])
@@ -451,7 +458,11 @@ function createNodeAt(type: DockNodeType, position: { x: number; y: number }) {
       id = addNode('mediaInput', { url: '', status: 'idle', title: '媒体输入', fileName: '' }, { position })
       break
     case 'videoComposition':
-      id = addNode('videoComposition', { title: '视频合成', clipCount: 0, status: 'draft' }, { position })
+      id = addNode(
+        'videoComposition',
+        { title: '视频合成', clipCount: 0, tracks: [], status: 'draft' },
+        { position },
+      )
       break
     case 'worldModel':
       id = addNode('worldModel', { title: '3D 世界', prompt: '', status: 'beta' }, { position })
@@ -1287,6 +1298,21 @@ const debouncedNodePatch = useDebouncedNodePatch(
   saveCanvas,
 )
 
+watch(
+  editorCompositionTracks,
+  (tracks) => {
+    const node = editorNode.value
+    if (!node || node.type !== 'videoComposition') return
+    const patch = compositionTracksToNodePatch(tracks)
+    const data = node.data ?? {}
+    const sameCount = data.clipCount === patch.clipCount
+    const sameTracks = JSON.stringify(data.tracks ?? []) === JSON.stringify(patch.tracks)
+    if (sameCount && sameTracks) return
+    debouncedNodePatch.patchNode(node.id, patch)
+  },
+  { deep: true },
+)
+
 async function loadSession() {
   try {
     const { data } = await api.get<{ data: { title: string; canvasData?: { nodes: Node[]; edges: Edge[] } } }>(
@@ -1488,6 +1514,7 @@ onMounted(() => {
         <DockStudioToolbar
           :node="editorNode"
           :upstream="editorUpstream"
+          :composition-tracks="editorCompositionTracks"
           :mentions="mentionOptions"
           :generating="nodeGenerating"
           :scale="viewportSettings.bottomToolbarScale"

--- a/apps/web/src/utils/compositionUpstream.ts
+++ b/apps/web/src/utils/compositionUpstream.ts
@@ -1,0 +1,63 @@
+import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
+import type { CanvasEdgeLike } from '@/composables/useUpstreamNodeContext'
+
+export type CompositionTrackType = 'video' | 'audio'
+
+export interface CompositionTrack {
+  nodeId: string
+  type: CompositionTrackType
+  title: string
+  url: string
+  label: string
+}
+
+function trackLabel(type: CompositionTrackType) {
+  return type === 'video' ? '视频' : '音频'
+}
+
+function readTrackTitle(node: EditableFlowNode) {
+  const data = node.data ?? {}
+  return String(data.title ?? data.prompt ?? data.content ?? node.id).slice(0, 48)
+}
+
+/** 收集指向合成节点的入边 video/audio 轨（C-2 基础，供 C-1 Dock 展示） */
+export function resolveCompositionTracks(
+  targetNodeId: string,
+  nodes: EditableFlowNode[],
+  edges: CanvasEdgeLike[],
+): CompositionTrack[] {
+  const nodeMap = new Map(nodes.map((node) => [node.id, node]))
+  const tracks: CompositionTrack[] = []
+
+  for (const edge of edges) {
+    if (edge.target !== targetNodeId) continue
+    const source = nodeMap.get(edge.source)
+    if (!source) continue
+    const type = String(source.type ?? '')
+    if (type !== 'video' && type !== 'audio') continue
+
+    const trackType = type as CompositionTrackType
+    const url = String(source.data?.url ?? '').trim()
+    tracks.push({
+      nodeId: source.id,
+      type: trackType,
+      title: readTrackTitle(source),
+      url,
+      label: trackLabel(trackType),
+    })
+  }
+
+  return tracks
+}
+
+export function compositionTracksToNodePatch(tracks: CompositionTrack[]) {
+  return {
+    clipCount: tracks.length,
+    tracks: tracks.map((track) => ({
+      nodeId: track.nodeId,
+      type: track.type,
+      title: track.title,
+      url: track.url,
+    })),
+  }
+}

--- a/docs/DOCK_STUDIO_E2E_TRACKING.md
+++ b/docs/DOCK_STUDIO_E2E_TRACKING.md
@@ -423,13 +423,13 @@ interface DockStudioEntry {
 
 | ID | 任务 | 状态 |
 |----|------|------|
-| C-1 | 加入 EDITABLE + `VideoCompositionDockPanel` | 未开始 |
-| C-2 | 读入边：收集所有 video/audio 轨 | 未开始 |
+| C-1 | 加入 EDITABLE + `VideoCompositionDockPanel` | ✅ |
+| C-2 | 读入边：收集所有 video/audio 轨 | 🟡 基础（Dock 实时展示） |
 | C-3 | 简易时间轴预览（可复用 VideoEditorPage MVP） | 未开始 |
 | C-4 | 后端：合成/export API（或 ffmpeg 任务） | 未开始 |
 
-- [ ] C-1 — VideoCompositionDockPanel
-- [ ] C-2 — 入边轨收集
+- [x] C-1 — VideoCompositionDockPanel
+- [ ] C-2 — 入边轨收集（基础展示已接入，待持久化/排序 polish）
 - [ ] C-3 — 时间轴预览 MVP
 - [ ] C-4 — 合成/export API
 


### PR DESCRIPTION
## Summary

- Register `videoComposition` as an editable Dock Studio node type
- Add `VideoCompositionDockPanel` with title, inbound video/audio track list, and C-3/C-4 placeholders
- Collect composition tracks from incoming edges and sync `clipCount` / `tracks` to node data
- Update canvas node card to show video/audio track breakdown

## Test plan

- [x] `pnpm build`
- [ ] 生产：添加「视频合成」节点 → 连线 video/audio → Dock 显示轨列表
- [ ] 刷新画布后 clipCount / tracks 持久化


Made with [Cursor](https://cursor.com)