### PR TITLE
fix: preserve API_PUBLIC_URL in deploy and harden CVM recover

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,8 @@ jobs:
     environment: production
     env:
       SSH_HOST: ${{ secrets.TENCENT_CLOUD_IP || secrets.DEPLOY_HOST }}
-      SSH_USER: ${{ secrets.TENCENT_CLOUD_USER || secrets.DEPLOY_USER }}
+      # 腾讯云 CVM 需使用 root + 密钥登录；非 root 用户会触发微信扫码且 sudo 易挂起
+      SSH_USER: ${{ secrets.TENCENT_CLOUD_USER || secrets.DEPLOY_USER || 'root' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -62,6 +63,8 @@ jobs:
             User ${{ env.SSH_USER }}
             IdentityFile ~/.ssh/deploy_key
             StrictHostKeyChecking no
+            BatchMode yes
+            LogLevel ERROR
             ServerAliveInterval 15
             ServerAliveCountMax 30
             TCPKeepAlive yes
@@ -89,7 +92,32 @@ jobs:
         run: |
           set -euo pipefail
           DEPLOY_DIR="${{ env.DEPLOY_DIR }}"
-          /tmp/lnkpi-ssh-retry.sh "recover-ssh" ssh -n deploy-cvm "sudo bash -lc 'if [[ -x ${DEPLOY_DIR}/deploy/cvm-recover.sh ]]; then ${DEPLOY_DIR}/deploy/cvm-recover.sh; else pkill -f deploy-remote-build || true; docker ps; fi'"
+          API_PORT="${{ env.API_PORT }}"
+          SSH_HOST="${{ env.SSH_HOST }}"
+          RECOVER_OK=0
+          # -T + bash -s 避免腾讯云登录 shell MOTD/二维码污染 SSH 输出
+          if /tmp/lnkpi-ssh-retry.sh "recover-ssh" ssh -T deploy-cvm "bash -s" < deploy/cvm-recover.sh; then
+            RECOVER_OK=1
+          elif ssh -T deploy-cvm "bash -s" <<EOF
+          set -euo pipefail
+          pkill -f deploy-remote-build || true
+          pkill -f launch-cvm-build || true
+          docker ps --filter name=lnkpi-api || true
+          EOF
+          then
+            RECOVER_OK=1
+          fi
+          if [[ "$RECOVER_OK" != "1" ]]; then
+            echo "WARN: recover SSH failed after retries; checking external health..."
+            if curl -fsS --connect-timeout 5 --max-time 10 "http://${SSH_HOST}:${API_PORT}/api/health" >/tmp/lnkpi-recover-health.json; then
+              echo "External health OK — continuing deploy"
+              head -c 200 /tmp/lnkpi-recover-health.json
+              echo ""
+            else
+              echo "ERROR: recover failed and API unreachable"
+              exit 1
+            fi
+          fi
 
       - name: Sync source to CVM
         if: ${{ github.event.inputs.recover_only != true }}
@@ -104,7 +132,7 @@ jobs:
               --exclude='**/dist' \
               --exclude='.cursor' \
               --exclude='docs' \
-              -czf - . | /tmp/lnkpi-ssh-retry.sh "sync-tar" ssh deploy-cvm "sudo bash -lc 'mkdir -p ${DEPLOY_DIR} && if [[ -f ${DEPLOY_DIR}/.env ]]; then cp ${DEPLOY_DIR}/.env /tmp/lnkpi.env.bak; fi && tar -xzf - -C ${DEPLOY_DIR} && if [[ -f /tmp/lnkpi.env.bak ]]; then mv /tmp/lnkpi.env.bak ${DEPLOY_DIR}/.env; elif [[ ! -f ${DEPLOY_DIR}/.env ]]; then cp ${DEPLOY_DIR}/deploy/.env.production.example ${DEPLOY_DIR}/.env; fi && chmod +x ${DEPLOY_DIR}/deploy/deploy-remote-build.sh ${DEPLOY_DIR}/deploy/deploy-remote.sh ${DEPLOY_DIR}/deploy/launch-cvm-build.sh ${DEPLOY_DIR}/deploy/cvm-recover.sh && rm -f /tmp/lnkpi-deploy-${IMAGE_TAG}.status /tmp/lnkpi-deploy-${IMAGE_TAG}.log'"
+              -czf - . | /tmp/lnkpi-ssh-retry.sh "sync-tar" ssh deploy-cvm "bash -lc 'mkdir -p ${DEPLOY_DIR} && if [[ -f ${DEPLOY_DIR}/.env ]]; then cp ${DEPLOY_DIR}/.env /tmp/lnkpi.env.bak; fi && tar -xzf - -C ${DEPLOY_DIR} && if [[ -f /tmp/lnkpi.env.bak ]]; then mv /tmp/lnkpi.env.bak ${DEPLOY_DIR}/.env; elif [[ ! -f ${DEPLOY_DIR}/.env ]]; then cp ${DEPLOY_DIR}/deploy/.env.production.example ${DEPLOY_DIR}/.env; fi && chmod +x ${DEPLOY_DIR}/deploy/deploy-remote-build.sh ${DEPLOY_DIR}/deploy/deploy-remote.sh ${DEPLOY_DIR}/deploy/launch-cvm-build.sh ${DEPLOY_DIR}/deploy/cvm-recover.sh && rm -f /tmp/lnkpi-deploy-${IMAGE_TAG}.status /tmp/lnkpi-deploy-${IMAGE_TAG}.log'"
 
       - name: Launch background build on CVM
         if: ${{ github.event.inputs.recover_only != true }}
@@ -117,14 +145,14 @@ jobs:
           PID_FILE="/tmp/lnkpi-deploy-${IMAGE_TAG}.pid"
 
           # 使用独立 launcher 脚本立即返回，避免 sudo bash -c 'cmd &' 等待后台任务
-          LAUNCH_OUT=$(/tmp/lnkpi-ssh-retry.sh "launch-ssh" ssh -n deploy-cvm "sudo bash ${DEPLOY_DIR}/deploy/launch-cvm-build.sh ${IMAGE_TAG}")
+          LAUNCH_OUT=$(/tmp/lnkpi-ssh-retry.sh "launch-ssh" ssh -n deploy-cvm "bash ${DEPLOY_DIR}/deploy/launch-cvm-build.sh ${IMAGE_TAG}")
           echo "${LAUNCH_OUT}"
 
           sleep 2
-          PID=$(ssh deploy-cvm "sudo cat ${PID_FILE} 2>/dev/null || true")
+          PID=$(ssh deploy-cvm "cat ${PID_FILE} 2>/dev/null || true")
           if [[ -z "${PID}" ]]; then
             echo "ERROR: CVM build pid file missing"
-            ssh deploy-cvm "sudo tail -40 ${LOG_FILE} 2>/dev/null || true"
+            ssh deploy-cvm "tail -40 ${LOG_FILE} 2>/dev/null || true"
             exit 1
           fi
           echo "Build started on CVM (pid=${PID}, log=${LOG_FILE})"
@@ -139,7 +167,7 @@ jobs:
           OK=0
 
           for i in $(seq 1 180); do
-            STATUS=$(/tmp/lnkpi-ssh-retry.sh "status-ssh" ssh -n deploy-cvm "sudo cat ${STATUS_FILE} 2>/dev/null || echo pending")
+            STATUS=$(/tmp/lnkpi-ssh-retry.sh "status-ssh" ssh -n deploy-cvm "cat ${STATUS_FILE} 2>/dev/null || echo pending")
             echo "Attempt $i: status=${STATUS}"
             case "$STATUS" in
               success)
@@ -148,7 +176,7 @@ jobs:
                 ;;
               failed)
                 echo "=== CVM build log (tail) ==="
