### PR TITLE
chore(test): T0 测试基础设施（Vitest + Server 集成 + CI）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Build packages
         run: pnpm build
 
-      - name: Agent tests
-        run: pnpm --filter @lnkpi/agent test
+      - name: Unit and integration tests
+        run: pnpm test
 
       - name: Build summary
         if: always()

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -9,7 +9,8 @@
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
     "db:seed": "tsx prisma/seed.ts",
-    "lint": "echo 'no lint configured'"
+    "lint": "echo 'no lint configured'",
+    "test": "vitest run"
   },
   "dependencies": {
     "@lnkpi/agent": "workspace:*",
@@ -19,18 +20,22 @@
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/platform-express": "^10.4.15",
     "@prisma/client": "^6.2.1",
-    "prisma": "^6.2.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "multer": "^2.2.0",
+    "prisma": "^6.2.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
+    "@nestjs/testing": "^10.4.22",
+    "@swc/core": "^1.15.43",
     "@types/express": "^5.0.0",
     "@types/multer": "^2.2.0",
     "@types/node": "^22.10.5",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "unplugin-swc": "^1.5.9",
+    "vitest": "^3.2.4"
   }
 }

--- a/apps/server/src/studio/studio.integration.test.ts
+++ b/apps/server/src/studio/studio.integration.test.ts
@@ -16,7 +16,9 @@ const imageGenerate = vi.fn(async () => ({
   url: 'https://example.com/a.png',
   urls: ['https://example.com/a.png'],
 }))
-const videoGenerate = vi.fn(async () => ({ url: 'https://example.com/v.mp4' }))
+const videoGenerate = vi.fn(async (_prompt: string, _opts?: Record<string, unknown>) => ({
+  url: 'https://example.com/v.mp4',
+}))
 const audioGenerate = vi.fn(async () => ({ url: 'https://example.com/a.mp3' }))
 const textGenerate = vi.fn(async (prompt: string) => ({ text: `ok:${prompt}` }))
 const visionGenerate = vi.fn(async (prompt: string) => ({ text: `vision:${prompt}` }))

--- a/apps/server/src/studio/studio.integration.test.ts
+++ b/apps/server/src/studio/studio.integration.test.ts
@@ -1,0 +1,117 @@
+import 'reflect-metadata'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { resolveImageSize } from '@lnkpi/shared'
+import {
+  createAudioProvider,
+  createImageProvider,
+  createTextProvider,
+  createVideoProvider,
+  generateTextWithImages,
+  mergeRefsToPrompt,
+} from '@lnkpi/agent'
+import { createStudioService } from './studio.test-utils'
+import type { StudioService } from './studio.service'
+
+const imageGenerate = vi.fn(async () => ({
+  url: 'https://example.com/a.png',
+  urls: ['https://example.com/a.png'],
+}))
+const videoGenerate = vi.fn(async () => ({ url: 'https://example.com/v.mp4' }))
+const audioGenerate = vi.fn(async () => ({ url: 'https://example.com/a.mp3' }))
+const textGenerate = vi.fn(async (prompt: string) => ({ text: `ok:${prompt}` }))
+const visionGenerate = vi.fn(async (prompt: string) => ({ text: `vision:${prompt}` }))
+
+vi.mock('@lnkpi/agent', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@lnkpi/agent')>()
+  return {
+    ...actual,
+    mergeRefsToPrompt: vi.fn(async (input: { localPrompt?: string }) => ({
+      mergedText: input.localPrompt ?? '',
+      skippedMerge: true,
+    })),
+    createImageProvider: vi.fn(() => ({ generate: imageGenerate })),
+    createVideoProvider: vi.fn(() => ({ generate: videoGenerate })),
+    createAudioProvider: vi.fn(() => ({ generate: audioGenerate })),
+    createTextProvider: vi.fn(() => ({ generate: textGenerate })),
+    generateTextWithImages: vi.fn(async (prompt: string) => visionGenerate(prompt)),
+  }
+})
+
+describe('StudioService integration (provider params)', () => {
+  let svc: StudioService
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.mocked(mergeRefsToPrompt).mockImplementation(async (input) => ({
+      mergedText: input.localPrompt ?? '',
+      skippedMerge: true,
+    }))
+    svc = await createStudioService()
+  })
+
+  it('passes modelId, size, and n to image provider', async () => {
+    await svc.generateImage('u1', 'a prompt', 'seedream-5.0-pro', '16:9', [], [], '1K', 2)
+
+    expect(createImageProvider).toHaveBeenCalled()
+    expect(imageGenerate).toHaveBeenCalledWith('a prompt', {
+      size: resolveImageSize('16:9', '1K'),
+      n: 2,
+      modelId: 'seedream-5.0-pro',
+    })
+  })
+
+  it('embeds reference image url in video prompt and passes duration params', async () => {
+    const refUrl = 'https://example.com/ref.png'
+    await svc.generateVideo(
+      'u1',
+      'a prompt',
+      'agnes-video-v2.0',
+      10,
+      '16:9',
+      [{ refKey: 'i1', mediaType: 'image', url: refUrl }],
+      [],
+      '720p',
+      'none',
+    )
+
+    await vi.waitFor(() => expect(videoGenerate).toHaveBeenCalled())
+    const [prompt, opts] = videoGenerate.mock.calls[0]
+    expect(prompt).toContain(refUrl)
+    expect(opts).toMatchObject({
+      model: 'agnes-video-v2.0',
+      duration: 10,
+      aspectRatio: '16:9',
+      resolution: '720p',
+      crop: 'none',
+    })
+  })
+
+  it('passes merged text and voice to audio provider', async () => {
+    await svc.generateAudio('u1', 'say hello', { voice: 'alloy' })
+
+    expect(createAudioProvider).toHaveBeenCalled()
+    expect(audioGenerate).toHaveBeenCalledWith('say hello', 'alloy')
+  })
+
+  it('passes model to text provider when no image refs', async () => {
+    await svc.generateText('u1', 'hello world', 'gpt-4o')
+
+    expect(createTextProvider).toHaveBeenCalled()
+    expect(textGenerate).toHaveBeenCalledWith('hello world', 'gpt-4o')
+    expect(generateTextWithImages).not.toHaveBeenCalled()
+  })
+
+  it('passes model to generateTextWithImages when image refs present', async () => {
+    const refUrl = 'https://example.com/dress.jpg'
+    await svc.generateText('u1', 'describe dress', 'gpt-4o', [
+      { refKey: 'i1', mediaType: 'image', url: refUrl },
+    ])
+
+    expect(generateTextWithImages).toHaveBeenCalledWith('describe dress', [refUrl], {
+      model: 'gpt-4o',
+      apiKey: process.env.OPENAI_API_KEY,
+      baseUrl: process.env.OPENAI_BASE_URL,
+    })
+    expect(createTextProvider).not.toHaveBeenCalled()
+  })
+})

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -173,7 +173,7 @@ export class StudioService {
     const primaryRef = referenceImages[0] // only I1 is sent to the image provider; see extractReferenceImages
     const effectivePrompt = primaryRef ? buildPromptWithRefImage(mergedText, primaryRef) : mergedText
     const size = resolveImageSize(aspectRatio, resolution as ImageResolutionTier)
-    const { url, urls } = await createImageProvider().generate(effectivePrompt, { size, n })
+    const { url, urls } = await createImageProvider().generate(effectivePrompt, { size, n, modelId: model })
     const imageUrls = urls?.length ? urls : [url]
     return this.prisma.generationRecord.create({
       data: {

--- a/apps/server/src/studio/studio.smoke.test.ts
+++ b/apps/server/src/studio/studio.smoke.test.ts
@@ -1,0 +1,42 @@
+import 'reflect-metadata'
+import { describe, it, expect } from 'vitest'
+import { Test } from '@nestjs/testing'
+import { StudioService } from './studio.service'
+import { PrismaService } from '../prisma/prisma.service'
+
+describe('studio nest harness', () => {
+  it('boots StudioService with mocked Prisma', async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        StudioService,
+        {
+          provide: PrismaService,
+          useValue: {
+            user: {
+              findUnique: async () => ({ id: 'u1', points: 9999 }),
+              update: async () => ({ id: 'u1', points: 9994 }),
+            },
+            pointTransaction: {
+              create: async (args: { data: Record<string, unknown> }) => ({
+                id: 'pt1',
+                ...args.data,
+              }),
+            },
+            generationRecord: {
+              create: async (args: { data: Record<string, unknown> }) => ({
+                id: 'g1',
+                ...args.data,
+              }),
+              update: async () => ({}),
+              findFirst: async () => null,
+              findMany: async () => [],
+            },
+            $transaction: async (ops: Promise<unknown>[]) => Promise.all(ops),
+          },
+        },
+      ],
+    }).compile()
+
+    expect(moduleRef.get(StudioService)).toBeDefined()
+  })
+})

