### PR TITLE
feat: prompt node intent routing and multi-mode templates

### DIFF
--- a/apps/server/src/studio/studio.controller.ts
+++ b/apps/server/src/studio/studio.controller.ts
@@ -63,6 +63,15 @@ class GenerateTextDto {
   model?: string
 }
 
+class GeneratePromptDto {
+  @IsString()
+  prompt!: string
+
+  @IsOptional()
+  @IsString()
+  model?: string
+}
+
 class ImageVariationDto {
   @IsString()
   prompt!: string
@@ -91,6 +100,13 @@ export class StudioController {
   @UseGuards(AuthGuard)
   async generateText(@Req() req: { user: { sub: string } }, @Body() dto: GenerateTextDto) {
     const data = await this.studioService.generateText(req.user.sub, dto.prompt, dto.model)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('prompt/generate')
+  @UseGuards(AuthGuard)
+  async generatePrompt(@Req() req: { user: { sub: string } }, @Body() dto: GeneratePromptDto) {
+    const data = await this.studioService.generatePrompt(req.user.sub, dto.prompt, dto.model)
     return { code: 0, message: 'ok', data }
   }
 

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -4,6 +4,7 @@ import {
   createImageProvider,
   createTextProvider,
   createVideoProvider,
+  generatePromptFromUserInput,
 } from '@lnkpi/agent'
 import { PrismaService } from '../prisma/prisma.service'
 
@@ -33,6 +34,28 @@ export class StudioService {
         url: null,
         status: 'completed',
         metadata: JSON.stringify({ text }),
+      },
+    })
+  }
+
+  async generatePrompt(userId: string, prompt: string, model?: string) {
+    const trimmed = prompt?.trim()
+    if (!trimmed) throw new BadRequestException('prompt 不能为空')
+    await this.consumePoints(userId, 5, '提示词模式生成')
+    const { mode, content } = await generatePromptFromUserInput(trimmed, {
+      model,
+      apiKey: process.env.OPENAI_API_KEY,
+      baseUrl: process.env.OPENAI_BASE_URL,
+    })
+    return this.prisma.generationRecord.create({
+      data: {
+        userId,
+        type: 'prompt',
+        prompt: trimmed,
+        model,
+        url: null,
+        status: 'completed',
+        metadata: JSON.stringify({ mode, content }),
       },
     })
   }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,10 @@
   },
   "dependencies": {
     "@lnkpi/shared": "workspace:*",
+    "@tiptap/extension-placeholder": "^3.28.0",
+    "@tiptap/extension-typography": "^3.28.0",
+    "@tiptap/starter-kit": "^3.28.0",
+    "@tiptap/vue-3": "^3.28.0",
     "@vue-flow/background": "^1.3.2",
     "@vue-flow/controls": "^1.1.2",
     "@vue-flow/core": "^1.42.1",
@@ -19,6 +23,7 @@
     "element-plus": "^2.14.2",
     "pinia": "^2.3.1",
     "playcanvas": "^2.17.2",
+    "tiptap-markdown": "^0.9.0",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0"
   },

--- a/apps/web/src/components/canvas/CanvasNodePrompt.vue
+++ b/apps/web/src/components/canvas/CanvasNodePrompt.vue
@@ -3,10 +3,11 @@ import { computed, ref } from 'vue'
 import { useNodeId, useVueFlow } from '@vue-flow/core'
 import NeoBaseNode from '@/components/canvas/NeoBaseNode.vue'
 import PromptMarkdownEditor from '@/components/canvas/PromptMarkdownEditor.vue'
+import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
 
 const props = defineProps<{
   selected?: boolean
-  data: { prompt?: string; content?: string; label?: string; status?: string }
+  data: { prompt?: string; content?: string; label?: string; status?: string; errorMessage?: string }
 }>()
 
 const nodeId = useNodeId()
@@ -20,6 +21,10 @@ const preview = computed(() => {
   if (c) return c.length > 180 ? `${c.slice(0, 180)}…` : c
   return ''
 })
+
+const isError = computed(
+  () => props.data.status === NODE_GENERATION_STATUS.error || props.data.status === 'error',
+)
 
 function openEditor() {
   draft.value = String(props.data.content ?? '')
@@ -42,6 +47,9 @@ function onSave(md: string) {
         <p class="text-[11px] text-white/35">双击编辑文本</p>
         <p v-if="data.prompt" class="mt-1 line-clamp-2 text-[11px] text-white/40">{{ data.prompt }}</p>
       </template>
+      <p v-if="isError && data.errorMessage" class="mt-1 line-clamp-2 text-[10px] text-red-400/90">
+        {{ data.errorMessage }}
+      </p>
     </div>
     <PromptMarkdownEditor
       v-model:visible="editorOpen"

--- a/apps/web/src/components/canvas/CanvasNodePrompt.vue
+++ b/apps/web/src/components/canvas/CanvasNodePrompt.vue
@@ -1,16 +1,52 @@
 <script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useNodeId, useVueFlow } from '@vue-flow/core'
 import NeoBaseNode from '@/components/canvas/NeoBaseNode.vue'
+import PromptMarkdownEditor from '@/components/canvas/PromptMarkdownEditor.vue'
 
-defineProps<{
+const props = defineProps<{
   selected?: boolean
-  data: { prompt: string; status?: string; label?: string }
+  data: { prompt?: string; content?: string; label?: string; status?: string }
 }>()
+
+const nodeId = useNodeId()
+const { updateNodeData } = useVueFlow()
+
+const editorOpen = ref(false)
+const draft = ref('')
+
+const preview = computed(() => {
+  const c = String(props.data.content ?? '').trim()
+  if (c) return c.length > 180 ? `${c.slice(0, 180)}…` : c
+  return ''
+})
+
+function openEditor() {
+  draft.value = String(props.data.content ?? '')
+  editorOpen.value = true
+}
+
+function onSave(md: string) {
+  updateNodeData(nodeId, { content: md })
+}
 </script>
 
 <template>
   <NeoBaseNode node-type="prompt" :selected="selected" :data="data" :status="data.status">
-    <div class="neo-text-card">
-      <p>{{ data.prompt || '点击下方 Dock Studio 编辑...' }}</p>
+    <div class="neo-text-card" @dblclick.stop="openEditor">
+      <template v-if="preview">
+        <p class="whitespace-pre-wrap text-left text-[12px] leading-relaxed text-white/80">{{ preview }}</p>
+      </template>
+      <template v-else>
+        <p>输入需求生成提示词</p>
+        <p class="text-[11px] text-white/35">双击编辑文本</p>
+        <p v-if="data.prompt" class="mt-1 line-clamp-2 text-[11px] text-white/40">{{ data.prompt }}</p>
+      </template>
     </div>
+    <PromptMarkdownEditor
+      v-model:visible="editorOpen"
+      v-model="draft"
+      @save="onSave"
+    />
   </NeoBaseNode>
 </template>

--- a/apps/web/src/components/canvas/NodeEditorToolbar.vue
+++ b/apps/web/src/components/canvas/NodeEditorToolbar.vue
@@ -84,25 +84,27 @@ function toggleVoice() {
       />
     </div>
 
-    <div class="bottom-toolbar-actions">
-      <button
-        type="button"
-        class="dock-icon-btn"
-        :class="speech.listening.value ? 'animate-pulse text-red-400' : ''"
-        title="语音输入"
-        @click="toggleVoice"
-      >
-        🎤
-      </button>
+    <div class="bottom-toolbar-actions flex-wrap items-center">
+      <div class="ml-auto flex items-center gap-2">
+        <button
+          type="button"
+          class="dock-icon-btn"
+          :class="speech.listening.value ? 'animate-pulse text-red-400' : ''"
+          title="语音输入"
+          @click="toggleVoice"
+        >
+          🎤
+        </button>
 
-      <button
-        type="button"
-        class="btn-primary ml-auto px-4 py-1.5 text-xs"
-        :disabled="!prompt.trim() || generating"
-        @click="onGenerate"
-      >
-        {{ generating ? '保存中...' : '应用' }}
-      </button>
+        <button
+          type="button"
+          class="btn-primary px-4 py-1.5 text-xs"
+          :disabled="!prompt.trim() || generating"
+          @click="onGenerate"
+        >
+          {{ generating ? '保存中...' : '应用' }}
+        </button>
+      </div>
     </div>
   </div>
 </template>

--- a/apps/web/src/components/canvas/NodePanelDock.vue
+++ b/apps/web/src/components/canvas/NodePanelDock.vue
@@ -4,6 +4,7 @@ import { CANVAS_DOCK_MENU_ITEMS } from '@/components/canvas/canvasDockMenu'
 
 export type DockNodeType =
   | 'text'
+  | 'prompt'
   | 'image'
   | 'video'
   | 'audio'

--- a/apps/web/src/components/canvas/PromptMarkdownEditor.css
+++ b/apps/web/src/components/canvas/PromptMarkdownEditor.css
@@ -1,0 +1,178 @@
+.prompt-md-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(6px);
+}
+
+.prompt-md-modal {
+  display: flex;
+  flex-direction: column;
+  width: min(920px, 100%);
+  max-height: min(85vh, 720px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  background: #1a1a1e;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.55);
+  overflow: hidden;
+}
+
+.prompt-md-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(0, 0, 0, 0.25);
+}
+
+.prompt-md-format-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+}
+
+.prompt-md-format-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  height: 28px;
+  padding: 0 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 11px;
+  font-weight: 600;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.prompt-md-format-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+}
+
+.prompt-md-format-btn.is-active {
+  border-color: rgba(99, 102, 241, 0.55);
+  background: rgba(99, 102, 241, 0.18);
+  color: #a5b4fc;
+}
+
+.prompt-md-spacer {
+  flex: 1;
+  min-width: 12px;
+}
+
+.prompt-md-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.prompt-md-actions .dock-icon-btn {
+  display: inline-flex;
+  min-width: 28px;
+  height: 28px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 6px;
+  border: none;
+  border-radius: 16px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.7);
+  transition: all 0.2s ease;
+}
+
+.prompt-md-actions .dock-icon-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+}
+
+.prompt-md-editor {
+  flex: 1;
+  min-height: 360px;
+  overflow-y: auto;
+  padding: 16px 20px;
+}
+
+.prompt-md-editor .tiptap {
+  min-height: 320px;
+  outline: none;
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 14px;
+  line-height: 1.65;
+}
+
+.prompt-md-editor .tiptap p.is-editor-empty:first-child::before {
+  color: rgba(255, 255, 255, 0.35);
+  content: attr(data-placeholder);
+  float: left;
+  height: 0;
+  pointer-events: none;
+}
+
+.prompt-md-editor .tiptap h1 {
+  margin: 0.6em 0 0.4em;
+  font-size: 1.6em;
+  font-weight: 700;
+}
+
+.prompt-md-editor .tiptap h2 {
+  margin: 0.55em 0 0.35em;
+  font-size: 1.35em;
+  font-weight: 650;
+}
+
+.prompt-md-editor .tiptap h3 {
+  margin: 0.5em 0 0.3em;
+  font-size: 1.15em;
+  font-weight: 600;
+}
+
+.prompt-md-editor .tiptap ul,
+.prompt-md-editor .tiptap ol {
+  margin: 0.4em 0;
+  padding-left: 1.4em;
+}
+
+.prompt-md-editor .tiptap hr {
+  margin: 1em 0;
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.prompt-md-editor .tiptap strong {
+  font-weight: 700;
+}
+
+.prompt-md-editor .tiptap em {
+  font-style: italic;
+}
+
+.prompt-md-btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.06);
+  padding: 6px 14px;
+  font-size: 12px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.82);
+  transition: background 0.15s, color 0.15s;
+}
+
+.prompt-md-btn-secondary:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+}

