### PR TITLE
fix(web): extend Vercel proxy timeout for prompt generate

### DIFF
--- a/apps/web/api/proxy.ts
+++ b/apps/web/api/proxy.ts
@@ -11,6 +11,7 @@ export const config = {
 
 const LONG_RUNNING_PATHS: Array<{ pattern: RegExp; timeoutMs: number }> = [
   { pattern: /\/studio\/text\/generate$/i, timeoutMs: 120_000 },
+  { pattern: /\/studio\/prompt\/generate$/i, timeoutMs: 120_000 },
   { pattern: /\/studio\/image\/generate$/i, timeoutMs: 120_000 },
   { pattern: /\/studio\/image\/variation$/i, timeoutMs: 120_000 },
   { pattern: /\/studio\/video\/generate$/i, timeoutMs: 90_000 },
@@ -52,7 +53,7 @@ function resolveUpstreamTimeoutMs(upstreamPath: string): number {
 function isStudioGeneratePost(method: string, upstreamPath: string): boolean {
   return (
     method === 'POST'
-    && /\/studio\/(text|image|video|audio)\/(generate|variation)$/i.test(upstreamPath)
+    && /\/studio\/(text|prompt|image|video|audio)\/(generate|variation)$/i.test(upstreamPath)
   )
 }
 


### PR DESCRIPTION
## Summary
- Add `/studio/prompt/generate` to Vercel proxy `LONG_RUNNING_PATHS` (120s), matching text generate.
- Include `prompt` in `isStudioGeneratePost` so long generates use a single attempt (no triple retry on timeout).

## Why
Direct API succeeds in ~30–40s, but `https://lnkpi-web.vercel.app/api/studio/prompt/generate` hit the default 20s upstream timeout and returned 502 (`API 上游暂时不可用`) or 500.

## Test plan
- [x] `pnpm build`
- [ ] After merge + Vercel deploy: POST via Vercel URL with prompts that take >20s (e.g. 分镜 / 车模) returns `code: 0`
- [ ] UI Prompt dock generate succeeds without 500


Made with [Cursor](https://cursor.com)