### PR TITLE
fix(web): Dock Studio 模型默认值对齐 Agnes 生产环境

### DIFF
--- a/apps/web/src/components/canvas/UniversalModelSelector.vue
+++ b/apps/web/src/components/canvas/UniversalModelSelector.vue
@@ -16,7 +16,14 @@ const { modelsFor, loading } = useCapabilities()
 const open = ref(false)
 
 const models = computed(() => modelsFor(props.type))
-const current = computed(() => models.value.find((m) => m.id === props.modelValue) ?? models.value[0])
+const current = computed(() => {
+  const found = models.value.find((m) => m.id === props.modelValue)
+  if (found) return found
+  if (props.modelValue) {
+    return { id: props.modelValue, name: props.modelValue, provider: '自定义' }
+  }
+  return models.value[0]
+})
 
 const typeLabel = computed(() => {
   if (props.type === 'text') return '文本模型'

--- a/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
@@ -9,7 +9,10 @@ import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbar
 import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
+import { useModelProviderSettings } from '@/composables/useModelProviderSettings'
 import { isNodeGenerating } from '@/constants/dockStudio'
+
+const { getConfig } = useModelProviderSettings()
 
 const props = defineProps<{
   node: EditableFlowNode
@@ -25,7 +28,7 @@ const emit = defineEmits<{
 }>()
 
 const prompt = ref('')
-const imageModel = ref('flux-pro')
+const imageModel = ref(getConfig('image').model)
 const imageAspect = ref<ImageAspectRatio>('16:9')
 const referenceImageUrl = ref('')
 const refInput = ref<HTMLInputElement | null>(null)
@@ -42,7 +45,7 @@ const effectiveRefUrl = computed(() => {
 function syncFromNode() {
   const data = props.node.data ?? {}
   prompt.value = String(data.prompt ?? data.content ?? '')
-  imageModel.value = String(data.imageModel ?? 'flux-pro')
+  imageModel.value = String(data.imageModel ?? getConfig('image').model)
   imageAspect.value = (data.imageAspect as ImageAspectRatio | undefined) ?? '16:9'
   referenceImageUrl.value = String(data.referenceImageUrl ?? '')
 }

--- a/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
@@ -9,7 +9,10 @@ import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPrompt
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockOptimizePrompt from '@/components/canvas/dock-studio/shared/DockOptimizePrompt.vue'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
+import { useModelProviderSettings } from '@/composables/useModelProviderSettings'
 import { isNodeGenerating } from '@/constants/dockStudio'
+
+const { getConfig } = useModelProviderSettings()
 
 const props = defineProps<{
   node: EditableFlowNode
@@ -25,7 +28,7 @@ const emit = defineEmits<{
 }>()
 
 const content = ref('')
-const textModel = ref('gpt-4o')
+const textModel = ref(getConfig('text').model)
 
 const speech = useSpeechRecognition()
 const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
@@ -34,7 +37,7 @@ const wordCount = computed(() => content.value.replace(/\s/g, '').length)
 function syncFromNode() {
   const data = props.node.data ?? {}
   content.value = String(data.content ?? data.prompt ?? '')
-  textModel.value = String(data.textModel ?? 'gpt-4o')
+  textModel.value = String(data.textModel ?? getConfig('text').model)
 }
 
 watch(() => props.node, syncFromNode, { immediate: true, deep: true })

--- a/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
@@ -13,8 +13,11 @@ import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbar
 import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
+import { useModelProviderSettings } from '@/composables/useModelProviderSettings'
 import { DEFAULT_VIDEO_SETTINGS, type VideoSettings } from '@lnkpi/shared'
 import { isNodeGenerating } from '@/constants/dockStudio'
+
+const { getConfig } = useModelProviderSettings()
 
 const props = defineProps<{
   node: EditableFlowNode
@@ -30,7 +33,7 @@ const emit = defineEmits<{
 }>()
 
 const prompt = ref('')
-const videoModel = ref('kling-v1')
+const videoModel = ref(getConfig('video').model)
 const videoSettings = ref<VideoSettings>({ ...DEFAULT_VIDEO_SETTINGS })
 const videoMode = ref<VideoGenerationMode>('text_to_video')
 const referenceImageUrl = ref('')
@@ -50,7 +53,7 @@ const modeLabel = computed(() => (videoMode.value === 'image_to_video' ? '图生
 function syncFromNode() {
   const data = props.node.data ?? {}
   prompt.value = String(data.prompt ?? data.content ?? '')
-  videoModel.value = String(data.videoModel ?? 'kling-v1')
+  videoModel.value = String(data.videoModel ?? getConfig('video').model)
   if (data.videoSettings && typeof data.videoSettings === 'object') {
     videoSettings.value = { ...DEFAULT_VIDEO_SETTINGS, ...(data.videoSettings as VideoSettings) }
   }

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -33,7 +33,7 @@ export interface NodeGenerationDeps {
   requireLogin: () => boolean
   startShotPolling: (shotIds: string[]) => void
   startGenerationPolling: (tasks: GenerationPollTask[]) => void
-  resolveProviderModels: () => { image: string; video: string }
+  resolveProviderModels: () => { image: string; video: string; text: string }
 }
 
 function findNodeById(nodes: EditableFlowNode[], id: string) {
@@ -75,7 +75,11 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     try {
       if (nodeType === 'text') {
         deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating, content: prompt, prompt })
-        const { data: res } = await studioApi.generateText(prompt, String(data.textModel ?? 'gpt-4o'))
+        const models = deps.resolveProviderModels()
+        const { data: res } = await studioApi.generateText(
+          prompt,
+          String(data.textModel ?? models.text),
+        )
         const content = parseRecordText(res.data)
         deps.patchNodeData(node.id, {
           content,
@@ -158,9 +162,10 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       const refImage = mergeReferenceImageUrl(data, upstream)
       const imagePrompt = buildPromptWithRefImage(prompt, refImage)
       const aspectRatio = String(data.imageAspect ?? '16:9')
+      const models = deps.resolveProviderModels()
       const { data: res } = await studioApi.generateImage(
         imagePrompt,
-        String(data.imageModel ?? 'flux-pro'),
+        String(data.imageModel ?? models.image),
         aspectRatio,
       )
       deps.patchNodeData(node.id, {
@@ -176,9 +181,10 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     const videoMode = resolveVideoMode(data, upstream)
     const refImage = videoMode === 'image_to_video' ? mergeReferenceImageUrl(data, upstream) : ''
     const videoPrompt = buildPromptWithRefImage(prompt, refImage)
+    const models = deps.resolveProviderModels()
     const { data: res } = await studioApi.generateVideo(
       videoPrompt,
-      String(data.videoModel ?? 'kling-v1'),
+      String(data.videoModel ?? models.video),
       settings?.duration,
       settings?.aspectRatio,
     )

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -1304,6 +1304,7 @@ const {
   startShotPolling: (ids) => shotPolling.start(ids),
   startGenerationPolling: (tasks) => generationPolling.start(tasks),
   resolveProviderModels: () => ({
+    text: getProviderConfig('text').model,
     image: getProviderConfig('image').model,
     video: getProviderConfig('video').model,
   }),

--- a/docs/DOCK_STUDIO_E2E_TRACKING.md
+++ b/docs/DOCK_STUDIO_E2E_TRACKING.md
@@ -3,11 +3,11 @@
 > **对标参考**：[NeoWOW Workflow](https://neowow.cn/workflow?sessionId=2074796563114016768)  
 > **UI 调研**：[NEOWOW_CANVAS_UI_RESEARCH.md](./NEOWOW_CANVAS_UI_RESEARCH.md)（§4.2 BottomToolbarWrapper / NodePanel）  
 > **创建日期**：2026-07-13  
-> **最后更新**：2026-07-14（生产登录 Edge 代理修复 + 浏览器 E2E 手测验收）
+> **最后更新**：2026-07-16（M3 export/sceneComposer 生产 API 验收；Deploy PR #11/#12；§0.5 P0 手测清单）
 
 ---
 
-## 零、完成情况审计（2026-07-14）
+## 零、完成情况审计（2026-07-16）
 
 ### 0.1 总体进度
 
@@ -15,13 +15,13 @@
 |------|--------|------|
 | **Phase 0** 基础架构 | **100%** | P0-1 ~ P0-6 全部完成 |
 | **Phase 1** 核心生成节点 | **~92%** | text/image/video/audio/shot 主链路完成；T-5/I-6/I-7/V-6 待补 |
-| **Phase 2** 输入与编排 | **~85%** | mediaInput ✅；sceneComposer D-1~D-4 ✅；videoComposition C-1~C-4 ✅；worldModel 未开始 |
-| **Phase 3** Dock UX | **~83%** | UX-1~UX-5 ✅；UX-6 Capabilities API 未开始 |
+| **Phase 2** 输入与编排 | **~90%** | mediaInput ✅；sceneComposer D-1~D-4 ✅（API 手测）；videoComposition C-1~C-4 ✅（export 生产）；worldModel 未开始 |
+| **Phase 3** Dock UX | **~88%** | UX-1~UX-5 ✅；UX-6 Capabilities **部分**（`useCapabilities` + `UniversalModelSelector` 已接，未全量替换硬编码） |
 | **Phase 4** 后端补齐 | **~67%** | B-1/B-3/B-4/B-6 ✅；B-2 upscale、B-5 lip-sync 未开始 |
-| **里程碑 M1/M2** | **已完成** | 代码落地，`pnpm build` 通过 |
-| **里程碑 M3** | **基本完成** | mediaInput + sceneComposer + videoComposition C-1~C-4 已落地 |
-| **里程碑 M4** | **未开始** | UX-6 + 后端 upscale/lip-sync/OSS STS |
-| **浏览器 E2E 手测** | **✅ 生产 P0 通过** | 2026-07-14 生产登录 + 5 类节点 Dock 验收（见 §0.4） |
+| **里程碑 M1/M2** | **已完成** | 代码落地；**真实 AI 生成**待生产 API Key |
+| **里程碑 M3** | **~90%** | 编排 + export 生产 API ✅；sceneComposer/shot **浏览器 UI** 待验 |
+| **里程碑 M4** | **未开始** | OSS STS + upscale/lip-sync + worldModel |
+| **浏览器 E2E 手测** | **🟡 部分** | 2026-07-14 Dock 壳层 ✅；2026-07-16 export/sceneComposer **API** ✅；UI 闭环 ☐（见 §0.5） |
 
 ### 0.4 生产环境 E2E 手测记录（2026-07-14）
 
@@ -40,6 +40,56 @@
 | 各节点「生成」闭环 | ☐ 待补 | 需生产配置模型 API Key 后再跑完整生成 |
 | 刷新持久化 | ☐ 待补 | 画布页可加载；节点参数刷新后需人工再验 |
 
+### 0.4b 生产环境 E2E 手测记录（2026-07-16）
+
+**环境**：https://lnkpi-web.vercel.app · API → CVM `119.29.173.89:5100` · 镜像 `lnkpi-api:396175a`
+
+| 项 | 结果 | 说明 |
+|----|------|------|
+| Deploy PR #11 | 🟡 | CVM 部署成功；GHA Wait 步骤 failure（MOTD 污染 status） |
+| Deploy PR #12 | ✅ | Recover/Sync/Build/Wait/Verify 全绿 |
+| `API_PUBLIC_URL` | ✅ | 容器 env 为公网 IP，export 不再返回 127.0.0.1 |
+| sceneComposer save | ✅ | curl `POST scene-composer/save` code=0 |
+| sceneComposer batch-generate | ✅ | 返回 materialId（占位/RuleBased 图） |
+| videoComposition export | ✅ | 公网 MP4 URL，HTTP 200 |
+| sceneComposer 展开子图 UI | ☐ | 代码 D-4 已落地，浏览器未验 |
+| videoComposition「导出合成」UI | ☐ | API 已验，Dock 按钮浏览器未验 |
+
+**一键 API 回归**：`scripts/p0-production-e2e.sh`（见 §0.5）
+
+### 0.5 P0 生产手测清单（人工 + 脚本）
+
+#### 自动化（API）
+
+```bash
+# 默认打 Vercel 生产；本地 API 可设 BASE_URL=http://127.0.0.1:5100/api
+./scripts/p0-production-e2e.sh
+```
+
+| # | 检查项 | 脚本覆盖 |
+|---|--------|---------|
+| A1 | 登录 | ✅ |
+| A2 | 创建画布 | ✅ |
+| A3 | sceneComposer save | ✅ |
+| A4 | sceneComposer batch-generate | ✅ |
+| A5 | videoComposition export + MP4 HEAD | ✅ |
+| A6 | health | ✅ |
+
+#### 浏览器 UI（约 15 分钟，需登录 13800138000 / 123456）
+
+| # | 步骤 | 预期 | 通过 |
+|---|------|------|------|
+| U1 | 创建画布 → 添加 **text** → Dock 改 prompt → 生成 | 状态 generating→completed，节点有文案 | ☐ |
+| U2 | text 连线 **video** → 选中 video → I2V 参考图带入 | Dock 见上游 prompt/参考图 | ☐ |
+| U3 | 添加 **shot** → 生成 | 子 image/video 节点或封面更新 | ☐ |
+| U4 | 添加 **导演台** → 编辑场景/镜头 → **保存编排** | 无报错，刷新后仍在 | ☐ |
+| U5 | 导演台 → **展开子图** | 画布出现 shot/image/video 子节点 | ☐ |
+| U6 | 导演台 → **批量生成素材** | 分镜 entering generating，轮询后 preview | ☐ |
+| U7 | video/audio 连线 **视频合成** → **导出合成** | Dock 出现 MP4 链接，可播放 | ☐ |
+| U8 | 改 Dock 参数 → F5 刷新 | node.data 与保存前一致 | ☐ |
+
+**阻塞真实生成**：CVM `.env` 配置 `OPENAI_API_KEY`（及视频 provider）；未配置时走 RuleBased/占位图，链路仍可验状态机。
+
 **登录修复摘要**：Vercel 外链 rewrite 跨境超时（~31s 502）→ 改为 `apps/web/api/proxy.ts` Serverless 代理（3 次重试）+ 客户端 auth retry。
 
 ### 0.2 节点 E2E 矩阵（审计后）
@@ -50,9 +100,9 @@
 | image | ✅ | ✅ | **已完成** | I-6 编辑器联动、I-7 upscale |
 | video | ✅ | ✅ | **已完成** | V-6 多选批量一致 |
 | audio | ✅ | ✅ | **已完成** | — |
-| shot | ✅ | ✅ | **已完成** | — |
+| shot | ✅ | ✅ | **代码完成** | 生产 UI 手测（§0.5 U3） |
 | mediaInput | ✅ | 🟡 | **基本完成** | M-3 升级 OSS STS |
-| sceneComposer | ✅ | 🟡 | **D-1~D-4 已落地** | 浏览器 UI 手测 |
+| sceneComposer | ✅ | 🟡 | **D-1~D-4 已落地** | 浏览器 UI：展开子图 / 批量生成（§0.5 U4–U6） |
 | videoComposition | ✅ | 🟢 | **C-1~C-4 已落地** | — |
 | worldModel | ❌ | ❌ | **未开始** | W-1~W-3 |
 | prompt | 🟡 Legacy | ⚠️ | **待定** | 是否合并进 text |
@@ -61,9 +111,10 @@
 
 1. ~~**P0 生产验收**~~：✅ 2026-07-14 已完成登录 + 5 节点 Dock 手测
 2. ~~**P1 sceneComposer**（D-1~D-4）~~ ✅ 2026-07-14 代码落地
-3. ~~**生产手测** videoComposition C-2~C-4 export~~ ✅ 2026-07-16 curl export MP4 公网 URL 可访问；或 sceneComposer 生成闭环
-4. **P1 可选 polish**：I-6 AIImageEditor 联动、UX-6 Capabilities API
-5. **P2** worldModel / upscale / lip-sync
+3. ~~**生产手测** videoComposition export~~ ✅ 2026-07-16 API；UI 见 §0.5 U7
+4. **P0 浏览器 UI**：§0.5 U1–U8 + 配置生产 AI Key
+5. **P1 polish**：I-6、UX-6 全量 Capabilities、OSS STS
+6. **P2** worldModel / upscale / lip-sync
 
 ---
 
@@ -150,7 +201,7 @@ completed → 写回 url / content / coverUrl
 | **video** | ✅ | 🟢 80% | ✅ 异步轮询 | ✅ I2V + 入边参考图 | crop 已 UI 未传 provider | 已完成 |
 | **audio** | ✅ | 🟢 80% | ✅ voice+settings | ✅ 入边 text 预填 | 情感/语速存 metadata | 已完成 |
 | **shot（分镜）** | ✅ | 🟢 85% | ✅ canvas | ✅ 入边 text + shotGenerateMode | ShotDockPanel 已拆 | 已完成 |
-| **sceneComposer** | ✅ | 🔴 20% | ❌ 仅 draft | ❌ | **无导演台专属 Dock + 编排 API** | 未开始 |
+| **sceneComposer** | ✅ | 🟢 85% | ✅ save/batch/expand | ✅ 可接 text synopsis | 浏览器 UI 闭环待验；批量生成依赖 API Key | D-1~D-4 完成 |
 | **mediaInput** | ✅ | 🟢 75% | 🟡 本地 upload | ✅ | 预览+转节点已完成；OSS STS 待升级 | 基本完成 |
 | **videoComposition** | ✅ | 🟢 85% | ✅ export | ✅ 入边 video/audio/mediaInput | ✅ 生产 export 2026-07-16 | C-1~C-4 完成 |
 | **worldModel** | ❌ | — | ❌ | ❌ | **无 Dock、无 3D API** | 未开始 |
@@ -161,7 +212,7 @@ completed → 写回 url / content / coverUrl
 
 | # | 缺口 | 影响 | 状态 |
 |---|------|------|------|
-| G-1 | `NodeEditorToolbar.vue` 单文件承载全部类型 | text/audio/shot/image/video 已拆 Panel；Legacy 仅 sceneComposer/prompt | 进行中 |
+| G-1 | `NodeEditorToolbar.vue` 单文件承载全部类型 | 主类型已拆 Panel；Legacy 仅 **prompt** | 基本完成 |
 | G-2 | `handleNodeGenerate` 在 `CanvasPage.vue` 600+ 行，缺 `useNodeGeneration` | 已迁出至 composable | 已完成 |
 | G-3 | 上游图解析未标准化（连线 text/image → prompt/refImage） | `useUpstreamNodeContext` 已实现 | 已完成 |
 | G-4 | 视频/分镜异步轮询不统一（shot 有 polling，studio video 无） | `useGenerationPolling` + B-6 部分提前 | 已完成 |
@@ -184,7 +235,7 @@ completed → 写回 url / content / coverUrl
 | `material/upscale` | ❌ | image | 未开始 |
 | `material/lip-sync` | ❌ | video（可选） | 未开始 |
 | OSS upload / STS | 本地 `POST /api/upload` + 静态 `/api/uploads/`（非 OSS STS） | mediaInput | 部分完成 |
-| `capabilities/list` → UniversalModelSelector | 需确认完全对接 | 全部生成节点 | 未开始 |
+| `capabilities/list` → UniversalModelSelector | 🟡 部分对接（`useCapabilities` 已接，fallback 硬编码） | 全部生成节点 | 进行中 |
 | `GET /studio/generations/:id` | ✅（Sprint A 提前落地，原 B-6） | video 轮询 | 已完成 |
 
 ---
@@ -497,7 +548,7 @@ interface DockStudioEntry {
 |--------|------|-----------|---------|------|
 | **M1** | Phase 0 | 架构就绪，旧功能不退化 | 2026-07-13 | 已完成 |
 | **M2** | text/image/video/audio/shot | 5 类节点完整「选中→Dock→生成→预览」 | 2026-07-13 | 已完成（待浏览器验收） |
-| **M3** | mediaInput + sceneComposer + composition | 输入→生成→合成链路 | — | 进行中（mediaInput 已落地） |
+| **M3** | mediaInput + sceneComposer + composition | 输入→生成→合成链路 | 2026-07-16 | ~90%（export API ✅；UI ☐） |
 | **M4** | UX + 后端补齐 | 对标 NeoWOW 会话级体验 | — | 未开始 |
 
 ### 5.2 依赖关系（简图）
@@ -550,7 +601,7 @@ Phase 0 (P0-1~P0-6)
 | **image** | 比例/模型生效；参考图来自入边或 Dock 上传；生成图可预览 | ✅ Dock/参数（生成待 API Key） |
 | **video** | T2V/I2V 切换；I2V 参考图正确；轮询完成后可播放 | ✅ Dock/T2V·I2V（生成待 API Key） |
 | **audio** | 音色可选；生成后可 `<audio>` 播放 | ✅ Dock/音色（生成待 API Key） |
-| **shot** | 生成后子节点创建/更新；封面与 polling 同步 | ☐ 待手测 |
+| **shot** | 生成后子节点创建/更新；封面与 polling 同步 | ☐ §0.5 U3 |
 | **mediaInput** | 预览正确；可转 image/video；OSS url 非 blob | ✅ Dock/上传入口 |
 | **sceneComposer** | 场景列表编辑；展开子图 | ✅ API 手测 2026-07-16（save + batch-generate） |
 | **videoComposition** | 入边轨收集 + 轨排序/时长持久化；时间轴预览；export MP4 | ✅ 生产 export（curl 2026-07-16） |
@@ -674,7 +725,9 @@ Phase 0 (P0-1~P0-6)
 | 2026-07-14 | M3 | C-2~C-3 videoComposition | C-4 export 未做 | 生产手测 C-2/C-3 |
 | 2026-07-14 | M3 | C-4 videoComposition export API | 生产 export 手测 | M4 / worldModel |
 | 2026-07-16 | M3 | C-2~C-4 生产 export 验收 | API_PUBLIC_URL 容器 env 曾错配 127.0.0.1（已热修） | sceneComposer 生产手测 / Deploy recover 加固 PR |
-| 2026-07-16 | M3 | sceneComposer 生产 API 手测 | GHA Wait 轮询被 MOTD 污染卡住（#11） | 浏览器 UI 手测 / fix deploy poll |
+| 2026-07-16 | M3 | sceneComposer 生产 API 手测 | — | §0.5 浏览器 UI |
+| 2026-07-16 | Deploy | PR #11 API_PUBLIC_URL + recover | GHA Wait failure | PR #12 轮询修复 ✅ |
+| 2026-07-16 | — | 节点 E2E 审计 + §0.5 P0 清单 | 真实生成待 API Key | U1–U8 浏览器手测 |
 
 ---
 
@@ -689,4 +742,4 @@ Phase 0 (P0-1~P0-6)
 
 ---
 
-**最后更新**：2026-07-14（D-1~D-4 sceneComposer 落地；`pnpm build` 通过）
+**最后更新**：2026-07-16（§0.5 P0 手测清单；M3 ~90%；Deploy PR #12 全绿）

--- a/scripts/dock-studio-generation-e2e.sh
+++ b/scripts/dock-studio-generation-e2e.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Dock Studio 生成链路 E2E（模拟用户：登录 → 画布 → text/video/audio 生成 → 持久化校验）
+# 用法: ./scripts/dock-studio-generation-e2e.sh
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-https://lnkpi-web.vercel.app/api}"
+PHONE="${PHONE:-13800138000}"
+CODE="${CODE:-123456}"
+
+pass=0
+fail=0
+
+ok() { echo "  ✅ $*"; pass=$((pass + 1)); }
+bad() { echo "  ❌ $*"; fail=$((fail + 1)); }
+
+echo "=== Dock Studio Generation E2E ==="
+echo "BASE_URL=$BASE_URL"
+
+TOKEN=$(curl -fsS --max-time 30 -X POST "$BASE_URL/auth/login" \
+  -H "Content-Type: application/json" \
+  -d "{\"phone\":\"${PHONE}\",\"code\":\"${CODE}\"}" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['data']['token'])")
+ok "login"
+
+SESSION=$(curl -fsS --max-time 30 -X POST "$BASE_URL/agent/canvas/create" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"title":"dock-studio-e2e"}' \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['data']['id'])")
+ok "canvas session=$SESSION"
+
+TEXT_NODE_ID="text-e2e-1"
+VIDEO_NODE_ID="video-e2e-1"
+AUDIO_NODE_ID="audio-e2e-1"
+
+echo "T1 text generate (Dock: 生成文案)"
+TEXT_RES=$(curl -sS --max-time 120 -X POST "$BASE_URL/studio/text/generate" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"用一句话介绍西湖","model":"agnes-2.0-flash"}')
+TEXT_CONTENT=$(python3 -c "import json,sys; d=json.load(sys.stdin); m=d.get('data',{}).get('metadata'); import json as j; print(j.loads(m).get('text','') if m else '')" <<<"$TEXT_RES")
+if [[ -n "$TEXT_CONTENT" && $(python3 -c "import json,sys; print(json.load(sys.stdin).get('code'))" <<<"$TEXT_RES") == "0" ]]; then
+  ok "text content len=${#TEXT_CONTENT}"
+else
+  bad "text generate failed: $TEXT_RES"
+fi
+
+echo "T2 audio generate (Dock: 生成音频)"
+AUDIO_RES=$(curl -sS --max-time 90 -X POST "$BASE_URL/studio/audio/generate" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"text":"你好，这是音频测试","voice":"female-1"}')
+AUDIO_URL=$(python3 -c "import json,sys; print(json.load(sys.stdin).get('data',{}).get('url',''))" <<<"$AUDIO_RES")
+if [[ -n "$AUDIO_URL" && $(python3 -c "import json,sys; print(json.load(sys.stdin).get('code'))" <<<"$AUDIO_RES") == "0" ]]; then
+  ok "audio url=${AUDIO_URL:0:60}..."
+else
+  bad "audio generate failed: $AUDIO_RES"
+fi
+
+echo "T3 video generate submit (Dock: 生成视频)"
+VIDEO_RES=$(curl -sS --max-time 60 -X POST "$BASE_URL/studio/video/generate" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"A cat by West Lake at sunset, cinematic","model":"agnes-video-v2.0","duration":3,"aspectRatio":"16:9"}')
+VIDEO_RECORD=$(python3 -c "import json,sys; print(json.load(sys.stdin).get('data',{}).get('id',''))" <<<"$VIDEO_RES")
+VIDEO_STATUS=$(python3 -c "import json,sys; print(json.load(sys.stdin).get('data',{}).get('status',''))" <<<"$VIDEO_RES")
+if [[ -n "$VIDEO_RECORD" && "$VIDEO_STATUS" == "generating" ]]; then
+  ok "video submitted record=$VIDEO_RECORD"
+else
+  bad "video submit failed: $VIDEO_RES"
+fi
+
+VIDEO_FINAL_URL=""
+VIDEO_FINAL_STATUS="generating"
+if [[ -n "$VIDEO_RECORD" ]]; then
+  echo "T3b video poll (前端 generationPolling 等价)"
+  for i in $(seq 1 36); do
+    POLL=$(curl -sS --max-time 30 -H "Authorization: Bearer $TOKEN" "$BASE_URL/studio/generations/$VIDEO_RECORD")
+    VIDEO_FINAL_STATUS=$(python3 -c "import json,sys; print(json.load(sys.stdin).get('data',{}).get('status',''))" <<<"$POLL")
+    VIDEO_FINAL_URL=$(python3 -c "import json,sys; print(json.load(sys.stdin).get('data',{}).get('url') or '')" <<<"$POLL")
+    echo "    poll $i: status=$VIDEO_FINAL_STATUS"
+    [[ "$VIDEO_FINAL_STATUS" == "completed" && -n "$VIDEO_FINAL_URL" ]] && break
+    [[ "$VIDEO_FINAL_STATUS" == "failed" ]] && break
+    sleep 10
+  done
+  if [[ "$VIDEO_FINAL_STATUS" == "completed" && -n "$VIDEO_FINAL_URL" ]]; then
+    ok "video completed"
+  else
+    bad "video final status=$VIDEO_FINAL_STATUS"
+  fi
+fi
+
+echo "T4 save canvas nodes (模拟 patchNodeData + saveCanvas)"
+CANVAS_JSON=$(python3 - <<PY
+import json
+text_content = """$TEXT_CONTENT"""
+audio_url = """$AUDIO_URL"""
+video_url = """$VIDEO_FINAL_URL"""
+video_status = "completed" if video_url else ("error" if "$VIDEO_FINAL_STATUS" == "failed" else "generating")
+nodes = [
+  {"id":"$TEXT_NODE_ID","type":"text","position":{"x":100,"y":100},"data":{"content":text_content,"prompt":"用一句话介绍西湖","status":"completed"}},
+  {"id":"$AUDIO_NODE_ID","type":"audio","position":{"x":100,"y":320},"data":{"url":audio_url,"prompt":"你好，这是音频测试","status":"completed"}},
+  {"id":"$VIDEO_NODE_ID","type":"video","position":{"x":100,"y":540},"data":{"url":video_url or "","status":video_status,"generationRecordId":"$VIDEO_RECORD","prompt":"A cat by West Lake"}},
+]
+print(json.dumps({"nodes":nodes,"edges":[]}))
+PY
+)
+
+SAVE=$(curl -sS --max-time 30 -X PUT "$BASE_URL/agent/canvas/update" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"id\":\"$SESSION\",\"canvasData\":$CANVAS_JSON}")
+if python3 -c "import json,sys; exit(0 if json.load(sys.stdin).get('code')==0 else 1)" <<<"$SAVE"; then
+  ok "canvas saved"
+else
+  bad "canvas save failed: $SAVE"
+fi
+
+echo "T5 reload canvas (刷新持久化)"
+RELOAD=$(curl -sS --max-time 30 -H "Authorization: Bearer $TOKEN" "$BASE_URL/sessions/$SESSION")
+python3 - <<'PY' "$RELOAD" "$TEXT_NODE_ID" "$AUDIO_NODE_ID" "$VIDEO_NODE_ID"
+import json,sys
+data=json.loads(sys.argv[1])
+text_id,audio_id,video_id=sys.argv[2:5]
+nodes={n['id']:n for n in (data.get('data',{}).get('canvasData',{}) or {}).get('nodes',[])}
+checks=[]
+for nid,field in [(text_id,'content'),(audio_id,'url'),(video_id,'url')]:
+    node=nodes.get(nid)
+    val=(node or {}).get('data',{}).get(field,'') if node else ''
+    checks.append((nid,field,bool(str(val).strip()),str(val)[:80]))
+for nid,field,ok,val in checks:
+    print(f"{'OK' if ok else 'FAIL'} {nid}.{field}={val}")
+    if not ok: sys.exit(1)
+PY
+if [[ $? -eq 0 ]]; then
+  ok "reload fields present"
+else
+  bad "reload missing node fields"
+fi
+
+echo ""
+echo "=== summary: ${pass} passed, ${fail} failed ==="
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
## Summary
- Dock Studio 文本/图片/视频面板与 `useNodeGeneration` 改为读取本地「模型服务配置」，不再硬编码 `gpt-4o` / `kling-v1`
- `UniversalModelSelector` 对未收录模型显示自定义 model id（如 `agnes-2.0-flash`）
- 新增 `scripts/dock-studio-generation-e2e.sh` 用于生产 text/audio/video 生成回归

## Test plan
- [x] 本地 `pnpm build`（web 改动无类型错误）
- [ ] Vercel 部署后浏览器：新建 text 节点 → 配置 agnes-2.0-flash → 生成文案
- [ ] `./scripts/dock-studio-generation-e2e.sh` text/audio/video 全绿


Made with [Cursor](https://cursor.com)