### PR TITLE
feat: videoComposition C-2~C-4 track persistence, timeline, and export

### DIFF
--- a/apps/server/src/canvas/canvas.controller.ts
+++ b/apps/server/src/canvas/canvas.controller.ts
@@ -1,15 +1,17 @@
 import { Body, Controller, Get, Inject, Post, Put, Query, Req, UseGuards } from '@nestjs/common'
-import { IsArray, IsIn, IsOptional, IsString, ValidateNested } from 'class-validator'
+import { IsArray, IsIn, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator'
 import { Type } from 'class-transformer'
 import type {
   SceneComposerBatchGenerateRequest,
   SceneComposerSaveRequest,
+  VideoCompositionExportRequest,
 } from '@lnkpi/shared'
 import { AuthGuard } from '../auth/auth.guard'
 import { CanvasService } from './canvas.service'
 import { MaterialService } from './material.service'
 import { SceneComposerService } from './scene-composer.service'
 import { ShotService } from './shot.service'
+import { VideoCompositionService } from './video-composition.service'
 
 class CreateCanvasDto {
   @IsOptional()
@@ -195,6 +197,43 @@ class BatchGenerateSceneComposerDto implements SceneComposerBatchGenerateRequest
   items!: SceneComposerBatchItemDto[]
 }
 
+class VideoCompositionExportTrackDto {
+  @IsString()
+  nodeId!: string
+
+  @IsIn(['video', 'audio'])
+  type!: 'video' | 'audio'
+
+  @IsString()
+  title!: string
+
+  @IsString()
+  url!: string
+
+  @IsNumber()
+  durationSec!: number
+
+  @IsOptional()
+  startSec?: number
+}
+
+class ExportVideoCompositionDto implements VideoCompositionExportRequest {
+  @IsString()
+  sessionId!: string
+
+  @IsString()
+  compositionNodeId!: string
+
+  @IsOptional()
+  @IsString()
+  title?: string
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => VideoCompositionExportTrackDto)
+  tracks!: VideoCompositionExportTrackDto[]
+}
+
 @Controller('agent/canvas')
 export class CanvasController {
   constructor(
@@ -202,6 +241,7 @@ export class CanvasController {
     @Inject(ShotService) private readonly shotService: ShotService,
     @Inject(MaterialService) private readonly materialService: MaterialService,
     @Inject(SceneComposerService) private readonly sceneComposerService: SceneComposerService,
+    @Inject(VideoCompositionService) private readonly videoCompositionService: VideoCompositionService,
   ) {}
 
   @Get('list')
@@ -298,6 +338,16 @@ export class CanvasController {
   @UseGuards(AuthGuard)
   async batchGenerateSceneComposer(@Body() dto: BatchGenerateSceneComposerDto) {
     const data = await this.sceneComposerService.batchGenerate(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('video-composition/export')
+  @UseGuards(AuthGuard)
+  async exportVideoComposition(
+    @Req() req: { user: { sub: string } },
+    @Body() dto: ExportVideoCompositionDto,
+  ) {
+    const data = await this.videoCompositionService.exportComposition(req.user.sub, dto)
     return { code: 0, message: 'ok', data }
   }
 }

--- a/apps/server/src/canvas/canvas.module.ts
+++ b/apps/server/src/canvas/canvas.module.ts
@@ -1,13 +1,28 @@
 import { Module } from '@nestjs/common'
+import { UploadModule } from '../upload/upload.module'
 import { CanvasController } from './canvas.controller'
 import { CanvasService } from './canvas.service'
 import { MaterialService } from './material.service'
 import { SceneComposerService } from './scene-composer.service'
 import { ShotService } from './shot.service'
+import { VideoCompositionService } from './video-composition.service'
 
 @Module({
+  imports: [UploadModule],
   controllers: [CanvasController],
-  providers: [CanvasService, ShotService, MaterialService, SceneComposerService],
-  exports: [CanvasService, ShotService, MaterialService, SceneComposerService],
+  providers: [
+    CanvasService,
+    ShotService,
+    MaterialService,
+    SceneComposerService,
+    VideoCompositionService,
+  ],
+  exports: [
+    CanvasService,
+    ShotService,
+    MaterialService,
+    SceneComposerService,
+    VideoCompositionService,
+  ],
 })
 export class CanvasModule {}

--- a/apps/server/src/canvas/video-composition.service.ts
+++ b/apps/server/src/canvas/video-composition.service.ts
@@ -1,0 +1,250 @@
+import { execFile } from 'child_process'
+import { randomUUID } from 'crypto'
+import { mkdir, readFile, rm, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { promisify } from 'util'
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common'
+import type {
+  VideoCompositionExportRequest,
+  VideoCompositionExportTrack,
+} from '@lnkpi/shared'
+import { PrismaService } from '../prisma/prisma.service'
+import { UploadService } from '../upload/upload.service'
+
+const execFileAsync = promisify(execFile)
+
+const OUTPUT_WIDTH = 1280
+const OUTPUT_HEIGHT = 720
+const OUTPUT_FPS = 25
+
+@Injectable()
+export class VideoCompositionService {
+  constructor(
+    @Inject(PrismaService) private readonly prisma: PrismaService,
+    @Inject(UploadService) private readonly uploadService: UploadService,
+  ) {}
+
+  async exportComposition(userId: string, dto: VideoCompositionExportRequest) {
+    await this.assertSession(dto.sessionId)
+    const tracks = (dto.tracks ?? []).filter((track) => track.url?.trim())
+    if (!tracks.length) {
+      throw new BadRequestException('没有可合成的媒体轨，请先连接 video / audio 节点')
+    }
+
+    const workDir = join(tmpdir(), `lnkpi-compose-${randomUUID()}`)
+    await mkdir(workDir, { recursive: true })
+
+    try {
+      const segments: string[] = []
+      let timelineCursor = 0
+
+      for (const [index, track] of tracks.entries()) {
+        const durationSec = this.normalizeDuration(track.durationSec)
+        const startSec = track.startSec && track.startSec > 0 ? track.startSec : timelineCursor
+        if (startSec > timelineCursor) {
+          segments.push(await this.createGapSegment(workDir, startSec - timelineCursor, index))
+        }
+
+        const sourcePath = await this.downloadTrack(workDir, track, index)
+        segments.push(await this.buildSegment(workDir, track, sourcePath, durationSec, index))
+        timelineCursor = startSec + durationSec
+      }
+
+      const outputPath = join(workDir, 'composed.mp4')
+      await this.concatSegments(workDir, segments, outputPath)
+      const outputBuffer = await readFile(outputPath)
+      const saved = await this.uploadService.saveUserFile(
+        userId,
+        outputBuffer,
+        `${dto.title?.trim() || 'composition'}.mp4`,
+        'video/mp4',
+      )
+
+      return {
+        compositionNodeId: dto.compositionNodeId,
+        url: saved.url,
+        durationSec: Math.round(timelineCursor * 10) / 10,
+        status: 'completed' as const,
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '合成失败'
+      if (message.includes('ENOENT') && message.includes('ffmpeg')) {
+        throw new InternalServerErrorException('服务器未安装 ffmpeg，暂无法导出合成视频')
+      }
+      throw new InternalServerErrorException(message)
+    } finally {
+      await rm(workDir, { recursive: true, force: true }).catch(() => undefined)
+    }
+  }
+
+  private async assertSession(sessionId: string) {
+    const session = await this.prisma.session.findUnique({ where: { id: sessionId } })
+    if (!session) throw new NotFoundException('画布不存在')
+    return session
+  }
+
+  private normalizeDuration(value: number | undefined) {
+    const sec = Number(value)
+    if (!Number.isFinite(sec) || sec <= 0) return 3
+    return Math.min(120, Math.max(0.5, sec))
+  }
+
+  private resolveMediaUrl(url: string) {
+    const trimmed = url.trim()
+    if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) return trimmed
+    const base = process.env.API_PUBLIC_URL?.replace(/\/$/, '') ?? 'http://127.0.0.1:3001'
+    if (trimmed.startsWith('/')) return `${base}${trimmed}`
+    return trimmed
+  }
+
+  private extFromUrl(url: string, fallback: string) {
+    const clean = url.split('?')[0] ?? url
+    const match = clean.match(/\.([a-z0-9]{2,5})$/i)
+    return match ? `.${match[1].toLowerCase()}` : fallback
+  }
+
+  private async downloadTrack(workDir: string, track: VideoCompositionExportTrack, index: number) {
+    const resolved = this.resolveMediaUrl(track.url)
+    const response = await fetch(resolved)
+    if (!response.ok) {
+      throw new BadRequestException(`无法下载素材：${track.title || track.nodeId}`)
+    }
+    const ext = this.extFromUrl(resolved, track.type === 'audio' ? '.mp3' : '.mp4')
+    const dest = join(workDir, `source-${index}${ext}`)
+    await writeFile(dest, Buffer.from(await response.arrayBuffer()))
+    return dest
+  }
+
+  private async buildSegment(
+    workDir: string,
+    track: VideoCompositionExportTrack,
+    sourcePath: string,
+    durationSec: number,
+    index: number,
+  ) {
+    const outputPath = join(workDir, `segment-${index}.mp4`)
+    if (track.type === 'audio') {
+      await this.runFfmpeg([
+        '-y',
+        '-f',
+        'lavfi',
+        '-i',
+        `color=c=black:s=${OUTPUT_WIDTH}x${OUTPUT_HEIGHT}:r=${OUTPUT_FPS}`,
+        '-i',
+        sourcePath,
+        '-t',
+        String(durationSec),
+        '-vf',
+        `scale=${OUTPUT_WIDTH}:${OUTPUT_HEIGHT}`,
+        '-c:v',
+        'libx264',
+        '-preset',
+        'veryfast',
+        '-crf',
+        '23',
+        '-c:a',
+        'aac',
+        '-ar',
+        '44100',
+        '-ac',
+        '2',
+        '-shortest',
+        outputPath,
+      ])
+      return outputPath
+    }
+
+    await this.runFfmpeg([
+      '-y',
+      '-i',
+      sourcePath,
+      '-t',
+      String(durationSec),
+      '-vf',
+      `scale=${OUTPUT_WIDTH}:${OUTPUT_HEIGHT}:force_original_aspect_ratio=decrease,pad=${OUTPUT_WIDTH}:${OUTPUT_HEIGHT}:(ow-iw)/2:(oh-ih)/2,setsar=1,fps=${OUTPUT_FPS}`,
+      '-c:v',
+      'libx264',
+      '-preset',
+      'veryfast',
+      '-crf',
+      '23',
+      '-c:a',
+      'aac',
+      '-ar',
+      '44100',
+      '-ac',
+      '2',
+      outputPath,
+    ])
+    return outputPath
+  }
+
+  private async createGapSegment(workDir: string, durationSec: number, index: number) {
+    const outputPath = join(workDir, `gap-${index}.mp4`)
+    await this.runFfmpeg([
+      '-y',
+      '-f',
+      'lavfi',
+      '-i',
+      `color=c=black:s=${OUTPUT_WIDTH}x${OUTPUT_HEIGHT}:r=${OUTPUT_FPS}`,
+      '-f',
+      'lavfi',
+      '-i',
+      'anullsrc=r=44100:cl=stereo',
+      '-t',
+      String(durationSec),
+      '-c:v',
+      'libx264',
+      '-preset',
+      'veryfast',
+      '-crf',
+      '23',
+      '-c:a',
+      'aac',
+      '-shortest',
+      outputPath,
+    ])
+    return outputPath
+  }
+
+  private async concatSegments(workDir: string, segments: string[], outputPath: string) {
+    const listPath = join(workDir, 'concat.txt')
+    const listBody = segments.map((segment) => `file '${segment.replace(/'/g, "'\\''")}'`).join('\n')
+    await writeFile(listPath, listBody, 'utf8')
+    await this.runFfmpeg([
+      '-y',
+      '-f',
+      'concat',
+      '-safe',
+      '0',
+      '-i',
+      listPath,
+      '-c:v',
+      'libx264',
+      '-preset',
+      'veryfast',
+      '-crf',
+      '23',
+      '-c:a',
+      'aac',
+      '-ar',
+      '44100',
+      '-ac',
+      '2',
+      '-movflags',
+      '+faststart',
+      outputPath,
+    ])
+  }
+
+  private async runFfmpeg(args: string[]) {
+    await execFileAsync('ffmpeg', args, { maxBuffer: 20 * 1024 * 1024 })
+  }
+}

--- a/apps/web/src/components/canvas/CanvasNodeVideoComposition.vue
+++ b/apps/web/src/components/canvas/CanvasNodeVideoComposition.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import NeoBaseNode from '@/components/canvas/NeoBaseNode.vue'
+import { resolveMediaUrl } from '@/services/api-base'
 
 const props = defineProps<{
   selected?: boolean
@@ -10,6 +11,7 @@ const props = defineProps<{
     clipCount?: number
     tracks?: Array<{ type?: string }>
     label?: string
+    url?: string
   }
 }>()
 
@@ -19,6 +21,10 @@ const videoCount = computed(
 const audioCount = computed(
   () => props.data.tracks?.filter((track) => track.type === 'audio').length ?? 0,
 )
+const previewUrl = computed(() => {
+  const url = String(props.data.url ?? '').trim()
+  return url ? resolveMediaUrl(url) : ''
+})
 </script>
 
 <template>
@@ -30,7 +36,14 @@ const audioCount = computed(
     :height="200"
   >
     <div class="neo-gen-card">
-      <div class="neo-node-placeholder">
+      <video
+        v-if="previewUrl"
+        :src="previewUrl"
+        class="h-full w-full object-cover"
+        muted
+        playsinline
+      />
+      <div v-else class="neo-node-placeholder">
         <div class="neo-placeholder-content">
           <svg class="neo-placeholder-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <rect x="2" y="3" width="20" height="14" rx="2" />

--- a/apps/web/src/components/canvas/DockStudioToolbar.vue
+++ b/apps/web/src/components/canvas/DockStudioToolbar.vue
@@ -26,6 +26,7 @@ const emit = defineEmits<{
   save: []
   expand: []
   batchGenerate: []
+  export: []
 }>()
 
 const visible = computed(() => {
@@ -72,6 +73,7 @@ const dockLocked = computed(() => {
           @save="emit('save')"
           @expand="emit('expand')"
           @batch-generate="emit('batchGenerate')"
+          @export="emit('export')"
         />
       </div>
     </div>

--- a/apps/web/src/components/canvas/dock-studio/DockStudioRouter.vue
+++ b/apps/web/src/components/canvas/dock-studio/DockStudioRouter.vue
@@ -32,6 +32,7 @@ const emit = defineEmits<{
   save: []
   expand: []
   batchGenerate: []
+  export: []
 }>()
 
 const nodeType = computed(() => String(props.node?.type ?? ''))
@@ -139,6 +140,7 @@ const panelBindings = {
     :readonly="dockReadonly"
     @patch="panelBindings.patch"
     @close="panelBindings.close"
+    @export="emit('export')"
   />
   <LegacyDockPanel
     v-else-if="node"

--- a/apps/web/src/components/canvas/dock-studio/panels/VideoCompositionDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/VideoCompositionDockPanel.vue
@@ -2,8 +2,14 @@
 import { computed, ref, watch } from 'vue'
 import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
-import type { CompositionTrack } from '@/utils/compositionUpstream'
+import type { CompositionTrack, CompositionTrackRecord } from '@/utils/compositionUpstream'
+import {
+  applyTrackOrder,
+  compositionTracksToNodePatch,
+  reorderTrackIds,
+} from '@/utils/compositionUpstream'
 import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
+import CompositionTimelinePreview from '@/components/canvas/dock-studio/shared/CompositionTimelinePreview.vue'
 import { isNodeGenerating } from '@/constants/dockStudio'
 
 const props = defineProps<{
@@ -25,8 +31,13 @@ const locked = computed(
   () => !!props.readonly || isNodeGenerating(props.node.data?.status) || !!props.generating,
 )
 
-const videoTrackCount = computed(() => props.tracks.filter((track) => track.type === 'video').length)
-const audioTrackCount = computed(() => props.tracks.filter((track) => track.type === 'audio').length)
+const orderedTracks = computed(() => {
+  const trackOrder = props.node.data?.trackOrder as string[] | undefined
+  return applyTrackOrder(props.tracks, trackOrder)
+})
+
+const videoTrackCount = computed(() => orderedTracks.value.filter((track) => track.type === 'video').length)
+const audioTrackCount = computed(() => orderedTracks.value.filter((track) => track.type === 'audio').length)
 
 function syncFromNode() {
   title.value = String(props.node.data?.title ?? '视频合成')
@@ -37,6 +48,26 @@ watch(() => props.node, syncFromNode, { immediate: true, deep: true })
 function onTitleInput(value: string) {
   title.value = value
   emit('patch', { title: value })
+}
+
+function moveTrack(index: number, delta: number) {
+  const ids = orderedTracks.value.map((track) => track.nodeId)
+  const nextOrder = reorderTrackIds(ids, index, index + delta)
+  emit('patch', compositionTracksToNodePatch(applyTrackOrder(props.tracks, nextOrder)))
+}
+
+function updateDuration(index: number, value: string) {
+  const sec = Number.parseFloat(value)
+  if (!Number.isFinite(sec) || sec <= 0) return
+  const tracks = orderedTracks.value.map((track, trackIndex) =>
+    trackIndex === index ? { ...track, durationSec: sec } : track,
+  )
+  emit('patch', compositionTracksToNodePatch(tracks))
+}
+
+function readSavedTracks(): CompositionTrackRecord[] {
+  const raw = props.node.data?.tracks
+  return Array.isArray(raw) ? (raw as CompositionTrackRecord[]) : []
 }
 </script>
 
@@ -51,30 +82,60 @@ function onTitleInput(value: string) {
     @close="emit('close')"
   >
     <div class="mb-2 flex flex-wrap items-center gap-2 px-1 text-[10px] text-white/45">
-      <span>{{ tracks.length }} 轨</span>
+      <span>{{ orderedTracks.length }} 轨</span>
       <span>视频 {{ videoTrackCount }}</span>
       <span>音频 {{ audioTrackCount }}</span>
-      <span v-if="!tracks.length" class="text-amber-300/80">请连接 video / audio 节点到本节点</span>
+      <span v-if="readSavedTracks().length" class="text-emerald-300/70">已持久化 {{ readSavedTracks().length }} 轨</span>
+      <span v-if="!orderedTracks.length" class="text-amber-300/80">请连接 video / audio / 媒体输入 节点</span>
     </div>
 
+    <CompositionTimelinePreview :tracks="orderedTracks" :readonly="locked" />
+
     <div class="composition-track-list">
-      <div v-if="!tracks.length" class="composition-empty">
+      <div v-if="!orderedTracks.length" class="composition-empty">
         <p>暂无入边素材</p>
-        <p class="text-white/35">从画布将视频或音频节点连线到「视频合成」节点</p>
+        <p class="text-white/35">支持 video、audio、媒体输入（视频/音频）连线</p>
       </div>
-      <div v-for="(track, index) in tracks" :key="track.nodeId" class="composition-track-row">
+      <div v-for="(track, index) in orderedTracks" :key="track.nodeId" class="composition-track-row">
         <span class="composition-track-index">{{ index + 1 }}</span>
         <span class="composition-track-type" :class="track.type">{{ track.label }}</span>
         <div class="min-w-0 flex-1">
           <p class="truncate text-[11px] text-white/80">{{ track.title }}</p>
           <p class="truncate text-[10px] text-white/35">{{ track.url || '尚无媒体 URL' }}</p>
         </div>
+        <label class="duration-input">
+          <span class="text-[10px] text-white/35">时长</span>
+          <input
+            type="number"
+            min="1"
+            step="0.5"
+            class="input-field w-14 px-2 py-1 text-[10px]"
+            :value="track.durationSec"
+            :readonly="locked"
+            @change="updateDuration(index, ($event.target as HTMLInputElement).value)"
+          >
+        </label>
+        <div class="flex flex-col gap-1">
+          <button
+            type="button"
+            class="order-btn"
+            :disabled="locked || index === 0"
+            title="上移"
+            @click="moveTrack(index, -1)"
+          >
+            ↑
+          </button>
+          <button
+            type="button"
+            class="order-btn"
+            :disabled="locked || index === orderedTracks.length - 1"
+            title="下移"
+            @click="moveTrack(index, 1)"
+          >
+            ↓
+          </button>
+        </div>
       </div>
-    </div>
-
-    <div class="composition-timeline-placeholder">
-      <span>时间轴预览</span>
-      <span class="text-white/35">（C-3 开发中）</span>
     </div>
 
     <div class="bottom-toolbar-actions flex-wrap">
@@ -84,7 +145,7 @@ function onTitleInput(value: string) {
         disabled
         title="C-4 合成/export API 开发中"
       >
-        导出合成（即将推出）
+        导出合成（C-4 即将推出）
       </button>
     </div>
   </DockToolbarShell>
@@ -144,17 +205,25 @@ function onTitleInput(value: string) {
   color: #6ee7b7;
 }
 
-.composition-timeline-placeholder {
+.duration-input {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
-  gap: 6px;
-  min-height: 52px;
-  margin-bottom: 4px;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.03);
-  font-size: 11px;
-  color: rgba(255, 255, 255, 0.55);
+  gap: 2px;
+}
+
+.order-btn {
+  width: 22px;
+  height: 18px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.order-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
 }
 </style>

--- a/apps/web/src/components/canvas/dock-studio/panels/VideoCompositionDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/VideoCompositionDockPanel.vue
@@ -11,6 +11,7 @@ import {
 import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
 import CompositionTimelinePreview from '@/components/canvas/dock-studio/shared/CompositionTimelinePreview.vue'
 import { isNodeGenerating } from '@/constants/dockStudio'
+import { resolveMediaUrl } from '@/services/api-base'
 
 const props = defineProps<{
   node: EditableFlowNode
@@ -22,6 +23,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   patch: [patch: Record<string, unknown>]
+  export: []
   close: []
 }>()
 
@@ -38,6 +40,12 @@ const orderedTracks = computed(() => {
 
 const videoTrackCount = computed(() => orderedTracks.value.filter((track) => track.type === 'video').length)
 const audioTrackCount = computed(() => orderedTracks.value.filter((track) => track.type === 'audio').length)
+const exportableTrackCount = computed(() => orderedTracks.value.filter((track) => track.url.trim()).length)
+const exportedUrl = computed(() => {
+  const url = String(props.node.data?.url ?? '').trim()
+  return url ? resolveMediaUrl(url) : ''
+})
+const canExport = computed(() => !locked.value && exportableTrackCount.value > 0)
 
 function syncFromNode() {
   title.value = String(props.node.data?.title ?? '视频合成')
@@ -91,6 +99,11 @@ function readSavedTracks(): CompositionTrackRecord[] {
 
     <CompositionTimelinePreview :tracks="orderedTracks" :readonly="locked" />
 
+    <div v-if="exportedUrl" class="export-preview">
+      <p class="mb-2 text-[10px] text-emerald-300/80">已导出合成视频</p>
+      <video :src="exportedUrl" class="w-full rounded-lg" controls />
+    </div>
+
     <div class="composition-track-list">
       <div v-if="!orderedTracks.length" class="composition-empty">
         <p>暂无入边素材</p>
@@ -141,17 +154,35 @@ function readSavedTracks(): CompositionTrackRecord[] {
     <div class="bottom-toolbar-actions flex-wrap">
       <button
         type="button"
-        class="rounded-lg border border-white/10 px-3 py-1.5 text-xs text-white/40"
-        disabled
-        title="C-4 合成/export API 开发中"
+        class="rounded-lg border border-indigo-400/30 bg-indigo-500/15 px-3 py-1.5 text-xs text-indigo-100"
+        :disabled="!canExport"
+        :title="exportableTrackCount ? '使用 ffmpeg 合成并导出 MP4' : '请先连接带 URL 的素材轨'"
+        @click="emit('export')"
       >
-        导出合成（C-4 即将推出）
+        {{ generating ? '合成中…' : '导出合成' }}
       </button>
+      <a
+        v-if="exportedUrl"
+        :href="exportedUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="rounded-lg border border-white/10 px-3 py-1.5 text-xs text-white/70"
+      >
+        下载 MP4
+      </a>
     </div>
   </DockToolbarShell>
 </template>
 
 <style scoped>
+.export-preview {
+  margin-bottom: 8px;
+  padding: 8px;
+  border-radius: 12px;
+  border: 1px solid rgba(16, 185, 129, 0.2);
+  background: rgba(16, 185, 129, 0.06);
+}
+
 .composition-track-list {
   max-height: 160px;
   margin-bottom: 8px;

--- a/apps/web/src/components/canvas/dock-studio/shared/CompositionTimelinePreview.vue
+++ b/apps/web/src/components/canvas/dock-studio/shared/CompositionTimelinePreview.vue
@@ -1,0 +1,206 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import type { CompositionTrack } from '@/utils/compositionUpstream'
+import { computeTimelineLayout, totalTimelineDurationSec } from '@/utils/compositionUpstream'
+import { resolveMediaUrl } from '@/services/api-base'
+
+const props = defineProps<{
+  tracks: CompositionTrack[]
+  readonly?: boolean
+}>()
+
+const playhead = ref(0)
+
+const layout = computed(() => computeTimelineLayout(props.tracks))
+const totalDuration = computed(() => totalTimelineDurationSec(props.tracks))
+const currentClip = computed(() => layout.value[playhead.value] ?? null)
+const previewUrl = computed(() => {
+  const url = currentClip.value?.url ?? ''
+  return url ? resolveMediaUrl(url) : ''
+})
+
+watch(
+  () => props.tracks.map((track) => track.nodeId).join(','),
+  () => {
+    playhead.value = 0
+  },
+)
+
+function prevClip() {
+  if (playhead.value > 0) playhead.value -= 1
+}
+
+function nextClip() {
+  if (playhead.value < layout.value.length - 1) playhead.value += 1
+}
+</script>
+
+<template>
+  <div class="composition-timeline">
+    <div class="composition-preview">
+      <video
+        v-if="currentClip?.type === 'video' && previewUrl"
+        :key="previewUrl"
+        :src="previewUrl"
+        class="h-full w-full object-contain"
+        controls
+        muted
+      />
+      <audio
+        v-else-if="currentClip?.type === 'audio' && previewUrl"
+        :key="previewUrl"
+        :src="previewUrl"
+        class="w-full px-3"
+        controls
+      />
+      <div v-else class="composition-preview-empty">
+        {{ tracks.length ? '当前片段暂无可用媒体' : '连接 video / audio 后在此预览' }}
+      </div>
+    </div>
+
+    <div class="composition-playhead-bar">
+      <button type="button" class="timeline-btn" :disabled="readonly || playhead <= 0" @click="prevClip">
+        上一段
+      </button>
+      <span class="text-[10px] text-white/50">
+        {{ layout.length ? playhead + 1 : 0 }} / {{ layout.length }} · 总长 ~{{ totalDuration }}s
+      </span>
+      <button
+        type="button"
+        class="timeline-btn"
+        :disabled="readonly || playhead >= layout.length - 1"
+        @click="nextClip"
+      >
+        下一段
+      </button>
+    </div>
+
+    <div class="composition-timeline-rail">
+      <button
+        v-for="(clip, index) in layout"
+        :key="clip.nodeId"
+        type="button"
+        class="timeline-clip"
+        :class="{ 'is-active': index === playhead, [clip.type]: true }"
+        :disabled="readonly"
+        @click="playhead = index"
+      >
+        <span class="timeline-clip-label">{{ clip.label }}</span>
+        <span class="timeline-clip-title">{{ clip.title }}</span>
+        <span class="timeline-clip-meta">{{ clip.durationSec }}s</span>
+      </button>
+      <p v-if="!layout.length" class="timeline-empty">时间轴为空</p>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.composition-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.composition-preview {
+  min-height: 120px;
+  overflow: hidden;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.composition-preview-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+  padding: 12px;
+  text-align: center;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.composition-playhead-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.timeline-btn {
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+  padding: 4px 10px;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.timeline-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.composition-timeline-rail {
+  display: flex;
+  gap: 8px;
+  min-height: 72px;
+  overflow-x: auto;
+  padding: 8px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.timeline-clip {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 108px;
+  flex-shrink: 0;
+  padding: 8px;
+  border-radius: 10px;
+  border: 2px solid transparent;
+  text-align: left;
+  background: rgba(0, 0, 0, 0.22);
+}
+
+.timeline-clip.is-active {
+  border-color: rgba(99, 102, 241, 0.65);
+}
+
+.timeline-clip.video {
+  box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.15);
+}
+
+.timeline-clip.audio {
+  box-shadow: inset 0 0 0 1px rgba(16, 185, 129, 0.15);
+}
+
+.timeline-clip-label {
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.timeline-clip-title {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.85);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.timeline-clip-meta {
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.timeline-empty {
+  display: flex;
+  align-items: center;
+  padding: 0 8px;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.35);
+}
+</style>

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -13,6 +13,8 @@ import {
 import { parseRecordText, parseRecordUrl, type GenerationPollTask } from '@/composables/useGenerationPolling'
 import { canvasApi } from '@/services/canvas-api'
 import { studioApi } from '@/services/studio-api'
+import type { CompositionTrack } from '@/utils/compositionUpstream'
+import { applyTrackOrder } from '@/utils/compositionUpstream'
 import {
   buildBatchGenerateItems,
   expandSceneComposerGraph,
@@ -313,11 +315,49 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     }
   }
 
+  async function exportVideoComposition(node: EditableFlowNode, tracks: CompositionTrack[]) {
+    if (!deps.requireLogin()) return
+    const ordered = applyTrackOrder(tracks, node.data?.trackOrder as string[] | undefined)
+    const exportTracks = ordered.filter((track) => track.url.trim())
+    if (!exportTracks.length) return
+
+    generating.value = true
+    try {
+      deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating })
+      const { data: res } = await canvasApi.exportVideoComposition({
+        sessionId: deps.sessionId.value,
+        compositionNodeId: node.id,
+        title: String(node.data?.title ?? '视频合成'),
+        tracks: exportTracks.map((track) => ({
+          nodeId: track.nodeId,
+          type: track.type,
+          title: track.title,
+          url: track.url,
+          durationSec: track.durationSec,
+          startSec: track.startSec,
+        })),
+      })
+      const result = res.data as { url: string; durationSec: number }
+      deps.patchNodeData(node.id, {
+        url: result.url,
+        exportDurationSec: result.durationSec,
+        status: NODE_GENERATION_STATUS.completed,
+        exportedAt: new Date().toISOString(),
+      })
+      await deps.saveCanvas()
+    } catch {
+      deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.error })
+    } finally {
+      generating.value = false
+    }
+  }
+
   return {
     generating,
     generateForNode,
     saveSceneComposer,
     expandSceneComposer,
     batchGenerateSceneComposer,
+    exportVideoComposition,
   }
 }

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -1116,6 +1116,13 @@ async function handleSceneComposerBatchGenerate() {
   await batchGenerateSceneComposer(node)
 }
 
+async function handleVideoCompositionExport() {
+  await debouncedNodePatch.flush()
+  const node = editorNode.value
+  if (!node || node.type !== 'videoComposition') return
+  await exportVideoComposition(node, editorCompositionTracks.value)
+}
+
 function getEventCoords(event: MouseEvent | TouchEvent) {
   if ('clientX' in event) {
     return { x: event.clientX, y: event.clientY }
@@ -1276,6 +1283,7 @@ const {
   saveSceneComposer,
   expandSceneComposer,
   batchGenerateSceneComposer,
+  exportVideoComposition,
 } = useNodeGeneration({
   nodes,
   edges,
@@ -1530,6 +1538,7 @@ onMounted(() => {
           @save="handleSceneComposerSave"
           @expand="handleSceneComposerExpand"
           @batch-generate="handleSceneComposerBatchGenerate"
+          @export="handleVideoCompositionExport"
           @upload="handleMediaInputUpload"
           @convert="handleMediaInputConvert"
           @close="onPaneClick"

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -16,7 +16,7 @@ import { useShotPolling } from '@/composables/useShotPolling'
 import { useGenerationPolling, parseRecordUrl, type GenerationPollTask } from '@/composables/useGenerationPolling'
 import { useNodeGeneration } from '@/composables/useNodeGeneration'
 import { createInitialSceneComposerNodeData } from '@/utils/sceneComposer'
-import { resolveCompositionTracks, compositionTracksToNodePatch } from '@/utils/compositionUpstream'
+import { resolveCompositionTracks, mergeCompositionTracks, compositionTracksToNodePatch } from '@/utils/compositionUpstream'
 import { resolveUpstreamContext } from '@/composables/useUpstreamNodeContext'
 import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
 import CanvasNodePrompt from '@/components/canvas/CanvasNodePrompt.vue'
@@ -315,7 +315,13 @@ const editorUpstream = computed(() => {
 const editorCompositionTracks = computed(() => {
   const node = editorNode.value
   if (!node || node.type !== 'videoComposition') return []
-  return resolveCompositionTracks(node.id, nodes.value, edges.value)
+  const live = resolveCompositionTracks(node.id, nodes.value, edges.value)
+  const data = node.data ?? {}
+  return mergeCompositionTracks(
+    live,
+    data.tracks as import('@/utils/compositionUpstream').CompositionTrackRecord[] | undefined,
+    data.trackOrder as string[] | undefined,
+  )
 })
 
 const multiSelectCanUngroup = computed(() => {
@@ -460,7 +466,7 @@ function createNodeAt(type: DockNodeType, position: { x: number; y: number }) {
     case 'videoComposition':
       id = addNode(
         'videoComposition',
-        { title: '视频合成', clipCount: 0, tracks: [], status: 'draft' },
+        { title: '视频合成', clipCount: 0, tracks: [], trackOrder: [], status: 'draft' },
         { position },
       )
       break
@@ -1307,7 +1313,8 @@ watch(
     const data = node.data ?? {}
     const sameCount = data.clipCount === patch.clipCount
     const sameTracks = JSON.stringify(data.tracks ?? []) === JSON.stringify(patch.tracks)
-    if (sameCount && sameTracks) return
+    const sameOrder = JSON.stringify(data.trackOrder ?? []) === JSON.stringify(patch.trackOrder)
+    if (sameCount && sameTracks && sameOrder) return
     debouncedNodePatch.patchNode(node.id, patch)
   },
   { deep: true },

--- a/apps/web/src/services/canvas-api.ts
+++ b/apps/web/src/services/canvas-api.ts
@@ -3,6 +3,7 @@ import type { VideoSettings } from '@lnkpi/shared'
 import type {
   SceneComposerBatchGenerateRequest,
   SceneComposerSaveRequest,
+  VideoCompositionExportRequest,
 } from '@lnkpi/shared'
 
 export const canvasApi = {
@@ -34,4 +35,6 @@ export const canvasApi = {
     api.post('/agent/canvas/scene-composer/save', payload),
   batchGenerateSceneComposer: (payload: SceneComposerBatchGenerateRequest) =>
     api.post('/agent/canvas/scene-composer/batch-generate', payload),
+  exportVideoComposition: (payload: VideoCompositionExportRequest) =>
+    api.post('/agent/canvas/video-composition/export', payload),
 }

--- a/apps/web/src/utils/compositionUpstream.ts
+++ b/apps/web/src/utils/compositionUpstream.ts
@@ -1,5 +1,6 @@
 import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import type { CanvasEdgeLike } from '@/composables/useUpstreamNodeContext'
+import { inferMediaInputKind } from '@/composables/useMediaUpload'
 
 export type CompositionTrackType = 'video' | 'audio'
 
@@ -9,7 +10,21 @@ export interface CompositionTrack {
   title: string
   url: string
   label: string
+  durationSec: number
+  startSec: number
 }
+
+export interface CompositionTrackRecord {
+  nodeId: string
+  type: CompositionTrackType
+  title: string
+  url: string
+  durationSec?: number
+  startSec?: number
+}
+
+const DEFAULT_VIDEO_DURATION_SEC = 5
+const DEFAULT_AUDIO_DURATION_SEC = 3
 
 function trackLabel(type: CompositionTrackType) {
   return type === 'video' ? '视频' : '音频'
@@ -17,10 +32,44 @@ function trackLabel(type: CompositionTrackType) {
 
 function readTrackTitle(node: EditableFlowNode) {
   const data = node.data ?? {}
-  return String(data.title ?? data.prompt ?? data.content ?? node.id).slice(0, 48)
+  return String(data.title ?? data.fileName ?? data.prompt ?? data.content ?? node.id).slice(0, 48)
 }
 
-/** 收集指向合成节点的入边 video/audio 轨（C-2 基础，供 C-1 Dock 展示） */
+function readTrackUrl(node: EditableFlowNode) {
+  return String(node.data?.url ?? '').trim()
+}
+
+function inferNodeTrackType(node: EditableFlowNode): CompositionTrackType | null {
+  const type = String(node.type ?? '')
+  if (type === 'video') return 'video'
+  if (type === 'audio') return 'audio'
+  if (type === 'mediaInput') {
+    const data = node.data ?? {}
+    const kindFromData = data.mediaKind as 'image' | 'video' | 'audio' | undefined
+    const kind = kindFromData ?? inferMediaInputKind(String(data.mimeType ?? ''), String(data.url ?? ''))
+    if (kind === 'video' || kind === 'audio') return kind
+  }
+  return null
+}
+
+function defaultDuration(type: CompositionTrackType) {
+  return type === 'video' ? DEFAULT_VIDEO_DURATION_SEC : DEFAULT_AUDIO_DURATION_SEC
+}
+
+function buildTrack(node: EditableFlowNode, saved?: CompositionTrackRecord): CompositionTrack {
+  const trackType = inferNodeTrackType(node)!
+  return {
+    nodeId: node.id,
+    type: trackType,
+    title: readTrackTitle(node),
+    url: readTrackUrl(node),
+    label: trackLabel(trackType),
+    durationSec: saved?.durationSec ?? defaultDuration(trackType),
+    startSec: saved?.startSec ?? 0,
+  }
+}
+
+/** 按入边顺序收集 video / audio / 媒体输入轨 */
 export function resolveCompositionTracks(
   targetNodeId: string,
   nodes: EditableFlowNode[],
@@ -32,32 +81,90 @@ export function resolveCompositionTracks(
   for (const edge of edges) {
     if (edge.target !== targetNodeId) continue
     const source = nodeMap.get(edge.source)
-    if (!source) continue
-    const type = String(source.type ?? '')
-    if (type !== 'video' && type !== 'audio') continue
-
-    const trackType = type as CompositionTrackType
-    const url = String(source.data?.url ?? '').trim()
-    tracks.push({
-      nodeId: source.id,
-      type: trackType,
-      title: readTrackTitle(source),
-      url,
-      label: trackLabel(trackType),
-    })
+    if (!source || !inferNodeTrackType(source)) continue
+    tracks.push(buildTrack(source))
   }
 
   return tracks
 }
 
+/** 合并实时轨与已保存 metadata，并按 trackOrder 排序（C-2） */
+export function mergeCompositionTracks(
+  liveTracks: CompositionTrack[],
+  savedTracks: CompositionTrackRecord[] | undefined,
+  trackOrder: string[] | undefined,
+): CompositionTrack[] {
+  const savedMap = new Map((savedTracks ?? []).map((track) => [track.nodeId, track]))
+  const merged = liveTracks.map((track) => {
+    const saved = savedMap.get(track.nodeId)
+    if (!saved) return track
+    return {
+      ...track,
+      durationSec: saved.durationSec ?? track.durationSec,
+      startSec: saved.startSec ?? track.startSec,
+    }
+  })
+
+  return applyTrackOrder(merged, trackOrder)
+}
+
+export function applyTrackOrder(tracks: CompositionTrack[], trackOrder?: string[]): CompositionTrack[] {
+  if (!trackOrder?.length) return tracks
+
+  const trackMap = new Map(tracks.map((track) => [track.nodeId, track]))
+  const ordered: CompositionTrack[] = []
+
+  for (const nodeId of trackOrder) {
+    const track = trackMap.get(nodeId)
+    if (!track) continue
+    ordered.push(track)
+    trackMap.delete(nodeId)
+  }
+
+  for (const track of trackMap.values()) {
+    ordered.push(track)
+  }
+
+  return ordered
+}
+
+export function reorderTrackIds(trackOrder: string[], fromIndex: number, toIndex: number) {
+  const next = [...trackOrder]
+  if (fromIndex < 0 || fromIndex >= next.length || toIndex < 0 || toIndex >= next.length) {
+    return next
+  }
+  const [item] = next.splice(fromIndex, 1)
+  next.splice(toIndex, 0, item)
+  return next
+}
+
 export function compositionTracksToNodePatch(tracks: CompositionTrack[]) {
   return {
     clipCount: tracks.length,
+    trackOrder: tracks.map((track) => track.nodeId),
     tracks: tracks.map((track) => ({
       nodeId: track.nodeId,
       type: track.type,
       title: track.title,
       url: track.url,
+      durationSec: track.durationSec,
+      startSec: track.startSec,
     })),
   }
+}
+
+export function computeTimelineLayout(tracks: CompositionTrack[]) {
+  let cursor = 0
+  return tracks.map((track) => {
+    const startSec = track.startSec > 0 ? track.startSec : cursor
+    const item = { ...track, startSec, endSec: startSec + track.durationSec }
+    cursor = item.endSec
+    return item
+  })
+}
+
+export function totalTimelineDurationSec(tracks: CompositionTrack[]) {
+  const layout = computeTimelineLayout(tracks)
+  if (!layout.length) return 0
+  return Math.max(...layout.map((item) => item.endSec))
 }

--- a/deploy/docker/Dockerfile.api
+++ b/deploy/docker/Dockerfile.api
@@ -1,7 +1,7 @@
 # lnkpi API（NestJS + Prisma SQLite）
 FROM node:22-bookworm-slim AS build
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && apt-get install -y --no-install-recommends openssl ca-certificates ffmpeg \
   && rm -rf /var/lib/apt/lists/*
 RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 WORKDIR /app
@@ -38,7 +38,7 @@ ENV PORT=3001
 ENV DATABASE_URL=file:/app/apps/server/data/lnkpi.db
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && apt-get install -y --no-install-recommends openssl ca-certificates ffmpeg \
   && rm -rf /var/lib/apt/lists/* \
   && mkdir -p /app/apps/server/data /app/apps/server/uploads
 

--- a/docs/DOCK_STUDIO_E2E_TRACKING.md
+++ b/docs/DOCK_STUDIO_E2E_TRACKING.md
@@ -15,11 +15,11 @@
 |------|--------|------|
 | **Phase 0** 基础架构 | **100%** | P0-1 ~ P0-6 全部完成 |
 | **Phase 1** 核心生成节点 | **~92%** | text/image/video/audio/shot 主链路完成；T-5/I-6/I-7/V-6 待补 |
-| **Phase 2** 输入与编排 | **~55%** | mediaInput ✅；sceneComposer D-1~D-4 ✅；videoComposition / worldModel 未开始 |
+| **Phase 2** 输入与编排 | **~70%** | mediaInput ✅；sceneComposer D-1~D-4 ✅；videoComposition C-1~C-3 ✅；C-4 / worldModel 未开始 |
 | **Phase 3** Dock UX | **~83%** | UX-1~UX-5 ✅；UX-6 Capabilities API 未开始 |
 | **Phase 4** 后端补齐 | **~67%** | B-1/B-3/B-4/B-6 ✅；B-2 upscale、B-5 lip-sync 未开始 |
 | **里程碑 M1/M2** | **已完成** | 代码落地，`pnpm build` 通过 |
-| **里程碑 M3** | **进行中** | mediaInput + sceneComposer 已落地；composition 未开始 |
+| **里程碑 M3** | **进行中** | mediaInput + sceneComposer + videoComposition C-1~C-3 已落地；C-4 未开始 |
 | **里程碑 M4** | **未开始** | UX-6 + 后端 upscale/lip-sync/OSS STS |
 | **浏览器 E2E 手测** | **✅ 生产 P0 通过** | 2026-07-14 生产登录 + 5 类节点 Dock 验收（见 §0.4） |
 
@@ -53,7 +53,7 @@
 | shot | ✅ | ✅ | **已完成** | — |
 | mediaInput | ✅ | 🟡 | **基本完成** | M-3 升级 OSS STS |
 | sceneComposer | ✅ | 🟡 | **D-1~D-4 已落地** | 生产手测 + 生成闭环 |
-| videoComposition | ❌ | ❌ | **未开始** | C-1~C-4 |
+| videoComposition | ✅ | 🟡 | **C-1~C-3 已落地** | C-4 合成/export API |
 | worldModel | ❌ | ❌ | **未开始** | W-1~W-3 |
 | prompt | 🟡 Legacy | ⚠️ | **待定** | 是否合并进 text |
 
@@ -61,7 +61,7 @@
 
 1. ~~**P0 生产验收**~~：✅ 2026-07-14 已完成登录 + 5 节点 Dock 手测
 2. ~~**P1 sceneComposer**（D-1~D-4）~~ ✅ 2026-07-14 代码落地
-3. **P1 videoComposition**（C-1~C-4）或生产 sceneComposer 手测
+3. **P1 videoComposition C-4**（合成/export API）或生产 C-2/C-3 手测
 4. **P1 可选 polish**：I-6 AIImageEditor 联动、UX-6 Capabilities API
 5. **P2** worldModel / upscale / lip-sync
 
@@ -152,7 +152,7 @@ completed → 写回 url / content / coverUrl
 | **shot（分镜）** | ✅ | 🟢 85% | ✅ canvas | ✅ 入边 text + shotGenerateMode | ShotDockPanel 已拆 | 已完成 |
 | **sceneComposer** | ✅ | 🔴 20% | ❌ 仅 draft | ❌ | **无导演台专属 Dock + 编排 API** | 未开始 |
 | **mediaInput** | ✅ | 🟢 75% | 🟡 本地 upload | ✅ | 预览+转节点已完成；OSS STS 待升级 | 基本完成 |
-| **videoComposition** | ❌ | — | ❌ | ❌ | **无 Dock、无合成 API** | 未开始 |
+| **videoComposition** | ✅ | 🟢 70% | 🟡 draft | ✅ 入边 video/audio/mediaInput | C-4 合成/export API | C-1~C-3 完成 |
 | **worldModel** | ❌ | — | ❌ | ❌ | **无 Dock、无 3D API** | 未开始 |
 | **prompt** | ✅ | 🟡 50% | ⚠️ 与 text 混用 | ❌ | Legacy 面板，是否合并进 text 待产品定稿 | 未开始 |
 | **group** | — | — | — | — | 容器节点，不需要 Dock | — |
@@ -424,13 +424,13 @@ interface DockStudioEntry {
 | ID | 任务 | 状态 |
 |----|------|------|
 | C-1 | 加入 EDITABLE + `VideoCompositionDockPanel` | ✅ |
-| C-2 | 读入边：收集所有 video/audio 轨 | 🟡 基础（Dock 实时展示） |
-| C-3 | 简易时间轴预览（可复用 VideoEditorPage MVP） | 未开始 |
+| C-2 | 读入边：收集所有 video/audio 轨 | ✅ |
+| C-3 | 简易时间轴预览（可复用 VideoEditorPage MVP） | ✅ |
 | C-4 | 后端：合成/export API（或 ffmpeg 任务） | 未开始 |
 
 - [x] C-1 — VideoCompositionDockPanel
-- [ ] C-2 — 入边轨收集（基础展示已接入，待持久化/排序 polish）
-- [ ] C-3 — 时间轴预览 MVP
+- [x] C-2 — 入边轨收集 + trackOrder/时长持久化 + mediaInput 支持
+- [x] C-3 — CompositionTimelinePreview 时间轴 MVP
 - [ ] C-4 — 合成/export API
 
 ---
@@ -553,7 +553,7 @@ Phase 0 (P0-1~P0-6)
 | **shot** | 生成后子节点创建/更新；封面与 polling 同步 | ☐ 待手测 |
 | **mediaInput** | 预览正确；可转 image/video；OSS url 非 blob | ✅ Dock/上传入口 |
 | **sceneComposer** | 场景列表编辑；展开子图 | ✅ Dock/展开（生成待 API Key） |
-| **videoComposition** | 入边轨收集；合成/export | ☐ |
+| **videoComposition** | 入边轨收集 + 轨排序/时长持久化；时间轴预览 | ☐ C-4 export 待做 |
 
 ### 6.3 回归清单（每次大改 Dock 后跑）
 
@@ -671,6 +671,7 @@ Phase 0 (P0-1~P0-6)
 | 2026-07-13 | A | P0-1~P0-6, I-1~I-5, V-1~V-5, B-6 | 图片比例未进 provider；参考图 blob | Sprint B |
 | 2026-07-13 | B | T-1~T-4, A-1~A-5, S-1~S-6, B-1, B-3 | 音频 emotion/speed 未进 TTS | Sprint C |
 | 2026-07-14 | M3 | D-1~D-4 sceneComposer | 生产手测待做 | videoComposition C-1 |
+| 2026-07-14 | M3 | C-2~C-3 videoComposition | C-4 export 未做 | 生产手测 C-2/C-3 |
 
 ---
 

--- a/docs/DOCK_STUDIO_E2E_TRACKING.md
+++ b/docs/DOCK_STUDIO_E2E_TRACKING.md
@@ -15,11 +15,11 @@
 |------|--------|------|
 | **Phase 0** 基础架构 | **100%** | P0-1 ~ P0-6 全部完成 |
 | **Phase 1** 核心生成节点 | **~92%** | text/image/video/audio/shot 主链路完成；T-5/I-6/I-7/V-6 待补 |
-| **Phase 2** 输入与编排 | **~70%** | mediaInput ✅；sceneComposer D-1~D-4 ✅；videoComposition C-1~C-3 ✅；C-4 / worldModel 未开始 |
+| **Phase 2** 输入与编排 | **~85%** | mediaInput ✅；sceneComposer D-1~D-4 ✅；videoComposition C-1~C-4 ✅；worldModel 未开始 |
 | **Phase 3** Dock UX | **~83%** | UX-1~UX-5 ✅；UX-6 Capabilities API 未开始 |
 | **Phase 4** 后端补齐 | **~67%** | B-1/B-3/B-4/B-6 ✅；B-2 upscale、B-5 lip-sync 未开始 |
 | **里程碑 M1/M2** | **已完成** | 代码落地，`pnpm build` 通过 |
-| **里程碑 M3** | **进行中** | mediaInput + sceneComposer + videoComposition C-1~C-3 已落地；C-4 未开始 |
+| **里程碑 M3** | **基本完成** | mediaInput + sceneComposer + videoComposition C-1~C-4 已落地 |
 | **里程碑 M4** | **未开始** | UX-6 + 后端 upscale/lip-sync/OSS STS |
 | **浏览器 E2E 手测** | **✅ 生产 P0 通过** | 2026-07-14 生产登录 + 5 类节点 Dock 验收（见 §0.4） |
 
@@ -53,7 +53,7 @@
 | shot | ✅ | ✅ | **已完成** | — |
 | mediaInput | ✅ | 🟡 | **基本完成** | M-3 升级 OSS STS |
 | sceneComposer | ✅ | 🟡 | **D-1~D-4 已落地** | 生产手测 + 生成闭环 |
-| videoComposition | ✅ | 🟡 | **C-1~C-3 已落地** | C-4 合成/export API |
+| videoComposition | ✅ | 🟢 | **C-1~C-4 已落地** | 生产手测 export |
 | worldModel | ❌ | ❌ | **未开始** | W-1~W-3 |
 | prompt | 🟡 Legacy | ⚠️ | **待定** | 是否合并进 text |
 
@@ -61,7 +61,7 @@
 
 1. ~~**P0 生产验收**~~：✅ 2026-07-14 已完成登录 + 5 节点 Dock 手测
 2. ~~**P1 sceneComposer**（D-1~D-4）~~ ✅ 2026-07-14 代码落地
-3. **P1 videoComposition C-4**（合成/export API）或生产 C-2/C-3 手测
+3. **生产手测** videoComposition C-2~C-4 export，或 sceneComposer 生成闭环
 4. **P1 可选 polish**：I-6 AIImageEditor 联动、UX-6 Capabilities API
 5. **P2** worldModel / upscale / lip-sync
 
@@ -152,7 +152,7 @@ completed → 写回 url / content / coverUrl
 | **shot（分镜）** | ✅ | 🟢 85% | ✅ canvas | ✅ 入边 text + shotGenerateMode | ShotDockPanel 已拆 | 已完成 |
 | **sceneComposer** | ✅ | 🔴 20% | ❌ 仅 draft | ❌ | **无导演台专属 Dock + 编排 API** | 未开始 |
 | **mediaInput** | ✅ | 🟢 75% | 🟡 本地 upload | ✅ | 预览+转节点已完成；OSS STS 待升级 | 基本完成 |
-| **videoComposition** | ✅ | 🟢 70% | 🟡 draft | ✅ 入边 video/audio/mediaInput | C-4 合成/export API | C-1~C-3 完成 |
+| **videoComposition** | ✅ | 🟢 85% | 🟡 export | ✅ 入边 video/audio/mediaInput | 生产 export 手测 | C-1~C-4 完成 |
 | **worldModel** | ❌ | — | ❌ | ❌ | **无 Dock、无 3D API** | 未开始 |
 | **prompt** | ✅ | 🟡 50% | ⚠️ 与 text 混用 | ❌ | Legacy 面板，是否合并进 text 待产品定稿 | 未开始 |
 | **group** | — | — | — | — | 容器节点，不需要 Dock | — |
@@ -426,12 +426,12 @@ interface DockStudioEntry {
 | C-1 | 加入 EDITABLE + `VideoCompositionDockPanel` | ✅ |
 | C-2 | 读入边：收集所有 video/audio 轨 | ✅ |
 | C-3 | 简易时间轴预览（可复用 VideoEditorPage MVP） | ✅ |
-| C-4 | 后端：合成/export API（或 ffmpeg 任务） | 未开始 |
+| C-4 | 后端：合成/export API（或 ffmpeg 任务） | ✅ |
 
 - [x] C-1 — VideoCompositionDockPanel
 - [x] C-2 — 入边轨收集 + trackOrder/时长持久化 + mediaInput 支持
 - [x] C-3 — CompositionTimelinePreview 时间轴 MVP
-- [ ] C-4 — 合成/export API
+- [x] C-4 — `POST video-composition/export` + ffmpeg 合成 + Dock 导出按钮
 
 ---
 
@@ -553,7 +553,7 @@ Phase 0 (P0-1~P0-6)
 | **shot** | 生成后子节点创建/更新；封面与 polling 同步 | ☐ 待手测 |
 | **mediaInput** | 预览正确；可转 image/video；OSS url 非 blob | ✅ Dock/上传入口 |
 | **sceneComposer** | 场景列表编辑；展开子图 | ✅ Dock/展开（生成待 API Key） |
-| **videoComposition** | 入边轨收集 + 轨排序/时长持久化；时间轴预览 | ☐ C-4 export 待做 |
+| **videoComposition** | 入边轨收集 + 轨排序/时长持久化；时间轴预览；export MP4 | ☐ 生产 export 手测 |
 
 ### 6.3 回归清单（每次大改 Dock 后跑）
 
@@ -672,6 +672,7 @@ Phase 0 (P0-1~P0-6)
 | 2026-07-13 | B | T-1~T-4, A-1~A-5, S-1~S-6, B-1, B-3 | 音频 emotion/speed 未进 TTS | Sprint C |
 | 2026-07-14 | M3 | D-1~D-4 sceneComposer | 生产手测待做 | videoComposition C-1 |
 | 2026-07-14 | M3 | C-2~C-3 videoComposition | C-4 export 未做 | 生产手测 C-2/C-3 |
+| 2026-07-14 | M3 | C-4 videoComposition export API | 生产 export 手测 | M4 / worldModel |
 
 ---
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ export type WorkType = 'canvas' | 'shortfilm'
 export type NodeType = 'prompt' | 'image' | 'video' | 'text' | 'group' | 'shot' | 'sceneComposer'
 
 export * from './sceneComposer'
+export * from './videoComposition'
 
 export type GenerationType = 'text' | 'image' | 'video'
 

--- a/packages/shared/src/videoComposition.ts
+++ b/packages/shared/src/videoComposition.ts
@@ -1,0 +1,26 @@
+/** 视频合成 videoComposition 节点 export 数据结构（C-4） */
+
+export type VideoCompositionTrackType = 'video' | 'audio'
+
+export interface VideoCompositionExportTrack {
+  nodeId: string
+  type: VideoCompositionTrackType
+  title: string
+  url: string
+  durationSec: number
+  startSec?: number
+}
+
+export interface VideoCompositionExportRequest {
+  sessionId: string
+  compositionNodeId: string
+  title?: string
+  tracks: VideoCompositionExportTrack[]
+}
+
+export interface VideoCompositionExportResult {
+  compositionNodeId: string
+  url: string
+  durationSec: number
+  status: 'completed'
+}


### PR DESCRIPTION
## Summary
- **C-2**: 入边轨收集 + `trackOrder`/时长持久化 + mediaInput 支持
- **C-3**: `CompositionTimelinePreview` 时间轴 MVP（片段预览 + 导航）
- **C-4**: `POST /agent/canvas/video-composition/export` — 服务端 ffmpeg 合成 MP4，Dock「导出合成」按钮，节点写回 `url`

## Backend
- `VideoCompositionService` — 下载素材轨、trim、concat、上传至 uploads
- Docker 镜像安装 `ffmpeg`（build + runner）

## Test plan
- [x] `pnpm build`
- [ ] 画布：videoComposition 连线 video/audio/mediaInput → Dock 轨列表 + 时间轴
- [ ] 调整排序/时长 → 刷新持久化
- [ ] 点击「导出合成」→ 节点与 Dock 显示 MP4 预览
- [ ] 合并后 API 部署（`deploy.yml` 触发）→ 生产 export 手测


Made with [Cursor](https://cursor.com)