--- a/apps/server/src/studio/studio.test-utils.ts
+++ b/apps/server/src/studio/studio.test-utils.ts
@@ -1,0 +1,53 @@
+import { Test } from '@nestjs/testing'
+import { vi } from 'vitest'
+import { StudioService } from './studio.service'
+import { PrismaService } from '../prisma/prisma.service'
+
+export function createPrismaMock() {
+  return {
+    user: {
+      findUnique: async () => ({ id: 'u1', points: 9999 }),
+      update: async () => ({ id: 'u1', points: 9994 }),
+    },
+    pointTransaction: {
+      create: async (args: { data: Record<string, unknown> }) => ({
+        id: 'pt1',
+        ...args.data,
+      }),
+    },
+    generationRecord: {
+      create: async (args: { data: Record<string, unknown> }) => ({
+        id: 'g1',
+        createdAt: new Date(),
+        ...args.data,
+      }),
+      update: async () => ({}),
+      findFirst: async () => null,
+      findMany: async () => [],
+    },
+    $transaction: async (ops: Promise<unknown>[]) => Promise.all(ops),
+  }
+}
+
+export async function createStudioService() {
+  const moduleRef = await Test.createTestingModule({
+    providers: [
+      StudioService,
+      {
+        provide: PrismaService,
+        useValue: createPrismaMock(),
+      },
+    ],
+  }).compile()
+
+  return moduleRef.get(StudioService)
+}
+
+export const defaultMergeRefsResult = {
+  mergedText: '',
+  skippedMerge: true,
+}
+
+export function mockMergeRefsToPrompt(mergedText: string) {
+  return vi.fn(async () => ({ mergedText, skippedMerge: true }))
+}

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vitest/config'
+import swc from 'unplugin-swc'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'src/**/*.integration.test.ts'],
+  },
+  plugins: [
+    swc.vite({
+      jsc: {
+        parser: {
+          syntax: 'typescript',
+          decorators: true,
+        },
+        transform: {
+          legacyDecorator: true,
+          decoratorMetadata: true,
+        },
+        target: 'es2022',
+      },
+      module: { type: 'es6' },
+    }),
+  ],
+})

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "preview": "vite preview",
-    "lint": "echo 'no lint configured'"
+    "lint": "echo 'no lint configured'",
+    "test": "vitest run"
   },
   "dependencies": {
     "@lnkpi/shared": "workspace:*",
@@ -29,11 +30,14 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.1",
+    "@vue/test-utils": "^2.4.11",
     "autoprefixer": "^10.4.20",
+    "jsdom": "^29.1.1",
     "postcss": "^8.5.1",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.3",
     "vite": "^6.0.7",
+    "vitest": "^3.2.4",
     "vue-tsc": "^2.2.0"
   }
 }

--- a/apps/web/src/composables/useNodeGeneration.test.ts
+++ b/apps/web/src/composables/useNodeGeneration.test.ts
@@ -1,6 +1,8 @@
+import type { AxiosResponse } from 'axios'
 import { ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
+import type { CanvasEdgeLike } from '@/composables/useUpstreamNodeContext'
 import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
 import { useNodeGeneration } from '@/composables/useNodeGeneration'
 import { studioApi } from '@/services/studio-api'
@@ -26,6 +28,10 @@ vi.mock('@/services/canvas-api', () => ({
     exportVideoComposition: vi.fn(),
   },
 }))
+
+function mockAxiosResponse<T>(data: T): AxiosResponse<T> {
+  return { data, status: 200, statusText: 'OK', headers: {}, config: {} as AxiosResponse<T>['config'] }
+}
 
 const completedRecord = {
   id: 'rec-1',
@@ -63,7 +69,7 @@ function createDeps(nodes: EditableFlowNode[]) {
 
   const deps = {
     nodes: ref(nodes),
-    edges: ref([]),
+    edges: ref<CanvasEdgeLike[]>([]),
     sessionId: ref('session-1'),
     patchNodeData,
     addNode: vi.fn(() => 'new-node'),
@@ -82,12 +88,12 @@ function createDeps(nodes: EditableFlowNode[]) {
 describe('useNodeGeneration', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(studioApi.generateAudio).mockResolvedValue({
-      data: { data: { ...completedRecord, type: 'audio', url: 'https://example.com/out.mp3' } },
-    })
-    vi.mocked(studioApi.generateImage).mockResolvedValue({
-      data: { data: completedRecord },
-    })
+    vi.mocked(studioApi.generateAudio).mockResolvedValue(
+      mockAxiosResponse({ data: { ...completedRecord, type: 'audio', url: 'https://example.com/out.mp3' } }),
+    )
+    vi.mocked(studioApi.generateImage).mockResolvedValue(
+      mockAxiosResponse({ data: completedRecord }),
+    )
   })
 
   it('passes audio options to studioApi.generateAudio', async () => {

--- a/apps/web/src/composables/useNodeGeneration.test.ts
+++ b/apps/web/src/composables/useNodeGeneration.test.ts
@@ -1,0 +1,175 @@
+import { ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
+import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
+import { useNodeGeneration } from '@/composables/useNodeGeneration'
+import { studioApi } from '@/services/studio-api'
+
+vi.mock('@/services/studio-api', () => ({
+  studioApi: {
+    generateImage: vi.fn(),
+    generateVideo: vi.fn(),
+    generateAudio: vi.fn(),
+    generateText: vi.fn(),
+    generatePrompt: vi.fn(),
+  },
+}))
+
+vi.mock('@/services/canvas-api', () => ({
+  canvasApi: {
+    generateImage: vi.fn(),
+    generateVideo: vi.fn(),
+    editShot: vi.fn(),
+    createShot: vi.fn(),
+    saveSceneComposer: vi.fn(),
+    batchGenerateSceneComposer: vi.fn(),
+    exportVideoComposition: vi.fn(),
+  },
+}))
+
+const completedRecord = {
+  id: 'rec-1',
+  type: 'image',
+  prompt: 'test',
+  status: NODE_GENERATION_STATUS.completed,
+  url: 'https://example.com/out.png',
+  createdAt: '2026-01-01T00:00:00.000Z',
+}
+
+function createNode(
+  type: string,
+  data: Record<string, unknown>,
+  id = `${type}-1`,
+): EditableFlowNode {
+  return {
+    id,
+    type,
+    position: { x: 0, y: 0 },
+    data,
+  }
+}
+
+function createDeps(nodes: EditableFlowNode[]) {
+  const patchNodeData = vi.fn()
+  const saveCanvas = vi.fn(async () => {})
+  const requireLogin = vi.fn(() => true)
+  const startShotPolling = vi.fn()
+  const startGenerationPolling = vi.fn()
+  const resolveProviderModels = vi.fn(() => ({
+    image: 'default-image-model',
+    video: 'default-video-model',
+    text: 'default-text-model',
+  }))
+
+  const deps = {
+    nodes: ref(nodes),
+    edges: ref([]),
+    sessionId: ref('session-1'),
+    patchNodeData,
+    addNode: vi.fn(() => 'new-node'),
+    addEdge: vi.fn(),
+    saveCanvas,
+    requireLogin,
+    startShotPolling,
+    startGenerationPolling,
+    resolveProviderModels,
+  }
+
+  const api = useNodeGeneration(deps)
+  return { api, deps }
+}
+
+describe('useNodeGeneration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(studioApi.generateAudio).mockResolvedValue({
+      data: { data: { ...completedRecord, type: 'audio', url: 'https://example.com/out.mp3' } },
+    })
+    vi.mocked(studioApi.generateImage).mockResolvedValue({
+      data: { data: completedRecord },
+    })
+  })
+
+  it('passes audio options to studioApi.generateAudio', async () => {
+    const node = createNode('audio', {
+      prompt: 'hello world',
+      audioVoice: 'male-1',
+      audioEmotion: 'happy',
+      audioLanguage: 'en',
+      audioSpeed: 1.5,
+    })
+    const { api } = createDeps([node])
+
+    await api.generateForNode(node)
+
+    expect(studioApi.generateAudio).toHaveBeenCalledWith(
+      'hello world',
+      {
+        voice: 'male-1',
+        emotion: 'happy',
+        language: 'en',
+        speed: 1.5,
+      },
+      [],
+      [],
+    )
+  })
+
+  it('passes model, resolution, and count to studioApi.generateImage', async () => {
+    const node = createNode('image', {
+      prompt: 'a cat',
+      imageModel: 'seedream-5.0-pro',
+      imageAspect: '16:9',
+      imageResolution: '2K',
+      imageCount: 3,
+    })
+    const { api } = createDeps([node])
+
+    await api.generateForNode(node)
+
+    expect(studioApi.generateImage).toHaveBeenCalledWith(
+      'a cat',
+      'seedream-5.0-pro',
+      '16:9',
+      [],
+      [],
+      '2K',
+      3,
+    )
+  })
+
+  it('blocks image generation when referenceImageUrl is a blob url', async () => {
+    const node = createNode('image', {
+      prompt: 'a cat',
+      referenceImageUrl: 'blob:http://localhost/abc-123',
+    })
+    const { api, deps } = createDeps([node])
+
+    await api.generateForNode(node)
+
+    expect(studioApi.generateImage).not.toHaveBeenCalled()
+    expect(deps.patchNodeData).toHaveBeenCalledWith('image-1', {
+      status: NODE_GENERATION_STATUS.error,
+      errorMessage: '参考图尚未上传，请先上传后再生成',
+    })
+  })
+
+  it('blocks image generation when a ref url is a blob url', async () => {
+    const refNode = createNode('image', { url: 'blob:http://localhost/ref-456' }, 'ref-1')
+    const node = createNode('image', {
+      prompt: 'a cat',
+      localRefs: [{ refKey: 'r1', sourceNodeId: 'ref-1', mediaType: 'image' }],
+      refOrder: ['r1'],
+    })
+    const { api, deps } = createDeps([node, refNode])
+    deps.edges.value = [{ id: 'e1', source: 'ref-1', target: 'image-1' }]
+
+    await api.generateForNode(node)
+
+    expect(studioApi.generateImage).not.toHaveBeenCalled()
+    expect(deps.patchNodeData).toHaveBeenCalledWith('image-1', {
+      status: NODE_GENERATION_STATUS.error,
+      errorMessage: '参考图尚未上传，请先上传后再生成',
+    })
+  })
+})

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -78,6 +78,15 @@ function resolveStudioRefs(
     }))
 }
 