--- a/apps/web/src/components/canvas/PromptMarkdownEditor.vue
+++ b/apps/web/src/components/canvas/PromptMarkdownEditor.vue
@@ -56,20 +56,20 @@ function ensureEditor() {
 
 watch(
   () => props.visible,
-  (v) => {
+  (v, wasVisible) => {
     if (v) {
       ensureEditor()
       editor.value?.commands.setContent(props.modelValue || '')
       setTimeout(() => editor.value?.commands.focus('end'), 50)
     } else {
       speech.stop()
+      if (wasVisible) flushSave()
     }
   },
 )
 
 function close() {
   speech.stop()
-  flushSave()
   emit('update:visible', false)
 }
 

--- a/apps/web/src/components/canvas/PromptMarkdownEditor.vue
+++ b/apps/web/src/components/canvas/PromptMarkdownEditor.vue
@@ -1,0 +1,195 @@
+<script setup lang="ts">
+import { watch, onBeforeUnmount, shallowRef } from 'vue'
+import { EditorContent, Editor } from '@tiptap/vue-3'
+import StarterKit from '@tiptap/starter-kit'
+import Placeholder from '@tiptap/extension-placeholder'
+import Typography from '@tiptap/extension-typography'
+import { Markdown } from 'tiptap-markdown'
+import type { MarkdownStorage } from 'tiptap-markdown'
+import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
+import './PromptMarkdownEditor.css'
+
+const props = defineProps<{ visible: boolean; modelValue: string }>()
+const emit = defineEmits<{
+  'update:visible': [boolean]
+  'update:modelValue': [string]
+  save: [string]
+}>()
+
+const speech = useSpeechRecognition()
+const editor = shallowRef<Editor>()
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+
+function getMarkdown(): string {
+  const storage = editor.value?.storage as { markdown?: MarkdownStorage } | undefined
+  return storage?.markdown?.getMarkdown?.() ?? ''
+}
+
+function flushSave() {
+  if (saveTimer) {
+    clearTimeout(saveTimer)
+    saveTimer = null
+  }
+  const md = getMarkdown()
+  emit('update:modelValue', md)
+  emit('save', md)
+}
+
+function scheduleSave() {
+  if (saveTimer) clearTimeout(saveTimer)
+  saveTimer = setTimeout(flushSave, 400)
+}
+
+function ensureEditor() {
+  if (editor.value) return
+  editor.value = new Editor({
+    extensions: [
+      StarterKit,
+      Typography,
+      Placeholder.configure({ placeholder: '输入或生成提示词内容...' }),
+      Markdown.configure({ html: false }),
+    ],
+    content: props.modelValue || '',
+    onUpdate: () => scheduleSave(),
+  })
+}
+
+watch(
+  () => props.visible,
+  (v) => {
+    if (v) {
+      ensureEditor()
+      editor.value?.commands.setContent(props.modelValue || '')
+      setTimeout(() => editor.value?.commands.focus('end'), 50)
+    } else {
+      speech.stop()
+    }
+  },
+)
+
+function close() {
+  speech.stop()
+  flushSave()
+  emit('update:visible', false)
+}
+
+function copyAll() {
+  void navigator.clipboard.writeText(getMarkdown())
+}
+
+function toggleVoice() {
+  if (speech.listening.value) {
+    speech.stop()
+    return
+  }
+  speech.start((text, isFinal) => {
+    if (!isFinal || !editor.value) return
+    editor.value.chain().focus().insertContent(text).run()
+    scheduleSave()
+  })
+}
+
+function isActive(name: string, attrs?: Record<string, unknown>) {
+  return editor.value?.isActive(name, attrs) ?? false
+}
+
+onBeforeUnmount(() => {
+  speech.stop()
+  if (saveTimer) clearTimeout(saveTimer)
+  editor.value?.destroy()
+  editor.value = undefined
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="visible" class="prompt-md-overlay" @click.self="close">
+      <div class="prompt-md-modal" @click.stop>
+        <div class="prompt-md-toolbar">
+          <div class="prompt-md-format-group">
+            <button
+              type="button"
+              class="prompt-md-format-btn"
+              :class="{ 'is-active': isActive('heading', { level: 1 }) }"
+              title="标题 1"
+              @click="editor?.chain().focus().toggleHeading({ level: 1 }).run()"
+            >
+              H1
+            </button>
+            <button
+              type="button"
+              class="prompt-md-format-btn"
+              :class="{ 'is-active': isActive('heading', { level: 2 }) }"
+              title="标题 2"
+              @click="editor?.chain().focus().toggleHeading({ level: 2 }).run()"
+            >
+              H2
+            </button>
+            <button
+              type="button"
+              class="prompt-md-format-btn"
+              :class="{ 'is-active': isActive('heading', { level: 3 }) }"
+              title="标题 3"
+              @click="editor?.chain().focus().toggleHeading({ level: 3 }).run()"
+            >
+              H3
+            </button>
+            <button
+              type="button"
+              class="prompt-md-format-btn"
+              :class="{ 'is-active': isActive('bold') }"
+              title="粗体"
+              @click="editor?.chain().focus().toggleBold().run()"
+            >
+              B
+            </button>
+            <button
+              type="button"
+              class="prompt-md-format-btn"
+              :class="{ 'is-active': isActive('italic') }"
+              title="斜体"
+              @click="editor?.chain().focus().toggleItalic().run()"
+            >
+              I
+            </button>
+            <button
+              type="button"
+              class="prompt-md-format-btn"
+              :class="{ 'is-active': isActive('bulletList') }"
+              title="无序列表"
+              @click="editor?.chain().focus().toggleBulletList().run()"
+            >
+              •
+            </button>
+            <button
+              type="button"
+              class="prompt-md-format-btn"
+              title="分隔线"
+              @click="editor?.chain().focus().setHorizontalRule().run()"
+            >
+              —
+            </button>
+          </div>
+
+          <div class="prompt-md-spacer" />
+
+          <div class="prompt-md-actions">
+            <button
+              type="button"
+              class="dock-icon-btn"
+              title="语音输入"
+              :class="speech.listening.value ? 'animate-pulse text-red-400' : ''"
+              @click="toggleVoice"
+            >
+              🎤
+            </button>
+            <button type="button" class="btn-primary text-xs" @click="copyAll">复制</button>
+            <button type="button" class="prompt-md-btn-secondary" @click="close">关闭</button>
+          </div>
+        </div>
+
+        <EditorContent :editor="editor" class="prompt-md-editor" />
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/apps/web/src/components/canvas/canvasDockMenu.ts
+++ b/apps/web/src/components/canvas/canvasDockMenu.ts
@@ -9,6 +9,7 @@ export interface CanvasDockMenuItem {
 }
 
 export const CANVAS_DOCK_MENU_ITEMS: CanvasDockMenuItem[] = [
+  { type: 'prompt', label: '提示词', desc: '多模式提示词扩写', badge: 'Prompt', tone: 'text-fuchsia-300 bg-fuchsia-500/15' },
   { type: 'text', label: '文本', desc: '脚本、广告词、品牌文案', badge: 'Neo-G', tone: 'text-sky-300 bg-sky-500/15' },
   { type: 'image', label: '图片', desc: 'AI 图像生成', badge: 'Image', tone: 'text-emerald-300 bg-emerald-500/15' },
   { type: 'video', label: '视频', desc: '文生视频 / 图生视频', tone: 'text-violet-300 bg-violet-500/15' },
@@ -24,6 +25,7 @@ export const CANVAS_DOCK_MENU_ITEMS: CanvasDockMenuItem[] = [
 /** 从源节点拖出连线时可创建的目标类型（简化规则，后续可按 Neo 细化） */
 export const CONNECT_OUT_TARGET_TYPES: DockNodeType[] = [
   'text',
+  'prompt',
   'image',
   'video',
   'audio',

--- a/apps/web/src/components/canvas/dock-studio/DockStudioRouter.vue
+++ b/apps/web/src/components/canvas/dock-studio/DockStudioRouter.vue
@@ -4,6 +4,7 @@ import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
 import type { MentionOption } from '@/components/canvas/MentionInput.vue'
 import TextDockPanel from '@/components/canvas/dock-studio/panels/TextDockPanel.vue'
+import PromptDockPanel from '@/components/canvas/dock-studio/panels/PromptDockPanel.vue'
 import ImageDockPanel from '@/components/canvas/dock-studio/panels/ImageDockPanel.vue'
 import VideoDockPanel from '@/components/canvas/dock-studio/panels/VideoDockPanel.vue'
 import AudioDockPanel from '@/components/canvas/dock-studio/panels/AudioDockPanel.vue'
@@ -58,6 +59,16 @@ const panelBindings = {
     :mentions="mentions"
     :generating="generating"
     :readonly="dockReadonly"
+    @patch="panelBindings.patch"
+    @generate="panelBindings.generate"
+    @close="panelBindings.close"
+  />
+  <PromptDockPanel
+    v-else-if="node && nodeType === 'prompt'"
+    :node="node"
+    :upstream="upstream"
+    :mentions="mentions"
+    :generating="generating"
     @patch="panelBindings.patch"
     @generate="panelBindings.generate"
     @close="panelBindings.close"

--- a/apps/web/src/components/canvas/dock-studio/panels/AudioDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/AudioDockPanel.vue
@@ -138,23 +138,25 @@ function toggleVoice() {
         @update:model-value="syncVoiceSettings"
       />
 
-      <button
-        type="button"
-        class="dock-icon-btn"
-        :class="speech.listening.value ? 'animate-pulse text-red-400' : ''"
-        title="语音输入"
-        :disabled="readonly"
-        @click="toggleVoice"
-      >
-        🎤
-      </button>
+      <div class="ml-auto flex items-center gap-2">
+        <button
+          type="button"
+          class="dock-icon-btn"
+          :class="speech.listening.value ? 'animate-pulse text-red-400' : ''"
+          title="语音输入"
+          :disabled="readonly"
+          @click="toggleVoice"
+        >
+          🎤
+        </button>
 
-      <DockGenerateButton
-        :generating="generating"
-        :disabled="!prompt.trim() && !upstream.textPrompt.trim()"
-        label="生成音频"
-        @generate="onGenerate"
-      />
+        <DockGenerateButton
+          :generating="generating"
+          :disabled="!prompt.trim() && !upstream.textPrompt.trim()"
+          label="生成音频"
+          @generate="onGenerate"
+        />
+      </div>
     </div>
   </DockToolbarShell>
 </template>

--- a/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
@@ -128,7 +128,7 @@ function clearReferenceImage() {
       @submit="onGenerate"
     />
 
-    <div class="bottom-toolbar-actions">
+    <div class="bottom-toolbar-actions flex-wrap items-center">
       <UniversalModelSelector
         v-model="imageModel"
         type="image"
@@ -166,22 +166,24 @@ function clearReferenceImage() {
         <input ref="refInput" type="file" accept="image/*" class="hidden" @change="onRefFileChange">
       </div>
 
-      <button
-        type="button"
-        class="dock-icon-btn"
-        :class="speech.listening.value ? 'animate-pulse text-red-400' : ''"
-        title="语音输入"
-        :disabled="readonly"
-        @click="toggleVoice"
-      >
-        🎤
-      </button>
+      <div class="ml-auto flex items-center gap-2">
+        <button
+          type="button"
+          class="dock-icon-btn"
+          :class="speech.listening.value ? 'animate-pulse text-red-400' : ''"
+          title="语音输入"
+          :disabled="readonly"
+          @click="toggleVoice"
+        >
+          🎤
+        </button>
 
-      <DockGenerateButton
-        :generating="generating"
-        :disabled="!prompt.trim()"
-        @generate="onGenerate"
-      />
+        <DockGenerateButton
+          :generating="generating"
+          :disabled="!prompt.trim()"
+          @generate="onGenerate"
+        />
+      </div>
     </div>
   </DockToolbarShell>
 </template>

--- a/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
@@ -11,6 +11,15 @@ import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
 import { useModelProviderSettings } from '@/composables/useModelProviderSettings'
 import { isNodeGenerating } from '@/constants/dockStudio'
 
+const MODE_LABELS: Record<string, string> = {
+  image_prompt_multi_style: '多风格绘画提示词',
+  character_turnaround: '人物三视图',
+  storyboard: '分镜提示词',
+  script: '剧本',
+  copywriting: '文案/旁白',
+  generic: '通用创作',
+}
+
 const { getConfig } = useModelProviderSettings()
 
 const props = defineProps<{
@@ -34,6 +43,11 @@ const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!p
 const promptMode = computed(() => {
   const mode = props.node.data?.promptMode
   return mode ? String(mode) : ''
+})
+
+const promptModeLabel = computed(() => {
+  const mode = promptMode.value
+  return mode ? (MODE_LABELS[mode] ?? mode) : ''
 })
 
 function syncFromNode() {
@@ -96,10 +110,10 @@ function toggleVoice() {
         @update:model-value="emit('patch', { textModel: $event })"
       />
       <span
-        v-if="promptMode"
+        v-if="promptModeLabel"
         class="rounded-md bg-fuchsia-500/15 px-2 py-0.5 text-[10px] text-fuchsia-300"
       >
-        {{ promptMode }}
+        {{ promptModeLabel }}
       </span>
 
       <div class="ml-auto flex items-center gap-2">

--- a/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
@@ -102,23 +102,25 @@ function toggleVoice() {
         {{ promptMode }}
       </span>
 
-      <button
-        type="button"
-        class="dock-icon-btn"
-        :class="speech.listening.value ? 'animate-pulse text-red-400' : ''"
-        title="语音输入"
-        :disabled="readonly"
-        @click="toggleVoice"
-      >
-        🎤
-      </button>
+      <div class="ml-auto flex items-center gap-2">
+        <button
+          type="button"
+          class="dock-icon-btn"
+          :class="speech.listening.value ? 'animate-pulse text-red-400' : ''"
+          title="语音输入"
+          :disabled="readonly"
+          @click="toggleVoice"
+        >
+          🎤
+        </button>
 
-      <DockGenerateButton
-        :generating="generating"
-        :disabled="!prompt.trim()"
-        label="生成提示词"
-        @generate="onGenerate"
-      />
+        <DockGenerateButton
+          :generating="generating"
+          :disabled="!prompt.trim()"
+          label="生成提示词"
+          @generate="onGenerate"
+        />
+      </div>
     </div>
   </DockToolbarShell>
 </template>

--- a/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
@@ -1,0 +1,124 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
+import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
+import type { MentionOption } from '@/components/canvas/MentionInput.vue'
+import UniversalModelSelector from '@/components/canvas/UniversalModelSelector.vue'
+import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
+import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
+import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
+import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
+import { useModelProviderSettings } from '@/composables/useModelProviderSettings'
+import { isNodeGenerating } from '@/constants/dockStudio'
+
+const { getConfig } = useModelProviderSettings()
+
+const props = defineProps<{
+  node: EditableFlowNode
+  upstream: UpstreamNodeContext
+  mentions?: MentionOption[]
+  generating?: boolean
+}>()
+
+const emit = defineEmits<{
+  patch: [patch: Record<string, unknown>]
+  generate: []
+  close: []
+}>()
+
+const prompt = ref('')
+const textModel = ref(getConfig('text').model)
+
+const speech = useSpeechRecognition()
+const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
+const promptMode = computed(() => {
+  const mode = props.node.data?.promptMode
+  return mode ? String(mode) : ''
+})
+
+function syncFromNode() {
+  const data = props.node.data ?? {}
+  prompt.value = String(data.prompt ?? '')
+  textModel.value = String(data.textModel ?? getConfig('text').model)
+}
+
+watch(() => props.node, syncFromNode, { immediate: true, deep: true })
+
+watch(
+  () => props.upstream,
+  (ctx) => {
+    if (!prompt.value.trim() && ctx.textPrompt) {
+      prompt.value = ctx.textPrompt
+      emit('patch', { prompt: ctx.textPrompt })
+    }
+  },
+  { immediate: true },
+)
+
+function onPromptInput(value: string) {
+  prompt.value = value
+  emit('patch', { prompt: value })
+}
+
+function onGenerate() {
+  emit('patch', { prompt: prompt.value, textModel: textModel.value })
+  emit('generate')
+}
+
+function toggleVoice() {
+  if (speech.listening.value) {
+    speech.stop()
+    return
+  }
+  speech.start((text, isFinal) => {
+    if (isFinal) {
+      const next = prompt.value ? `${prompt.value} ${text}` : text
+      onPromptInput(next)
+    }
+  })
+}
+</script>
+
+<template>
+  <DockToolbarShell type-label="提示词" @close="emit('close')">
+    <DockPromptSection
+      :model-value="prompt"
+      :mentions="mentions"
+      placeholder="描述创作需求，生成结构化提示词..."
+      @update:model-value="onPromptInput"
+      @submit="onGenerate"
+    />
+
+    <div class="bottom-toolbar-actions flex-wrap">
+      <UniversalModelSelector
+        v-model="textModel"
+        type="text"
+        @update:model-value="emit('patch', { textModel: $event })"
+      />
+      <span
+        v-if="promptMode"
+        class="rounded-md bg-fuchsia-500/15 px-2 py-0.5 text-[10px] text-fuchsia-300"
+      >
+        {{ promptMode }}
+      </span>
+
+      <button
+        type="button"
+        class="dock-icon-btn"
+        :class="speech.listening.value ? 'animate-pulse text-red-400' : ''"
+        title="语音输入"
+        :disabled="readonly"
+        @click="toggleVoice"
+      >
+        🎤
+      </button>
+
+      <DockGenerateButton
+        :generating="generating"
+        :disabled="!prompt.trim()"
+        label="生成提示词"
+        @generate="onGenerate"
+      />
+    </div>
+  </DockToolbarShell>
+</template>

--- a/apps/web/src/components/canvas/dock-studio/panels/ShotDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ShotDockPanel.vue
@@ -154,22 +154,24 @@ function toggleVoice() {
         @optimized="onOptimized"
       />
 
-      <button
-        type="button"
-        class="dock-icon-btn"
-        :class="speech.listening.value ? 'animate-pulse text-red-400' : ''"
-        title="语音输入"
-        :disabled="readonly"
-        @click="toggleVoice"
-      >
-        🎤
-      </button>
+      <div class="ml-auto flex items-center gap-2">
+        <button
+          type="button"
+          class="dock-icon-btn"
+          :class="speech.listening.value ? 'animate-pulse text-red-400' : ''"
+          title="语音输入"
+          :disabled="readonly"
+          @click="toggleVoice"
+        >
+          🎤
+        </button>
 
-      <DockGenerateButton
-        :generating="generating"
-        :disabled="!prompt.trim()"
-        @generate="onGenerate"
-      />
+        <DockGenerateButton
+          :generating="generating"
+          :disabled="!prompt.trim()"
+          @generate="onGenerate"
+        />
+      </div>
     </div>
   </DockToolbarShell>
 </template>

--- a/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
@@ -106,23 +106,25 @@ function toggleVoice() {
       />
       <span class="text-[10px] text-white/35">{{ wordCount }} 字</span>
 
-      <button
-        type="button"
-        class="dock-icon-btn"
-        :class="speech.listening.value ? 'animate-pulse text-red-400' : ''"
-        title="语音输入"
-        :disabled="readonly"
-        @click="toggleVoice"
-      >
-        🎤
-      </button>
+      <div class="ml-auto flex items-center gap-2">
+        <button
+          type="button"
+          class="dock-icon-btn"
+          :class="speech.listening.value ? 'animate-pulse text-red-400' : ''"
+          title="语音输入"
+          :disabled="readonly"
+          @click="toggleVoice"
+        >
+          🎤
+        </button>
 
-      <DockGenerateButton
-        :generating="generating"
-        :disabled="!content.trim()"
-        label="生成文案"
-        @generate="onGenerate"
-      />
+        <DockGenerateButton
+          :generating="generating"
+          :disabled="!content.trim()"
+          label="生成文案"
+          @generate="onGenerate"
+        />
+      </div>
     </div>
   </DockToolbarShell>
 </template>

--- a/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
@@ -213,22 +213,24 @@ function clearReferenceImage() {
         </div>
       </template>
 
-      <button
-        type="button"
-        class="dock-icon-btn"
-        :class="speech.listening.value ? 'animate-pulse text-red-400' : ''"
-        title="语音输入"
-        :disabled="readonly"
-        @click="toggleVoice"
-      >
-        🎤
-      </button>
+      <div class="ml-auto flex items-center gap-2">
+        <button
+          type="button"
+          class="dock-icon-btn"
+          :class="speech.listening.value ? 'animate-pulse text-red-400' : ''"
+          title="语音输入"
+          :disabled="readonly"
+          @click="toggleVoice"
+        >
+          🎤
+        </button>
 
-      <DockGenerateButton
-        :generating="generating"
-        :disabled="!prompt.trim() || (videoMode === 'image_to_video' && !effectiveRefUrl)"
-        @generate="onGenerate"
-      />
+        <DockGenerateButton
+          :generating="generating"
+          :disabled="!prompt.trim() || (videoMode === 'image_to_video' && !effectiveRefUrl)"
+          @generate="onGenerate"
+        />
+      </div>
     </div>
   </DockToolbarShell>
 </template>

--- a/apps/web/src/composables/useGenerationPolling.ts
+++ b/apps/web/src/composables/useGenerationPolling.ts
@@ -64,6 +64,19 @@ export function useGenerationPolling(
   return { start, stop, clearTasks }
 }
 
+export function parseRecordPromptContent(record: { metadata?: string | null; prompt: string }) {
+  if (!record.metadata) return { content: record.prompt, mode: null as string | null }
+  try {
+    const meta = JSON.parse(record.metadata) as { content?: string; mode?: string; text?: string }
+    return {
+      content: meta.content ?? meta.text ?? record.prompt,
+      mode: meta.mode ?? null,
+    }
+  } catch {
+    return { content: record.prompt, mode: null }
+  }
+}
+
 export function parseRecordText(record: { metadata?: string | null; prompt: string }) {
   if (!record.metadata) return record.prompt
   try {

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -10,7 +10,12 @@ import {
   resolveVideoMode,
   type CanvasEdgeLike,
 } from '@/composables/useUpstreamNodeContext'
-import { parseRecordText, parseRecordUrl, type GenerationPollTask } from '@/composables/useGenerationPolling'
+import {
+  parseRecordPromptContent,
+  parseRecordText,
+  parseRecordUrl,
+  type GenerationPollTask,
+} from '@/composables/useGenerationPolling'
 import { canvasApi } from '@/services/canvas-api'
 import { studioApi } from '@/services/studio-api'
 import type { CompositionTrack } from '@/utils/compositionUpstream'
@@ -73,6 +78,26 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     generating.value = true
 
     try {
+      if (nodeType === 'prompt') {
+        const userPrompt = String(data.prompt ?? '').trim() || prompt
+        if (!userPrompt) return
+        deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating })
+        const models = deps.resolveProviderModels()
+        const { data: res } = await studioApi.generatePrompt(
+          userPrompt,
+          String(data.textModel ?? models.text),
+        )
+        const parsed = parseRecordPromptContent(res.data)
+        deps.patchNodeData(node.id, {
+          content: parsed.content,
+          promptMode: parsed.mode,
+          status: NODE_GENERATION_STATUS.completed,
+          errorMessage: null,
+        })
+        await deps.saveCanvas()
+        return
+      }
+
       if (nodeType === 'text') {
         deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating, content: prompt, prompt })
         const models = deps.resolveProviderModels()

--- a/apps/web/src/composables/useUpstreamNodeContext.ts
+++ b/apps/web/src/composables/useUpstreamNodeContext.ts
@@ -19,6 +19,10 @@ export interface UpstreamNodeContext {
 
 function nodeTextContent(node: EditableFlowNode): string {
   const data = node.data ?? {}
+  const type = String(node.type ?? '')
+  if (type === 'prompt') {
+    return String(data.content ?? data.prompt ?? '').trim()
+  }
   return String(data.content ?? data.prompt ?? '').trim()
 }
 

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -447,6 +447,9 @@ function createNodeAt(type: DockNodeType, position: { x: number; y: number }) {
     case 'text':
       id = addNode('text', { content: '', status: 'idle', textModel }, { position })
       break
+    case 'prompt':
+      id = addNode('prompt', { prompt: '', label: '提示词', status: 'idle', textModel }, { position })
+      break
     case 'image':
       id = addNode('image', { url: '', status: 'idle', prompt: '', imageModel }, { position })
       break

--- a/apps/web/src/services/studio-api.ts
+++ b/apps/web/src/services/studio-api.ts
@@ -29,6 +29,8 @@ export const studioApi = {
     api.post<{ data: GenerationRecord }>('/studio/image/variation', { prompt, basePrompt, model }, { timeout: 120_000 }),
   generateText: (prompt: string, model?: string) =>
     api.post<{ data: GenerationRecord }>('/studio/text/generate', { prompt, model }, { timeout: 90_000 }),
+  generatePrompt: (prompt: string, model?: string) =>
+    api.post<{ data: GenerationRecord }>('/studio/prompt/generate', { prompt, model }, { timeout: 90_000 }),
   generateVideo: (prompt: string, model?: string, duration?: number, aspectRatio?: string) =>
     api.post<{ data: GenerationRecord }>('/studio/video/generate', { prompt, model, duration, aspectRatio }, { timeout: 60_000 }),
   generateAudio: (text: string, options?: AudioGenerateOptions) =>

--- a/docs/superpowers/plans/2026-07-17-prompt-node-intent-templates.md
+++ b/docs/superpowers/plans/2026-07-17-prompt-node-intent-templates.md
@@ -1,0 +1,845 @@
+# Prompt 节点意图路由 + 多模式模板 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让画布 `prompt` 节点支持「短需求 → 意图分类 → 模式最佳实践长文 Markdown」，双击 TipTap 编辑（含语音），Dock 语音紧贴生成按钮。
+
+**Architecture:** `@lnkpi/agent` 内建模式注册表 + 两段式 LLM（classify → generate）；Nest `POST /studio/prompt/generate` 记账落库；前端 `PromptDockPanel` + `useNodeGeneration` prompt 分支 + `PromptMarkdownEditor`；现有 Dock 统一 🎤 紧贴提交按钮。
+
+**Tech Stack:** Vue 3, TypeScript, NestJS, Prisma, Vitest, TipTap (`@tiptap/vue-3` + starter-kit + markdown), `useSpeechRecognition`, OpenAI-compatible `chat/completions`
+
+**Spec:** `docs/superpowers/specs/2026-07-17-prompt-node-intent-templates-design.md`
+
+## Global Constraints
+
+- 仅改造 `prompt` 节点；`text` 节点 `/studio/text/generate` 行为不变
+- `prompt`（用户短需求）与 `content`（生成长文）严格分离，输入时禁止同步为同一字符串
+- 第一期纯 LLM 分类；`tryRuleShortcut` 钩子恒返回 `null`
+- 积分 5 点；前端超时 90s
+- 第一期不做节点 resize；Markdown / 全 Dock 必须有语音，🎤 紧贴生成/关闭主按钮
+- 无 `OPENAI_API_KEY` 时按 mode 返回 Placeholder 长文，禁止 echo `prompt`
+- 提交前本地：`pnpm --filter @lnkpi/agent test`；涉及 web 时 `pnpm --filter @lnkpi/web build`（或 monorepo `pnpm build`）
+
+---
+
+## File Structure Map
+
+| 路径 | 职责 |
+|------|------|
+| `packages/agent/src/prompt-modes/types.ts` | ModeId、PromptModeDefinition 类型 |
+| `packages/agent/src/prompt-modes/registry.ts` | 6 模式注册表 + `getPromptMode` |
+| `packages/agent/src/prompt-modes/modes/*.ts` | 各模式 system / fewShot / placeholder / classifyHints |
+| `packages/agent/src/prompt-modes/classify.ts` | Call-1 分类 + `tryRuleShortcut` 钩子 |
+| `packages/agent/src/prompt-modes/generate.ts` | Call-2 生成 + 无 Key Placeholder |
+| `packages/agent/src/prompt-modes/index.ts` | 对外导出 |
+| `packages/agent/src/prompt-modes/*.test.ts` | 单元测试 |
+| `packages/agent/src/index.ts` | re-export |
+| `apps/server/src/studio/studio.service.ts` | `generatePrompt` |
+| `apps/server/src/studio/studio.controller.ts` | `POST prompt/generate` |
+| `apps/web/src/services/studio-api.ts` | `generatePrompt` |
+| `apps/web/src/composables/useGenerationPolling.ts` | `parseRecordPromptContent` |
+| `apps/web/src/composables/useNodeGeneration.ts` | `prompt` 分支 |
+| `apps/web/src/composables/useUpstreamNodeContext.ts` | prompt 节点优先 `content` |
+| `apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue` | Prompt Dock |
+| `apps/web/src/components/canvas/dock-studio/DockStudioRouter.vue` | 路由到 PromptDockPanel |
+| `apps/web/src/components/canvas/PromptMarkdownEditor.vue` | TipTap 弹窗 + 语音 |
+| `apps/web/src/components/canvas/CanvasNodePrompt.vue` | 预览 + 双击打开编辑器 |
+| `apps/web/src/components/canvas/canvasDockMenu.ts` | 菜单增加 prompt |
+| `apps/web/src/components/canvas/NodePanelDock.vue` | DockNodeType 含 prompt |
+| `apps/web/src/components/canvas/dock-studio/panels/*DockPanel.vue` | 🎤 紧贴生成按钮 |
+| `apps/web/package.json` | TipTap 依赖 |
+
+---
+
+### Task 1: 模式类型、注册表与分类/生成核心（agent 包）
+
+**Files:**
+- Create: `packages/agent/src/prompt-modes/types.ts`
+- Create: `packages/agent/src/prompt-modes/registry.ts`
+- Create: `packages/agent/src/prompt-modes/modes/image-prompt-multi-style.ts`
+- Create: `packages/agent/src/prompt-modes/modes/character-turnaround.ts`
+- Create: `packages/agent/src/prompt-modes/modes/storyboard.ts`
+- Create: `packages/agent/src/prompt-modes/modes/script.ts`
+- Create: `packages/agent/src/prompt-modes/modes/copywriting.ts`
+- Create: `packages/agent/src/prompt-modes/modes/generic.ts`
+- Create: `packages/agent/src/prompt-modes/classify.ts`
+- Create: `packages/agent/src/prompt-modes/generate.ts`
+- Create: `packages/agent/src/prompt-modes/index.ts`
+- Create: `packages/agent/src/prompt-modes/classify.test.ts`
+- Create: `packages/agent/src/prompt-modes/generate.test.ts`
+- Modify: `packages/agent/src/index.ts`
+
+**Interfaces:**
+- Produces:
+  - `export type PromptModeId = 'image_prompt_multi_style' | 'character_turnaround' | 'storyboard' | 'script' | 'copywriting' | 'generic'`
+  - `export interface PromptModeDefinition { id: PromptModeId; label: string; classifyHints: string; system: string; fewShot: { user: string; assistant: string }; placeholder: (prompt: string) => string }`
+  - `export function tryRuleShortcut(_prompt: string): PromptModeId | null` → 一期恒 `null`
+  - `export async function classifyPromptMode(prompt: string, opts?: { apiKey?: string; baseUrl?: string; model?: string }): Promise<{ mode: PromptModeId; confidence: number }>`
+  - `export async function generatePromptContent(prompt: string, mode: PromptModeId, opts?: { apiKey?: string; baseUrl?: string; model?: string }): Promise<{ mode: PromptModeId; content: string }>`
+  - `export async function generatePromptFromUserInput(prompt: string, opts?: ...): Promise<{ mode: PromptModeId; content: string }>`（内部 classify → generate）
+
+- [ ] **Step 1: 写分类失败测试（无 Key 走启发式占位选 mode）**
+
+Create `packages/agent/src/prompt-modes/classify.test.ts`:
+
+```ts
+import { describe, it, expect, afterEach } from 'vitest'
+import { tryRuleShortcut, classifyPromptMode } from './classify'
+
+describe('tryRuleShortcut', () => {
+  it('returns null in phase 1', () => {
+    expect(tryRuleShortcut('帮我生成一个分镜提示词')).toBeNull()
+  })
+})
+
+describe('classifyPromptMode without API key', () => {
+  afterEach(() => {
+    delete process.env.OPENAI_API_KEY
+  })
+
+  it('uses keyword heuristic for turnaround when no key', async () => {
+    delete process.env.OPENAI_API_KEY
+    const res = await classifyPromptMode('帮我生成一个包含人物三视图的提示词')
+    expect(res.mode).toBe('character_turnaround')
+    expect(res.confidence).toBeLessThan(1)
+  })
+
+  it('falls back to generic for ambiguous text when no key', async () => {
+    delete process.env.OPENAI_API_KEY
+    const res = await classifyPromptMode('你好')
+    expect(res.mode).toBe('generic')
+  })
+})
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `pnpm --filter @lnkpi/agent test -- src/prompt-modes/classify.test.ts`
+
+Expected: FAIL（模块不存在）
+
+- [ ] **Step 3: 实现 types + 6 个 mode 文件 + registry**
+
+`types.ts` 按 Interfaces 定义。
+
+每个 mode 文件导出 `PromptModeDefinition`。`system` 必须覆盖 spec §2.3 质量原则；至少包含输出 Markdown 骨架说明。示例如 `image-prompt-multi-style.ts`：
+
+```ts
+import type { PromptModeDefinition } from '../types'
+
+export const imagePromptMultiStyleMode: PromptModeDefinition = {
+  id: 'image_prompt_multi_style',
+  label: '多风格绘画提示词',
+  classifyHints: '用户要多组 AI 绘画/Midjourney/SD 风格提示词、海报/车模/角色外观多风格方案',
+  system: `你是资深 AI 绘画提示词工程师。根据用户短需求输出 Markdown：
+1) 简短开场；2) 至少 3 种风格，每组含「中文描述」+「Prompt (EN)」引用块；3) 建议与技巧（比例、负面词等）；4) 禁止只复述用户原句。用中文说明、英文 Prompt。`,
+  fewShot: {
+    user: '赛博朋克猫咖啡馆海报',
+    assistant: '### 风格一：霓虹夜雨\n- **中文描述：** …\n- **Prompt:**\n> neon rain, cyberpunk cat cafe…',
+  },
+  placeholder: (prompt) =>
+    `【提示词草案·多风格】\n\n基于「${prompt}」：\n\n### 风格一\n- 中文描述：…\n- Prompt: \`sample prompt\`\n\n（配置 OPENAI_API_KEY 后可获得真实 LLM 输出）`,
+}
+```
+
+其余 5 个 mode 同结构，`system`/`placeholder`/`classifyHints` 按 spec 模式表填写（三视图强制正侧背一致性；分镜含镜号景别；剧本含主题人物分场；文案可口播；generic 兜底）。
+
+`registry.ts`:
+
+```ts
+import type { PromptModeDefinition, PromptModeId } from './types'
+import { imagePromptMultiStyleMode } from './modes/image-prompt-multi-style'
+// ... import others
+
+export const PROMPT_MODES: Record<PromptModeId, PromptModeDefinition> = {
+  image_prompt_multi_style: imagePromptMultiStyleMode,
+  character_turnaround: characterTurnaroundMode,
+  storyboard: storyboardMode,
+  script: scriptMode,
+  copywriting: copywritingMode,
+  generic: genericMode,
+}
+
+export function getPromptMode(id: PromptModeId): PromptModeDefinition {
+  return PROMPT_MODES[id]
+}
+
+export const PROMPT_MODE_IDS = Object.keys(PROMPT_MODES) as PromptModeId[]
+```
+
+- [ ] **Step 4: 实现 classify.ts**
+
+```ts
+import { getPromptMode, PROMPT_MODE_IDS, PROMPT_MODES } from './registry'
+import type { PromptModeId } from './types'
+
+export function tryRuleShortcut(_prompt: string): PromptModeId | null {
+  return null
+}
+
+/** 仅无 Key / Placeholder 路径使用；不用于跳过有 Key 时的 Call-1 */
+export function heuristicMode(prompt: string): PromptModeId {
+  const p = prompt.toLowerCase()
+  if (/三视图|正侧背|turnaround/.test(p)) return 'character_turnaround'
+  if (/分镜/.test(p)) return 'storyboard'
+  if (/剧本|剧本大纲|人生观/.test(p)) return 'script'
+  if (/旁白|口播|文案/.test(p)) return 'copywriting'
+  if (/提示词|midjourney|stable diffusion|绘画|车模/.test(p)) return 'image_prompt_multi_style'
+  return 'generic'
+}
+
+export async function classifyPromptMode(
+  prompt: string,
+  opts?: { apiKey?: string; baseUrl?: string; model?: string },
+): Promise<{ mode: PromptModeId; confidence: number }> {
+  const shortcut = tryRuleShortcut(prompt)
+  if (shortcut) return { mode: shortcut, confidence: 0.99 }
+
+  const key = opts?.apiKey ?? process.env.OPENAI_API_KEY
+  if (!key) return { mode: heuristicMode(prompt), confidence: 0.4 }
+
+  const hints = PROMPT_MODE_IDS.map((id) => `- ${id}: ${PROMPT_MODES[id].classifyHints}`).join('\n')
+  const baseUrl = (opts?.baseUrl ?? process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1').replace(/\/$/, '')
+  const res = await fetch(`${baseUrl}/chat/completions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
+    body: JSON.stringify({
+      model: opts?.model ?? process.env.OPENAI_CHAT_MODEL ?? 'gpt-4o',
+      temperature: 0,
+      messages: [
+        {
+          role: 'system',
+          content: `你是意图分类器。只输出 JSON：{"mode":"<id>","confidence":0-1}。mode 必须是其一：${PROMPT_MODE_IDS.join(', ')}。\n判别：\n${hints}`,
+        },
+        { role: 'user', content: prompt.slice(0, 500) },
+      ],
+    }),
+  })
+  if (!res.ok) return { mode: 'generic', confidence: 0 }
+  const json = (await res.json()) as { choices: Array<{ message: { content: string } }> }
+  const raw = json.choices[0]?.message?.content ?? ''
+  try {
+    const parsed = JSON.parse(raw.replace(/```json|```/g, '').trim()) as { mode?: string; confidence?: number }
+    const mode = PROMPT_MODE_IDS.includes(parsed.mode as PromptModeId)
+      ? (parsed.mode as PromptModeId)
+      : 'generic'
+    const confidence = typeof parsed.confidence === 'number' ? parsed.confidence : 0.5
+    if (confidence < 0.5) return { mode: 'generic', confidence }
+    return { mode, confidence }
+  } catch {
+    return { mode: 'generic', confidence: 0 }
+  }
+}
+```
+
+- [ ] **Step 5: 实现 generate.ts + generate.test.ts**
+
+```ts
+// generate.test.ts
+import { describe, it, expect } from 'vitest'
+import { generatePromptContent } from './generate'
+
+describe('generatePromptContent without key', () => {
+  it('returns placeholder that includes user prompt and is longer than input', async () => {
+    delete process.env.OPENAI_API_KEY
+    const input = '美女模特车模展会'
+    const { mode, content } = await generatePromptContent(input, 'image_prompt_multi_style')
+    expect(mode).toBe('image_prompt_multi_style')
+    expect(content).toContain(input)
+    expect(content.length).toBeGreaterThan(input.length)
+    expect(content).not.toBe(input)
+  })
+})
+```
+
+`generate.ts`：有 Key 时用 mode.system + fewShot + user 调 `chat/completions`；无 Key 时 `getPromptMode(mode).placeholder(prompt)`。
+
+`generatePromptFromUserInput`：`const { mode } = await classifyPromptMode(...); return generatePromptContent(prompt, mode, opts)`。
+
+- [ ] **Step 6: 导出并跑通测试**
+
+Modify `packages/agent/src/index.ts` 增加 prompt-modes 导出。
+
+Run: `pnpm --filter @lnkpi/agent test`
+
+Expected: PASS（含新测试）
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/agent/src/prompt-modes packages/agent/src/index.ts
+git commit -m "feat(agent): add prompt mode registry with classify/generate"
+```
+
+---
+
+### Task 2: Nest Studio API `POST /studio/prompt/generate`
+
+**Files:**
+- Modify: `apps/server/src/studio/studio.service.ts`
+- Modify: `apps/server/src/studio/studio.controller.ts`
+- Test: 手动或最小 e2e；若无可加 `apps/server` 单测，优先 service 逻辑靠 agent 单测覆盖
+
+**Interfaces:**
+- Consumes: `generatePromptFromUserInput` from `@lnkpi/agent`
+- Produces: GenerationRecord with `type: 'prompt'`, `metadata: JSON.stringify({ mode, content })`
+
+- [ ] **Step 1: 在 StudioService 增加方法**
+
+```ts
+async generatePrompt(userId: string, prompt: string, model?: string) {
+  const trimmed = prompt?.trim()
+  if (!trimmed) throw new BadRequestException('prompt 不能为空')
+  await this.consumePoints(userId, 5, '提示词模式生成')
+  const { mode, content } = await generatePromptFromUserInput(trimmed, {
+    model,
+    apiKey: process.env.OPENAI_API_KEY,
+    baseUrl: process.env.OPENAI_BASE_URL,
+  })
+  return this.prisma.generationRecord.create({
+    data: {
+      userId,
+      type: 'prompt',
+      prompt: trimmed,
+      model,
+      url: null,
+      status: 'completed',
+      metadata: JSON.stringify({ mode, content }),
+    },
+  })
+}
+```
+
+（确保文件顶部已 `import { BadRequestException } from '@nestjs/common'` 与 `generatePromptFromUserInput`。）
+
+- [ ] **Step 2: Controller DTO + 路由**
+
+在 `studio.controller.ts` 增加：
+
+```ts
+class GeneratePromptDto {
+  @IsString()
+  prompt!: string
+
+  @IsOptional()
+  @IsString()
+  model?: string
+}
+
+@Post('prompt/generate')
+@UseGuards(AuthGuard)
+async generatePrompt(@Req() req: { user: { sub: string } }, @Body() dto: GeneratePromptDto) {
+  const data = await this.studioService.generatePrompt(req.user.sub, dto.prompt, dto.model)
+  return { code: 0, message: 'ok', data }
+}
+```
+
+- [ ] **Step 3: 本地冒烟（无 Key 亦可）**
+
+启动 server 后（或 vitest mock），确认路由注册：`POST /api/studio/prompt/generate`（以项目全局前缀为准，与 text/generate 同级）。
+
+Run: `pnpm --filter @lnkpi/server build`（或 monorepo build 中 server 部分）
+
+Expected: 编译通过
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/server/src/studio/studio.service.ts apps/server/src/studio/studio.controller.ts
+git commit -m "feat(server): add POST /studio/prompt/generate"
+```
+
+---
+
+### Task 3: 前端 API、解析、生成链路与上游
+
+**Files:**
+- Modify: `apps/web/src/services/studio-api.ts`
+- Modify: `apps/web/src/composables/useGenerationPolling.ts`
+- Modify: `apps/web/src/composables/useNodeGeneration.ts`
+- Modify: `apps/web/src/composables/useUpstreamNodeContext.ts`
+
+**Interfaces:**
+- Produces: `studioApi.generatePrompt(prompt, model?)`；`parseRecordPromptContent(record) => { content: string; mode: string | null }`
+
+- [ ] **Step 1: studio-api**
+
+```ts
+generatePrompt: (prompt: string, model?: string) =>
+  api.post<{ data: GenerationRecord }>('/studio/prompt/generate', { prompt, model }, { timeout: 90_000 }),
+```
+
+- [ ] **Step 2: parseRecordPromptContent**
+
+在 `useGenerationPolling.ts` 旁或同文件：
+
+```ts
+export function parseRecordPromptContent(record: { metadata?: string | null; prompt: string }) {
+  if (!record.metadata) return { content: record.prompt, mode: null as string | null }
+  try {
+    const meta = JSON.parse(record.metadata) as { content?: string; mode?: string; text?: string }
+    return {
+      content: meta.content ?? meta.text ?? record.prompt,
+      mode: meta.mode ?? null,
+    }
+  } catch {
+    return { content: record.prompt, mode: null }
+  }
+}
+```
+
+- [ ] **Step 3: useNodeGeneration 增加 prompt 分支**
+
+在 `nodeType === 'text'` 分支之前或之后插入：
+
+```ts
+if (nodeType === 'prompt') {
+  const userPrompt = String(data.prompt ?? '').trim() || prompt
+  if (!userPrompt) return
+  deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating })
+  const models = deps.resolveProviderModels()
+  const { data: res } = await studioApi.generatePrompt(
+    userPrompt,
+    String(data.textModel ?? models.text),
+  )
+  const parsed = parseRecordPromptContent(res.data)
+  deps.patchNodeData(node.id, {
+    content: parsed.content,
+    promptMode: parsed.mode,
+    status: NODE_GENERATION_STATUS.completed,
+    errorMessage: null,
+  })
+  await deps.saveCanvas()
+  return
+}
+```
+
+注意：`mergePromptWithUpstream` 对 prompt 节点可能拼上游；生成请求应以节点自身 `data.prompt` 为主（可把 upstream 文本拼进 userPrompt，若现有 merge 已含则复用 `prompt` 变量但**不要**把合并结果写回覆盖用户短需求字段——只用于请求体）。实现时：请求用 `mergePromptWithUpstream` 结果；patch 成功时**不**改 `data.prompt`。
+
+- [ ] **Step 4: useUpstreamNodeContext**
+
+将 `nodeTextContent` 改为对 prompt 类型优先 content：
+
+```ts
+function nodeTextContent(node: EditableFlowNode): string {
+  const data = node.data ?? {}
+  const type = String(node.type ?? '')
+  if (type === 'prompt') {
+    return String(data.content ?? data.prompt ?? '').trim()
+  }
+  return String(data.content ?? data.prompt ?? '').trim()
+}
+```
+
+（与现状等价但意图显式；保持 `content` 优先。）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/services/studio-api.ts apps/web/src/composables/useGenerationPolling.ts apps/web/src/composables/useNodeGeneration.ts apps/web/src/composables/useUpstreamNodeContext.ts
+git commit -m "feat(web): wire prompt node generation to studio API"
+```
+
+---
+
+### Task 4: PromptDockPanel + Router + 菜单可添加 prompt
+
+**Files:**
+- Create: `apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue`
+- Modify: `apps/web/src/components/canvas/dock-studio/DockStudioRouter.vue`
+- Modify: `apps/web/src/components/canvas/NodePanelDock.vue`
+- Modify: `apps/web/src/components/canvas/canvasDockMenu.ts`
+- Modify: `apps/web/src/pages/CanvasPage.vue`（若 `add` 节点工厂不支持 prompt，补默认 data）
+
+**Interfaces:**
+- Consumes: `emit('patch')` / `emit('generate')` 与其它 Dock 一致
+- Produces: 只 patch `{ prompt, textModel }`，不写 `content`
+
+- [ ] **Step 1: 扩展 DockNodeType 与菜单**
+
+`NodePanelDock.vue` 的 `DockNodeType` 增加 `'prompt'`。
+
+`canvasDockMenu.ts` 在列表顶部或 text 旁增加：
+
+```ts
+{ type: 'prompt', label: '提示词', desc: '多模式提示词扩写', badge: 'Prompt', tone: 'text-fuchsia-300 bg-fuchsia-500/15' },
+```
+
+`CONNECT_OUT_TARGET_TYPES` 视需要加入 `'prompt'`。
+
+- [ ] **Step 2: 创建 PromptDockPanel.vue**
+
+对照 `TextDockPanel.vue`，但：
+
+- `syncFromNode`：`prompt.value = String(data.prompt ?? '')`（不要用 content 填输入框，除非 prompt 空且仅预填需求——默认只用 `data.prompt`）
+- `onPromptInput`：`emit('patch', { prompt: value })` **不** patch content
+- 底栏布局：`[UniversalModelSelector] [可选 promptMode 标签] … ml-auto [🎤] [DockGenerateButton label=生成提示词]`
+- 🎤 必须紧挨 `DockGenerateButton` 左侧（`ml-auto` 包住二者或 flex 右对齐成组）
+
+- [ ] **Step 3: DockStudioRouter**
+
+在 `text` 分支旁增加：
+
+```vue
+<PromptDockPanel
+  v-else-if="node && nodeType === 'prompt'"
+  ...
+/>
+```
+
+确保不再落到 LegacyDockPanel。
+
+- [ ] **Step 4: CanvasPage addNode**
+
+确认添加 `prompt` 类型时 `data: { prompt: '', label: '提示词' }`（搜索现有 `add`/`onAddNode` 映射并补全）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue apps/web/src/components/canvas/dock-studio/DockStudioRouter.vue apps/web/src/components/canvas/NodePanelDock.vue apps/web/src/components/canvas/canvasDockMenu.ts apps/web/src/pages/CanvasPage.vue
+git commit -m "feat(web): add PromptDockPanel and dock menu entry"
+```
+
+---
+
+### Task 5: TipTap PromptMarkdownEditor + 语音
+
+**Files:**
+- Modify: `apps/web/package.json`（添加依赖）
+- Create: `apps/web/src/components/canvas/PromptMarkdownEditor.vue`
+- Create: `apps/web/src/components/canvas/PromptMarkdownEditor.css`（可选 scoped 外置）
+
+**Interfaces:**
+- Props: `visible: boolean`, `modelValue: string`
+- Emits: `update:visible`, `update:modelValue`, `save(content: string)`
+
+- [ ] **Step 1: 安装 TipTap**
+
+Run（在 repo 根目录）:
+
+```bash
+pnpm --filter @lnkpi/web add @tiptap/vue-3 @tiptap/starter-kit @tiptap/extension-placeholder @tiptap/extension-typography tiptap-markdown
+```
+
+若 `tiptap-markdown` 与当前 TipTap 主版本不兼容，改用：存储纯文本 Markdown 时用 `editor.getText()` 不理想——优先 `tiptap-markdown` 的 `getMarkdown()`；不兼容则用 `@tiptap/core` + 手动 `markdown-it` 双向转换，但计划默认 `tiptap-markdown`。
+
+- [ ] **Step 2: 实现 PromptMarkdownEditor.vue**
+
+结构：
+
+```vue
+<script setup lang="ts">
+import { watch, onBeforeUnmount } from 'vue'
+import { EditorContent, Editor } from '@tiptap/vue-3'
+import StarterKit from '@tiptap/starter-kit'
+import Placeholder from '@tiptap/extension-placeholder'
+import { Markdown } from 'tiptap-markdown'
+import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
+
+const props = defineProps<{ visible: boolean; modelValue: string }>()
+const emit = defineEmits<{
+  'update:visible': [boolean]
+  'update:modelValue': [string]
+  save: [string]
+}>()
+
+const speech = useSpeechRecognition()
+let editor: Editor | null = null
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+
+function getMarkdown(): string {
+  return (editor?.storage as { markdown?: { getMarkdown: () => string } }).markdown?.getMarkdown?.() ?? ''
+}
+
+function scheduleSave() {
+  if (saveTimer) clearTimeout(saveTimer)
+  saveTimer = setTimeout(() => {
+    const md = getMarkdown()
+    emit('update:modelValue', md)
+    emit('save', md)
+  }, 400)
+}
+
+function ensureEditor() {
+  if (editor) return
+  editor = new Editor({
+    extensions: [
+      StarterKit,
+      Placeholder.configure({ placeholder: '输入或生成提示词内容...' }),
+      Markdown.configure({ html: false }),
+    ],
+    content: props.modelValue || '',
+    onUpdate: () => scheduleSave(),
+  })
+}
+
+watch(() => props.visible, (v) => {
+  if (v) {
+    ensureEditor()
+    editor?.commands.setContent(props.modelValue || '')
+    setTimeout(() => editor?.commands.focus('end'), 50)
+  }
+})
+
+function close() {
+  const md = getMarkdown()
+  emit('update:modelValue', md)
+  emit('save', md)
+  emit('update:visible', false)
+}
+
+function copyAll() {
+  void navigator.clipboard.writeText(getMarkdown())
+}
+
+function toggleVoice() {
+  if (speech.listening.value) {
+    speech.stop()
+    return
+  }
+  speech.start((text, isFinal) => {
+    if (!isFinal || !editor) return
+    editor.chain().focus().insertContent(text).run()
+    scheduleSave()
+  })
+}
+
+onBeforeUnmount(() => {
+  if (saveTimer) clearTimeout(saveTimer)
+  editor?.destroy()
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="visible" class="prompt-md-overlay" @click.self="close">
+      <div class="prompt-md-modal" @click.stop>
+        <div class="prompt-md-toolbar">
+          <!-- 格式按钮：H1/H2/H3/Bold/Italic/List/HR -->
+          <div class="prompt-md-spacer" />
+          <button type="button" class="dock-icon-btn" title="语音输入" :class="speech.listening.value ? 'animate-pulse text-red-400' : ''" @click="toggleVoice">🎤</button>
+          <button type="button" class="btn-primary text-xs" @click="copyAll">复制</button>
+          <button type="button" class="btn-secondary text-xs" @click="close">关闭</button>
+        </div>
+        <EditorContent :editor="editor" class="prompt-md-editor" />
+      </div>
+    </div>
+  </Teleport>
+</template>
+```
+
+样式：深色大弹窗、遮罩、`toolbar` 中 **🎤 紧邻复制/关闭**（主操作组右侧成对）。格式按钮在左，右侧 `spacer + 🎤 + 复制 + 关闭`。
+
+- [ ] **Step 3: 构建校验**
+
+Run: `pnpm --filter @lnkpi/web build`
+
+Expected: PASS（若 TipTap 类型报错，补 `// @ts-expect-error` 或正确 storage 类型）
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/package.json pnpm-lock.yaml apps/web/src/components/canvas/PromptMarkdownEditor.vue
+git commit -m "feat(web): add TipTap PromptMarkdownEditor with voice"
+```
+
+---
+
+### Task 6: CanvasNodePrompt 双击打开编辑器
+
+**Files:**
+- Modify: `apps/web/src/components/canvas/CanvasNodePrompt.vue`
+
+- [ ] **Step 1: 改写节点组件**
+
+```vue
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import NeoBaseNode from '@/components/canvas/NeoBaseNode.vue'
+import PromptMarkdownEditor from '@/components/canvas/PromptMarkdownEditor.vue'
+
+const props = defineProps<{
+  selected?: boolean
+  data: { prompt?: string; content?: string; label?: string; status?: string }
+}>()
+
+const emit = defineEmits<{
+  patch: [patch: Record<string, unknown>]
+}>()
+
+const editorOpen = ref(false)
+const draft = ref('')
+
+const preview = computed(() => {
+  const c = String(props.data.content ?? '').trim()
+  if (c) return c.length > 180 ? `${c.slice(0, 180)}…` : c
+  return ''
+})
+
+function openEditor() {
+  draft.value = String(props.data.content ?? '')
+  editorOpen.value = true
+}
+
+function onSave(md: string) {
+  emit('patch', { content: md })
+}
+</script>
+
+<template>
+  <NeoBaseNode node-type="prompt" :selected="selected" :data="data" :status="data.status">
+    <div class="neo-text-card" @dblclick.stop="openEditor">
+      <template v-if="preview">
+        <p class="whitespace-pre-wrap text-left text-[12px] leading-relaxed text-white/80">{{ preview }}</p>
+      </template>
+      <template v-else>
+        <p>输入需求生成提示词</p>
+        <p class="text-[11px] text-white/35">双击编辑文本</p>
+        <p v-if="data.prompt" class="mt-1 line-clamp-2 text-[11px] text-white/40">{{ data.prompt }}</p>
+      </template>
+    </div>
+    <PromptMarkdownEditor
+      v-model:visible="editorOpen"
+      v-model="draft"
+      @save="onSave"
+    />
+  </NeoBaseNode>
+</template>
+```
+
+若 Vue Flow 节点不能直接 `emit('patch')`，改为 inject/provide 或通过 `CanvasPage` 已有的节点更新总线（查看 `NeoBaseNode` / 其它节点如何更新 data）。**实现时以项目现有节点更新模式为准**：常见做法是 `updateNodeData` 回调 via `useVueFlow` 的 `updateNodeData(id,)`，需在组件内 `const id = getNodeId()` 或 props 增加 `id`。检查 `CanvasNodeText`——若无 patch，则在 `CanvasPage` 用 `@node-double-click` 或给 Prompt 节点包一层。  
+
+**校正步骤：** 打开 `CanvasPage.vue` 中 `<VueFlow>` 节点类型注册；若节点组件无法 emit 到页面，使用：
+
+```ts
+import { useVueFlow } from '@vue-flow/core'
+const { updateNodeData } = useVueFlow()
+// onSave:
+updateNodeData(nodeId, { content: md })
+```
+
+并从 `useNodeId()`（@vue-flow/core）取 id。
+
+- [ ] **Step 2: 手动验证清单**
+
+- 双击打开弹窗、编辑、关闭后节点 preview 更新  
+- 标题双击仍只重命名，不打开编辑器  
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/canvas/CanvasNodePrompt.vue
+git commit -m "feat(web): double-click prompt node opens markdown editor"
+```
+
+---
+
+### Task 7: 全 Dock 语音按钮紧贴生成按钮
+
+**Files:**
+- Modify: `apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue`
+- Modify: `apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue`
+- Modify: `apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue`
+- Modify: `apps/web/src/components/canvas/dock-studio/panels/AudioDockPanel.vue`
+- Modify: `apps/web/src/components/canvas/dock-studio/panels/ShotDockPanel.vue`
+- 检查其它含 🎤 的 Dock / Legacy 面板一并调整
+
+- [ ] **Step 1: 统一布局模式**
+
+每个面板 `bottom-toolbar-actions` 改为：
+
+```vue
+<div class="bottom-toolbar-actions flex-wrap items-center">
+  <!-- 左侧：模型、优化、字数等 -->
+  <div class="ml-auto flex items-center gap-2">
+    <button type="button" class="dock-icon-btn" ... @click="toggleVoice">🎤</button>
+    <DockGenerateButton ... />
+  </div>
+</div>
+```
+
+从原位置删除离散的 🎤，避免重复。
+
+- [ ] **Step 2: 目视确认**
+
+Prompt / Text / Image / Video / Audio / Shot：🎤 均在生成按钮左侧紧邻。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/canvas/dock-studio/panels/*.vue
+git commit -m "fix(web): place dock voice control beside generate button"
+```
+
+---
+
+### Task 8: 端到端验收与收尾
+
+**Files:** 无新文件；按需修 bug
+
+- [ ] **Step 1: 跑测试与构建**
+
+```bash
+pnpm --filter @lnkpi/agent test
+pnpm --filter @lnkpi/server exec prisma generate
+pnpm build
+```
+
+Expected: 全部通过
+
+- [ ] **Step 2: 对照 spec §3.6 手工点验**
+
+| # | 操作 | 期望 |
+|---|---|---|
+| 1 | prompt 节点输入车模短需求 → 生成 | mode 多风格，content 长文，prompt 不变 |
+| 2 | 「人物三视图」 | character_turnaround |
+| 3 | 「分镜提示词」 | storyboard |
+| 4 | 「按××人生观写剧本」 | script |
+| 5 | 双击 TipTap + 语音 | 写入 content，Dock prompt 不变 |
+| 6 | 无 Key | Placeholder，非 echo |
+| 7 | 失败 | 旧 content 保留 |
+| 8 | 连 image | 上游带 content |
+| 9–10 | Dock/Markdown 🎤 位置 | 紧贴提交 |
+
+- [ ] **Step 3: 最终 commit（若有修复）**
+
+```bash
+git add -u
+git commit -m "fix: prompt node intent-templates acceptance polish"
+```
+
+---
+
+## Spec Coverage Checklist
+
+| Spec 项 | Task |
+|---------|------|
+| 6 模式注册表 + 质量原则 | Task 1 |
+| 两段式 classify → generate | Task 1 |
+| tryRuleShortcut 恒 null | Task 1 |
+| POST /studio/prompt/generate，5 点 | Task 2 |
+| 前端 generate + 不覆盖 prompt | Task 3–4 |
+| 上游优先 content | Task 3 |
+| PromptDockPanel「生成提示词」 | Task 4 |
+| TipTap 弹窗 | Task 5 |
+| 双击打开 | Task 6 |
+| Dock + Markdown 语音，紧贴提交 | Task 4–5、7 |
+| resize 不做 | 无任务（刻意） |
+| text 节点不变 | 无改 text generate |
+
+## Placeholder Scan
+
+无 TBD /「类似 Task N」未展开项；TipTap 依赖名已给出，若不兼容在 Task 5 Step 1 有明确回退路径。
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-07-17-prompt-node-intent-templates.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven（推荐）** — 每任务新开子代理，任务间审查，迭代快  
+2. **Inline Execution** — 本会话按 `executing-plans` 连续执行并设检查点  
+
+Which approach?

--- a/docs/superpowers/specs/2026-07-17-prompt-node-intent-templates-design.md
+++ b/docs/superpowers/specs/2026-07-17-prompt-node-intent-templates-design.md
@@ -1,0 +1,413 @@
+# Prompt 节点：意图路由 + 多模式模板生成（设计文档）
+
+> 状态：第一～三节已定稿，待全文确认后 commit  
+> 日期：2026-07-17  
+> 范围：画布 `prompt` 节点（非 `text` 节点）  
+> 竞品参考：neowow `/workflow` 文本生成（`POST /agent/story-canvas/generate-text`，`data.result` 与输入分离，双击打开 MarkdownEditor）
+
+## 决策摘要
+
+| 项 | 选择 |
+|---|---|
+| 作用节点 | **B**：现有 `prompt` 节点专门承载 |
+| 结果形态 | **A**：长文 Markdown（快速对齐竞品多风格长文观感） |
+| 数据分离 | **A**：用户短需求与生成结果分字段存储 |
+| 能力范围 | **P2**：意图路由 + 4～6 个模式模板 |
+| 实现路径 | **方案 2**：两段式（分类 → 模式模板生成），专用生成接口 |
+| 展开 UI | **C3**：TipTap Markdown 编辑弹窗（可编辑 + 复制 + 工具栏 + **语音输入**）；节点尺寸第一期固定 |
+| 节点 resize | **迭代 B**（第一期不做拖拽放大） |
+| 语音输入 | **Dock Studio 全覆盖 + Markdown 弹窗均需**；图标紧贴提交/生成按钮 |
+| 积分 / 超时 | **对齐文本生成**：5 点 / 前端超时 90s |
+| 意图分类 | **第一期纯 LLM 分类**；规则预筛延后到迭代期（见 §2.8） |
+
+---
+
+## 第一节：范围与节点行为
+
+### 1.1 目标
+
+用户在 `prompt` 节点输入短需求后点击生成，系统先识别创作意图，再按对应模式的最佳实践模板调用 LLM，产出**可读的 Markdown 长文**（如多风格绘画提示词、三视图提示词、分镜表、剧本草案等）。双击节点可展开查看完整内容。
+
+### 1.2 非目标（第一期不做）
+
+- 不改造 `text` 节点的文案生成链路（`/studio/text/generate` 保持现状）
+- 不做结构化 `styles[]` 卡片点选与一键灌入下游图片节点（留给后续 C 形态）
+- 不接入作品知识库 / RAG（如「万物生」深度资料检索）
+- 不把生成主路径绑到 Agent 画布对话（`/agent/chat/conversation`）
+- **不做节点 resize handle**（迭代 B；长文阅读靠双击 TipTap 弹窗）
+- 不做规则预筛跳过 Call-1（见 §2.8）
+
+### 1.3 数据模型（节点 `data`）
+
+| 字段 | 含义 | 编辑方式 |
+|---|---|---|
+| `prompt` | 用户短需求（输入区内容） | Dock 输入；生成前后均保留 |
+| `content` | 生成后的 Markdown 长文 | 由生成接口写入；双击展开查看 |
+| `promptMode` | 最近一次识别到的模式 id | 后端写入；可选 UI 展示 |
+| `textModel` | 选用的文本模型 | Dock 模型选择器 |
+| `status` | `idle` / `generating` / `completed` / `error` | 生成流程维护 |
+| `errorMessage` | 失败信息 | 失败时写入 |
+
+约定：
+
+- **禁止**在输入过程中把 `content` 与 `prompt` 同步成同一字符串（避免与现有 `TextDockPanel` 行为混淆）。
+- 生成前可乐观将 `status=generating`，**不要**用 `prompt` 覆盖已有 `content`（保留上一次结果直到新结果返回）。
+- 上游消费（连到 image/audio 等）第一期：优先使用 `content`（有则用之），否则回退 `prompt`。后续 C 形态再支持「选用某一风格段落」。
+
+### 1.4 Dock Studio 行为
+
+- `prompt` 节点不再走仅「应用/保存」的 Legacy 工具条语义。
+- 主按钮文案：**生成提示词**（生成中禁用）。
+- 输入区 placeholder：引导短需求，例如「描述你想要的提示词目标，如：车模展会美女模特 / 人物三视图 / 分镜…」。
+- 支持文本模型选择（复用现有 UniversalModelSelector / text 配置）。
+- 可选：生成完成后在 Dock 或节点角标展示 `promptMode` 中文名（便于用户理解「系统按哪种模式生成的」）。
+
+### 1.5 节点卡片与双击展开（对齐竞品）
+
+竞品 `TextGenerationNode` 实测行为（neowow WorkflowCanvas 逆向）：
+
+- 占位文案：「输入提示词生成文本」+「双击编辑文本」
+- 结果在节点内 Markdown 渲染；节点右下角有 **resize handle** 可拖大
+- **双击**内容区 / 占位区 → `visible=true` 打开 **`MarkdownEditor`**（`Teleport` 到 `body`）
+- 弹窗能力：TipTap Markdown 编辑、标题/加粗/列表工具栏、复制、关闭；编辑防抖后 `save` 写回 `data.result`
+- 支持语音插入（本项目**第一期同步实现**，见 §1.8）
+
+本项目 `prompt` 节点对齐目标（**C3**：弹窗 TipTap 优先，节点尺寸固定）：
+
+| 状态 | 卡片展示 |
+|---|---|
+| 无 `content` | 占位：「输入需求生成提示词」+ 次行提示「双击编辑文本」；若有 `prompt` 可一行截断预览需求 |
+| 有 `content` | 固定尺寸卡片内 Markdown 截断预览（约 120～200 字或卡片高度内滚动）；完整阅读靠双击弹窗 |
+| generating | 与现有节点生成中态一致 |
+| error | 显示错误摘要，保留旧 `content`（若有） |
+
+**双击节点内容区**（非标题重命名区域）：
+
+1. 打开 `PromptMarkdownEditor` 弹窗（Teleport + modal-fade，视觉贴近竞品深色大编辑器）。
+2. **实现选型：TipTap**（含 Markdown 扩展），所见即所得；工具栏至少：复制、H1/H2/H3、加粗、斜体、列表、分割线、关闭。
+3. **语音输入**：弹窗内具备麦克风按钮，录音结果插入光标处（对齐竞品 MarkdownEditor + VoiceInput）。
+4. 初始内容 = 当前 `content`（无则空，可手写）。
+5. 保存策略对齐竞品：编辑变更防抖写回 `content`，关闭时再 flush 一次；**不**改写 `prompt`（用户短需求仍在 Dock）。
+6. 关闭后不触发重新生成。
+7. 第一期不做节点右下角 resize（迭代 B）。
+
+说明：标题双击重命名（`NeoBaseNode` 已有）与内容双击展开需事件隔离（`stop`），避免冲突。
+
+### 1.8 语音输入（Dock + Markdown，第一期必做）
+
+#### 覆盖范围
+
+| 表面 | 是否要语音 | 写入目标 |
+|---|---|---|
+| 所有 Dock Studio 面板（含新建的 `PromptDockPanel`，以及现有 text/image/video/audio/shot 等） | **要** | 当前面板的主输入（prompt / content 等） |
+| `PromptMarkdownEditor`（TipTap 弹窗） | **要** | 插入到编辑器光标位置；最终仍落在节点 `content` |
+
+复用现有 `useSpeechRecognition`；行为与现有面板一致：听写中图标脉冲/变红，最终结果追加或插入文本。
+
+#### 图标摆放（统一规范）
+
+**语音图标必须紧贴「提交/生成」主按钮**，不要夹在模型选择、字数、优化提示词等次要控件中间。
+
+推荐底栏从左到右（可换行）：
+
+```text
+[模型选择] [优化等次要操作] …弹性空白… [🎤 语音] [生成/提交主按钮]
+```
+
+具象例子（`PromptDockPanel`）：
+
+```text
+[文本模型 ▾] [优化提示词]  12字          [🎤] [生成提示词]
+                                         ↑紧邻↑
+```
+
+错误摆放（避免）：
+
+```text
+[🎤] [文本模型 ▾] [优化] … [生成提示词]   ← 语音离提交太远
+[文本模型] [🎤] [优化] [字数] [生成提示词] ← 语音被次要控件隔开
+```
+
+Markdown 弹窗工具栏：
+
+```text
+[复制] [H1][H2][H3] … [B][I][列表] …弹性空白… [🎤 语音] [关闭]
+```
+
+或底部操作条：`[🎤]` 紧挨主操作区右侧关闭/完成按钮左侧——以「用户点完语音后立刻能点关闭/保存」为原则，**语音与主操作成对出现**。
+
+#### 实现注意
+
+- `PromptDockPanel` 新建时按上述规范放置，勿照搬 Legacy「应用」条的旧布局若其语音位置不合规。
+- 现有 Dock 面板（Text/Image/Video/Audio/Shot 等）若语音未紧贴生成按钮，**同期调整**到规范位置（小改布局，不改听写逻辑）。
+- 生成中 / 只读态：语音按钮 `disabled`，与生成按钮一致。
+
+### 1.6 第一期模式清单（6 个）
+
+| `promptMode` | 中文名 | 典型用户说法 | 输出侧重 |
+|---|---|---|---|
+| `image_prompt_multi_style` | 多风格绘画提示词 | 「车模展会美女模特…」 | 多组风格：中文描述 + EN Prompt + 使用建议 |
+| `character_turnaround` | 人物三视图 | 「生成包含人物三视图的提示词」 | 正/侧/背一致性约束 + 可生图 Prompt |
+| `storyboard` | 分镜提示词 | 「帮我生成一个分镜提示词」 | 镜号、景别、运镜、动作、中英 Prompt |
+| `script` | 剧本 | 「按××人生观生成相似剧本」 | 主题、人物、冲突、分场/对白草案 |
+| `copywriting` | 文案/旁白 | 「写一段品牌旁白」 | 可直接使用的文案结构 |
+| `generic` | 通用创作 | 无法归类时 | 澄清意图式的结构化创作回复 |
+
+### 1.7 成功标准（第一节）
+
+- 短需求生成后，`prompt` 仍为原文，`content` 为明显更长的专业 Markdown，而非原文回显。
+- 「车模」类需求稳定落到 `image_prompt_multi_style`，观感接近竞品多风格长文。
+- 「三视图 / 分镜 / 剧本」类需求分别落到对应模式，而非一律绘画多风格。
+- 双击打开 TipTap Markdown 编辑弹窗，可阅读/编辑/语音插入/复制完整 `content`（对齐竞品交互）。
+- Dock Studio（含 Prompt）与 Markdown 弹窗均有语音输入，且 🎤 紧贴提交/生成按钮。
+
+---
+
+## 第二节：后端路由、模式模板与 API
+
+### 2.1 总体链路
+
+```text
+前端 prompt 节点「生成提示词」
+  → POST /studio/prompt/generate  { prompt, model? }
+  → PromptGenerationService
+       ① classify(prompt) → promptMode
+       ② buildMessages(mode, prompt)  // system + few-shot + user
+       ③ LLM chat/completions
+       ④ 落 GenerationRecord + 返回 { mode, content, record }
+  → 前端 patch: { content, promptMode, status }
+```
+
+说明：
+
+- 与现有 `POST /studio/text/generate`（文本节点文案）**并行存在**，不复用同一 system prompt。
+- 不走 `/agent/chat/conversation`（避免画布 Agent tool-calling 耦合）。
+- Provider 复用 `@lnkpi/agent` 的 OpenAI 兼容调用能力，或在 `packages/agent` 新增 `PromptModeProvider`；无 `OPENAI_API_KEY` 时返回**按模式区分的 Placeholder 长文**（禁止原样 echo `prompt`）。
+
+### 2.2 两段式调用
+
+#### Call-1：意图分类（短、稳）
+
+- 输入：用户 `prompt`（可截断至前 N 字，如 500）。
+- 输出：严格 JSON，例如 `{"mode":"storyboard","confidence":0.82}`。
+- System：只允许从 6 个 mode id 中选择；给每类 1～2 句判别标准 + 边界例子。
+- 失败/解析失败/低置信度（如 `<0.5`）：回退 `generic`。
+- **第一期不做规则预筛跳过 Call-1**（决策见 §2.8）；分类始终走 LLM（无 Key 时用轻量规则仅用于 Placeholder 选 mode，见下）。
+
+#### Call-2：模式生成（长、质）
+
+- 按 `promptMode` 从**模式注册表**取：
+  - `system`：角色 + 输出骨架（Markdown 标题结构）+ 质量 checklist + 禁区
+  - `fewShots`：1 个金样例（教格式，不背答案）
+  - `userWrapper`：把用户短需求包进「请基于以下需求生成…」
+- `temperature`：创作类可 0.7～0.9；分类 Call-1 用 0～0.2。
+- 输出：纯 Markdown 字符串写入 `content`（不要包一层 JSON）。
+
+### 2.3 模式注册表（逻辑结构）
+
+建议位置：`packages/agent/src/prompt-modes/`（或 `apps/server/src/studio/prompt-modes/`），每个 mode 一文件 + `index` 导出注册表，便于后续迭代文案而不改控制器。
+
+每个 mode 至少包含：
+
+| 字段 | 用途 |
+|---|---|
+| `id` | 与 `promptMode` 一致 |
+| `label` | 中文名 |
+| `classifyHints` | 给 Call-1 的判别句子 |
+| `system` | Call-2 系统提示（最佳实践本体） |
+| `fewShot` | 输入→输出示例一对 |
+| `placeholder` | 无 Key 时的本地样例长文 |
+
+**质量原则（写入各 mode 的 system）：**
+
+- `image_prompt_multi_style`：至少 3 种风格差异；每组含中文描述 + EN Prompt；附负面词/参数建议；禁止只复述用户原句。
+- `character_turnaround`：强制同一角色锁定；正/侧/背；白底或干净背景；一致性关键词；禁止每视图换装换脸。
+- `storyboard`：镜号序列；景别/机位/运镜/动作；每镜可生图 Prompt；禁止只有形容词堆砌。
+- `script`：主题解读→人物→冲突→分场；允许声明「未检索原著时基于常识近似」；禁止伪引用大段「原著原文」。
+- `copywriting`：目标受众、语气、版本（短/长）；可直接口播。
+- `generic`：先用小节结构给出最可能有用的创作物，并提示用户可改写需求以命中更专模式。
+
+### 2.4 API 契约（草案）
+
+`POST /api/studio/prompt/generate`
+
+请求：
+
+```json
+{
+  "prompt": "帮我生成一个包含人物三视图的提示词",
+  "model": "gpt-4o"
+}
+```
+
+响应：
+
+```json
+{
+  "data": {
+    "id": "generation-record-id",
+    "type": "prompt",
+    "prompt": "帮我生成一个包含人物三视图的提示词",
+    "model": "gpt-4o",
+    "status": "completed",
+    "metadata": {
+      "mode": "character_turnaround",
+      "content": "### 人物三视图提示词\n\n..."
+    }
+  }
+}
+```
+
+前端解析：`content = metadata.content`，`promptMode = metadata.mode`。
+
+积分 / 超时（已定）：
+
+- **积分：5 点**，账本备注「提示词模式生成」（与 `studio.generateText` 的 5 点对齐，充分借鉴现有文本生成计费）。
+- **前端超时：90s**（与 `studioApi.generateText` 一致）。
+- 说明：第一期虽可能两次 LLM，仍先对齐 5 点降低产品摩擦；若线上成本明显偏高，迭代期再调价或合并为单次带 tool 的调用。
+
+### 2.5 错误处理
+
+| 情况 | 行为 |
+|---|---|
+| 未登录 | 前端 `requireLogin`，不发请求 |
+| 空 prompt | 前端禁用按钮；后端 400 |
+| 无 API Key | 用轻量关键词规则或 `generic` 选 mode → Placeholder 长文，`completed`，文内标注「草案/需配置密钥」 |
+| Call-1 失败 | 回退 `generic` 继续 Call-2 |
+| Call-2 失败 | `status=error`，保留旧 `content`，写入 `errorMessage` |
+| 超时 | 前端 90s；失败提示，保留旧 `content` |
+
+### 2.6 与竞品差异（有意为之）
+
+| 点 | 竞品 neowow | 本设计 |
+|---|---|---|
+| 节点类型 | `text` 文本生成 | 本项目 `prompt` 节点 |
+| 接口 | `/agent/story-canvas/generate-text` 异步 task | 第一期同步 `/studio/prompt/generate`（足够简单；过慢再改轮询） |
+| 结果字段 | `data.result` | `data.content` + `metadata.content`（与画布现有 content 习惯对齐） |
+| 双击 | `MarkdownEditor` 弹窗可编辑 | **对齐**：同交互形态的 Markdown 编辑弹窗 |
+| 智能 | 偏通用文本模型 | **显式意图路由 + 模式最佳实践包** |
+
+### 2.7 第二节确认结论
+
+| 问题 | 结论 |
+|---|---|
+| 展开 UI | **对齐竞品 MarkdownEditor 弹窗**（可编辑+复制+工具栏），不是只读 Dialog / 不是纯节点内放大 |
+| 积分 / 超时 | **5 点 / 90s**，对齐文本生成 |
+| 规则预筛 | **第一期不做**；见 §2.8 |
+
+### 2.8 意图分类：规则预筛 vs 纯 LLM（决策与迭代路径）
+
+#### 鉴定
+
+| 维度 | 纯 LLM 分类（Call-1） | 规则预筛跳过 Call-1 |
+|---|---|---|
+| 覆盖「千人千面」 | 高：能处理「按万物生人生观写剧本」这类无强关键词 | 低：依赖显式词；隐喻/复合句易漏 |
+| 误伤风险 | 低（有 confidence + `generic` 兜底） | 中高：如「写一个分镜师的人物小传」含「分镜」但应走 `script`/`generic` |
+| 质量主因 | **否**——质量主要在 Call-2 模板 | **否**——规则不提升文案质量 |
+| 延迟 / 成本 | 多 1 次短调用（通常 &lt;1s、token 很少） | 可省 Call-1；对总耗时占比通常 **&lt;15%**（大头在 Call-2 长文） |
+| 维护成本 | 维护分类 system + 边界样例 | 维护关键词表 + 排除规则，模式一多易腐烂 |
+| 第一期显著成效？ | **有**：把需求送进正确模板，这是 P2 的核心 | **不显著**：省下的延迟/费用有限，却引入误分类风险 |
+
+**决策（第一期）：纯 LLM 分类。**
+
+依据：
+
+1. 用户明确要覆盖剧本 / 三视图 / 分镜等差异大需求 → **分类准确度 &gt; 省一次短调用**。  
+2. 体验瓶颈是「模式对不对 + 长文好不好」，不是分类多 300～800ms。  
+3. 规则适合做**加速层**，不适合做**正确性层**；过早上规则容易用错误 mode 生成「看起来很长但任务错了」的内容，比慢一点更伤信任。  
+4. 无 Key 环境例外：可用规则仅选择 Placeholder 模板（不宣称智能分类成功）。
+
+#### 迭代路径（后期做规则预筛）
+
+| 阶段 | 内容 | 进入条件 |
+|---|---|---|
+| **一期（当前）** | 仅 LLM Call-1；记录 `mode`、耗时、（可选）confidence 到 GenerationRecord.metadata | — |
+| **一期+** | 后台/日志统计：各 mode 占比、Call-1 p50/p95、用户是否立即再次生成（代理不满意） | 有真实流量 |
+| **二期** | **高精规则捷径**：仅当命中「强意图短语」且排除歧义时跳过 Call-1。例：整句含「三视图/正侧背」→ `character_turnaround`；「分镜提示词/分镜脚本」→ `storyboard`；「旁白/口播文案」→ `copywriting`。必须带 **否定上下文**（如同时含「剧本/小说」则不走 storyboard） | Call-1 p95 &gt; 1.5s 或分类成本需优化；或明确关键词句占比 &gt; 40% |
+| **二期验证** | A/B 或影子模式：规则先只打日志「若启用会选 X」，与 LLM 结果对比，一致率 ≥ 95% 再开启跳过 | 影子一致率达标 |
+| **三期** | 用户可手动覆盖 mode（Dock 下拉）；规则 + LLM + 手动 三层 | 有误分类客诉或高级用户需求 |
+
+实现预留：`classify(prompt)` 接口内部保留 `tryRuleShortcut(prompt): mode | null` 钩子，一期恒返回 `null`，避免二期大改。
+
+---
+
+## 第三节：前端交互与数据流
+
+### 3.1 组件改造点
+
+| 模块 | 变更 |
+|---|---|
+| `DockStudioRouter` | `nodeType === 'prompt'` → 新 `PromptDockPanel`（不再落入 Legacy「应用」） |
+| `PromptDockPanel` | 输入只 patch `prompt`；按钮「生成提示词」emit `generate`；模型选择 `textModel`；**语音紧贴生成按钮**；可选展示 `promptMode` 标签 |
+| `CanvasNodePrompt` | 预览 `content`（Markdown 截断）；占位+「双击编辑文本」；`@dblclick.stop` 打开编辑弹窗 |
+| `PromptMarkdownEditor` | 新建；TipTap + **语音输入**（紧贴关闭/主操作）；Teleport 弹窗 |
+| 现有 `*DockPanel` | 统一将 🎤 挪到生成按钮左侧紧邻（§1.8） |
+| `useNodeGeneration` | 增加 `prompt` 分支：调 `studioApi.generatePrompt`，写回 `content`/`promptMode`/`status` |
+| `studio-api.ts` | `generatePrompt(prompt, model?)` → `POST /studio/prompt/generate`，timeout 90_000 |
+| `useUpstreamNodeContext` | `nodeTextContent`：`prompt` 类型优先 `content`，否则 `prompt`（保证下游吃到生成长文） |
+
+### 3.2 生成时序
+
+```text
+用户编辑 Dock.prompt
+  → patch { prompt }          // 不碰 content
+点击「生成提示词」
+  → requireLogin
+  → patch { status: generating }  // 不覆盖 content
+  → POST /studio/prompt/generate
+  → 成功：patch { content, promptMode, status: completed, errorMessage: null }
+  → 失败：patch { status: error, errorMessage }
+  → saveCanvas
+双击节点
+  → 打开 PromptMarkdownEditor(content)
+  → 用户编辑 → 防抖/关闭时 patch { content }（仍不改 prompt）
+```
+
+### 3.3 与 text 节点边界
+
+| | `text` 节点 | `prompt` 节点（本设计） |
+|---|---|---|
+| Dock | `TextDockPanel`「生成文案」 | `PromptDockPanel`「生成提示词」 |
+| API | `/studio/text/generate` | `/studio/prompt/generate` |
+| 输入/输出 | 历史上 content≈prompt 同步 | **严格分离** |
+| 智能 | 单 system 文案扩写 | 意图路由 + 多模式模板 |
+
+### 3.4 第三节确认结论（C3）
+
+| 问题 | 结论 |
+|---|---|
+| Markdown 弹窗 | **TipTap**（更贴竞品所见即所得）+ **语音输入** |
+| 节点 resize handle | **迭代 B**；第一期节点固定尺寸，长文靠双击弹窗 |
+| 语音图标位置 | Dock / Markdown **均紧贴提交（生成/关闭）按钮**；现有 Dock 同期校正 |
+
+### 3.5 迭代 B 预留（resize）
+
+- 节点 `data` 可预留 `nodeWidth` / `nodeHeight`（第一期不写、不读）。
+- UI 预留右下角 handle 挂载点，第一期不渲染。
+- 进入条件：用户反馈「画布上扫读长文不便」或需并排对比多个 prompt 结果时再做。
+
+### 3.6 测试要点（设计层）
+
+| # | 场景 | 期望 |
+|---|---|---|
+| 1 | 输入车模短需求生成 | `promptMode=image_prompt_multi_style`，`content` 含多风格中英 Prompt，`prompt` 未变 |
+| 2 | 「人物三视图」 | 落到 `character_turnaround`，含正侧背一致性 |
+| 3 | 「分镜提示词」 | 落到 `storyboard`，含镜号/景别 |
+| 4 | 「按××人生观写剧本」 | 落到 `script`，非绘画多风格 |
+| 5 | 双击 | TipTap 弹窗打开，可编辑/语音插入并写回 `content`，Dock 里短需求不变 |
+| 6 | 无 API Key | Placeholder 长文，非 echo |
+| 7 | 生成失败 | 旧 `content` 保留，`status=error` |
+| 8 | 连到 image 节点 | 上游优先带上 `content` |
+| 9 | Dock 语音 | Prompt 及其他 Dock 的 🎤 紧邻生成按钮，听写写入主输入 |
+| 10 | Markdown 语音 | 弹窗内 🎤 紧邻主操作，插入光标处 |
+
+---
+
+## 修订记录
+
+| 日期 | 变更 |
+|---|---|
+| 2026-07-17 | 初稿：第一节范围与节点行为；第二节后端路由/模板/API |
+| 2026-07-17 | 第二节确认：展开对齐竞品 MarkdownEditor；积分 5/超时 90s；分类一期纯 LLM + 规则迭代路径；增补第三节前端数据流 |
+| 2026-07-17 | 第三节确认 **C3**：TipTap 弹窗 + resize 迭代 B；补测试要点与迭代预留 |
+| 2026-07-17 | 语音输入改为第一期必做：全 Dock Studio + Markdown 弹窗；图标统一紧贴提交/生成按钮（§1.8） |

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -10,3 +10,14 @@ export type { TextProvider } from './tools/text-provider'
 export type { VideoProvider } from './tools/video-provider'
 export type { AudioProvider } from './tools/audio-provider'
 export type { AgentStreamEvent, AgentMessage, AgentToolCall, AgentContext, AgentToolDefinition } from './types'
+export type { PromptModeId, PromptModeDefinition } from './prompt-modes'
+export {
+  PROMPT_MODES,
+  PROMPT_MODE_IDS,
+  getPromptMode,
+  tryRuleShortcut,
+  heuristicMode,
+  classifyPromptMode,
+  generatePromptContent,
+  generatePromptFromUserInput,
+} from './prompt-modes'

--- a/packages/agent/src/prompt-modes/classify.test.ts
+++ b/packages/agent/src/prompt-modes/classify.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { tryRuleShortcut, classifyPromptMode } from './classify'
+
+describe('tryRuleShortcut', () => {
+  it('returns null in phase 1', () => {
+    expect(tryRuleShortcut('帮我生成一个分镜提示词')).toBeNull()
+  })
+})
+
+describe('classifyPromptMode without API key', () => {
+  afterEach(() => {
+    delete process.env.OPENAI_API_KEY
+  })
+
+  it('uses keyword heuristic for turnaround when no key', async () => {
+    delete process.env.OPENAI_API_KEY
+    const res = await classifyPromptMode('帮我生成一个包含人物三视图的提示词')
+    expect(res.mode).toBe('character_turnaround')
+    expect(res.confidence).toBeLessThan(1)
+  })
+
+  it('falls back to generic for ambiguous text when no key', async () => {
+    delete process.env.OPENAI_API_KEY
+    const res = await classifyPromptMode('你好')
+    expect(res.mode).toBe('generic')
+  })
+})

--- a/packages/agent/src/prompt-modes/classify.ts
+++ b/packages/agent/src/prompt-modes/classify.ts
@@ -1,0 +1,60 @@
+import { PROMPT_MODE_IDS, PROMPT_MODES } from './registry'
+import type { PromptModeId } from './types'
+
+export function tryRuleShortcut(_prompt: string): PromptModeId | null {
+  return null
+}
+
+/** 仅无 Key / Placeholder 路径使用；不用于跳过有 Key 时的 Call-1 */
+export function heuristicMode(prompt: string): PromptModeId {
+  const p = prompt.toLowerCase()
+  if (/三视图|正侧背|turnaround/.test(p)) return 'character_turnaround'
+  if (/分镜/.test(p)) return 'storyboard'
+  if (/剧本|剧本大纲|人生观/.test(p)) return 'script'
+  if (/旁白|口播|文案/.test(p)) return 'copywriting'
+  if (/提示词|midjourney|stable diffusion|绘画|车模/.test(p)) return 'image_prompt_multi_style'
+  return 'generic'
+}
+
+export async function classifyPromptMode(
+  prompt: string,
+  opts?: { apiKey?: string; baseUrl?: string; model?: string },
+): Promise<{ mode: PromptModeId; confidence: number }> {
+  const shortcut = tryRuleShortcut(prompt)
+  if (shortcut) return { mode: shortcut, confidence: 0.99 }
+
+  const key = opts?.apiKey ?? process.env.OPENAI_API_KEY
+  if (!key) return { mode: heuristicMode(prompt), confidence: 0.4 }
+
+  const hints = PROMPT_MODE_IDS.map((id) => `- ${id}: ${PROMPT_MODES[id].classifyHints}`).join('\n')
+  const baseUrl = (opts?.baseUrl ?? process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1').replace(/\/$/, '')
+  const res = await fetch(`${baseUrl}/chat/completions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
+    body: JSON.stringify({
+      model: opts?.model ?? process.env.OPENAI_CHAT_MODEL ?? 'gpt-4o',
+      temperature: 0,
+      messages: [
+        {
+          role: 'system',
+          content: `你是意图分类器。只输出 JSON：{"mode":"<id>","confidence":0-1}。mode 必须是其一：${PROMPT_MODE_IDS.join(', ')}。\n判别：\n${hints}`,
+        },
+        { role: 'user', content: prompt.slice(0, 500) },
+      ],
+    }),
+  })
+  if (!res.ok) return { mode: 'generic', confidence: 0 }
+  const json = (await res.json()) as { choices: Array<{ message: { content: string } }> }
+  const raw = json.choices[0]?.message?.content ?? ''
+  try {
+    const parsed = JSON.parse(raw.replace(/```json|```/g, '').trim()) as { mode?: string; confidence?: number }
+    const mode = PROMPT_MODE_IDS.includes(parsed.mode as PromptModeId)
+      ? (parsed.mode as PromptModeId)
+      : 'generic'
+    const confidence = typeof parsed.confidence === 'number' ? parsed.confidence : 0.5
+    if (confidence < 0.5) return { mode: 'generic', confidence }
+    return { mode, confidence }
+  } catch {
+    return { mode: 'generic', confidence: 0 }
+  }
+}

--- a/packages/agent/src/prompt-modes/generate.test.ts
+++ b/packages/agent/src/prompt-modes/generate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { generatePromptContent } from './generate'
 
 describe('generatePromptContent without key', () => {
@@ -10,5 +10,33 @@ describe('generatePromptContent without key', () => {
     expect(content).toContain(input)
     expect(content.length).toBeGreaterThan(input.length)
     expect(content).not.toBe(input)
+  })
+})
+
+describe('generatePromptContent with key', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    delete process.env.OPENAI_API_KEY
+  })
+
+  it('throws when API returns !ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    }))
+    await expect(
+      generatePromptContent('test', 'generic', { apiKey: 'test-key' }),
+    ).rejects.toThrow(/LLM 请求失败/)
+  })
+
+  it('throws when API returns empty content', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: '' } }] }),
+    }))
+    await expect(
+      generatePromptContent('test', 'generic', { apiKey: 'test-key' }),
+    ).rejects.toThrow(/LLM 返回空内容/)
   })
 })

--- a/packages/agent/src/prompt-modes/generate.test.ts
+++ b/packages/agent/src/prompt-modes/generate.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { generatePromptContent } from './generate'
+
+describe('generatePromptContent without key', () => {
+  it('returns placeholder that includes user prompt and is longer than input', async () => {
+    delete process.env.OPENAI_API_KEY
+    const input = '美女模特车模展会'
+    const { mode, content } = await generatePromptContent(input, 'image_prompt_multi_style')
+    expect(mode).toBe('image_prompt_multi_style')
+    expect(content).toContain(input)
+    expect(content.length).toBeGreaterThan(input.length)
+    expect(content).not.toBe(input)
+  })
+})

--- a/packages/agent/src/prompt-modes/generate.ts
+++ b/packages/agent/src/prompt-modes/generate.ts
@@ -30,10 +30,13 @@ export async function generatePromptContent(
     }),
   })
   if (!res.ok) {
-    return { mode, content: def.placeholder(prompt) }
+    throw new Error(`LLM 请求失败: ${res.status} ${res.statusText}`)
   }
   const json = (await res.json()) as { choices: Array<{ message: { content: string } }> }
-  const content = json.choices[0]?.message?.content ?? def.placeholder(prompt)
+  const content = json.choices[0]?.message?.content?.trim()
+  if (!content) {
+    throw new Error('LLM 返回空内容')
+  }
   return { mode, content }
 }
 

--- a/packages/agent/src/prompt-modes/generate.ts
+++ b/packages/agent/src/prompt-modes/generate.ts
@@ -1,0 +1,46 @@
+import { getPromptMode } from './registry'
+import type { PromptModeId } from './types'
+import { classifyPromptMode } from './classify'
+
+export async function generatePromptContent(
+  prompt: string,
+  mode: PromptModeId,
+  opts?: { apiKey?: string; baseUrl?: string; model?: string },
+): Promise<{ mode: PromptModeId; content: string }> {
+  const key = opts?.apiKey ?? process.env.OPENAI_API_KEY
+  const def = getPromptMode(mode)
+
+  if (!key) {
+    return { mode, content: def.placeholder(prompt) }
+  }
+
+  const baseUrl = (opts?.baseUrl ?? process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1').replace(/\/$/, '')
+  const res = await fetch(`${baseUrl}/chat/completions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
+    body: JSON.stringify({
+      model: opts?.model ?? process.env.OPENAI_CHAT_MODEL ?? 'gpt-4o',
+      temperature: 0.8,
+      messages: [
+        { role: 'system', content: def.system },
+        { role: 'user', content: def.fewShot.user },
+        { role: 'assistant', content: def.fewShot.assistant },
+        { role: 'user', content: `请基于以下需求生成：\n\n${prompt}` },
+      ],
+    }),
+  })
+  if (!res.ok) {
+    return { mode, content: def.placeholder(prompt) }
+  }
+  const json = (await res.json()) as { choices: Array<{ message: { content: string } }> }
+  const content = json.choices[0]?.message?.content ?? def.placeholder(prompt)
+  return { mode, content }
+}
+
+export async function generatePromptFromUserInput(
+  prompt: string,
+  opts?: { apiKey?: string; baseUrl?: string; model?: string },
+): Promise<{ mode: PromptModeId; content: string }> {
+  const { mode } = await classifyPromptMode(prompt, opts)
+  return generatePromptContent(prompt, mode, opts)
+}

--- a/packages/agent/src/prompt-modes/index.ts
+++ b/packages/agent/src/prompt-modes/index.ts
@@ -1,0 +1,4 @@
+export type { PromptModeId, PromptModeDefinition } from './types'
+export { PROMPT_MODES, PROMPT_MODE_IDS, getPromptMode } from './registry'
+export { tryRuleShortcut, heuristicMode, classifyPromptMode } from './classify'
+export { generatePromptContent, generatePromptFromUserInput } from './generate'

--- a/packages/agent/src/prompt-modes/modes/character-turnaround.ts
+++ b/packages/agent/src/prompt-modes/modes/character-turnaround.ts
@@ -1,0 +1,16 @@
+import type { PromptModeDefinition } from '../types'
+
+export const characterTurnaroundMode: PromptModeDefinition = {
+  id: 'character_turnaround',
+  label: '人物三视图',
+  classifyHints: '用户要人物三视图/正侧背/turnaround 角色设定，强调同一角色一致性',
+  system: `你是角色设定与 AI 绘画提示词专家。根据用户短需求输出 Markdown：
+1) 角色锁定说明（同一人物、同一服装发型）；2) 正/侧/背三视图各一组，含中文描述 + EN Prompt；3) 白底或干净背景、一致性关键词；4) 禁止每视图换装换脸；5) 禁止只复述用户原句。`,
+  fewShot: {
+    user: '生成包含人物三视图的提示词，赛博朋克女黑客',
+    assistant:
+      '### 角色锁定\n同一角色：赛博朋克女黑客，短紫发，黑色机能夹克…\n\n### 正面\n- **中文描述：** …\n- **Prompt:**\n> front view, same character…\n\n### 侧面\n…\n\n### 背面\n…',
+  },
+  placeholder: (prompt) =>
+    `【提示词草案·人物三视图】\n\n基于「${prompt}」：\n\n### 角色锁定\n同一角色特征描述…\n\n### 正面\n- 中文描述：…\n- Prompt: \`front view, same character…\`\n\n### 侧面\n- 中文描述：…\n- Prompt: \`side view…\`\n\n### 背面\n- 中文描述：…\n- Prompt: \`back view…\`\n\n（配置 OPENAI_API_KEY 后可获得真实 LLM 输出）`,
+}

--- a/packages/agent/src/prompt-modes/modes/copywriting.ts
+++ b/packages/agent/src/prompt-modes/modes/copywriting.ts
@@ -1,0 +1,16 @@
+import type { PromptModeDefinition } from '../types'
+
+export const copywritingMode: PromptModeDefinition = {
+  id: 'copywriting',
+  label: '文案/旁白',
+  classifyHints: '用户要旁白/口播/品牌文案/广告词，可直接使用的文案结构',
+  system: `你是资深文案与口播撰稿人。根据用户短需求输出 Markdown：
+1) 目标受众与语气；2) 短版与长版（或主文案 + 备选）；3) 可直接口播的完整文案；4) 禁止只复述用户原句。`,
+  fewShot: {
+    user: '写一段品牌旁白，科技创业公司',
+    assistant:
+      '### 目标受众与语气\n…\n\n### 短版（15秒口播）\n…\n\n### 长版（30秒口播）\n…',
+  },
+  placeholder: (prompt) =>
+    `【文案草案】\n\n基于「${prompt}」：\n\n### 目标受众与语气\n…\n\n### 短版（口播）\n…\n\n### 长版（口播）\n…\n\n（配置 OPENAI_API_KEY 后可获得真实 LLM 输出）`,
+}

--- a/packages/agent/src/prompt-modes/modes/generic.ts
+++ b/packages/agent/src/prompt-modes/modes/generic.ts
@@ -1,0 +1,16 @@
+import type { PromptModeDefinition } from '../types'
+
+export const genericMode: PromptModeDefinition = {
+  id: 'generic',
+  label: '通用创作',
+  classifyHints: '无法归类到其他模式时的兜底；短问候或模糊需求',
+  system: `你是通用 AI 创作助手。根据用户短需求输出 Markdown：
+1) 先用小节结构给出最可能有用的创作物；2) 提示用户可改写需求以命中更专模式（如三视图、分镜、剧本、文案、绘画提示词）；3) 禁止只复述用户原句。`,
+  fewShot: {
+    user: '你好，帮我写点东西',
+    assistant:
+      '### 创作草案\n…\n\n### 提示\n若您需要更专业的输出，可说明具体类型，例如「人物三视图」「分镜提示词」「品牌旁白」等。',
+  },
+  placeholder: (prompt) =>
+    `【创作草案·通用】\n\n基于「${prompt}」：\n\n### 创作草案\n…\n\n### 提示\n若您需要更专业的输出，可说明具体类型，例如「人物三视图」「分镜提示词」「品牌旁白」等。\n\n（配置 OPENAI_API_KEY 后可获得真实 LLM 输出）`,
+}

--- a/packages/agent/src/prompt-modes/modes/image-prompt-multi-style.ts
+++ b/packages/agent/src/prompt-modes/modes/image-prompt-multi-style.ts
@@ -1,0 +1,16 @@
+import type { PromptModeDefinition } from '../types'
+
+export const imagePromptMultiStyleMode: PromptModeDefinition = {
+  id: 'image_prompt_multi_style',
+  label: '多风格绘画提示词',
+  classifyHints: '用户要多组 AI 绘画/Midjourney/SD 风格提示词、海报/车模/角色外观多风格方案',
+  system: `你是资深 AI 绘画提示词工程师。根据用户短需求输出 Markdown：
+1) 简短开场；2) 至少 3 种风格，每组含「中文描述」+「Prompt (EN)」引用块；3) 建议与技巧（比例、负面词等）；4) 禁止只复述用户原句。用中文说明、英文 Prompt。`,
+  fewShot: {
+    user: '赛博朋克猫咖啡馆海报',
+    assistant:
+      '### 风格一：霓虹夜雨\n- **中文描述：** …\n- **Prompt:**\n> neon rain, cyberpunk cat cafe…',
+  },
+  placeholder: (prompt) =>
+    `【提示词草案·多风格】\n\n基于「${prompt}」：\n\n### 风格一\n- 中文描述：…\n- Prompt: \`sample prompt\`\n\n（配置 OPENAI_API_KEY 后可获得真实 LLM 输出）`,
+}

--- a/packages/agent/src/prompt-modes/modes/script.ts
+++ b/packages/agent/src/prompt-modes/modes/script.ts
@@ -1,0 +1,16 @@
+import type { PromptModeDefinition } from '../types'
+
+export const scriptMode: PromptModeDefinition = {
+  id: 'script',
+  label: '剧本',
+  classifyHints: '用户要剧本/剧本大纲/按某人生观或主题生成相似剧本',
+  system: `你是专业编剧。根据用户短需求输出 Markdown：
+1) 主题解读；2) 主要人物；3) 核心冲突；4) 分场/对白草案；5) 若未检索原著可声明「基于常识近似」；6) 禁止伪引用大段「原著原文」；7) 禁止只复述用户原句。`,
+  fewShot: {
+    user: '按奋斗人生观生成相似剧本大纲',
+    assistant:
+      '### 主题解读\n…\n\n### 主要人物\n- 主角：…\n\n### 核心冲突\n…\n\n### 分场草案\n**第一场** …\n\n（未检索原著，基于常识近似创作）',
+  },
+  placeholder: (prompt) =>
+    `【剧本草案】\n\n基于「${prompt}」：\n\n### 主题解读\n…\n\n### 主要人物\n- 主角：…\n\n### 核心冲突\n…\n\n### 分场草案\n**第一场** …\n\n（配置 OPENAI_API_KEY 后可获得真实 LLM 输出）`,
+}

--- a/packages/agent/src/prompt-modes/modes/storyboard.ts
+++ b/packages/agent/src/prompt-modes/modes/storyboard.ts
@@ -1,0 +1,16 @@
+import type { PromptModeDefinition } from '../types'
+
+export const storyboardMode: PromptModeDefinition = {
+  id: 'storyboard',
+  label: '分镜提示词',
+  classifyHints: '用户要分镜提示词/分镜脚本，含镜号、景别、运镜、动作描述',
+  system: `你是资深分镜师与 AI 绘画提示词工程师。根据用户短需求输出 Markdown：
+1) 简短开场；2) 按镜号序列（镜1、镜2…），每镜含景别/机位/运镜/动作/中英 Prompt；3) 禁止只有形容词堆砌；4) 禁止只复述用户原句。`,
+  fewShot: {
+    user: '帮我生成一个分镜提示词，追逐场景',
+    assistant:
+      '### 镜1\n- **景别/机位：** 远景，俯拍\n- **运镜/动作：** 主角奔跑穿过巷道\n- **Prompt:**\n> wide shot, chase scene…\n\n### 镜2\n…',
+  },
+  placeholder: (prompt) =>
+    `【提示词草案·分镜】\n\n基于「${prompt}」：\n\n### 镜1\n- 景别/机位：远景\n- 运镜/动作：…\n- Prompt: \`wide shot…\`\n\n### 镜2\n- 景别/机位：中景\n- 运镜/动作：…\n- Prompt: \`medium shot…\`\n\n（配置 OPENAI_API_KEY 后可获得真实 LLM 输出）`,
+}

--- a/packages/agent/src/prompt-modes/registry.ts
+++ b/packages/agent/src/prompt-modes/registry.ts
@@ -1,0 +1,22 @@
+import type { PromptModeDefinition, PromptModeId } from './types'
+import { imagePromptMultiStyleMode } from './modes/image-prompt-multi-style'
+import { characterTurnaroundMode } from './modes/character-turnaround'
+import { storyboardMode } from './modes/storyboard'
+import { scriptMode } from './modes/script'
+import { copywritingMode } from './modes/copywriting'
+import { genericMode } from './modes/generic'
+
+export const PROMPT_MODES: Record<PromptModeId, PromptModeDefinition> = {
+  image_prompt_multi_style: imagePromptMultiStyleMode,
+  character_turnaround: characterTurnaroundMode,
+  storyboard: storyboardMode,
+  script: scriptMode,
+  copywriting: copywritingMode,
+  generic: genericMode,
+}
+
+export function getPromptMode(id: PromptModeId): PromptModeDefinition {
+  return PROMPT_MODES[id]
+}
+
+export const PROMPT_MODE_IDS = Object.keys(PROMPT_MODES) as PromptModeId[]

--- a/packages/agent/src/prompt-modes/types.ts
+++ b/packages/agent/src/prompt-modes/types.ts
@@ -1,0 +1,16 @@
+export type PromptModeId =
+  | 'image_prompt_multi_style'
+  | 'character_turnaround'
+  | 'storyboard'
+  | 'script'
+  | 'copywriting'
+  | 'generic'
+
+export interface PromptModeDefinition {
+  id: PromptModeId
+  label: string
+  classifyHints: string
+  system: string
+  fewShot: { user: string; assistant: string }
+  placeholder: (prompt: string) => string
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,18 @@ importers:
       '@lnkpi/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@tiptap/extension-placeholder':
+        specifier: ^3.28.0
+        version: 3.28.0(@tiptap/extensions@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))
+      '@tiptap/extension-typography':
+        specifier: ^3.28.0
+        version: 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))
+      '@tiptap/starter-kit':
+        specifier: ^3.28.0
+        version: 3.28.0
+      '@tiptap/vue-3':
+        specifier: ^3.28.0
+        version: 3.28.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)(vue@3.5.39(typescript@5.9.3))
       '@vue-flow/background':
         specifier: ^1.3.2
         version: 1.3.2(@vue-flow/core@1.48.2(vue@3.5.39(typescript@5.9.3)))(vue@3.5.39(typescript@5.9.3))
@@ -95,6 +107,9 @@ importers:
       playcanvas:
         specifier: ^2.17.2
         version: 2.17.2
+      tiptap-markdown:
+        specifier: ^0.9.0
+        version: 0.9.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))
       vue:
         specifier: ^3.5.13
         version: 3.5.39(typescript@5.9.3)
@@ -751,6 +766,164 @@ packages:
   '@sxzz/popperjs-es@2.11.8':
     resolution: {integrity: sha512-wOwESXvvED3S8xBmcPWHs2dUuzrE4XiZeFu7e1hROIJkm02a49N120pmOXxY33sBb6hArItm5W5tcg1cBtV+HQ==}
 
+  '@tiptap/core@3.28.0':
+    resolution: {integrity: sha512-gUuD5WAYfbDxNSSJya/emh2KSzXZXLUYKW4fEnc1AQ5FE2twzh4LJ9UlKFIawigrUCAksWI5Fy1hRbv+5m4ZdQ==}
+    peerDependencies:
+      '@tiptap/pm': 3.28.0
+
+  '@tiptap/extension-blockquote@3.28.0':
+    resolution: {integrity: sha512-y8Xi6Z3AQLXedz0J8Z3kDsu7SKBmL50gKVXx3RK1Oo1cuCGhNChm3syChkAz3PLAbrPUM5rvJDSZdF2jUrDnng==}
+    peerDependencies:
+      '@tiptap/core': 3.28.0
+      '@tiptap/pm': 3.28.0
+
+  '@tiptap/extension-bold@3.28.0':
+    resolution: {integrity: sha512-JhZQmr0AU741bOwjVMfuwJdK4g0TQwwPbeca9aqKHv5zvZw4i4G9G6fESVyMFc3Yag1ffpnq5EtNldHKTnMhlw==}
+    peerDependencies:
+      '@tiptap/core': 3.28.0
+
+  '@tiptap/extension-bubble-menu@3.28.0':
+    resolution: {integrity: sha512-7AUNoHj2K4XLKCgW4uspeD/ENejPu2BeHvLTsiOoIO+XXDNSi2j0bbaIS8f2s/qnFirscwp/sbznp1qph/76qg==}
+    peerDependencies:
+      '@tiptap/core': 3.28.0
+      '@tiptap/pm': 3.28.0
+
+  '@tiptap/extension-bullet-list@3.28.0':
+    resolution: {integrity: sha512-dSVuNiH7PFMmWGkNER9vfUb5bXUHDARvHbJ3l+APEb+ZiusVN1KFdM3nd/RsW/Rt5Gd3XwlIEU/c2Uf7cxYDcw==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.28.0
+
+  '@tiptap/extension-code-block@3.28.0':
+    resolution: {integrity: sha512-bHITDzT0umTLh+SiEVQzIXkCMt/TzbPM1+HQy9ZxgQDHAJj/vdmfNAnP3RCOrz4lETXyhNQ2b6kxeu3lWckxyA==}
+    peerDependencies:
+      '@tiptap/core': 3.28.0
+      '@tiptap/pm': 3.28.0
+
+  '@tiptap/extension-code@3.28.0':
+    resolution: {integrity: sha512-AUw2Acof3CQE6Q6Y22saK4lyg0nkeJ4XXniU65TdAi/9TE66TGiO4NQJJNNPgu8+VMEwl5j8VsIFK8sfTcNYtg==}
+    peerDependencies:
+      '@tiptap/core': 3.28.0
+
+  '@tiptap/extension-document@3.28.0':
+    resolution: {integrity: sha512-5SAKtlB1Tr/eZFhISL86HqmUup6rItvPtuPyRjmZo/VgbMwXEwiyAh1sMgFp5VNaeSMM14vJSyQpjhSaOmaBqg==}
+    peerDependencies:
+      '@tiptap/core': 3.28.0
+
+  '@tiptap/extension-dropcursor@3.28.0':
+    resolution: {integrity: sha512-JA+dXQjjfJBpD0nVsZeddGVXRsmanESM9+8CtM35hI9wJnYMXay/B+5GUhswO20zhT3zhB2ZOTGe9knu6A8nIQ==}
+    peerDependencies:
+      '@tiptap/extensions': 3.28.0
+
+  '@tiptap/extension-floating-menu@3.28.0':
+    resolution: {integrity: sha512-59SECvJq3pQfeJBuydEdhQqrpl0oDlk8N1Ovs1Si3/fJa6rEQAJB2zIvcpBHky9Z+5JodI2eueDnv8eimiyGbg==}
+    peerDependencies:
+      '@floating-ui/dom': ^1.0.0
+      '@tiptap/core': 3.28.0
+      '@tiptap/pm': 3.28.0
+
+  '@tiptap/extension-gapcursor@3.28.0':
+    resolution: {integrity: sha512-Wo73kM4q8z4Va9i4+0n1cO0UEMVUVBHPqM6cAqEYXjB4T48LQkKjRsiQydCezm185rQAsmm1dyi72gtvVQfdMg==}
+    peerDependencies:
+      '@tiptap/extensions': 3.28.0
+
+  '@tiptap/extension-hard-break@3.28.0':
+    resolution: {integrity: sha512-JHIFjX1luJgQ4VFEkIeXZpbc54Qiw+69P8FmlazYTh7AIJ6iLCpMFgQFELnivEAZ+/vS0lMPQubg0rCeM3UrHw==}
+    peerDependencies:
+      '@tiptap/core': 3.28.0
+
+  '@tiptap/extension-heading@3.28.0':
+    resolution: {integrity: sha512-rKjGG/Ik2lNaXBNVmONEDm5DBfGDLM1NWgSf5RRfBISrH8Lm1xqFruOB9tIaB0YUoSV3SBOiwTF9svmzvKSoRA==}
+    peerDependencies:
+      '@tiptap/core': 3.28.0
+
+  '@tiptap/extension-horizontal-rule@3.28.0':
+    resolution: {integrity: sha512-neBCMWprkppQUoLWyeJZDHqBw+xKX2oNhLD9MbFlhKIr092zgfP4mpCvQnSkn1OHl156KzZMp070+NyLBjgQ7A==}
+    peerDependencies:
+      '@tiptap/core': 3.28.0
+      '@tiptap/pm': 3.28.0
+
+  '@tiptap/extension-italic@3.28.0':
+    resolution: {integrity: sha512-Yur/ELz6dNVKQC7m8wGjtoLFxamGjJmA0rUEEOacTH6J39aFmcSxYkEGNDkYHbZFyHFYqbej6eI3VE0h08O0mg==}
+    peerDependencies:
+      '@tiptap/core': 3.28.0
+
+  '@tiptap/extension-link@3.28.0':
+    resolution: {integrity: sha512-hy/PqSeTyl317yseFcHGE+3XVfQKQYaL4uZuj27xlrcO7MZ15drt1h9sUZy1FTBF3mr8676pQu7aoEm/Ww4ZRA==}
+    peerDependencies:
+      '@tiptap/core': 3.28.0
+      '@tiptap/pm': 3.28.0
+
+  '@tiptap/extension-list-item@3.28.0':
+    resolution: {integrity: sha512-GbXrnMac6knSetZY33NHwOrgXFPqH28uCklQqmOZQlsrdGqezDKk31qoEMr4GsKW9n/lViAeuc07oIzwLwCMng==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.28.0
+
+  '@tiptap/extension-list-keymap@3.28.0':
+    resolution: {integrity: sha512-u9Wks8c/eQAv0RkULNggOyTKDD69WVbcV9H5cbasPDUbq5XbEFVa9ajxhEGfMmQ5et3EX0QL8qBi50K0GqbIjA==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.28.0
+
+  '@tiptap/extension-list@3.28.0':
+    resolution: {integrity: sha512-zQ66i5DuhVOndmZ0d7H475Y5Yb+BMx+zfCjFkCzEc6WVef5MumtxBVTkGLQ0ibxUaD71s4QQZbjHWagpaTg0eQ==}
+    peerDependencies:
+      '@tiptap/core': 3.28.0
+      '@tiptap/pm': 3.28.0
+
+  '@tiptap/extension-ordered-list@3.28.0':
+    resolution: {integrity: sha512-OZNYrKKL9D01ySOujlNbKlLS9/3wGgKNYeoHZUg0e+Ta8WPVvL3W1zH6TgiU5sF2ZSGUBoq3w7mdaO/iROlUkw==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.28.0
+
+  '@tiptap/extension-paragraph@3.28.0':
+    resolution: {integrity: sha512-8UMlQIjzqf6r2hSJ/VeJ00RqaOrOB1J5rTk02Vcw2pYeHkOqp+B0ff0HFu4abT9x1q4oXrBAgMsxRtgh/kR14Q==}
+    peerDependencies:
+      '@tiptap/core': 3.28.0
+
+  '@tiptap/extension-placeholder@3.28.0':
+    resolution: {integrity: sha512-zueiqNeCHOshDa8dGGSa/0cOBZkMjPrxQhemjF4tj2yZ6EeWHBPtCE5h/uQCagEePxsoaJtvaCRh88199zrgBw==}
+    peerDependencies:
+      '@tiptap/extensions': 3.28.0
+
+  '@tiptap/extension-strike@3.28.0':
+    resolution: {integrity: sha512-VVj2ZZU9QYqiHLcjqMqRYvuHSsokj/AgUl+6TzLrKjlWwyZ18D4H2vkyI0g70iVTKnUpZ3sEy8WA/rqjgBjqBg==}
+    peerDependencies:
+      '@tiptap/core': 3.28.0
+
+  '@tiptap/extension-text@3.28.0':
+    resolution: {integrity: sha512-Jqp1LgfY1mnp4TQHoy+vnHyfn6qnnAM6nHgGwbY5zA8b/Xf1Etll6pziTx9p1J1qcfAgSrnjOyAmA++H7VQqww==}
+    peerDependencies:
+      '@tiptap/core': 3.28.0
+
+  '@tiptap/extension-typography@3.28.0':
+    resolution: {integrity: sha512-6iwxXqtT6HuFv9LYrpT7YV6TpIauWBXCGGs3liHPrY4P7aMwpRmC3QTbgq655PMpjV8xMT6S2Wa6cQi2CNrXmQ==}
+    peerDependencies:
+      '@tiptap/core': 3.28.0
+
+  '@tiptap/extension-underline@3.28.0':
+    resolution: {integrity: sha512-rwxCS6vTh2DJkNIYQX7JSrrRSmm76e2y48aZeuZO5ShkvLWMuJ3/zqDHRxAQVDiJhuE2Cp8NrTmPYlUc9YrT0A==}
+    peerDependencies:
+      '@tiptap/core': 3.28.0
+
+  '@tiptap/extensions@3.28.0':
+    resolution: {integrity: sha512-DJT1khCK+O/pT1gQlAnoKAx6zwDkgv7GtnhSfkqm1/4KHC3x+SSJnBIgBl9oGHymA+DxWbW1EULU4V3d/kT2uQ==}
+    peerDependencies:
+      '@tiptap/core': 3.28.0
+      '@tiptap/pm': 3.28.0
+
+  '@tiptap/pm@3.28.0':
+    resolution: {integrity: sha512-ALcpwZMUdat9gjJKlpscpoqXStoLhU246LPEVBDvJdIsoUKvUu3MrzfXik2Y8mtSGfhjtm9O2TRkWxQiFVMwsQ==}
+
+  '@tiptap/starter-kit@3.28.0':
+    resolution: {integrity: sha512-pqvFpValV+ONtlu3l4s73ROm/tEjoGMmt6uHmSJaLbqTcMHkdWuR3flJ/5brr4IDHe1foxmNicMbRxlje7yBYw==}
+
+  '@tiptap/vue-3@3.28.0':
+    resolution: {integrity: sha512-twb3T6hofM0ajncCSgrLYIjfn86WfR2NVXteurdNOcnkJCIMTij5OhO/xn0z7y8+lp3TMkF6H5kajUpivBpnzw==}
+    peerDependencies:
+      '@floating-ui/dom': ^1.0.0
+      '@tiptap/core': 3.28.0
+      '@tiptap/pm': 3.28.0
+      vue: ^3.0.0
+
   '@tokenizer/inflate@0.2.7':
     resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
     engines: {node: '>=18'}
@@ -785,11 +958,29 @@ packages:
   '@types/jsonwebtoken@9.0.5':
     resolution: {integrity: sha512-VRLSGzik+Unrup6BsouBeHsf4d1hOEgYWTm/7Nmw1sXoN1+tRly/Gy/po3yeahnP4jfnQWWAhQAqcNfH7ngOkA==}
 
+  '@types/linkify-it@3.0.5':
+    resolution: {integrity: sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==}
+
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
   '@types/lodash-es@4.17.12':
     resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
 
   '@types/lodash@4.17.24':
     resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
+
+  '@types/markdown-it@13.0.9':
+    resolution: {integrity: sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdurl@1.0.5':
+    resolution: {integrity: sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   '@types/multer@2.2.0':
     resolution: {integrity: sha512-3U1troeqGV8Ntp7Q3klwf4zr23VEoqYVocYXaswm9+8z3O9UHDYAqLxjJ/h550iRADTjKdOdhhasXw6gD6kYtg==}
@@ -984,6 +1175,9 @@ packages:
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
@@ -1322,6 +1516,10 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
@@ -1587,6 +1785,12 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
+
+  linkifyjs@4.3.3:
+    resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
+
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
@@ -1627,9 +1831,19 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-it-task-lists@2.1.1:
+    resolution: {integrity: sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==}
+
+  markdown-it@14.3.0:
+    resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -1773,6 +1987,9 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  orderedmap@2.1.1:
+    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -1897,6 +2114,48 @@ packages:
       typescript:
         optional: true
 
+  prosemirror-changeset@2.4.1:
+    resolution: {integrity: sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==}
+
+  prosemirror-commands@1.7.1:
+    resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
+
+  prosemirror-dropcursor@1.8.3:
+    resolution: {integrity: sha512-FoYbsJR8gK+DGlqhNoE29Loa38eIZPzQRIb1VMaDNBoo4OLP6vVof/jR8qFY/6XvUd6Dhug8MDCHl2a/h8RTfQ==}
+
+  prosemirror-gapcursor@1.4.1:
+    resolution: {integrity: sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==}
+
+  prosemirror-history@1.5.0:
+    resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
+
+  prosemirror-inputrules@1.5.1:
+    resolution: {integrity: sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==}
+
+  prosemirror-keymap@1.2.3:
+    resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
+
+  prosemirror-markdown@1.13.5:
+    resolution: {integrity: sha512-ac8trNQ01ybKDRTcfUc56LZufG3oYyU4N25qSXgp8dS0U4JtzzCj7oQlKu5v09VSmS5IseYoQ2yDkTbo7f7D8Q==}
+
+  prosemirror-model@1.25.11:
+    resolution: {integrity: sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==}
+
+  prosemirror-schema-list@1.5.1:
+    resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
+
+  prosemirror-state@1.4.4:
+    resolution: {integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==}
+
+  prosemirror-tables@1.8.5:
+    resolution: {integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==}
+
+  prosemirror-transform@1.12.0:
+    resolution: {integrity: sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==}
+
+  prosemirror-view@1.42.1:
+    resolution: {integrity: sha512-rRqzZnRgkyh69XoOMrfFJHwauHscLBmHbq772kwbic1ymQAM8gXjzEbJse5j1ep2UO2HRIAQL0bY3kZ/RoqjVw==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -1907,6 +2166,10 @@ packages:
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
@@ -1964,6 +2227,9 @@ packages:
     resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rope-sequence@1.3.4:
+    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -2108,6 +2374,11 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tiptap-markdown@0.9.0:
+    resolution: {integrity: sha512-dKLQ9iiuGNgrlGVjrNauF/UBzWu4LYOx5pkD0jNkmQt/GOwfCJsBuzZTsf1jZ204ANHOm572mZ9PYvGh1S7tpQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.0.1
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -2148,6 +2419,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   uid@2.0.2:
     resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}
@@ -2293,6 +2567,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -2702,6 +2979,180 @@ snapshots:
 
   '@sxzz/popperjs-es@2.11.8': {}
 
+  '@tiptap/core@3.28.0(@tiptap/pm@3.28.0)':
+    dependencies:
+      '@tiptap/pm': 3.28.0
+
+  '@tiptap/extension-blockquote@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)':
+    dependencies:
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+      '@tiptap/pm': 3.28.0
+
+  '@tiptap/extension-bold@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))':
+    dependencies:
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-bubble-menu@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+      '@tiptap/pm': 3.28.0
+    optional: true
+
+  '@tiptap/extension-bullet-list@3.28.0(@tiptap/extension-list@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-code-block@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)':
+    dependencies:
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+      '@tiptap/pm': 3.28.0
+
+  '@tiptap/extension-code@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))':
+    dependencies:
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-document@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))':
+    dependencies:
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-dropcursor@3.28.0(@tiptap/extensions@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))':
+    dependencies:
+      '@tiptap/extensions': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-floating-menu@3.28.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+      '@tiptap/pm': 3.28.0
+    optional: true
+
+  '@tiptap/extension-gapcursor@3.28.0(@tiptap/extensions@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))':
+    dependencies:
+      '@tiptap/extensions': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-hard-break@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))':
+    dependencies:
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-heading@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))':
+    dependencies:
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-horizontal-rule@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)':
+    dependencies:
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+      '@tiptap/pm': 3.28.0
+
+  '@tiptap/extension-italic@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))':
+    dependencies:
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-link@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)':
+    dependencies:
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+      '@tiptap/pm': 3.28.0
+      linkifyjs: 4.3.3
+
+  '@tiptap/extension-list-item@3.28.0(@tiptap/extension-list@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-list-keymap@3.28.0(@tiptap/extension-list@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-list@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)':
+    dependencies:
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+      '@tiptap/pm': 3.28.0
+
+  '@tiptap/extension-ordered-list@3.28.0(@tiptap/extension-list@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))':
+    dependencies:
+      '@tiptap/extension-list': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-paragraph@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))':
+    dependencies:
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-placeholder@3.28.0(@tiptap/extensions@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))':
+    dependencies:
+      '@tiptap/extensions': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-strike@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))':
+    dependencies:
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-text@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))':
+    dependencies:
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-typography@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))':
+    dependencies:
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-underline@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))':
+    dependencies:
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+
+  '@tiptap/extensions@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)':
+    dependencies:
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+      '@tiptap/pm': 3.28.0
+
+  '@tiptap/pm@3.28.0':
+    dependencies:
+      prosemirror-changeset: 2.4.1
+      prosemirror-commands: 1.7.1
+      prosemirror-dropcursor: 1.8.3
+      prosemirror-gapcursor: 1.4.1
+      prosemirror-history: 1.5.0
+      prosemirror-inputrules: 1.5.1
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.11
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.4
+      prosemirror-tables: 1.8.5
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.1
+
+  '@tiptap/starter-kit@3.28.0':
+    dependencies:
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+      '@tiptap/extension-blockquote': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
+      '@tiptap/extension-bold': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))
+      '@tiptap/extension-bullet-list': 3.28.0(@tiptap/extension-list@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))
+      '@tiptap/extension-code': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))
+      '@tiptap/extension-code-block': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
+      '@tiptap/extension-document': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))
+      '@tiptap/extension-dropcursor': 3.28.0(@tiptap/extensions@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))
+      '@tiptap/extension-gapcursor': 3.28.0(@tiptap/extensions@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))
+      '@tiptap/extension-hard-break': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))
+      '@tiptap/extension-heading': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))
+      '@tiptap/extension-horizontal-rule': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
+      '@tiptap/extension-italic': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))
+      '@tiptap/extension-link': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
+      '@tiptap/extension-list': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
+      '@tiptap/extension-list-item': 3.28.0(@tiptap/extension-list@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))
+      '@tiptap/extension-list-keymap': 3.28.0(@tiptap/extension-list@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))
+      '@tiptap/extension-ordered-list': 3.28.0(@tiptap/extension-list@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))
+      '@tiptap/extension-paragraph': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))
+      '@tiptap/extension-strike': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))
+      '@tiptap/extension-text': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))
+      '@tiptap/extension-underline': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))
+      '@tiptap/extensions': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
+      '@tiptap/pm': 3.28.0
+
+  '@tiptap/vue-3@3.28.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)(vue@3.5.39(typescript@5.9.3))':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+      '@tiptap/pm': 3.28.0
+      vue: 3.5.39(typescript@5.9.3)
+    optionalDependencies:
+      '@tiptap/extension-bubble-menu': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
+      '@tiptap/extension-floating-menu': 3.28.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
+
   '@tokenizer/inflate@0.2.7':
     dependencies:
       debug: 4.4.3