-                ssh deploy-cvm "sudo tail -80 ${LOG_FILE} 2>/dev/null || true"
+                ssh deploy-cvm "tail -80 ${LOG_FILE} 2>/dev/null || true"
                 exit 1
                 ;;
             esac
@@ -157,7 +185,7 @@ jobs:
 
           if [[ "$OK" != "1" ]]; then
             echo "Build timed out after 90 minutes"
-            ssh deploy-cvm "sudo tail -80 ${LOG_FILE} 2>/dev/null || true"
+            ssh deploy-cvm "tail -80 ${LOG_FILE} 2>/dev/null || true"
             exit 1
           fi
 

--- a/deploy/cvm-recover.sh
+++ b/deploy/cvm-recover.sh
@@ -27,8 +27,20 @@ docker image prune -f 2>/dev/null || true
 log "=== Restart lnkpi-api with existing image if present ==="
 if [[ -d "${DEPLOY_DIR}/deploy" ]]; then
   cd "${DEPLOY_DIR}"
+  if [[ -f .env ]]; then
+    set -a
+    # shellcheck disable=SC1091
+    source .env
+    set +a
+  fi
   if docker images lnkpi-api --format '{{.Tag}}' 2>/dev/null | grep -q .; then
-    export LNKPI_API_IMAGE="lnkpi-api:latest"
+    if docker images lnkpi-api:latest --format '{{.Tag}}' 2>/dev/null | grep -q latest; then
+      export LNKPI_API_IMAGE="lnkpi-api:latest"
+    else
+      LATEST_TAG=$(docker images lnkpi-api --format '{{.Tag}}' | grep -v '<none>' | head -1)
+      export LNKPI_API_IMAGE="lnkpi-api:${LATEST_TAG}"
+    fi
+    log "using image ${LNKPI_API_IMAGE}"
     docker compose -f deploy/docker-compose.prod.yml up -d --no-build --force-recreate --remove-orphans 2>/dev/null || true
   fi
 fi

