### PR TITLE
feat(canvas): 资产库时间线网格、公共资产与 dock 毛玻璃对齐

### DIFF
--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common'
+import { AssetsModule } from './assets/assets.module'
 import { AuthModule } from './auth/auth.module'
 import { SessionsModule } from './sessions/sessions.module'
 import { WorksModule } from './works/works.module'
@@ -13,6 +14,6 @@ import { UsersModule } from './users/users.module'
 import { HealthModule } from './health/health.module'
 
 @Module({
-  imports: [PrismaModule, AuthModule, SessionsModule, WorksModule, AgentModule, CanvasModule, UsersModule, MembershipModule, StudioModule, StoriesModule, UploadModule, HealthModule],
+  imports: [PrismaModule, AssetsModule, AuthModule, SessionsModule, WorksModule, AgentModule, CanvasModule, UsersModule, MembershipModule, StudioModule, StoriesModule, UploadModule, HealthModule],
 })
 export class AppModule {}

--- a/apps/server/src/assets/assets.controller.ts
+++ b/apps/server/src/assets/assets.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Query } from '@nestjs/common'
+import { IsIn, IsOptional, IsString } from 'class-validator'
+import { PUBLIC_ASSETS } from './public-assets.data'
+
+class PublicAssetsQueryDto {
+  @IsOptional()
+  @IsIn(['image', 'video', 'audio'])
+  kind?: 'image' | 'video' | 'audio'
+
+  @IsOptional()
+  @IsString()
+  search?: string
+}
+
+@Controller('assets')
+export class AssetsController {
+  @Get('public')
+  findPublic(@Query() query: PublicAssetsQueryDto) {
+    let items = PUBLIC_ASSETS
+    if (query.kind) {
+      items = items.filter((item) => item.kind === query.kind)
+    }
+    if (query.search) {
+      const q = query.search.toLowerCase()
+      items = items.filter((item) => item.label.toLowerCase().includes(q))
+    }
+    return { code: 0, message: 'ok', data: { items } }
+  }
+}

--- a/apps/server/src/assets/assets.module.ts
+++ b/apps/server/src/assets/assets.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common'
+import { AssetsController } from './assets.controller'
+
+@Module({
+  controllers: [AssetsController],
+})
+export class AssetsModule {}

--- a/apps/server/src/assets/public-assets.data.ts
+++ b/apps/server/src/assets/public-assets.data.ts
@@ -1,0 +1,81 @@
+export interface PublicAssetItem {
+  id: string
+  url: string
+  label: string
+  kind: 'image' | 'video' | 'audio'
+  publishedAt: string
+}
+
+/** 平台发布的公共资产，供所有用户在画布资产库中调用 */
+export const PUBLIC_ASSETS: PublicAssetItem[] = [
+  {
+    id: 'pub-img-001',
+    url: 'https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?w=1200&q=80',
+    label: '流体渐变背景',
+    kind: 'image',
+    publishedAt: '2026-07-10T08:00:00.000Z',
+  },
+  {
+    id: 'pub-img-002',
+    url: 'https://images.unsplash.com/photo-1635070041078-e363dbe005cb?w=1200&q=80',
+    label: '星际粒子',
+    kind: 'image',
+    publishedAt: '2026-07-10T08:00:00.000Z',
+  },
+  {
+    id: 'pub-img-003',
+    url: 'https://images.unsplash.com/photo-1620641788421-7a1c342ea42e?w=1200&q=80',
+    label: '紫色霓虹抽象',
+    kind: 'image',
+    publishedAt: '2026-07-02T08:00:00.000Z',
+  },
+  {
+    id: 'pub-img-004',
+    url: 'https://images.unsplash.com/photo-1614728263932-097ed562d636?w=1200&q=80',
+    label: '深空行星',
+    kind: 'image',
+    publishedAt: '2026-07-02T08:00:00.000Z',
+  },
+  {
+    id: 'pub-img-005',
+    url: 'https://images.unsplash.com/photo-1579546929518-9e396f3cc809?w=1200&q=80',
+    label: '彩虹渐变',
+    kind: 'image',
+    publishedAt: '2026-06-20T08:00:00.000Z',
+  },
+  {
+    id: 'pub-img-006',
+    url: 'https://images.unsplash.com/photo-1557683316-973673baf926?w=1200&q=80',
+    label: '蓝紫波纹',
+    kind: 'image',
+    publishedAt: '2026-06-20T08:00:00.000Z',
+  },
+  {
+    id: 'pub-vid-001',
+    url: 'https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
+    label: '示例短片·Big Buck Bunny',
+    kind: 'video',
+    publishedAt: '2026-07-05T08:00:00.000Z',
+  },
+  {
+    id: 'pub-vid-002',
+    url: 'https://storage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4',
+    label: '示例短片·Escapes',
+    kind: 'video',
+    publishedAt: '2026-06-28T08:00:00.000Z',
+  },
+  {
+    id: 'pub-aud-001',
+    url: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3',
+    label: '示例配乐·Helix 1',
+    kind: 'audio',
+    publishedAt: '2026-07-05T08:00:00.000Z',
+  },
+  {
+    id: 'pub-aud-002',
+    url: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3',
+    label: '示例配乐·Helix 2',
+    kind: 'audio',
+    publishedAt: '2026-06-28T08:00:00.000Z',
+  },
+]