@@ -2749,11 +3200,29 @@ snapshots:
     dependencies:
       '@types/node': 22.20.1
 
+  '@types/linkify-it@3.0.5': {}
+
+  '@types/linkify-it@5.0.0': {}
+
   '@types/lodash-es@4.17.12':
     dependencies:
       '@types/lodash': 4.17.24
 
   '@types/lodash@4.17.24': {}
+
+  '@types/markdown-it@13.0.9':
+    dependencies:
+      '@types/linkify-it': 3.0.5
+      '@types/mdurl': 1.0.5
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdurl@1.0.5': {}
+
+  '@types/mdurl@2.0.0': {}
 
   '@types/multer@2.2.0':
     dependencies:
@@ -3006,6 +3475,8 @@ snapshots:
   append-field@1.0.0: {}
 
   arg@5.0.2: {}
+
+  argparse@2.0.1: {}
 
   array-flatten@1.1.1: {}
 
@@ -3354,6 +3825,8 @@ snapshots:
       once: 1.4.0
     optional: true
 
+  entities@4.5.0: {}
+
   entities@7.0.1: {}
 
   es-define-property@1.0.1: {}
@@ -3695,6 +4168,12 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  linkify-it@5.0.2:
+    dependencies:
+      uc.micro: 2.1.0
+
+  linkifyjs@4.3.3: {}
+
   lodash-es@4.18.1: {}
 
   lodash-unified@1.0.3(@types/lodash-es@4.17.12)(lodash-es@4.18.1)(lodash@4.18.1):