--- a/deploy/deploy-remote-build.sh
+++ b/deploy/deploy-remote-build.sh
@@ -3,6 +3,12 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
+if [[ -f .env ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
+fi
 IMAGE_TAG="${IMAGE_TAG:?set IMAGE_TAG to git commit sha}"
 STATUS_FILE="${STATUS_FILE:-/tmp/lnkpi-deploy-${IMAGE_TAG}.status}"
 LOG_FILE="${LOG_FILE:-/tmp/lnkpi-deploy-${IMAGE_TAG}.log}"

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -27,7 +27,6 @@ services:
     environment:
       PORT: "3001"
       DATABASE_URL: file:/app/apps/server/data/lnkpi.db
-      API_PUBLIC_URL: ${API_PUBLIC_URL:-http://127.0.0.1:5100}
     ports:
       - "0.0.0.0:5100:3001"
     volumes:

--- a/docs/DOCK_STUDIO_E2E_TRACKING.md
+++ b/docs/DOCK_STUDIO_E2E_TRACKING.md
@@ -53,7 +53,7 @@
 | shot | ✅ | ✅ | **已完成** | — |
 | mediaInput | ✅ | 🟡 | **基本完成** | M-3 升级 OSS STS |
 | sceneComposer | ✅ | 🟡 | **D-1~D-4 已落地** | 生产手测 + 生成闭环 |
-| videoComposition | ✅ | 🟢 | **C-1~C-4 已落地** | 生产手测 export |
+| videoComposition | ✅ | 🟢 | **C-1~C-4 已落地** | — |
 | worldModel | ❌ | ❌ | **未开始** | W-1~W-3 |
 | prompt | 🟡 Legacy | ⚠️ | **待定** | 是否合并进 text |
 
@@ -61,7 +61,7 @@
 
 1. ~~**P0 生产验收**~~：✅ 2026-07-14 已完成登录 + 5 节点 Dock 手测
 2. ~~**P1 sceneComposer**（D-1~D-4）~~ ✅ 2026-07-14 代码落地
-3. **生产手测** videoComposition C-2~C-4 export，或 sceneComposer 生成闭环
+3. ~~**生产手测** videoComposition C-2~C-4 export~~ ✅ 2026-07-16 curl export MP4 公网 URL 可访问；或 sceneComposer 生成闭环
 4. **P1 可选 polish**：I-6 AIImageEditor 联动、UX-6 Capabilities API
 5. **P2** worldModel / upscale / lip-sync
 
@@ -152,7 +152,7 @@ completed → 写回 url / content / coverUrl
 | **shot（分镜）** | ✅ | 🟢 85% | ✅ canvas | ✅ 入边 text + shotGenerateMode | ShotDockPanel 已拆 | 已完成 |
 | **sceneComposer** | ✅ | 🔴 20% | ❌ 仅 draft | ❌ | **无导演台专属 Dock + 编排 API** | 未开始 |
 | **mediaInput** | ✅ | 🟢 75% | 🟡 本地 upload | ✅ | 预览+转节点已完成；OSS STS 待升级 | 基本完成 |
-| **videoComposition** | ✅ | 🟢 85% | 🟡 export | ✅ 入边 video/audio/mediaInput | 生产 export 手测 | C-1~C-4 完成 |
+| **videoComposition** | ✅ | 🟢 85% | ✅ export | ✅ 入边 video/audio/mediaInput | ✅ 生产 export 2026-07-16 | C-1~C-4 完成 |
 | **worldModel** | ❌ | — | ❌ | ❌ | **无 Dock、无 3D API** | 未开始 |
 | **prompt** | ✅ | 🟡 50% | ⚠️ 与 text 混用 | ❌ | Legacy 面板，是否合并进 text 待产品定稿 | 未开始 |
 | **group** | — | — | — | — | 容器节点，不需要 Dock | — |
@@ -553,7 +553,7 @@ Phase 0 (P0-1~P0-6)
 | **shot** | 生成后子节点创建/更新；封面与 polling 同步 | ☐ 待手测 |
 | **mediaInput** | 预览正确；可转 image/video；OSS url 非 blob | ✅ Dock/上传入口 |
 | **sceneComposer** | 场景列表编辑；展开子图 | ✅ Dock/展开（生成待 API Key） |
-| **videoComposition** | 入边轨收集 + 轨排序/时长持久化；时间轴预览；export MP4 | ☐ 生产 export 手测 |
+| **videoComposition** | 入边轨收集 + 轨排序/时长持久化；时间轴预览；export MP4 | ✅ 生产 export（curl 2026-07-16） |
 
 ### 6.3 回归清单（每次大改 Dock 后跑）
 
@@ -673,6 +673,7 @@ Phase 0 (P0-1~P0-6)
 | 2026-07-14 | M3 | D-1~D-4 sceneComposer | 生产手测待做 | videoComposition C-1 |
 | 2026-07-14 | M3 | C-2~C-3 videoComposition | C-4 export 未做 | 生产手测 C-2/C-3 |
 | 2026-07-14 | M3 | C-4 videoComposition export API | 生产 export 手测 | M4 / worldModel |
+| 2026-07-16 | M3 | C-2~C-4 生产 export 验收 | API_PUBLIC_URL 容器 env 曾错配 127.0.0.1（已热修） | sceneComposer 生产手测 / Deploy recover 加固 PR |
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove docker-compose `environment` override that forced `API_PUBLIC_URL` to `127.0.0.1:5100`, so container reads the value from `/opt/lnkpi/.env`
- Source `.env` in CVM build/recover scripts and pick the newest `lnkpi-api` tag when `latest` is missing
- Harden Deploy workflow: root SSH default, BatchMode/LogLevel, recover via `ssh -T bash -s`, and continue when external health is OK
- Update E2E tracking for videoComposition production export verification

## Test plan
- [ ] Deploy workflow completes on merge (Recover + Sync + CVM build + health)
- [ ] `docker exec lnkpi-api printenv API_PUBLIC_URL` shows public IP, not localhost
- [ ] `POST /api/agent/canvas/video-composition/export` returns public upload URL
- [ ] Browser UI: videoComposition Dock「导出合成」returns playable MP4


Made with [Cursor](https://cursor.com)