+function hasBlobReference(refs: StudioRefPayload[], data: Record<string, unknown>): boolean {
+  const direct = String(data.referenceImageUrl ?? '').trim()
+  if (direct.startsWith('blob:')) return true
+  for (const ref of refs) {
+    if (ref.url?.trim().startsWith('blob:')) return true
+  }
+  return false
+}
+
 function firstImageRefUrl(refs: StudioRefPayload[]): string {
   for (const ref of refs) {
     if (ref.mediaType === 'image' && ref.url?.trim()) return ref.url.trim()
@@ -232,6 +241,14 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       }
       deps.startShotPolling([shotId])
       await deps.saveCanvas()
+      return
+    }
+
+    if (hasBlobReference(refs, data)) {
+      deps.patchNodeData(node.id, {
+        status: NODE_GENERATION_STATUS.error,
+        errorMessage: '参考图尚未上传，请先上传后再生成',
+      })
       return
     }
 

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+import { fileURLToPath } from 'node:url'
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.test.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+})

--- a/docs/superpowers/plans/2026-07-19-test-infrastructure.md
+++ b/docs/superpowers/plans/2026-07-19-test-infrastructure.md
@@ -1,0 +1,325 @@
+# 测试基础设施 T0 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 建立全仓 Vitest 测试地基（shared/agent 进 CI、server 集成、web composable），根脚本 `pnpm test` 一次跑齐。
+
+**Architecture:** Server 用 `@nestjs/testing` + mock Prisma/Provider，测 Studio Controller→Service→Adapter→mock Provider；Web 用 Vitest + Vue Test Utils + jsdom，测 `useNodeGeneration` 请求组装；CI 在 build 后跑 `pnpm test`。
+
+**Tech Stack:** Vitest 3、@nestjs/testing、unplugin-swc（或等价）、@vue/test-utils、jsdom、pnpm workspace
+
+**Spec:** `docs/superpowers/specs/2026-07-19-test-infrastructure-design.md`
+
+## Global Constraints
+
+- 范围仅 **T0**：单元 + Server 集成；无 Playwright、无真库
+- 全仓 **Vitest**；Prisma **mock**；Provider **mock**
+- Web：**composable 为主**，少量组件冒烟即可
+- 独立分支 `chore/test-infrastructure-t0`（从 main）；**不要**往 #25 分支继续堆代码
+- C1 PR #25 暂停合并，待本 PR 合入后再 rebase
+- 提交前：`pnpm test` 与 `pnpm build` 全绿
+
+---
+
+## File Structure Map
+
+| 路径 | 职责 |
+|------|------|
+| `package.json` | `"test": "pnpm -r --if-present test"` |
+| `.github/workflows/ci.yml` | build 后 `pnpm test` |
+| `apps/server/package.json` | test 脚本 + vitest / @nestjs/testing / unplugin-swc 等 |
+| `apps/server/vitest.config.ts` | Nest + SWC |
+| `apps/server/src/studio/studio.integration.test.ts` | Studio 集成 |
+| `apps/server/src/studio/studio.test-utils.ts`（可选） | mock Prisma / 模块工厂 |
+| `apps/web/package.json` | test + vitest / @vue/test-utils / jsdom |
+| `apps/web/vitest.config.ts` | Vue + jsdom |
+| `apps/web/src/composables/useNodeGeneration.test.ts` | 生成 payload |
+| `docs/superpowers/plans/2026-07-19-test-infrastructure.md` | 本计划 |
+
+---
+
+### Task 1: 根脚本 + CI 跑 shared + agent
+
+**Files:**
+- Modify: `package.json`
+- Modify: `.github/workflows/ci.yml`
+
+**Interfaces:**
+- Produces: 根命令 `pnpm test` 递归调用各包 `test`（`--if-present` 过渡；本计划结束时四包皆有）
+
+- [ ] **Step 1: 改根 package.json**
+
+在 `scripts` 中增加：
+
+```json
+"test": "pnpm -r --if-present test"
+```
+
+- [ ] **Step 2: 改 CI**
+
+将 `Agent tests` 步骤替换为：
+
+```yaml
+      - name: Unit and integration tests
+        run: pnpm test
+```
+
+- [ ] **Step 3: 本地验证**
+
+```bash
+pnpm --filter @lnkpi/shared test
+pnpm --filter @lnkpi/agent test
+pnpm test
+```
+
+Expected: shared + agent 绿；server/web 若尚无 script 则被 `--if-present` 跳过。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json .github/workflows/ci.yml
+git commit -m "chore(ci): run workspace pnpm test after build"
+```
+
+---
+
+### Task 2: Server Vitest + Nest 装饰器配置
+
+**Files:**
+- Modify: `apps/server/package.json`
+- Create: `apps/server/vitest.config.ts`
+- Create: `apps/server/src/studio/studio.smoke.test.ts`
+
+**Interfaces:**
+- Produces: `pnpm --filter @lnkpi/server test` 可执行
+
+- [ ] **Step 1: 安装依赖**
+
+```bash
+pnpm --filter @lnkpi/server add -D vitest @nestjs/testing @swc/core unplugin-swc
+```
+
+- [ ] **Step 2: vitest.config.ts + scripts**
+
+```ts
+import { defineConfig } from 'vitest/config'
+import swc from 'unplugin-swc'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'src/**/*.integration.test.ts'],
+  },
+  plugins: [
+    swc.vite({
+      module: { type: 'es6' },
+    }),
+  ],
+})
+```
+
+`package.json` 增加 `"test": "vitest run"`。
+
+- [ ] **Step 3: 最小 smoke（证明 DI 可跑）**
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { Test } from '@nestjs/testing'
+import { StudioService } from './studio.service'
+import { PrismaService } from '../prisma/prisma.service'
+
+describe('studio nest harness', () => {
+  it('boots StudioService with mocked Prisma', async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        StudioService,
+        {
+          provide: PrismaService,
+          useValue: {
+            user: { findUnique: async () => ({ id: 'u1', points: 9999 }) },
+            generationRecord: {
+              create: async (args: { data: Record<string, unknown> }) => ({ id: 'g1', ...args.data }),
+              update: async () => ({}),
+              findFirst: async () => null,
+              findMany: async () => [],
+            },
+            // 按 StudioService.consumePoints 实际表名补齐
+          },
+        },
+      ],
+    }).compile()
+
+    expect(moduleRef.get(StudioService)).toBeDefined()
+  })
+})
+```
+
+打开 `studio.service.ts` 确认 `consumePoints` / Prisma 调用点，补全 mock。
+
+- [ ] **Step 4: Run**
+
+```bash
+pnpm --filter @lnkpi/server test
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/package.json apps/server/vitest.config.ts apps/server/src/studio/studio.smoke.test.ts pnpm-lock.yaml
+git commit -m "chore(server): add vitest and nest testing harness"
+```
+
+---
+
+### Task 3: Studio 集成测试（mock Provider + 参数断言）
+
+**Files:**
+- Create: `apps/server/src/studio/studio.integration.test.ts`
+- Create: `apps/server/src/studio/studio.test-utils.ts`（可选）
+- 可用 `vi.mock('@lnkpi/agent', ...)` mock `createImageProvider` / `createVideoProvider` / `createAudioProvider` / `createTextProvider` / `generateTextWithImages` / `mergeRefsToPrompt`
+
+**Interfaces:**
+- Consumes: `StudioService.generateImage|Video|Audio|Text`
+- Produces: 断言 mock provider 收到的 options
+
+- [ ] **Step 1: 写 Image 失败测试**
+
+```ts
+it('passes modelId size n to image provider', async () => {
+  const generate = vi.fn(async () => ({ url: 'https://example.com/a.png', urls: ['https://example.com/a.png'] }))
+  // mock createImageProvider → { generate }
+  // mock mergeRefsToPrompt → { mergedText: 'a prompt', skippedMerge: true }
+  await svc.generateImage('u1', 'a prompt', 'seedream-5.0-pro', '16:9', [], [], '1K', 2)
+  expect(generate).toHaveBeenCalled()
+  const opts = generate.mock.calls[0][1]
+  expect(opts.modelId).toBeTruthy()
+  expect(opts.n).toBe(2)
+  expect(opts.size).toBeTruthy()
+})
+```
+
+- [ ] **Step 2: Video / Audio / Text 同文件追加**
+
+- Video：refs 含 image url → `generate` 第二参含 `image` 等于该 url  
+- Audio：options 含 model、voice、speed、volume、pitch  
+- Text：gatewayModelId 来自 `resolveModelKey('text', model)`  
+
+- [ ] **Step 3: Run**
+
+```bash
+pnpm --filter @lnkpi/server test
+```
+
+Expected: PASS；无外网。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -am "test(server): studio integration tests for model param passthrough"
+```
+
+---
+
+### Task 4: Web Vitest + useNodeGeneration 测试
+
+**Files:**
+- Modify: `apps/web/package.json`
+- Create: `apps/web/vitest.config.ts`
+- Create: `apps/web/src/composables/useNodeGeneration.test.ts`
+
+**Interfaces:**
+- Consumes: `useNodeGeneration(deps)`
+- Produces: 断言 `studioApi.generate*` mock 参数
+
+- [ ] **Step 1: 依赖 + config**
+
+```bash
+pnpm --filter @lnkpi/web add -D vitest @vue/test-utils jsdom
+```
+
+```ts
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+import { fileURLToPath } from 'node:url'
+
+export default defineConfig({
+  plugins: [vue()],
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.test.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+})
+```
+
+`"test": "vitest run"`
+
+- [ ] **Step 2: Mock studio-api 并写用例**
+
+1. audio：`generateAudio` 收到 model / volume / pitch  
+2. image：`generateImage` 收到 model / resolution / count  
+3. `blob:` referenceImageUrl → 不调用 API，patch error  
+
+构造最小 `deps`（`ref` nodes/edges、`requireLogin: () => true`、stub patch/save/polling）。
+
+- [ ] **Step 3: Run + Commit**
+
+```bash
+pnpm --filter @lnkpi/web test
+git add apps/web && git commit -m "test(web): useNodeGeneration payload and blob guard tests"
+```
+
+---
+
+### Task 5: 全仓验收 + PR
+
+**Files:**
+- Modify（可选）: `docs/superpowers/specs/2026-07-19-test-infrastructure-design.md` 状态栏
+
+- [ ] **Step 1: 全量**
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @lnkpi/server exec prisma generate
+pnpm build
+pnpm test
+```
+
+Expected: all green
+
+- [ ] **Step 2: 可选更新规格状态 + Commit**
+
+```bash
+git commit -am "docs(spec): mark T0 test infrastructure implemented"
+```
+
+- [ ] **Step 3: Push + 独立 PR**
+
+标题：`chore(test): T0 测试基础设施（Vitest + Server 集成 + CI）`  
+Body：引用规格 §6；注明合入后需 rebase #25。
+
+---
+
+## Spec coverage
+
+| 规格要求 | Task |
+|----------|------|
+| 根 `pnpm test` + CI | T1 |
+| Server Vitest + Nest harness | T2 |
+| Studio 集成四模态 | T3 |
+| Web composable 测试 | T4 |
+| 无 E2E / 无真库 | Global |
+| 验收 build+test + PR | T5 |
+
+## Self-review
+
+- 无 TBD；Provider 用 `vi.mock('@lnkpi/agent')`  
+- Task 1 `--if-present` 过渡，T2–T4 补齐后 CI 四包全跑  
+- 分支：`chore/test-infrastructure-t0` from main；规格 commit 从 #25 分支 cherry-pick 过来  