--- a/apps/web/src/components/canvas/CanvasAssetPanel.vue
+++ b/apps/web/src/components/canvas/CanvasAssetPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
+import { assetsApi } from '@/services/assets-api'
 
 export interface CanvasAssetItem {
   id: string
@@ -7,6 +8,10 @@ export interface CanvasAssetItem {
   url: string
   label: string
   kind: 'image' | 'video' | 'audio' | 'other'
+  /** 资产产生时间（毫秒时间戳），用于时间线分组 */
+  createdAt?: number
+  /** user = 画布同步的用户资产；public = 平台发布的公共资产 */
+  source?: 'user' | 'public'
 }
 
 const props = defineProps<{
@@ -18,12 +23,109 @@ const emit = defineEmits<{
   upload: []
 }>()
 
+type AssetTab = 'user' | 'public'
+type AssetKindFilter = 'all' | 'image' | 'video' | 'audio'
+
+const tab = ref<AssetTab>('user')
+const kindFilter = ref<AssetKindFilter>('all')
 const search = ref('')
 
+const publicAssets = ref<CanvasAssetItem[]>([])
+const publicLoading = ref(false)
+const publicLoaded = ref(false)
+
+const kindOptions: Array<{ value: AssetKindFilter; label: string }> = [
+  { value: 'all', label: '全部' },
+  { value: 'image', label: '图片' },
+  { value: 'video', label: '视频' },
+  { value: 'audio', label: '音频' },
+]
+
+async function loadPublicAssets() {
+  if (publicLoaded.value || publicLoading.value) return
+  publicLoading.value = true
+  try {
+    const res = await assetsApi.listPublic()
+    publicAssets.value = (res.data?.data?.items ?? []).map((item) => ({
+      id: item.id,
+      nodeId: '',
+      url: item.url,
+      label: item.label,
+      kind: item.kind,
+      createdAt: Date.parse(item.publishedAt) || undefined,
+      source: 'public' as const,
+    }))
+    publicLoaded.value = true
+  } catch {
+    // 公共资产加载失败时留空，用户切换 tab 可重试
+  } finally {
+    publicLoading.value = false
+  }
+}
+
+onMounted(() => {
+  void loadPublicAssets()
+})
+
+function switchTab(next: AssetTab) {
+  tab.value = next
+  if (next === 'public') void loadPublicAssets()
+}
+
+const activeAssets = computed<CanvasAssetItem[]>(() =>
+  tab.value === 'user' ? props.assets : publicAssets.value,
+)
+
 const filtered = computed(() => {
+  let items = activeAssets.value
+  if (kindFilter.value !== 'all') {
+    items = items.filter((a) => a.kind === kindFilter.value)
+  }
   const q = search.value.trim().toLowerCase()
-  if (!q) return props.assets
-  return props.assets.filter((a) => a.label.toLowerCase().includes(q) || a.kind.includes(q))
+  if (q) {
+    items = items.filter((a) => a.label.toLowerCase().includes(q))
+  }
+  return items
+})
+
+interface TimelineGroup {
+  label: string
+  items: CanvasAssetItem[]
+}
+
+function dayLabel(ts: number) {
+  const date = new Date(ts)
+  const now = new Date()
+  const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime()
+  const diffDays = Math.round((startOfDay(now) - startOfDay(date)) / 86_400_000)
+  if (diffDays === 0) return '今天'
+  if (diffDays === 1) return '昨天'
+  if (date.getFullYear() === now.getFullYear()) return `${date.getMonth() + 1}月${date.getDate()}日`
+  return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`
+}
+
+const timeline = computed<TimelineGroup[]>(() => {
+  const withTime = filtered.value
+    .filter((a) => a.createdAt)
+    .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0))
+  const withoutTime = filtered.value.filter((a) => !a.createdAt)
+
+  const groups: TimelineGroup[] = []
+  const index = new Map<string, TimelineGroup>()
+  for (const asset of withTime) {
+    const label = dayLabel(asset.createdAt as number)
+    let group = index.get(label)
+    if (!group) {
+      group = { label, items: [] }
+      index.set(label, group)
+      groups.push(group)
+    }
+    group.items.push(asset)
+  }
+  if (withoutTime.length) {
+    groups.push({ label: '更早', items: withoutTime })
+  }
+  return groups
 })
 
 function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
@@ -31,69 +133,135 @@ function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
   event.dataTransfer?.setData('text/plain', asset.url)
   if (event.dataTransfer) event.dataTransfer.effectAllowed = 'copy'
 }
-
-function kindLabel(kind: string) {
-  const map: Record<string, string> = {
-    image: '图片',
-    video: '视频',
-    audio: '音频',
-  }
-  return map[kind] ?? '媒体'
-}
 </script>
 
 <template>
-  <div class="flex max-h-[min(420px,55vh)] w-[236px] flex-col">
-    <div class="flex items-center gap-2 border-b border-white/[0.06] px-3 py-2">
-      <span class="flex flex-1 items-center gap-2 text-xs font-medium text-white/80">
-        <svg class="h-3.5 w-3.5 text-[#818cf8]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-        </svg>
-        素材库
-        <span class="text-[10px] font-normal text-white/35">{{ assets.length }}</span>
-      </span>
+  <div class="flex max-h-[min(480px,60vh)] w-[312px] flex-col">
+    <!-- 用户资产 / 公共资产 tab -->
+    <div class="flex items-center gap-1 border-b border-white/[0.06] px-3 pt-2.5 pb-2">
       <button
         type="button"
-        class="rounded-lg px-2 py-1 text-[10px] text-[#818cf8] hover:bg-white/5"
+        class="rounded-lg px-2.5 py-1 text-[11px] font-medium transition"
+        :class="tab === 'user' ? 'bg-[#6366f1]/20 text-[#a5b4fc]' : 'text-white/50 hover:bg-white/5 hover:text-white/75'"
+        @click="switchTab('user')"
+      >
+        我的资产
+        <span class="ml-0.5 text-[9px] font-normal opacity-60">{{ assets.length }}</span>
+      </button>
+      <button
+        type="button"
+        class="rounded-lg px-2.5 py-1 text-[11px] font-medium transition"
+        :class="tab === 'public' ? 'bg-[#6366f1]/20 text-[#a5b4fc]' : 'text-white/50 hover:bg-white/5 hover:text-white/75'"
+        @click="switchTab('public')"
+      >
+        公共资产
+      </button>
+      <span class="flex-1" />
+      <button
+        v-if="tab === 'user'"
+        type="button"
+        class="flex items-center gap-1 rounded-lg px-2 py-1 text-[10px] text-[#818cf8] hover:bg-white/5"
         title="上传素材"
         @click="emit('upload')"
       >
+        <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M12 4v12m0-12l-4 4m4-4l4 4" />
+        </svg>
         上传
       </button>
     </div>
 
-    <div class="px-2 pt-2">
+    <!-- 分类检索：类型 chips + 关键词搜索 -->
+    <div class="flex items-center gap-1.5 px-3 pt-2">
+      <button
+        v-for="opt in kindOptions"
+        :key="opt.value"
+        type="button"
+        class="rounded-full px-2 py-0.5 text-[10px] transition"
+        :class="kindFilter === opt.value
+          ? 'bg-white/10 text-white/90'
+          : 'text-white/40 hover:bg-white/5 hover:text-white/70'"
+        @click="kindFilter = opt.value"
+      >
+        {{ opt.label }}
+      </button>
+    </div>
+    <div class="px-3 pt-2">
       <input
         v-model="search"
         class="w-full rounded-lg border border-white/10 bg-white/5 px-2 py-1.5 text-[11px] outline-none focus:border-[#6366f1]/40"
-        placeholder="搜索素材..."
+        placeholder="搜索资产..."
       >
     </div>
 
-    <div class="min-h-0 flex-1 overflow-y-auto p-2 space-y-1.5">
-      <p v-if="!filtered.length" class="px-1 py-4 text-center text-[11px] text-white/30">
-        拖入图片/视频或从节点生成后出现在此
+    <!-- 历史时间线 + 网格 -->
+    <div class="min-h-0 flex-1 overflow-y-auto px-3 py-2">
+      <p v-if="tab === 'public' && publicLoading" class="py-6 text-center text-[11px] text-white/30">
+        加载公共资产中...
       </p>
-      <button
-        v-for="asset in filtered"
-        :key="asset.id"
-        type="button"
-        draggable="true"
-        class="flex w-full items-center gap-2 rounded-lg border border-transparent p-1.5 text-left transition hover:border-white/10 hover:bg-white/[0.04]"
-        @dragstart="onDragStart($event, asset)"
-        @click="emit('apply', asset)"
-      >
-        <div class="h-10 w-10 shrink-0 overflow-hidden rounded-md bg-white/5">
-          <img v-if="asset.kind === 'image'" :src="asset.url" alt="" class="h-full w-full object-cover">
-          <div v-else class="flex h-full w-full items-center justify-center text-[9px] text-white/40">
-            {{ kindLabel(asset.kind) }}
-          </div>
+      <p v-else-if="!timeline.length" class="py-6 text-center text-[11px] text-white/30">
+        {{ tab === 'user' ? '画布中生成或上传的素材会同步到这里' : '暂无公共资产' }}
+      </p>
+
+      <div v-for="group in timeline" :key="group.label" class="mb-3 last:mb-1">
+        <p class="mb-1.5 flex items-center gap-1.5 text-[10px] text-white/35">
+          <span class="h-1 w-1 rounded-full bg-[#6366f1]/70" />
+          {{ group.label }}
+        </p>
+        <div class="grid grid-cols-3 gap-1.5">
+          <button
+            v-for="asset in group.items"
+            :key="asset.id"
+            type="button"
+            draggable="true"
+            class="group relative aspect-square overflow-hidden rounded-lg border border-white/[0.06] bg-white/5 transition hover:border-[#6366f1]/50"
+            :title="asset.label"
+            @dragstart="onDragStart($event, asset)"
+            @click="emit('apply', asset)"
+          >
+            <img
+              v-if="asset.kind === 'image'"
+              :src="asset.url"
+              alt=""
+              loading="lazy"
+              class="h-full w-full object-cover"
+            >
+            <video
+              v-else-if="asset.kind === 'video'"
+              :src="asset.url"
+              muted
+              preload="metadata"
+              class="h-full w-full object-cover"
+            />
+            <div v-else class="flex h-full w-full items-center justify-center text-white/35">
+              <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 19V6l12-3v13M9 19a3 3 0 11-6 0 3 3 0 016 0zm12-3a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+            </div>
+
+            <!-- 类型角标 -->
+            <span
+              v-if="asset.kind !== 'image'"
+              class="absolute left-1 top-1 rounded bg-black/60 px-1 py-px text-[8px] text-white/80"
+            >
+              {{ asset.kind === 'video' ? '视频' : '音频' }}
+            </span>
+            <span
+              v-if="asset.source === 'public'"
+              class="absolute right-1 top-1 rounded bg-[#6366f1]/80 px-1 py-px text-[8px] text-white"
+            >
+              公共
+            </span>
+
+            <!-- hover 显示名称 -->
+            <span
+              class="absolute inset-x-0 bottom-0 truncate bg-gradient-to-t from-black/80 to-transparent px-1 pb-0.5 pt-3 text-left text-[9px] text-white/85 opacity-0 transition group-hover:opacity-100"
+            >
+              {{ asset.label }}
+            </span>
+          </button>
         </div>
-        <div class="min-w-0 flex-1">
-          <p class="truncate text-[11px] text-white/75">{{ asset.label }}</p>
-          <p class="text-[9px] text-white/30">{{ kindLabel(asset.kind) }}</p>
-        </div>
-      </button>
+      </div>
     </div>
   </div>
 </template>

--- a/apps/web/src/components/canvas/NodePanelDock.vue
+++ b/apps/web/src/components/canvas/NodePanelDock.vue
@@ -64,9 +64,9 @@ useClickOutside(rootRef, () => {
     class="node-panel-dock pointer-events-none absolute left-3 top-3 z-[50]"
   >
     <div class="pointer-events-auto relative">
-      <!-- 竖向胶囊：添加节点 + 素材库 + 模型设置 -->
+      <!-- 竖向面板：添加节点 + 资产库 + 模型设置（文字+图标组合） -->
       <div
-        class="vertical-capsule flex flex-col items-center gap-0.5 rounded-full border border-white/[0.08] bg-[rgba(22,22,22,0.94)] p-1 shadow-[0_8px_28px_rgba(0,0,0,0.42)] backdrop-blur-xl"
+        class="vertical-capsule flex flex-col items-stretch gap-0.5 rounded-2xl border border-white/[0.08] bg-[rgba(22,22,22,0.94)] p-1 shadow-[0_8px_28px_rgba(0,0,0,0.42)] backdrop-blur-xl"
       >
         <button
           type="button"
@@ -76,7 +76,7 @@ useClickOutside(rootRef, () => {
           @click.stop="toggleMenu"
         >
           <svg
-            class="h-[18px] w-[18px] transition-transform duration-200"
+            class="h-[17px] w-[17px] transition-transform duration-200"
             :class="showMenu ? 'rotate-45' : ''"
             fill="none"
             viewBox="0 0 24 24"
@@ -84,27 +84,29 @@ useClickOutside(rootRef, () => {
           >
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
           </svg>
+          <span class="rail-btn-label">添加</span>
         </button>
 
         <button
           type="button"
           class="rail-btn text-white/55"
           :class="showAssets ? 'is-active' : ''"
-          title="素材库"
+          title="资产库"
           @click.stop="toggleAssets"
         >
-          <svg class="h-[17px] w-[17px]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg class="h-[16px] w-[16px]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
           </svg>
+          <span class="rail-btn-label">资产库</span>
           <span
             v-if="assets.length"
-            class="absolute -right-0.5 -top-0.5 flex h-3.5 min-w-[14px] items-center justify-center rounded-full bg-[#6366f1] px-0.5 text-[8px] font-semibold text-white"
+            class="absolute -right-1 -top-1 flex h-3.5 min-w-[14px] items-center justify-center rounded-full bg-[#6366f1] px-0.5 text-[8px] font-semibold text-white"
           >
             {{ assets.length > 99 ? '99+' : assets.length }}
           </span>
         </button>
 
-        <span class="my-0.5 h-px w-5 bg-white/[0.08]" />
+        <span class="mx-auto my-0.5 h-px w-8 bg-white/[0.08]" />
 
         <button
           type="button"
@@ -112,7 +114,7 @@ useClickOutside(rootRef, () => {
           title="模型服务配置"
           @click.stop="emit('open-settings')"
         >
-          <svg class="h-[17px] w-[17px]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <svg class="h-[16px] w-[16px]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path
               stroke-linecap="round"
               stroke-linejoin="round"
@@ -121,6 +123,7 @@ useClickOutside(rootRef, () => {
             />
             <circle cx="12" cy="12" r="3" stroke-width="1.75" />
           </svg>
+          <span class="rail-btn-label">设置</span>
         </button>
       </div>
 
@@ -176,13 +179,16 @@ useClickOutside(rootRef, () => {
 
 <style scoped>
 .rail-btn {
-  @apply relative flex h-9 w-9 items-center justify-center rounded-full transition;
+  @apply relative flex w-[52px] flex-col items-center justify-center gap-0.5 rounded-xl px-1 py-1.5 transition;
 }
 .rail-btn:hover {
   @apply bg-white/[0.06] text-[#a5b4fc];
 }
 .rail-btn.is-active {
   @apply bg-[#6366f1]/15 text-[#a5b4fc];
+}
+.rail-btn-label {
+  @apply text-[10px] leading-none;
 }
 
 .menu-pop-enter-active,

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -190,12 +190,15 @@ const canvasAssets = computed((): CanvasAssetItem[] => {
     if (type === 'image') kind = url.match(/\.(mp4|webm|mov)/i) ? 'video' : 'image'
     else if (type === 'video') kind = 'video'
     else if (type === 'audio') kind = 'audio'
+    const createdAt = Number(data.createdAt ?? 0)
     out.push({
       id: `${node.id}-asset`,
       nodeId: node.id,
       url,
       label: String(data.title ?? data.fileName ?? data.prompt ?? node.id),
       kind,
+      createdAt: Number.isFinite(createdAt) && createdAt > 0 ? createdAt : undefined,
+      source: 'user',
     })
   }
   return out
@@ -586,7 +589,7 @@ function addNode(
     id,
     type,
     position: opts?.position ?? { x: 200 + nodeCounter * 60, y: 150 + nodeCounter * 40 },
-    data,
+    data: { createdAt: Date.now(), ...data },
   })
   return id
 }

--- a/apps/web/src/services/assets-api.ts
+++ b/apps/web/src/services/assets-api.ts
@@ -1,0 +1,14 @@
+import { api } from './api'
+
+export interface PublicAssetItem {
+  id: string
+  url: string
+  label: string
+  kind: 'image' | 'video' | 'audio'
+  publishedAt: string
+}
+
+export const assetsApi = {
+  listPublic: (params?: { kind?: string; search?: string }) =>
+    api.get<{ code: number; data: { items: PublicAssetItem[] } }>('/assets/public', { params }),
+}

--- a/apps/web/src/styles/neo-node.css
+++ b/apps/web/src/styles/neo-node.css
@@ -486,14 +486,42 @@
   /* 弹出卡片（模型/参数选择）需溢出容器显示，不可用 hidden */
   overflow: visible;
   border: 1px solid var(--neo-glass-border);
-  border-radius: 20px;
+  /* aimarket creation-panel: rounded-[1.5rem] + backdrop-blur-2xl + saturate-150 */
+  border-radius: 24px;
   background: var(--neo-glass-bg);
-  backdrop-filter: blur(var(--neo-glass-blur)) saturate(1.15);
-  -webkit-backdrop-filter: blur(var(--neo-glass-blur)) saturate(1.15);
+  backdrop-filter: blur(var(--neo-glass-blur)) saturate(1.5);
+  -webkit-backdrop-filter: blur(var(--neo-glass-blur)) saturate(1.5);
   box-shadow: var(--neo-glass-shadow);
   transition:
     border-color 0.2s ease,
     box-shadow 0.2s ease;
+}
+
+/* aimarket 顶部高光细线 */
+.bottom-toolbar-container::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 24px;
+  left: 24px;
+  height: 1px;
+  pointer-events: none;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.25), transparent);
+}
+
+/* aimarket 两侧氛围光斑（橙/紫） */
+.bottom-toolbar-container::after {
+  content: '';
+  position: absolute;
+  top: -8px;
+  right: -32px;
+  left: -40px;
+  height: 112px;
+  pointer-events: none;
+  background:
+    radial-gradient(56px 56px at 48px 56px, rgba(249, 115, 22, 0.08), transparent 70%),
+    radial-gradient(48px 48px at calc(100% - 44px) 52px, rgba(139, 92, 246, 0.08), transparent 70%);
+  filter: blur(28px);
 }
 
 .bottom-toolbar-container:hover {

--- a/apps/web/src/styles/neowow-tokens.css
+++ b/apps/web/src/styles/neowow-tokens.css
@@ -17,17 +17,24 @@
   --neo-panel-bg-rgba: rgba(24, 24, 27, 0.92);
   --neo-node-card-bg: rgba(40, 40, 45, 0.4);
   --neo-node-border: rgba(255, 255, 255, 0.08);
-  --neo-glass-bg: radial-gradient(135% 135% at 30% 25%, rgba(96, 102, 128, 0.26), rgba(8, 8, 12, 0.2));
-  --neo-glass-border: rgba(255, 255, 255, 0.14);
-  --neo-glass-blur: 28px;
-  --neo-glass-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+  /* 与 aimarket creation-panel 一致的毛玻璃配方 */
+  --neo-glass-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.07) 0%, rgba(9, 9, 11, 0.76) 50%, rgba(9, 9, 11, 0.92) 100%);
+  --neo-glass-border: rgba(255, 255, 255, 0.12);
+  --neo-glass-blur: 40px;
+  --neo-glass-shadow:
+    0 12px 48px rgba(0, 0, 0, 0.5),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.05),
+    0 -18px 42px rgba(249, 115, 22, 0.06),
+    0 12px 48px rgba(139, 92, 246, 0.05);
   --neo-glass-glow: 0 0 18px 1px rgba(170, 178, 205, 0.22);
 }
 
 /* 画布白天模式：仅覆盖画布相关 token（面板/节点内部仍保持深色系） */
 :root[data-canvas-theme='light'] {
   --neo-bg: #eceef2;
-  --neo-glass-bg: radial-gradient(135% 135% at 30% 25%, rgba(120, 126, 150, 0.3), rgba(30, 30, 38, 0.42));
+  --neo-glass-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.1) 0%, rgba(24, 24, 30, 0.68) 50%, rgba(24, 24, 30, 0.86) 100%);
   --neo-glass-border: rgba(0, 0, 0, 0.12);
-  --neo-glass-shadow: 0 4px 18px rgba(0, 0, 0, 0.18);
+  --neo-glass-shadow:
+    0 12px 40px rgba(0, 0, 0, 0.24),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.06);
 }


### PR DESCRIPTION
## Summary
- 资产库改为历史时间线 + 网格布局，支持图片/视频/音频分类检索，并区分「我的资产」与平台「公共资产」
- dock-studio 毛玻璃样式对齐本机 aimarket（渐变背景、blur-2xl、氛围光斑与顶部高光线）
- 左侧「添加 / 资产库 / 设置」改为图标 + 文字组合模式

## Test plan
- [ ] `pnpm build` 通过
- [ ] 打开画布 → 左侧点「资产库」：我的资产按时间线网格展示，可按类型筛选/搜索
- [ ] 切换「公共资产」Tab，确认可拖拽/点击应用到画布
- [ ] 选中节点查看 dock-studio 毛玻璃透明度与 aimarket 接近
- [ ] 确认左侧按钮为图标+文字（添加 / 资产库 / 设置）


Made with [Cursor](https://cursor.com)