@@ -3725,7 +4204,20 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-it-task-lists@2.1.1: {}
+
+  markdown-it@14.3.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.2
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   math-intrinsics@1.1.0: {}
+
+  mdurl@2.0.0: {}
 
   media-typer@0.3.0: {}
 
@@ -3845,6 +4337,8 @@ snapshots:
       wrappy: 1.0.2
     optional: true
 
+  orderedmap@2.1.1: {}
+
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
@@ -3957,6 +4451,86 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
+  prosemirror-changeset@2.4.1:
+    dependencies:
+      prosemirror-transform: 1.12.0
+
+  prosemirror-commands@1.7.1:
+    dependencies:
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-dropcursor@1.8.3:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.1
+
+  prosemirror-gapcursor@1.4.1:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.42.1
+
+  prosemirror-history@1.5.0:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.1
+      rope-sequence: 1.3.4
+
+  prosemirror-inputrules@1.5.1:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-keymap@1.2.3:
+    dependencies:
+      prosemirror-state: 1.4.4
+      w3c-keyname: 2.2.8
+
+  prosemirror-markdown@1.13.5:
+    dependencies:
+      '@types/markdown-it': 14.1.2
+      markdown-it: 14.3.0
+      prosemirror-model: 1.25.11
+
+  prosemirror-model@1.25.11:
+    dependencies:
+      orderedmap: 2.1.1
+
+  prosemirror-schema-list@1.5.1:
+    dependencies:
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-state@1.4.4:
+    dependencies:
+      prosemirror-model: 1.25.11
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.1
+
+  prosemirror-tables@1.8.5:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.1
+
+  prosemirror-transform@1.12.0:
+    dependencies:
+      prosemirror-model: 1.25.11
+
+  prosemirror-view@1.42.1:
+    dependencies:
+      prosemirror-model: 1.25.11
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -3969,6 +4543,8 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
     optional: true