--- a/docs/superpowers/specs/2026-07-19-test-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-07-19-test-infrastructure-design.md
@@ -1,6 +1,6 @@
 # 测试基础设施（T0 前置）产品与技术规格
 
-> 状态：**待审阅**（§1–§3 已共创确认；实现计划待 `writing-plans`）  
+> 状态：**已实现**（T0 已落地；§6 后续迭代见 T1–T4）  
 > 日期：2026-07-19  
 > 范围：**T0** — 单元 + 服务端集成测试地基，并全量接入 CI；**不含** Playwright E2E / 真库  
 > 背景：C1 PR [#25](https://github.com/sev7n4/lnkpi/pull/25) **暂停合并**，本规格作为其前置；合入 main 后再 rebase #25 并按需补 C1 专项用例  
@@ -152,7 +152,7 @@ install → prisma generate → pnpm build → pnpm test → (pull_request) dock
 
 | 轮次 | 名称 | 内容 | 依赖 | 状态 |
 | --- | --- | --- | --- | --- |
-| **T0** | 测试地基 | 本规格：Vitest 全仓、Server 集成、Web composable、CI 全量 | — | 规格确认中 → 实现 |
+| **T0** | 测试地基 | 本规格：Vitest 全仓、Server 集成、Web composable、CI 全量 | — | **已实现** |
 | **T1** | C1 合入 | PR #25 rebase 到含 T0 的 main；按需补 C1 专项用例；再 Squash & Merge | T0 合入 | 暂停（#25 待 rebase） |
 | **T2** | Playwright E2E | 起 web + api（网关 mock）；画布：选模型/参数/生成/断言请求或节点状态 | T0 | 规划中 |
 | **T3** | 可选加固 | 真库 Prisma 集成子集；部署后鉴权 API 冒烟（不止 health） | T0 / T2 | 可选 |

--- a/docs/superpowers/specs/2026-07-19-test-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-07-19-test-infrastructure-design.md
@@ -1,0 +1,197 @@
+# 测试基础设施（T0 前置）产品与技术规格
+
+> 状态：**待审阅**（§1–§3 已共创确认；实现计划待 `writing-plans`）  
+> 日期：2026-07-19  
+> 范围：**T0** — 单元 + 服务端集成测试地基，并全量接入 CI；**不含** Playwright E2E / 真库  
+> 背景：C1 PR [#25](https://github.com/sev7n4/lnkpi/pull/25) **暂停合并**，本规格作为其前置；合入 main 后再 rebase #25 并按需补 C1 专项用例  
+> 关联：`2026-07-19-dock-studio-model-adapter-design.md`（C1）
+
+---
+
+## 0. 决策摘要
+
+| 项 | 结论 |
+| --- | --- |
+| 本轮代号 | **T0**（测试地基前置 PR） |
+| 覆盖层 | **单元 + Server 集成**；E2E 留 **T2** |
+| 测试栈 | **全仓 Vitest**（与 shared/agent 一致） |
+| Server Nest | Vitest + `@nestjs/testing`；装饰器经 SWC / 等价转换一次配好 |
+| Prisma | **Mock PrismaService**（不启真库） |
+| Provider | **Mock** Image/Video/Audio/Text Provider（或等价注入点） |
+| Web | Vitest + Vue Test Utils + jsdom；**composable 为主**，少量组件冒烟 |
+| CI | `install → prisma generate → build → pnpm test → (PR) docker-build` |
+| C1 #25 | 不合并；T0 合入后 rebase #25 |
+
+---
+
+## 1. 目标与非目标
+
+### 1.1 目标
+
+建立可持续的「单元 + 服务端集成」测试地基并接入 CI，保障：
+
+- Controller → Service → Adapter →（mock）Provider 的**参数与 refs 传递正确**
+- Web 侧 `useNodeGeneration` 等组装的 **studio-api 请求 payload 齐全**
+- CI 对 `shared` / `agent` / `server` / `web` **四包测试全跑**（现仅 agent，且 shared 有测未进 CI）
+
+### 1.2 非目标（T0 明确不做）
+
+| 能力 | 说明 |
+| --- | --- |
+| Playwright / Cypress E2E | **T2** |
+| 真实 Postgres/SQLite 集成库 | **T3**（可选） |
+| 部署后业务 API 冒烟扩展 | **T3**；现有 `/api/health` 保留 |
+| Web 全量 Dock 组件渲染矩阵 | 超出本轮；仅 composable + 少量冒烟 |
+| 为历史全业务补齐测试 | 只保关键路径与地基 |
+
+### 1.3 验收标准
+
+1. 根目录存在 `pnpm test`（`pnpm -r test`），四包均可执行且本地全绿。  
+2. `.github/workflows/ci.yml` 在 build 之后运行全仓测试（不仅 agent）。  
+3. `apps/server` 可跑至少一组 Studio 集成用例（见 §4）。  
+4. `apps/web` 可跑至少一组 `useNodeGeneration`（及 catalog/blob 护栏）用例。  
+5. 规格文档含 **后续迭代计划**（§6）；T0 PR 描述中引用本文件。
+
+---
+
+## 2. 架构
+
+### 2.1 测试金字塔（本仓约定）
+
+```text
+        ┌─────────────┐
+        │  E2E (T2)   │  Playwright：画布关键路径（后置）
+        ├─────────────┤
+        │ Integration │  Server：@nestjs/testing + mock Prisma/Provider（T0）
+        ├─────────────┤
+        │    Unit     │  shared / agent / web composables（T0 加固 + CI）
+        └─────────────┘
+```
+
+### 2.2 Server 集成边界
+
+```text
+HTTP DTO (Controller)
+  → StudioService
+       → resolveMergedPrompt / StudioGenerationAdapter（真逻辑）
+       → create*Provider() 或可注入的 Provider 工厂（测试中替换为 mock）
+       → PrismaService（测试中 mock：user 积分、generationRecord.create/update）
+```
+
+断言重点：传入 mock Provider 的 `model` / `modelId` / `size` / `n` / `options.image` / audio options；写入 record 的 `metadata` 含 AdapterMeta 关键字段。
+
+### 2.3 Web 单元边界
+
+- Mock `studio-api` / `canvas-api` 与 deps（nodes/edges/patch/save）。  
+- 调用 `generateForNode`，断言 mock API 收到的参数。  
+- 不启动真实 VueFlow / 浏览器。
+
+---
+
+## 3. 文件与 CI 改动
+
+| 路径 | 职责 |
+| --- | --- |
+| `package.json` | `"test": "pnpm -r test"` |
+| `.github/workflows/ci.yml` | build 后 `pnpm test`（覆盖四包） |
+| `apps/server/package.json` | `test` + vitest、@nestjs/testing、相关依赖 |
+| `apps/server/vitest.config.ts` | Vitest + Nest 装饰器支持 |
+| `apps/server/src/studio/studio.integration.test.ts` | Studio 集成用例 |
+| `apps/web/package.json` | `test` + vitest、@vue/test-utils、jsdom、@vitejs/plugin-vue（若需） |
+| `apps/web/vitest.config.ts` | Vitest + Vue + jsdom |
+| `apps/web/src/composables/useNodeGeneration.test.ts` | 生成 payload |
+| `apps/web/src/...`（可选） | catalog / blob 护栏小测 |
+| 本文档 | 规格 + 后续路线 |
+
+### CI 目标流水线
+
+```text
+install → prisma generate → pnpm build → pnpm test → (pull_request) docker-build
+```
+
+说明：`paths-ignore` 对 `**/*.md` / `docs/**` 的 push 忽略可保留；**本前置 PR 含代码**，PR 事件仍会跑全量 CI。
+
+---
+
+## 4. 首批用例清单
+
+### 4.1 Server 集成（必须）
+
+1. **Image**：`model` → provider `modelId`；resolution/count → size/n；refs 路径可执行；I2+ 经 suffix 或 metadata **可观测**（禁止静默丢多图）。  
+2. **Video**：主参考图 → `options.image`；duration / aspectRatio / resolution 透传。  
+3. **Audio**：`model` / `voice` / `speed` / `volume` / `pitch` 进 provider options；能力外字段进 prefix 或 metadata。  
+4. **Text**：`resolveModelKey('text')` 后的 `gatewayModelId` 进入 text（或 vision）调用；metadata 含 modelKey / fallback 标志（若触发）。
+
+### 4.2 Web composable（必须）
+
+1. image / video / audio / text 生成时，`studioApi.*` 收到的参数齐全（含 audio `volume`/`pitch`/`model`）。  
+2. 非法或旧 modelKey 经 `resolveModelKey` 纠正后再请求。  
+3. refs 或 `referenceImageUrl` 含 `blob:` 时阻断生成并写入 error 状态。
+
+### 4.3 已有（必须进 CI）
+
+- `@lnkpi/shared` 现有 vitest  
+- `@lnkpi/agent` 现有 vitest（含 adapter / providers）
+
+---
+
+## 5. 风险与缓解
+
+| 风险 | 缓解 |
+| --- | --- |
+| Nest 装饰器在 Vitest 下反射失败 | 首版用 SWC / 官方推荐插件一次配通；失败则文档化备选 |
+| Provider 为模块内 `createXProvider()` 难 mock | 测试中优先 mock `@lnkpi/agent` 工厂；必要时小 refactor 支持注入（YAGNI：能 mock 就不改生产 API） |
+| Web 测依赖过多 CanvasPage 图 | 只测 `useNodeGeneration`，构造最小 deps |
+| CI 时间变长 | 单测保持无网络、无 DB；并行 `-r test` |
+
+---
+
+## 6. 后续迭代计划（记录备查）
+
+> 以下为产品/工程路线，**不在本 T0 PR 实现**。变更时更新本节状态列。
+
+| 轮次 | 名称 | 内容 | 依赖 | 状态 |
+| --- | --- | --- | --- | --- |
+| **T0** | 测试地基 | 本规格：Vitest 全仓、Server 集成、Web composable、CI 全量 | — | 规格确认中 → 实现 |
+| **T1** | C1 合入 | PR #25 rebase 到含 T0 的 main；按需补 C1 专项用例；再 Squash & Merge | T0 合入 | 暂停（#25 待 rebase） |
+| **T2** | Playwright E2E | 起 web + api（网关 mock）；画布：选模型/参数/生成/断言请求或节点状态 | T0 | 规划中 |
+| **T3** | 可选加固 | 真库 Prisma 集成子集；部署后鉴权 API 冒烟（不止 health） | T0 / T2 | 可选 |
+| **C2** | 旁路统一 | shot / scene composer 与 studio 共用参数 + refs | C1 合入后 | 产品规格已拆 |
+| **C3** | 视频芯片 | V* 抽帧 / 理解 | C1 后 | 产品规格已拆 |
+| **C4** | 音频芯片 | A* ASR / 音色参考（若 provider 支持） | C1 后 | 产品规格已拆 |
+
+### 与 C1 的关系
+
+```text
+T0 (本 PR) ──merge──► main
+                         │
+                         ▼
+              rebase #25 (C1) ──CI + 手工清单──► merge C1
+                         │
+                         ▼
+              T2 E2E / C2–C4 按优先级推进
+```
+
+---
+
+## 7. 与现状差距（事实）
+
+| 项 | 现状 | T0 后 |
+| --- | --- | --- |
+| CI 测试 | 仅 `@lnkpi/agent test` | 四包 `pnpm test` |
+| shared | 有测、CI 未跑 | CI 跑 |
+| server | 无 test 脚本 | Vitest + 集成用例 |
+| web | 无 test | Vitest + composable 用例 |
+| E2E | 无 | 仍无（T2） |
+| 部署验证 | `/api/health` | 不变（T3 再扩） |
+
+---
+
+## 8. 实现交接
+
+规格审阅通过后：
+
+1. `writing-plans` → `docs/superpowers/plans/2026-07-19-test-infrastructure.md`  
+2. 新分支（建议 `chore/test-infrastructure-t0`，勿与 #25 混提交）  
+3. Subagent-Driven 或 Inline 执行  
+4. 独立 PR → CI 绿 → Squash & Merge → 再处理 #25 rebase  

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev:web": "pnpm --filter @lnkpi/web dev",
     "dev:server": "pnpm --filter @lnkpi/server dev",
     "build": "pnpm -r build",
-    "lint": "pnpm -r lint"
+    "lint": "pnpm -r lint",
+    "test": "pnpm -r --if-present test"
   },
   "engines": {
     "node": ">=20"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,12 @@ importers:
         specifier: ^7.8.1
         version: 7.8.2
     devDependencies:
+      '@nestjs/testing':
+        specifier: ^10.4.22
+        version: 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/platform-express@10.4.22)
+      '@swc/core':
+        specifier: ^1.15.43
+        version: 1.15.43
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.6
@@ -65,6 +71,12 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
+      unplugin-swc:
+        specifier: ^1.5.9
+        version: 1.5.9(@swc/core@1.15.43)(rollup@4.62.2)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.0)
 
   apps/web:
     dependencies:
@@ -523,6 +535,9 @@ packages:
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -578,6 +593,19 @@ packages:
       '@nestjs/common': ^10.0.0
       '@nestjs/core': ^10.0.0
 
+  '@nestjs/testing@10.4.22':
+    resolution: {integrity: sha512-HO9aPus3bAedAC+jKVAA8jTdaj4fs5M9fing4giHrcYV2txe9CvC1l1WAjwQ9RDhEHdugjY4y+FZA/U/YqPZrA==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0
+      '@nestjs/core': ^10.0.0
+      '@nestjs/microservices': ^10.0.0
+      '@nestjs/platform-express': ^10.0.0
+    peerDependenciesMeta:
+      '@nestjs/microservices':
+        optional: true
+      '@nestjs/platform-express':
+        optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -624,6 +652,15 @@ packages:
 
   '@prisma/get-platform@6.19.3':
     resolution: {integrity: sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==}
+
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
     resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
@@ -765,6 +802,99 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@swc/core-darwin-arm64@1.15.43':
+    resolution: {integrity: sha512-v1aVuvXdo/BHxJzco9V2xpHrvwWmhfS8t6gziY5wJxd+Z2h8AeJRnAwPD8itCDaGXVBwJ/CaKfxEzTkG0Va0OA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.15.43':
+    resolution: {integrity: sha512-lp3d4Lamc8dt5huYdGLSR+9hLxmfr1jb0l+4XXG2zPqZwYWRN9R0U2qYoTrggiU2RWW0oV9VbWM3kBnqIc2kdQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.15.43':
+    resolution: {integrity: sha512-JWTQQELtsG5GgphDrr/XqqmM2pDN3cZqbMS0Mrg+iTiXL3F74sn/S2IyYE/5u4h2KLkTf9qQ7dXyxsbx7YzkeA==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.15.43':
+    resolution: {integrity: sha512-B4otJRdPWIsmiSBf0uG7Z/+vMWmkufjz5MmYxubwKuZazDW14Zd3symga1N62QR4RT+kEFeHEgsXfZGyn/w0hw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-arm64-musl@1.15.43':
+    resolution: {integrity: sha512-6zB6OnpViBxYy4tgY3v2i6AZY9fwkcHZ032UOwtwUuW1d19sdT07qF0kZe6/3UR1tUaK6jjg2rmVcUIBCEYVjQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@swc/core-linux-ppc64-gnu@1.15.43':
+    resolution: {integrity: sha512-coxE1ZWdB3uSDVNoEtYNrRi/1epvckZx9cTJ8ICUxTMTxGk+yvQ/Twacp3ruZSaMPGCriUjP86C37VhaT6nyRg==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-s390x-gnu@1.15.43':
+    resolution: {integrity: sha512-lXfLhs+LpBsD5inuYx+YDH5WsPPBQ95KPUiy8P5wq9ob9xKDZFqwNfU2QW6bGO8NqRO/H9JQomTSt5Yyh+FGfA==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-x64-gnu@1.15.43':
+    resolution: {integrity: sha512-07XnKwTmKy8TGOZG3D9fRnLWGynxPjwQnZLVmBFbo6F+7vHYzBIOuwXEhemrChBWb6yDNZsVCcMWCPX6FDD2xg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@swc/core-linux-x64-musl@1.15.43':
+    resolution: {integrity: sha512-TJc+bsSIaBh+hZvZ5GRtW/K1bw66TJ9vsUwvVIsZdiWxU5ObLwZvfcnZ3UpgVfMnFibRes9uriJrQNBHEEogRQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@swc/core-win32-arm64-msvc@1.15.43':
+    resolution: {integrity: sha512-jfd7s2/bUQYkOHLs+LWQNKZdmDa8+sufKLllhpWAhVQ2GDCwsHe3vR/j+OSiItZNtkzFuaawa3+SAKz9y5gYfw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.15.43':
+    resolution: {integrity: sha512-rLAE8JvucqEW1ZGohxPQrQWPBQeJG4+ypKbWfdlU/qmKScvCkxf9/Jxnzki1dkUQCQ7P5Enp13RlvqOlvx/32g==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.15.43':
+    resolution: {integrity: sha512-h8MLDHZcfIukwQWj03rIJZx1I0E81AYj2X7J/nGErG4nz+QAv6G1Z+peotvinL3lqpbo32tLYSMFo32/ySzxKg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.15.43':
+    resolution: {integrity: sha512-1CuKjFkPxIgGdeHVuNbkxmBxkcbdc08u0aiI43pFq6yY1tTVKmXT9hFEooyyKs/sJ3xf1GPHyEwTtk9Xl8dvQw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@swc/counter@0.1.3':
+    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/types@0.1.27':
+    resolution: {integrity: sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==}
 
   '@sxzz/popperjs-es@2.11.8':
     resolution: {integrity: sha512-wOwESXvvED3S8xBmcPWHs2dUuzrE4XiZeFu7e1hROIJkm02a49N120pmOXxY33sBb6hArItm5W5tcg1cBtV+HQ==}
@@ -1154,6 +1284,11 @@ packages:
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -1793,6 +1928,10 @@ packages:
 
   linkifyjs@4.3.3:
     resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
@@ -2441,6 +2580,15 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  unplugin-swc@1.5.9:
+    resolution: {integrity: sha512-RKwK3yf0M+MN17xZfF14bdKqfx0zMXYdtOdxLiE6jHAoidupKq3jGdJYANyIM1X/VmABhh1WpdO+/f4+Ol89+g==}
+    peerDependencies:
+      '@swc/core': ^1.2.108
+
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -2576,6 +2724,9 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -2789,6 +2940,11 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -2848,6 +3004,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@nestjs/testing@10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/platform-express@10.4.22)':
+    dependencies:
+      '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@nestjs/platform-express': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2902,6 +3066,14 @@ snapshots:
   '@prisma/get-platform@6.19.3':
     dependencies:
       '@prisma/debug': 6.19.3
+
+  '@rollup/pluginutils@5.4.0(rollup@4.62.2)':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.5
+    optionalDependencies:
+      rollup: 4.62.2
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
     optional: true
@@ -2979,6 +3151,66 @@ snapshots:
     optional: true
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@swc/core-darwin-arm64@1.15.43':
+    optional: true
+
+  '@swc/core-darwin-x64@1.15.43':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.15.43':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.15.43':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.15.43':
+    optional: true
+
+  '@swc/core-linux-ppc64-gnu@1.15.43':
+    optional: true
+
+  '@swc/core-linux-s390x-gnu@1.15.43':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.15.43':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.15.43':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.15.43':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.15.43':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.15.43':
+    optional: true
+
+  '@swc/core@1.15.43':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.27
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.15.43
+      '@swc/core-darwin-x64': 1.15.43
+      '@swc/core-linux-arm-gnueabihf': 1.15.43
+      '@swc/core-linux-arm64-gnu': 1.15.43
+      '@swc/core-linux-arm64-musl': 1.15.43
+      '@swc/core-linux-ppc64-gnu': 1.15.43
+      '@swc/core-linux-s390x-gnu': 1.15.43
+      '@swc/core-linux-x64-gnu': 1.15.43
+      '@swc/core-linux-x64-musl': 1.15.43
+      '@swc/core-win32-arm64-msvc': 1.15.43
+      '@swc/core-win32-ia32-msvc': 1.15.43
+      '@swc/core-win32-x64-msvc': 1.15.43
+
+  '@swc/counter@0.1.3': {}
+
+  '@swc/types@0.1.27':
+    dependencies:
+      '@swc/counter': 0.1.3
 
   '@sxzz/popperjs-es@2.11.8': {}
 
@@ -3455,6 +3687,8 @@ snapshots:
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
+
+  acorn@8.17.0: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -4177,6 +4411,8 @@ snapshots:
 
   linkifyjs@4.3.3: {}
 
+  load-tsconfig@0.2.5: {}
+
   lodash-es@4.18.1: {}
 
   lodash-unified@1.0.3(@types/lodash-es@4.17.12)(lodash-es@4.18.1)(lodash@4.18.1):
@@ -4891,6 +5127,22 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  unplugin-swc@1.5.9(@swc/core@1.15.43)(rollup@4.62.2):
+    dependencies:
+      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
+      '@swc/core': 1.15.43
+      load-tsconfig: 0.2.5
+      unplugin: 2.3.11
+    transitivePeerDependencies:
+      - rollup
+
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.17.0
+      picomatch: 4.0.5
+      webpack-virtual-modules: 0.6.2
+
   update-browserslist-db@1.2.3(browserslist@4.28.5):
     dependencies:
       browserslist: 4.28.5
@@ -5027,6 +5279,8 @@ snapshots:
   w3c-keyname@2.2.8: {}
 
   webidl-conversions@3.0.1: {}
+
+  webpack-virtual-modules@0.6.2: {}
 
   whatwg-url@5.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,7 @@ importers:
         version: 1.5.9(@swc/core@1.15.43)(rollup@4.62.2)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.0)
+        version: 3.2.7(@types/node@22.20.1)(jiti@2.7.0)(jsdom@29.1.1(canvas@3.2.1))(tsx@4.23.0)
 
   apps/web:
     dependencies:
@@ -132,9 +132,15 @@ importers:
       '@vitejs/plugin-vue':
         specifier: ^5.2.1
         version: 5.2.4(vite@6.4.3(@types/node@22.20.1)(jiti@1.21.7)(tsx@4.23.0))(vue@3.5.39(typescript@5.9.3))
+      '@vue/test-utils':
+        specifier: ^2.4.11
+        version: 2.4.11(@vue/compiler-dom@3.5.39)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@5.9.3)))(vue@3.5.39(typescript@5.9.3))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.5.2(postcss@8.5.16)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1(canvas@3.2.1)
       postcss:
         specifier: ^8.5.1
         version: 8.5.16
@@ -147,6 +153,9 @@ importers:
       vite:
         specifier: ^6.0.7
         version: 6.4.3(@types/node@22.20.1)(jiti@1.21.7)(tsx@4.23.0)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/node@22.20.1)(jiti@1.21.7)(jsdom@29.1.1(canvas@3.2.1))(tsx@4.23.0)
       vue-tsc:
         specifier: ^2.2.0
         version: 2.2.12(typescript@5.9.3)
@@ -165,7 +174,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.0)
+        version: 3.2.7(@types/node@22.20.1)(jiti@2.7.0)(jsdom@29.1.1(canvas@3.2.1))(tsx@4.23.0)
 
   packages/shared:
     devDependencies:
@@ -174,13 +183,28 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.0)
+        version: 3.2.7(@types/node@22.20.1)(jiti@2.7.0)(jsdom@29.1.1(canvas@3.2.1))(tsx@4.23.0)
 
 packages:
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
@@ -201,6 +225,46 @@ packages:
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.9':
+    resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6':
+    resolution: {integrity: sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@ctrl/tinycolor@4.2.0':
     resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
@@ -523,6 +587,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
@@ -531,6 +604,10 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -622,6 +699,13 @@ packages:
     resolution: {integrity: sha512-um0xL3fO7Mf4fDxcqx9KryrB7zgRM5JSlvGN5AGkP6JLM5XEKyjeAiPbNxdXVXQ16isuAhYpvP88NgL2BGd6aA==}
     engines: {node: '>=8.0.0', npm: '>=5.0.0'}
     hasBin: true
+
+  '@one-ini/wasm@0.1.1':
+    resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@prisma/client@6.19.3':
     resolution: {integrity: sha512-mKq3jQFhjvko5LTJFHGilsuQs+W+T3Gm451NzuTDGQxwCzwXHYnIu2zGkRoW+Exq3Rob7yp2MfzSrdIiZVhrBg==}
@@ -1256,6 +1340,16 @@ packages:
   '@vue/shared@3.5.39':
     resolution: {integrity: sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==}
 
+  '@vue/test-utils@2.4.11':
+    resolution: {integrity: sha512-GDqaqZsA6m2E5vNzej0aYiIb6BX8xV9pNSbbbXKOfEYwg7ZNblVX8suyqmUBThq8VIrgAJNxn+z72hVtUeiWHA==}
+    peerDependencies:
+      '@vue/compiler-dom': 3.x
+      '@vue/server-renderer': 3.x
+      vue: 3.x
+    peerDependenciesMeta:
+      '@vue/server-renderer':
+        optional: true
+
   '@vueuse/core@10.11.1':
     resolution: {integrity: sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==}
 
@@ -1281,6 +1375,10 @@ packages:
   '@webgpu/types@0.1.71':
     resolution: {integrity: sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==}
 
+  abbrev@2.0.0:
+    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -1297,9 +1395,21 @@ packages:
   alien-signals@1.0.13:
     resolution: {integrity: sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -1350,6 +1460,9 @@ packages:
     resolution: {integrity: sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -1468,6 +1581,10 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -1478,6 +1595,9 @@ packages:
 
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
   consola@2.15.3:
     resolution: {integrity: sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==}
@@ -1504,6 +1624,14 @@ packages:
   cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
     engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -1551,6 +1679,10 @@ packages:
     resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   dayjs@1.11.21:
     resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
@@ -1573,6 +1705,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -1626,8 +1761,16 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  editorconfig@1.0.7:
+    resolution: {integrity: sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -1642,6 +1785,12 @@ packages:
     resolution: {integrity: sha512-eNH9uP3wQoNqieEIHXiNvIVv+zO5sZDU0CAZq5b0zqSN06DD0/V9xIq1R/qm3rw5k3nBTM1JvpxhCfRbaFLzDQ==}
     peerDependencies:
       vue: ^3.3.7
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
@@ -1661,6 +1810,10 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -1770,6 +1923,10 @@ packages:
       debug:
         optional: true
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
@@ -1819,6 +1976,10 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -1842,6 +2003,10 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -1880,6 +2045,10 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -1888,9 +2057,18 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
   iterare@1.2.1:
     resolution: {integrity: sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==}
     engines: {node: '>=6'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
@@ -1900,8 +2078,25 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  js-beautify@1.15.4:
+    resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  js-cookie@3.0.8:
+    resolution: {integrity: sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==}
+
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsonwebtoken@9.0.2:
     resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
@@ -1970,6 +2165,13 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1983,6 +2185,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
@@ -2032,6 +2237,10 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
@@ -2095,6 +2304,11 @@ packages:
     resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
     engines: {node: '>=18'}
 
+  nopt@7.2.1:
+    resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -2132,6 +2346,12 @@ packages:
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -2139,8 +2359,16 @@ packages:
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
@@ -2298,6 +2526,9 @@ packages:
   prosemirror-view@1.42.1:
     resolution: {integrity: sha512-rRqzZnRgkyh69XoOMrfFJHwauHscLBmHbq772kwbic1ymQAM8gXjzEbJse5j1ep2UO2HRIAQL0bY3kZ/RoqjVw==}
 
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -2311,6 +2542,10 @@ packages:
 
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   pure-rand@6.1.0:
@@ -2356,6 +2591,10 @@ packages:
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
@@ -2385,6 +2624,10 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -2400,6 +2643,14 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
@@ -2419,6 +2670,10 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
@@ -2444,8 +2699,24 @@ packages:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -2470,6 +2741,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwindcss@3.4.19:
     resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
@@ -2521,6 +2795,13 @@ packages:
     peerDependencies:
       '@tiptap/core': ^3.0.1
 
+  tldts-core@7.4.9:
+    resolution: {integrity: sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==}
+
+  tldts@7.4.9:
+    resolution: {integrity: sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -2533,8 +2814,16 @@ packages:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
 
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -2575,6 +2864,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -2722,22 +3015,58 @@ packages:
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
 
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -2746,6 +3075,26 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/helper-string-parser@7.29.7': {}
 
@@ -2761,6 +3110,34 @@ snapshots:
       '@babel/helper-validator-identifier': 7.29.7
 
   '@borewit/text-codec@0.2.2': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@ctrl/tinycolor@4.2.0': {}
 
@@ -2924,6 +3301,8 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
+  '@exodus/bytes@1.15.1': {}
+
   '@floating-ui/core@1.7.5':
     dependencies:
       '@floating-ui/utils': 0.2.11
@@ -2934,6 +3313,15 @@ snapshots:
       '@floating-ui/utils': 0.2.11
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -3031,6 +3419,11 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  '@one-ini/wasm@0.1.1': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@prisma/client@6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)':
     optionalDependencies:
@@ -3501,6 +3894,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
+  '@vitest/mocker@3.2.7(vite@6.4.3(@types/node@22.20.1)(jiti@1.21.7)(tsx@4.23.0))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.3(@types/node@22.20.1)(jiti@1.21.7)(tsx@4.23.0)
+
   '@vitest/mocker@3.2.7(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.0))':
     dependencies:
       '@vitest/spy': 3.2.7
@@ -3649,6 +4050,15 @@ snapshots:
 
   '@vue/shared@3.5.39': {}
 
+  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.5.39)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@5.9.3)))(vue@3.5.39(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-dom': 3.5.39
+      js-beautify: 1.15.4
+      vue: 3.5.39(typescript@5.9.3)
+      vue-component-type-helpers: 3.3.7
+    optionalDependencies:
+      '@vue/server-renderer': 3.5.39(vue@3.5.39(typescript@5.9.3))
+
   '@vueuse/core@10.11.1(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
@@ -3683,6 +4093,8 @@ snapshots:
 
   '@webgpu/types@0.1.71': {}
 
+  abbrev@2.0.0: {}
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -3698,9 +4110,15 @@ snapshots:
 
   alien-signals@1.0.13: {}
 
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
 
@@ -3748,6 +4166,10 @@ snapshots:
     optional: true
 
   baseline-browser-mapping@2.10.42: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   binary-extensions@2.3.0: {}
 
@@ -3902,6 +4324,8 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  commander@10.0.1: {}
+
   commander@4.1.1: {}
 
   concat-stream@2.0.0:
@@ -3912,6 +4336,11 @@ snapshots:
       typedarray: 0.0.6
 
   confbox@0.2.4: {}
+
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
 
   consola@2.15.3: {}
 
@@ -3931,6 +4360,17 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
 
   cssesc@3.0.0: {}
 
@@ -3972,6 +4412,13 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   dayjs@1.11.21: {}
 
   de-indent@1.0.2: {}
@@ -3983,6 +4430,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decompress-response@6.0.0:
     dependencies:
@@ -4021,9 +4470,18 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
+
+  editorconfig@1.0.7:
+    dependencies:
+      '@one-ini/wasm': 0.1.1
+      commander: 10.0.1
+      minimatch: 9.0.9
+      semver: 7.8.5
 
   ee-first@1.1.1: {}
 
@@ -4053,6 +4511,10 @@ snapshots:
       vue: 3.5.39(typescript@5.9.3)
       vue-component-type-helpers: 3.3.7
 
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
   empathic@2.0.0: {}
 
   encodeurl@2.0.0: {}
@@ -4065,6 +4527,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@7.0.1: {}
+
+  entities@8.0.0: {}
 
   es-define-property@1.0.1: {}
 
@@ -4247,6 +4711,11 @@ snapshots:
 
   follow-redirects@1.16.0: {}
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
@@ -4307,6 +4776,15 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@10.4.5:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   gopd@1.2.0: {}
 
   has-flag@4.0.0: {}
@@ -4322,6 +4800,12 @@ snapshots:
       function-bind: 1.1.2
 
   he@1.2.0: {}
+
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   http-errors@2.0.1:
     dependencies:
@@ -4346,8 +4830,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ini@1.3.8:
-    optional: true
+  ini@1.3.8: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -4361,19 +4844,69 @@ snapshots:
 
   is-extglob@2.1.1: {}
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
   is-number@7.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
+  isexe@2.0.0: {}
+
   iterare@1.2.1: {}
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   jiti@1.21.7: {}
 
   jiti@2.7.0: {}
 
+  js-beautify@1.15.4:
+    dependencies:
+      config-chain: 1.1.13
+      editorconfig: 1.0.7
+      glob: 10.4.5
+      js-cookie: 3.0.8
+      nopt: 7.2.1
+
+  js-cookie@3.0.8: {}
+
   js-tokens@9.0.1: {}
+
+  jsdom@29.1.1(canvas@3.2.1):
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 7.28.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    optionalDependencies:
+      canvas: 3.2.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsonwebtoken@9.0.2:
     dependencies:
@@ -4439,6 +4972,10 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@10.4.3: {}
+
+  lru-cache@11.5.2: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4455,6 +4992,8 @@ snapshots:
       uc.micro: 2.1.0
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   mdurl@2.0.0: {}
 
@@ -4489,6 +5028,8 @@ snapshots:
       brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
 
   mkdirp-classic@0.5.3:
     optional: true
@@ -4549,6 +5090,10 @@ snapshots:
 
   node-releases@2.0.50: {}
 
+  nopt@7.2.1:
+    dependencies:
+      abbrev: 2.0.0
+
   normalize-path@3.0.0: {}
 
   normalize-wheel-es@1.2.0: {}
@@ -4578,11 +5123,24 @@ snapshots:
 
   orderedmap@2.1.1: {}
 
+  package-json-from-dist@1.0.1: {}
+
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
 
+  path-key@3.1.1: {}
+
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-to-regexp@0.1.13: {}
 
@@ -4770,6 +5328,8 @@ snapshots:
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
 
+  proto-list@1.2.4: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -4784,6 +5344,8 @@ snapshots:
     optional: true
 
   punycode.js@2.3.1: {}
+
+  punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
 
@@ -4832,6 +5394,8 @@ snapshots:
   readdirp@4.1.2: {}
 
   reflect-metadata@0.2.2: {}
+
+  require-from-string@2.0.2: {}
 
   resolve@1.22.12:
     dependencies:
@@ -4887,6 +5451,10 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   semver@7.8.5: {}
 
   send@0.19.2:
@@ -4918,6 +5486,12 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
@@ -4948,6 +5522,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@4.1.0: {}
+
   simple-concat@1.0.1:
     optional: true
 
@@ -4968,9 +5544,29 @@ snapshots:
 
   streamsearch@1.1.0: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-json-comments@2.0.1:
     optional: true
@@ -4998,6 +5594,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  symbol-tree@3.2.4: {}
 
   tailwindcss@3.4.19(tsx@4.23.0):
     dependencies:
@@ -5077,6 +5675,12 @@ snapshots:
       markdown-it-task-lists: 2.1.1
       prosemirror-markdown: 1.13.5
 
+  tldts-core@7.4.9: {}
+
+  tldts@7.4.9:
+    dependencies:
+      tldts-core: 7.4.9
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -5089,7 +5693,15 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.9
+
   tr46@0.0.3: {}
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-interface-checker@0.1.13: {}
 
@@ -5125,6 +5737,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici@7.28.0: {}
+
   unpipe@1.0.0: {}
 
   unplugin-swc@1.5.9(@swc/core@1.15.43)(rollup@4.62.2):
@@ -5156,6 +5770,27 @@ snapshots:
   validator@13.15.35: {}
 
   vary@1.1.2: {}
+
+  vite-node@3.2.4(@types/node@22.20.1)(jiti@1.21.7)(tsx@4.23.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.3(@types/node@22.20.1)(jiti@1.21.7)(tsx@4.23.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vite-node@3.2.4(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.0):
     dependencies:
@@ -5206,7 +5841,49 @@ snapshots:
       jiti: 2.7.0
       tsx: 4.23.0
 
-  vitest@3.2.7(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.0):
+  vitest@3.2.7(@types/node@22.20.1)(jiti@1.21.7)(jsdom@29.1.1(canvas@3.2.1))(tsx@4.23.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@6.4.3(@types/node@22.20.1)(jiti@1.21.7)(tsx@4.23.0))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.3(@types/node@22.20.1)(jiti@1.21.7)(tsx@4.23.0)
+      vite-node: 3.2.4(@types/node@22.20.1)(jiti@1.21.7)(tsx@4.23.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.20.1
+      jsdom: 29.1.1(canvas@3.2.1)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.7(@types/node@22.20.1)(jiti@2.7.0)(jsdom@29.1.1(canvas@3.2.1))(tsx@4.23.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
@@ -5233,6 +5910,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.20.1
+      jsdom: 29.1.1(canvas@3.2.1)
     transitivePeerDependencies:
       - jiti
       - less
@@ -5278,21 +5956,57 @@ snapshots:
 
   w3c-keyname@2.2.8: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   webidl-conversions@3.0.1: {}
 
+  webidl-conversions@8.0.1: {}
+
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
   wrappy@1.0.2:
     optional: true
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}


### PR DESCRIPTION
## Summary

- 根目录 `pnpm test`（`pnpm -r --if-present test`）覆盖 **shared / agent / server / web** 四包；CI 在 build 之后运行全仓测试（不再仅跑 agent）
- **Server**：Vitest + `@nestjs/testing` 集成测试（mock Prisma / Provider），覆盖 Studio 模型参数与 refs 传递
- **Web**：Vitest + jsdom + `useNodeGeneration` composable 用例（payload 齐全 + blob 参考图护栏）
- **T0 明确不含**：Playwright E2E、真实 Postgres/SQLite 集成库（见规格 §1.2 非目标）

## 规格与后续迭代

实现依据：[docs/superpowers/specs/2026-07-19-test-infrastructure-design.md](docs/superpowers/specs/2026-07-19-test-infrastructure-design.md)

后续路线见规格 **§6**：

| 轮次 | 内容 |
| --- | --- |
| **T1** | C1 PR #25 rebase 到含 T0 的 main，按需补 C1 专项用例后再合并 |
| **T2** | Playwright E2E（画布关键路径） |
| **T3** | 可选：真库 Prisma 子集、部署后鉴权 API 冒烟 |

> **合入本 PR 后**：请 **rebase #25**（C1 Dock Studio Model Adapter）到最新 main，再推进 C1 合并；**勿与本 PR 混提交**。

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @lnkpi/server exec prisma generate`
- [x] `pnpm build`
- [x] `pnpm test`（shared 4 + agent 24 + server 6 + web 4 = 38 tests）


Made with [Cursor](https://cursor.com)