### PR TITLE
fix: use launch-cvm-build.sh for immediate CVM build detach

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,6 +97,7 @@ jobs:
           fi
           sudo chmod +x ${DEPLOY_DIR}/deploy/deploy-remote-build.sh
           sudo chmod +x ${DEPLOY_DIR}/deploy/deploy-remote.sh
+          sudo chmod +x ${DEPLOY_DIR}/deploy/launch-cvm-build.sh
           sudo rm -f /tmp/lnkpi-deploy-${IMAGE_TAG}.status /tmp/lnkpi-deploy-${IMAGE_TAG}.log
           rm -f /tmp/lnkpi-src.tgz
           EOF
@@ -112,8 +113,9 @@ jobs:
           LOG_FILE="/tmp/lnkpi-deploy-${IMAGE_TAG}.log"
           PID_FILE="/tmp/lnkpi-deploy-${IMAGE_TAG}.pid"
 
-          # setsid + 全量重定向，避免 docker build 日志经 SSH 回传阻塞 GHA（此前导致 90min 超时）
-          ssh -n deploy-cvm "sudo bash -c 'cd ${DEPLOY_DIR} && rm -f ${STATUS_FILE} ${LOG_FILE} ${PID_FILE} && setsid env IMAGE_TAG=${IMAGE_TAG} STATUS_FILE=${STATUS_FILE} LOG_FILE=${LOG_FILE} bash deploy/deploy-remote-build.sh </dev/null >>${LOG_FILE} 2>&1 & echo \$! > ${PID_FILE}'"
+          # 使用独立 launcher 脚本立即返回，避免 sudo bash -c 'cmd &' 等待后台任务
+          LAUNCH_OUT=$(ssh -n deploy-cvm "sudo bash ${DEPLOY_DIR}/deploy/launch-cvm-build.sh ${IMAGE_TAG}")
+          echo "${LAUNCH_OUT}"
 
           sleep 2
           PID=$(ssh deploy-cvm "sudo cat ${PID_FILE} 2>/dev/null || true")

--- a/deploy/launch-cvm-build.sh
+++ b/deploy/launch-cvm-build.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# 在 CVM 上由 deploy workflow 调用：立即返回，构建在后台执行
+set -euo pipefail
+
+IMAGE_TAG="${1:?usage: launch-cvm-build.sh <git-sha>}"
+DEPLOY_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$DEPLOY_DIR"
+
+STATUS_FILE="/tmp/lnkpi-deploy-${IMAGE_TAG}.status"
+LOG_FILE="/tmp/lnkpi-deploy-${IMAGE_TAG}.log"
+PID_FILE="/tmp/lnkpi-deploy-${IMAGE_TAG}.pid"
+
+export IMAGE_TAG STATUS_FILE LOG_FILE
+
+rm -f "$STATUS_FILE" "$LOG_FILE" "$PID_FILE"
+
+nohup env IMAGE_TAG="$IMAGE_TAG" STATUS_FILE="$STATUS_FILE" LOG_FILE="$LOG_FILE" \
+  bash deploy/deploy-remote-build.sh </dev/null >>"$LOG_FILE" 2>&1 &
+echo $! >"$PID_FILE"
+disown -a 2>/dev/null || true
+
+echo "launched pid=$(cat "$PID_FILE") log=$LOG_FILE"


### PR DESCRIPTION
## Summary
PR #8 合并后 Deploy #29321185554 的 Launch 仍长时间阻塞。补充专用 launcher 脚本，避免 `sudo bash -c 'cmd &'` 等待后台 docker build。

## Test plan
- [ ] Launch 步骤 <10s 完成，Wait 开始轮询 status
- [ ] Deploy 全绿后 export API 非 404


Made with [Cursor](https://cursor.com)