+
+  punycode.js@2.3.1: {}
 
   pure-rand@6.1.0: {}
 
@@ -4057,6 +4633,8 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.62.2
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
+
+  rope-sequence@1.3.4: {}
 
   run-parallel@1.2.0:
     dependencies:
@@ -4252,6 +4830,14 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tiptap-markdown@0.9.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0)):
+    dependencies:
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+      '@types/markdown-it': 13.0.9
+      markdown-it: 14.3.0
+      markdown-it-task-lists: 2.1.1
+      prosemirror-markdown: 1.13.5
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -4289,6 +4875,8 @@ snapshots:
   typedarray@0.0.6: {}
 
   typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
 
   uid@2.0.2:
     dependencies:
@@ -4432,6 +5020,8 @@ snapshots:
       '@vue/shared': 3.5.39
     optionalDependencies:
       typescript: 5.9.3
+
+  w3c-keyname@2.2.8: {}
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
## Summary
- Add 6-mode prompt registry with classify → generate (`@lnkpi/agent`) and `POST /studio/prompt/generate` (5 pts / 90s).
- Wire `prompt` nodes via `PromptDockPanel`, TipTap markdown editor (double-click + voice), and keep user `prompt` separate from generated `content`.
- Unify Dock voice controls beside generate; surface LLM failures as node errors with Chinese mode labels.

## Spec / Plan
- Design: `docs/superpowers/specs/2026-07-17-prompt-node-intent-templates-design.md`
- Plan: `docs/superpowers/plans/2026-07-17-prompt-node-intent-templates.md`

## Test plan
- [ ] `pnpm --filter @lnkpi/agent test` (11/11)
- [ ] `pnpm build`
- [ ] Prompt node: short demand → generate → long Markdown; `prompt` field unchanged
- [ ] Modes: car-model multi-style / 三视图 / 分镜 / 剧本 route correctly (with API key)
- [ ] No API key: placeholder (not echo); LLM failure keeps old content + error message
- [ ] Double-click opens TipTap; edit/voice/copy; Dock 🎤 beside generate on prompt/text/image/video/audio/shot


Made with [Cursor](https://cursor.com)