### PR TITLE
fix(web): restore auth session for canvas Dock generation

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -1,10 +1,17 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import AppHeader from '@/components/layout/AppHeader.vue'
+import LoginDialog from '@/components/auth/LoginDialog.vue'
+import { useAuthStore } from '@/stores/auth'
 
 const route = useRoute()
+const auth = useAuthStore()
 const isImmersiveCanvas = computed(() => route.name === 'canvas')
+
+onMounted(() => {
+  void auth.restoreSession()
+})
 </script>
 
 <template>
@@ -14,5 +21,6 @@ const isImmersiveCanvas = computed(() => route.name === 'canvas')
     <main class="relative" :class="isImmersiveCanvas ? 'h-screen overflow-hidden' : ''">
       <RouterView />
     </main>
+    <LoginDialog />
   </div>
 </template>

--- a/apps/web/src/components/layout/AppHeader.vue
+++ b/apps/web/src/components/layout/AppHeader.vue
@@ -3,7 +3,6 @@ import { computed, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import BrandLogo from '@/components/brand/BrandLogo.vue'
-import LoginDialog from '@/components/auth/LoginDialog.vue'
 import MembershipModal from '@/components/membership/MembershipModal.vue'
 
 const showMembership = ref(false)
@@ -85,6 +84,5 @@ function navigate(path: string) {
     </div>
   </header>
 
-  <LoginDialog />
   <MembershipModal v-model="showMembership" />
 </template>

--- a/apps/web/src/services/api.ts
+++ b/apps/web/src/services/api.ts
@@ -3,7 +3,7 @@ import { getApiBaseUrl } from './api-base'
 
 export const api = axios.create({
   baseURL: getApiBaseUrl(),
-  timeout: 30000,
+  timeout: 120_000,
 })
 
 api.interceptors.request.use((config) => {

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -70,6 +70,18 @@ export const useAuthStore = defineStore('auth', () => {
     showLoginDialog.value = true
   }
 
+  async function restoreSession() {
+    if (!token.value) return
+    try {
+      const { data } = await withAuthRetry(() =>
+        api.get<{ data: User }>('/auth/profile', { timeout: AUTH_TIMEOUT_MS }),
+      )
+      user.value = data.data
+    } catch {
+      logout()
+    }
+  }
+
   return {
     user,
     token,
@@ -80,5 +92,6 @@ export const useAuthStore = defineStore('auth', () => {
     login,
     logout,
     openLogin,
+    restoreSession,
   }
 })


### PR DESCRIPTION
## Summary
- 应用启动时若有 token 则调用 `/auth/profile` 恢复 `user`，修复刷新后 `isLoggedIn` 为 false 导致 Dock 生成被静默拦截
- 将 `LoginDialog` 挂到 `App.vue` 全局，沉浸画布页（无 AppHeader）也能弹出登录框
- axios 默认超时 30s → 120s，避免长耗时文本生成被客户端截断

## Test plan
- [ ] 登录后进入画布，刷新页面
- [ ] 选中 text 节点，Dock 点击「生成文案」，节点应出现「生成中...」并更新内容
- [ ] 同样验证 audio / video 节点实时生成
- [ ] `./scripts/dock-studio-generation-e2e.sh` 仍全绿


Made with [Cursor](https://cursor.com)