### PR TITLE
feat(canvas): C2 旁路接入 Studio adapter 与统一计费

### DIFF
--- a/apps/server/src/canvas/canvas.controller.ts
+++ b/apps/server/src/canvas/canvas.controller.ts
@@ -301,8 +301,12 @@ export class CanvasController {
 
   @Post('material/generate-image')
   @UseGuards(AuthGuard)
-  async generateImage(@Body() dto: GenerateImageDto) {
-    const data = await this.materialService.generateImage(dto.shotId, dto.prompt)
+  async generateImage(@Req() req: { user: { sub: string } }, @Body() dto: GenerateImageDto) {
+    const data = await this.materialService.generateImage({
+      userId: req.user.sub,
+      shotId: dto.shotId,
+      prompt: dto.prompt,
+    })
     return { code: 0, message: 'ok', data }
   }
 

--- a/apps/server/src/canvas/canvas.controller.ts
+++ b/apps/server/src/canvas/canvas.controller.ts
@@ -388,15 +388,21 @@ export class CanvasController {
 
   @Post('scene-composer/save')
   @UseGuards(AuthGuard)
-  async saveSceneComposer(@Body() dto: SaveSceneComposerDto) {
-    const data = await this.sceneComposerService.save(dto)
+  async saveSceneComposer(
+    @Req() req: { user: { sub: string } },
+    @Body() dto: SaveSceneComposerDto,
+  ) {
+    const data = await this.sceneComposerService.save(req.user.sub, dto)
     return { code: 0, message: 'ok', data }
   }
 
   @Post('scene-composer/batch-generate')
   @UseGuards(AuthGuard)
-  async batchGenerateSceneComposer(@Body() dto: BatchGenerateSceneComposerDto) {
-    const data = await this.sceneComposerService.batchGenerate(dto)
+  async batchGenerateSceneComposer(
+    @Req() req: { user: { sub: string } },
+    @Body() dto: BatchGenerateSceneComposerDto,
+  ) {
+    const data = await this.sceneComposerService.batchGenerate(req.user.sub, dto)
     return { code: 0, message: 'ok', data }
   }
 

--- a/apps/server/src/canvas/canvas.controller.ts
+++ b/apps/server/src/canvas/canvas.controller.ts
@@ -312,14 +312,15 @@ export class CanvasController {
 
   @Post('material/generate-video')
   @UseGuards(AuthGuard)
-  async generateVideo(@Body() dto: GenerateVideoDto) {
-    const data = await this.materialService.generateVideo(
-      dto.shotId,
-      dto.prompt,
-      dto.duration,
-      dto.aspectRatio,
-      dto.crop,
-    )
+  async generateVideo(@Req() req: { user: { sub: string } }, @Body() dto: GenerateVideoDto) {
+    const data = await this.materialService.generateVideo({
+      userId: req.user.sub,
+      shotId: dto.shotId,
+      prompt: dto.prompt,
+      duration: dto.duration,
+      aspectRatio: dto.aspectRatio,
+      crop: dto.crop,
+    })
     return { code: 0, message: 'ok', data }
   }
 

--- a/apps/server/src/canvas/canvas.controller.ts
+++ b/apps/server/src/canvas/canvas.controller.ts
@@ -80,7 +80,9 @@ class GenerateVideoDto {
   model?: string
 
   @IsOptional()
-  duration?: number
+  @IsNumber()
+  @IsIn([5, 10, 15])
+  duration?: 5 | 10 | 15
 
   @IsOptional()
   @IsString()

--- a/apps/server/src/canvas/canvas.controller.ts
+++ b/apps/server/src/canvas/canvas.controller.ts
@@ -50,6 +50,22 @@ class GenerateImageDto {
 
   @IsString()
   prompt!: string
+
+  @IsOptional()
+  @IsString()
+  model?: string
+
+  @IsOptional()
+  @IsString()
+  aspectRatio?: string
+
+  @IsOptional()
+  @IsString()
+  resolution?: string
+
+  @IsOptional()
+  @IsNumber()
+  count?: number
 }
 
 class GenerateVideoDto {
@@ -60,11 +76,19 @@ class GenerateVideoDto {
   prompt!: string
 
   @IsOptional()
+  @IsString()
+  model?: string
+
+  @IsOptional()
   duration?: number
 
   @IsOptional()
   @IsString()
   aspectRatio?: string
+
+  @IsOptional()
+  @IsString()
+  resolution?: string
 
   @IsOptional()
   @IsString()
@@ -182,6 +206,30 @@ class SceneComposerBatchItemDto {
 
   @IsIn(['image', 'video'])
   mediaType!: 'image' | 'video'
+
+  @IsOptional()
+  @IsString()
+  model?: string
+
+  @IsOptional()
+  @IsString()
+  aspectRatio?: string
+
+  @IsOptional()
+  @IsString()
+  resolution?: string
+
+  @IsOptional()
+  @IsIn([5, 10, 15])
+  duration?: 5 | 10 | 15
+
+  @IsOptional()
+  @IsString()
+  crop?: string
+
+  @IsOptional()
+  @IsNumber()
+  count?: number
 }
 
 class BatchGenerateSceneComposerDto implements SceneComposerBatchGenerateRequest {
@@ -306,6 +354,10 @@ export class CanvasController {
       userId: req.user.sub,
       shotId: dto.shotId,
       prompt: dto.prompt,
+      model: dto.model,
+      aspectRatio: dto.aspectRatio,
+      resolution: dto.resolution,
+      count: dto.count,
     })
     return { code: 0, message: 'ok', data }
   }
@@ -317,8 +369,10 @@ export class CanvasController {
       userId: req.user.sub,
       shotId: dto.shotId,
       prompt: dto.prompt,
+      model: dto.model,
       duration: dto.duration,
       aspectRatio: dto.aspectRatio,
+      resolution: dto.resolution,
       crop: dto.crop,
     })
     return { code: 0, message: 'ok', data }

--- a/apps/server/src/canvas/canvas.module.ts
+++ b/apps/server/src/canvas/canvas.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common'
+import { PointsModule } from '../points/points.module'
 import { UploadModule } from '../upload/upload.module'
 import { CanvasController } from './canvas.controller'
 import { CanvasService } from './canvas.service'
@@ -8,7 +9,7 @@ import { ShotService } from './shot.service'
 import { VideoCompositionService } from './video-composition.service'
 
 @Module({
-  imports: [UploadModule],
+  imports: [UploadModule, PointsModule],
   controllers: [CanvasController],
   providers: [
     CanvasService,

--- a/apps/server/src/canvas/material.service.test.ts
+++ b/apps/server/src/canvas/material.service.test.ts
@@ -82,6 +82,17 @@ describe('MaterialService image', () => {
     expect(consume).not.toHaveBeenCalled()
     expect(materialCreate).not.toHaveBeenCalled()
   })
+
+  it('does not charge when skipCharge is true', async () => {
+    await svc.generateImage({
+      userId: 'u1',
+      shotId: 'shot-1',
+      prompt: 'a cat',
+      skipCharge: true,
+    })
+    expect(consume).not.toHaveBeenCalled()
+    expect(materialCreate).toHaveBeenCalled()
+  })
 })
 
 describe('MaterialService video', () => {

--- a/apps/server/src/canvas/material.service.test.ts
+++ b/apps/server/src/canvas/material.service.test.ts
@@ -3,17 +3,19 @@ import { NotFoundException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Test } from '@nestjs/testing'
 import { resolveImageSize } from '@lnkpi/shared'
-import { createImageProvider } from '@lnkpi/agent'
+import { createImageProvider, createVideoProvider } from '@lnkpi/agent'
 import { MaterialService } from './material.service'
 import { PointsService } from '../points/points.service'
 import { PrismaService } from '../prisma/prisma.service'
 
 const imageGenerate = vi.fn(async () => ({ url: 'https://example.com/a.png' }))
+const videoGenerate = vi.fn(async () => ({ url: 'https://example.com/v.mp4' }))
 vi.mock('@lnkpi/agent', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@lnkpi/agent')>()
   return {
     ...actual,
     createImageProvider: vi.fn(() => ({ generate: imageGenerate })),
+    createVideoProvider: vi.fn(() => ({ generate: videoGenerate })),
   }
 })
 
@@ -79,5 +81,61 @@ describe('MaterialService image', () => {
     ).rejects.toBeInstanceOf(NotFoundException)
     expect(consume).not.toHaveBeenCalled()
     expect(materialCreate).not.toHaveBeenCalled()
+  })
+})
+
+describe('MaterialService video', () => {
+  let svc: MaterialService
+  const consume = vi.fn(async () => {})
+  const materialCreate = vi.fn(async (args: { data: Record<string, unknown> }) => ({
+    id: 'm1',
+    ...args.data,
+  }))
+  const materialUpdate = vi.fn(async () => ({}))
+  const shotFindUnique = vi.fn(async () => ({
+    id: 'shot-1',
+    sessionId: 'sess-1',
+    session: { id: 'sess-1', userId: 'u1' },
+  }))
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        MaterialService,
+        { provide: PointsService, useValue: { consume } },
+        {
+          provide: PrismaService,
+          useValue: {
+            shot: { findUnique: shotFindUnique },
+            material: { create: materialCreate, update: materialUpdate },
+          },
+        },
+      ],
+    }).compile()
+    svc = moduleRef.get(MaterialService)
+  })
+
+  it('passes video adapter options and charges by duration', async () => {
+    await svc.generateVideo({
+      userId: 'u1',
+      shotId: 'shot-1',
+      prompt: 'walk',
+      model: 'seedance-2.0-min',
+      duration: 10,
+      aspectRatio: '16:9',
+      resolution: '720p',
+      crop: 'none',
+    })
+    await vi.waitFor(() => expect(videoGenerate).toHaveBeenCalled())
+    expect(consume).toHaveBeenCalledWith('u1', 50, '视频生成')
+    const [prompt, opts] = videoGenerate.mock.calls[0]
+    expect(prompt).toBe('walk')
+    expect(opts).toMatchObject({
+      model: 'seedance-2.0-min',
+      duration: 10,
+      aspectRatio: '16:9',
+      resolution: '720p',
+    })
   })
 })

--- a/apps/server/src/canvas/material.service.test.ts
+++ b/apps/server/src/canvas/material.service.test.ts
@@ -1,0 +1,83 @@
+import 'reflect-metadata'
+import { NotFoundException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Test } from '@nestjs/testing'
+import { resolveImageSize } from '@lnkpi/shared'
+import { createImageProvider } from '@lnkpi/agent'
+import { MaterialService } from './material.service'
+import { PointsService } from '../points/points.service'
+import { PrismaService } from '../prisma/prisma.service'
+
+const imageGenerate = vi.fn(async () => ({ url: 'https://example.com/a.png' }))
+vi.mock('@lnkpi/agent', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@lnkpi/agent')>()
+  return {
+    ...actual,
+    createImageProvider: vi.fn(() => ({ generate: imageGenerate })),
+  }
+})
+
+describe('MaterialService image', () => {
+  let svc: MaterialService
+  const consume = vi.fn(async () => {})
+  const materialCreate = vi.fn(async (args: { data: Record<string, unknown> }) => ({
+    id: 'm1',
+    ...args.data,
+  }))
+  const materialUpdate = vi.fn(async () => ({}))
+  const shotFindUnique = vi.fn(async () => ({
+    id: 'shot-1',
+    sessionId: 'sess-1',
+    session: { id: 'sess-1', userId: 'u1' },
+  }))
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        MaterialService,
+        { provide: PointsService, useValue: { consume } },
+        {
+          provide: PrismaService,
+          useValue: {
+            shot: { findUnique: shotFindUnique },
+            material: { create: materialCreate, update: materialUpdate },
+          },
+        },
+      ],
+    }).compile()
+    svc = moduleRef.get(MaterialService)
+  })
+
+  it('passes adapter modelId/size/n=1 and charges 10', async () => {
+    await svc.generateImage({
+      userId: 'u1',
+      shotId: 'shot-1',
+      prompt: 'a cat',
+      model: 'seedream-5.0-pro',
+      aspectRatio: '16:9',
+      resolution: '1K',
+      count: 3,
+    })
+    await vi.waitFor(() => expect(imageGenerate).toHaveBeenCalled())
+    expect(consume).toHaveBeenCalledWith('u1', 10, '图像生成')
+    expect(imageGenerate).toHaveBeenCalledWith('a cat', {
+      modelId: 'seedream-5.0-pro',
+      size: resolveImageSize('16:9', '1K'),
+      n: 1,
+    })
+  })
+
+  it('rejects foreign shot without charging', async () => {
+    shotFindUnique.mockResolvedValueOnce({
+      id: 'shot-1',
+      sessionId: 'sess-1',
+      session: { id: 'sess-1', userId: 'other' },
+    })
+    await expect(
+      svc.generateImage({ userId: 'u1', shotId: 'shot-1', prompt: 'x' }),
+    ).rejects.toBeInstanceOf(NotFoundException)
+    expect(consume).not.toHaveBeenCalled()
+    expect(materialCreate).not.toHaveBeenCalled()
+  })
+})

--- a/apps/server/src/canvas/material.service.test.ts
+++ b/apps/server/src/canvas/material.service.test.ts
@@ -129,13 +129,14 @@ describe('MaterialService video', () => {
     })
     await vi.waitFor(() => expect(videoGenerate).toHaveBeenCalled())
     expect(consume).toHaveBeenCalledWith('u1', 50, '视频生成')
-    const [prompt, opts] = videoGenerate.mock.calls[0]
-    expect(prompt).toBe('walk')
-    expect(opts).toMatchObject({
-      model: 'seedance-2.0-min',
-      duration: 10,
-      aspectRatio: '16:9',
-      resolution: '720p',
-    })
+    expect(videoGenerate).toHaveBeenCalledWith(
+      'walk',
+      expect.objectContaining({
+        model: 'seedance-2.0-min',
+        duration: 10,
+        aspectRatio: '16:9',
+        resolution: '720p',
+      }),
+    )
   })
 })

--- a/apps/server/src/canvas/material.service.test.ts
+++ b/apps/server/src/canvas/material.service.test.ts
@@ -150,4 +150,17 @@ describe('MaterialService video', () => {
       }),
     )
   })
+
+  it('rejects foreign shot without charging', async () => {
+    shotFindUnique.mockResolvedValueOnce({
+      id: 'shot-1',
+      sessionId: 'sess-1',
+      session: { id: 'sess-1', userId: 'other' },
+    })
+    await expect(
+      svc.generateVideo({ userId: 'u1', shotId: 'shot-1', prompt: 'x' }),
+    ).rejects.toBeInstanceOf(NotFoundException)
+    expect(consume).not.toHaveBeenCalled()
+    expect(materialCreate).not.toHaveBeenCalled()
+  })
 })

--- a/apps/server/src/canvas/material.service.ts
+++ b/apps/server/src/canvas/material.service.ts
@@ -17,6 +17,7 @@ export type CanvasImageGenerateInput = {
   aspectRatio?: string
   resolution?: string
   count?: number
+  skipCharge?: boolean
 }
 
 export type CanvasVideoGenerateInput = {
@@ -28,6 +29,7 @@ export type CanvasVideoGenerateInput = {
   aspectRatio?: string
   resolution?: string
   crop?: string
+  skipCharge?: boolean
 }
 
 function videoCredits(duration: number): number {
@@ -67,7 +69,7 @@ export class MaterialService {
   }
 
   async generateImage(input: CanvasImageGenerateInput) {
-    const { userId, shotId, prompt, model, aspectRatio, resolution, count } = input
+    const { userId, shotId, prompt, model, aspectRatio, resolution, count, skipCharge } = input
 
     const shot = await this.prisma.shot.findUnique({
       where: { id: shotId },
@@ -88,7 +90,9 @@ export class MaterialService {
       )
     }
 
-    await this.points.consume(userId, 10, '图像生成')
+    if (!skipCharge) {
+      await this.points.consume(userId, 10, '图像生成')
+    }
 
     const material = await this.prisma.material.create({
       data: { shotId, type: 'image', prompt, status: 'generating' },
@@ -109,6 +113,7 @@ export class MaterialService {
       aspectRatio = '16:9',
       resolution = '720p',
       crop = 'none',
+      skipCharge,
     } = input
 
     const shot = await this.prisma.shot.findUnique({
@@ -119,7 +124,9 @@ export class MaterialService {
       throw new NotFoundException('分镜不存在')
     }
 
-    await this.points.consume(userId, videoCredits(duration), '视频生成')
+    if (!skipCharge) {
+      await this.points.consume(userId, videoCredits(duration), '视频生成')
+    }
 
     const material = await this.prisma.material.create({
       data: { shotId, type: 'video', prompt, status: 'generating' },

--- a/apps/server/src/canvas/material.service.ts
+++ b/apps/server/src/canvas/material.service.ts
@@ -8,6 +8,7 @@ import {
 import { resolveImageSize, type ImageResolutionTier } from '@lnkpi/shared'
 import { PrismaService } from '../prisma/prisma.service'
 import { PointsService } from '../points/points.service'
+import { videoCredits } from '../points/video-credits'
 
 export type CanvasImageGenerateInput = {
   userId: string
@@ -30,12 +31,6 @@ export type CanvasVideoGenerateInput = {
   resolution?: string
   crop?: string
   skipCharge?: boolean
-}
-
-function videoCredits(duration: number): number {
-  if (duration >= 15) return 70
-  if (duration >= 10) return 50
-  return 30
 }
 
 @Injectable()
@@ -199,7 +194,8 @@ export class MaterialService {
         crop,
         referenceImages: [],
       })
-      const { url } = await createVideoProvider().generate(prompt, {
+      const effectivePrompt = [prompt, built.effectivePromptSuffix].filter(Boolean).join('\n')
+      const { url } = await createVideoProvider().generate(effectivePrompt, {
         model: built.model,
         duration: built.duration,
         aspectRatio: built.aspectRatio,

--- a/apps/server/src/canvas/material.service.ts
+++ b/apps/server/src/canvas/material.service.ts
@@ -1,10 +1,31 @@
-import { Inject, Injectable } from '@nestjs/common'
-import { createImageProvider, createVideoProvider } from '@lnkpi/agent'
+import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common'
+import {
+  buildImageProviderOptions,
+  createImageProvider,
+  createVideoProvider,
+} from '@lnkpi/agent'
+import { resolveImageSize, type ImageResolutionTier } from '@lnkpi/shared'
 import { PrismaService } from '../prisma/prisma.service'
+import { PointsService } from '../points/points.service'
+
+export type CanvasImageGenerateInput = {
+  userId: string
+  shotId: string
+  prompt: string
+  model?: string
+  aspectRatio?: string
+  resolution?: string
+  count?: number
+}
 
 @Injectable()
 export class MaterialService {
-  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
+  private readonly logger = new Logger(MaterialService.name)
+
+  constructor(
+    @Inject(PrismaService) private readonly prisma: PrismaService,
+    @Inject(PointsService) private readonly points: PointsService,
+  ) {}
 
   async createFromAgent(data: {
     id?: string
@@ -27,11 +48,36 @@ export class MaterialService {
     })
   }
 
-  async generateImage(shotId: string, prompt: string) {
+  async generateImage(input: CanvasImageGenerateInput) {
+    const { userId, shotId, prompt, model, aspectRatio, resolution, count } = input
+
+    const shot = await this.prisma.shot.findUnique({
+      where: { id: shotId },
+      include: { session: true },
+    })
+    if (!shot || shot.session.userId !== userId) {
+      throw new NotFoundException('分镜不存在')
+    }
+
+    const requested = count ?? 1
+    if (requested > 1) {
+      this.logger.log(
+        JSON.stringify({
+          event: 'canvas_image_count_clamped',
+          requested,
+          effective: 1,
+        }),
+      )
+    }
+
+    await this.points.consume(userId, 10, '图像生成')
+
     const material = await this.prisma.material.create({
       data: { shotId, type: 'image', prompt, status: 'generating' },
     })
-    this.runImageGeneration(material.id, prompt).catch(console.error)
+    this.runImageGeneration(material.id, prompt, model, aspectRatio, resolution).catch(
+      console.error,
+    )
     return material
   }
 
@@ -49,10 +95,31 @@ export class MaterialService {
     return material
   }
 
-  private async runImageGeneration(materialId: string, prompt: string) {
+  private async runImageGeneration(
+    materialId: string,
+    prompt: string,
+    model?: string,
+    aspectRatio?: string,
+    resolution?: string,
+  ) {
     try {
+      const size = resolveImageSize(
+        aspectRatio ?? '16:9',
+        (resolution ?? '1K') as ImageResolutionTier,
+      )
+      const built = buildImageProviderOptions({
+        modelKey: model,
+        size,
+        n: 1,
+        referenceImages: [],
+      })
+      const effectivePrompt = [prompt, built.effectivePromptSuffix].filter(Boolean).join('\n')
       const provider = createImageProvider()
-      const { url } = await provider.generate(prompt)
+      const { url } = await provider.generate(effectivePrompt, {
+        modelId: built.modelId,
+        size: built.size,
+        n: built.n,
+      })
       await this.prisma.material.update({
         where: { id: materialId },
         data: { url, thumbnail: url, status: 'completed' },

--- a/apps/server/src/canvas/material.service.ts
+++ b/apps/server/src/canvas/material.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common'
 import {
   buildImageProviderOptions,
+  buildVideoProviderOptions,
   createImageProvider,
   createVideoProvider,
 } from '@lnkpi/agent'
@@ -16,6 +17,23 @@ export type CanvasImageGenerateInput = {
   aspectRatio?: string
   resolution?: string
   count?: number
+}
+
+export type CanvasVideoGenerateInput = {
+  userId: string
+  shotId: string
+  prompt: string
+  model?: string
+  duration?: number
+  aspectRatio?: string
+  resolution?: string
+  crop?: string
+}
+
+function videoCredits(duration: number): number {
+  if (duration >= 15) return 70
+  if (duration >= 10) return 50
+  return 30
 }
 
 @Injectable()
@@ -81,17 +99,40 @@ export class MaterialService {
     return material
   }
 
-  async generateVideo(
-    shotId: string,
-    prompt: string,
-    duration = 5,
-    aspectRatio = '16:9',
-    crop = 'none',
-  ) {
+  async generateVideo(input: CanvasVideoGenerateInput) {
+    const {
+      userId,
+      shotId,
+      prompt,
+      model,
+      duration = 5,
+      aspectRatio = '16:9',
+      resolution = '720p',
+      crop = 'none',
+    } = input
+
+    const shot = await this.prisma.shot.findUnique({
+      where: { id: shotId },
+      include: { session: true },
+    })
+    if (!shot || shot.session.userId !== userId) {
+      throw new NotFoundException('分镜不存在')
+    }
+
+    await this.points.consume(userId, videoCredits(duration), '视频生成')
+
     const material = await this.prisma.material.create({
       data: { shotId, type: 'video', prompt, status: 'generating' },
     })
-    this.runVideoGeneration(material.id, prompt, duration, aspectRatio, crop).catch(console.error)
+    this.runVideoGeneration(
+      material.id,
+      prompt,
+      model,
+      duration,
+      aspectRatio,
+      resolution,
+      crop,
+    ).catch(console.error)
     return material
   }
 
@@ -136,15 +177,29 @@ export class MaterialService {
   private async runVideoGeneration(
     materialId: string,
     prompt: string,
+    model: string | undefined,
     duration: number,
     aspectRatio: string,
+    resolution: string,
     crop: string,
   ) {
     try {
-      const enriched = crop !== 'none'
-        ? `${prompt} [aspect:${aspectRatio}, crop:${crop}]`
-        : `${prompt} [aspect:${aspectRatio}]`
-      const { url } = await createVideoProvider().generate(enriched, { duration, aspectRatio })
+      const built = buildVideoProviderOptions({
+        modelKey: model,
+        duration,
+        aspectRatio,
+        resolution,
+        crop,
+        referenceImages: [],
+      })
+      const { url } = await createVideoProvider().generate(prompt, {
+        model: built.model,
+        duration: built.duration,
+        aspectRatio: built.aspectRatio,
+        resolution: built.resolution,
+        crop: built.crop,
+        image: built.image,
+      })
       await this.prisma.material.update({
         where: { id: materialId },
         data: { url, thumbnail: url, status: 'completed' },

--- a/apps/server/src/canvas/scene-composer.service.test.ts
+++ b/apps/server/src/canvas/scene-composer.service.test.ts
@@ -13,7 +13,7 @@ describe('SceneComposerService batchGenerate', () => {
   const consume = vi.fn(async () => {})
   const generateImage = vi.fn(async () => ({ id: 'm-img' }))
   const generateVideo = vi.fn(async () => ({ id: 'm-vid' }))
-  const sessionFindFirst = vi.fn(async () => ({
+  const sessionFindFirst = vi.fn(async (): Promise<{ id: string; userId: string } | null> => ({
     id: 'sess-1',
     userId: 'u1',
   }))

--- a/apps/server/src/canvas/scene-composer.service.test.ts
+++ b/apps/server/src/canvas/scene-composer.service.test.ts
@@ -1,0 +1,131 @@
+import 'reflect-metadata'
+import { NotFoundException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Test } from '@nestjs/testing'
+import { SceneComposerService } from './scene-composer.service'
+import { MaterialService } from './material.service'
+import { ShotService } from './shot.service'
+import { PointsService } from '../points/points.service'
+import { PrismaService } from '../prisma/prisma.service'
+
+describe('SceneComposerService batchGenerate', () => {
+  let svc: SceneComposerService
+  const consume = vi.fn(async () => {})
+  const generateImage = vi.fn(async () => ({ id: 'm-img' }))
+  const generateVideo = vi.fn(async () => ({ id: 'm-vid' }))
+  const sessionFindFirst = vi.fn(async () => ({
+    id: 'sess-1',
+    userId: 'u1',
+  }))
+  const shotFindUnique = vi.fn(async (args: { where: { id: string } }) => {
+    if (args.where.id === 'shot-img') {
+      return { id: 'shot-img', sessionId: 'sess-1' }
+    }
+    if (args.where.id === 'shot-vid') {
+      return { id: 'shot-vid', sessionId: 'sess-1' }
+    }
+    return null
+  })
+  const shotUpdate = vi.fn(async () => ({}))
+  const shotCreate = vi.fn(async () => ({}))
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        SceneComposerService,
+        { provide: PointsService, useValue: { consume } },
+        {
+          provide: MaterialService,
+          useValue: { generateImage, generateVideo },
+        },
+        {
+          provide: ShotService,
+          useValue: { update: shotUpdate, create: shotCreate, reorder: vi.fn() },
+        },
+        {
+          provide: PrismaService,
+          useValue: {
+            session: { findFirst: sessionFindFirst },
+            shot: { findUnique: shotFindUnique },
+          },
+        },
+      ],
+    }).compile()
+    svc = moduleRef.get(SceneComposerService)
+  })
+
+  it('precomputes total cost and consumes once before starting materials', async () => {
+    await svc.batchGenerate('u1', {
+      sessionId: 'sess-1',
+      composerNodeId: 'composer-1',
+      items: [
+        {
+          shotNodeId: 'shot-img',
+          prompt: 'a cat',
+          mediaType: 'image',
+          model: 'seedream-5.0-pro',
+          aspectRatio: '16:9',
+          resolution: '1K',
+        },
+        {
+          shotNodeId: 'shot-vid',
+          prompt: 'walk',
+          mediaType: 'video',
+          model: 'seedance-2.0-min',
+          duration: 10,
+          aspectRatio: '16:9',
+          resolution: '720p',
+          crop: 'none',
+        },
+      ],
+    })
+
+    expect(consume).toHaveBeenCalledTimes(1)
+    expect(consume).toHaveBeenCalledWith('u1', 60, '导演台批量生成 ×2')
+    expect(generateImage).toHaveBeenCalledWith({
+      userId: 'u1',
+      shotId: 'shot-img',
+      prompt: 'a cat',
+      model: 'seedream-5.0-pro',
+      aspectRatio: '16:9',
+      resolution: '1K',
+      skipCharge: true,
+    })
+    expect(generateVideo).toHaveBeenCalledWith({
+      userId: 'u1',
+      shotId: 'shot-vid',
+      prompt: 'walk',
+      model: 'seedance-2.0-min',
+      duration: 10,
+      aspectRatio: '16:9',
+      resolution: '720p',
+      crop: 'none',
+      skipCharge: true,
+    })
+  })
+
+  it('rejects foreign session with zero side effects', async () => {
+    sessionFindFirst.mockResolvedValueOnce(null)
+
+    await expect(
+      svc.batchGenerate('u1', {
+        sessionId: 'sess-other',
+        composerNodeId: 'composer-1',
+        items: [
+          {
+            shotNodeId: 'shot-img',
+            prompt: 'a cat',
+            mediaType: 'image',
+          },
+        ],
+      }),
+    ).rejects.toBeInstanceOf(NotFoundException)
+
+    expect(consume).not.toHaveBeenCalled()
+    expect(generateImage).not.toHaveBeenCalled()
+    expect(generateVideo).not.toHaveBeenCalled()
+    expect(shotUpdate).not.toHaveBeenCalled()
+    expect(shotCreate).not.toHaveBeenCalled()
+  })
+})

--- a/apps/server/src/canvas/scene-composer.service.test.ts
+++ b/apps/server/src/canvas/scene-composer.service.test.ts
@@ -128,4 +128,117 @@ describe('SceneComposerService batchGenerate', () => {
     expect(shotUpdate).not.toHaveBeenCalled()
     expect(shotCreate).not.toHaveBeenCalled()
   })
+
+  it('rejects shot from another session before consume', async () => {
+    shotFindUnique.mockImplementation(async (args: { where: { id: string } }) => {
+      if (args.where.id === 'shot-foreign') {
+        return { id: 'shot-foreign', sessionId: 'sess-other' }
+      }
+      return null
+    })
+
+    await expect(
+      svc.batchGenerate('u1', {
+        sessionId: 'sess-1',
+        composerNodeId: 'composer-1',
+        items: [
+          {
+            shotNodeId: 'shot-foreign',
+            prompt: 'a cat',
+            mediaType: 'image',
+          },
+        ],
+      }),
+    ).rejects.toBeInstanceOf(NotFoundException)
+
+    expect(consume).not.toHaveBeenCalled()
+    expect(generateImage).not.toHaveBeenCalled()
+    expect(generateVideo).not.toHaveBeenCalled()
+    expect(shotUpdate).not.toHaveBeenCalled()
+    expect(shotCreate).not.toHaveBeenCalled()
+  })
+
+  it('does not create shots or materials when consume throws', async () => {
+    consume.mockRejectedValueOnce(new Error('积分不足'))
+
+    await expect(
+      svc.batchGenerate('u1', {
+        sessionId: 'sess-1',
+        composerNodeId: 'composer-1',
+        items: [
+          {
+            shotNodeId: 'shot-img',
+            prompt: 'a cat',
+            mediaType: 'image',
+          },
+        ],
+      }),
+    ).rejects.toThrow('积分不足')
+
+    expect(consume).toHaveBeenCalledTimes(1)
+    expect(generateImage).not.toHaveBeenCalled()
+    expect(generateVideo).not.toHaveBeenCalled()
+    expect(shotUpdate).not.toHaveBeenCalled()
+    expect(shotCreate).not.toHaveBeenCalled()
+  })
+})
+
+describe('SceneComposerService save', () => {
+  let svc: SceneComposerService
+  const sessionFindFirst = vi.fn(async (): Promise<{ id: string; userId: string } | null> => ({
+    id: 'sess-1',
+    userId: 'u1',
+  }))
+  const shotFindUnique = vi.fn(async () => null)
+  const shotUpdate = vi.fn(async () => ({}))
+  const shotCreate = vi.fn(async () => ({}))
+  const reorder = vi.fn(async () => ({}))
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        SceneComposerService,
+        { provide: PointsService, useValue: { consume: vi.fn() } },
+        {
+          provide: MaterialService,
+          useValue: { generateImage: vi.fn(), generateVideo: vi.fn() },
+        },
+        {
+          provide: ShotService,
+          useValue: { update: shotUpdate, create: shotCreate, reorder },
+        },
+        {
+          provide: PrismaService,
+          useValue: {
+            session: { findFirst: sessionFindFirst },
+            shot: { findUnique: shotFindUnique },
+          },
+        },
+      ],
+    }).compile()
+    svc = moduleRef.get(SceneComposerService)
+  })
+
+  it('rejects foreign session with NotFoundException', async () => {
+    sessionFindFirst.mockResolvedValueOnce(null)
+
+    await expect(
+      svc.save('u1', {
+        sessionId: 'sess-other',
+        composerNodeId: 'composer-1',
+        scenes: [
+          {
+            id: 'scene-1',
+            title: 'Scene',
+            shots: [{ id: 's1', title: 'Shot', prompt: 'p', mediaType: 'none' }],
+          },
+        ],
+      }),
+    ).rejects.toBeInstanceOf(NotFoundException)
+
+    expect(shotUpdate).not.toHaveBeenCalled()
+    expect(shotCreate).not.toHaveBeenCalled()
+    expect(reorder).not.toHaveBeenCalled()
+  })
 })

--- a/apps/server/src/canvas/scene-composer.service.ts
+++ b/apps/server/src/canvas/scene-composer.service.ts
@@ -8,6 +8,7 @@ import type {
 import { MaterialService } from './material.service'
 import { ShotService } from './shot.service'
 import { PointsService } from '../points/points.service'
+import { videoCredits } from '../points/video-credits'
 import { PrismaService } from '../prisma/prisma.service'
 
 @Injectable()
@@ -29,8 +30,7 @@ export class SceneComposerService {
 
   private itemCredits(item: SceneComposerBatchItem): number {
     if (item.mediaType === 'video') {
-      const d = item.duration ?? 5
-      return d >= 15 ? 70 : d >= 10 ? 50 : 30
+      return videoCredits(item.duration ?? 5)
     }
     return 10
   }

--- a/apps/server/src/canvas/scene-composer.service.ts
+++ b/apps/server/src/canvas/scene-composer.service.ts
@@ -71,11 +71,11 @@ export class SceneComposerService {
   }
 
   async batchGenerate(dto: SceneComposerBatchGenerateRequest) {
-    await this.assertSession(dto.sessionId)
+    const session = await this.assertSession(dto.sessionId)
     const results: Array<{ shotNodeId: string; materialId?: string; mediaType: string }> = []
 
     for (const item of dto.items) {
-      const result = await this.generateItem(dto.sessionId, item)
+      const result = await this.generateItem(dto.sessionId, session.userId, item)
       results.push(result)
     }
 
@@ -85,7 +85,11 @@ export class SceneComposerService {
     }
   }
 
-  private async generateItem(sessionId: string, item: SceneComposerBatchItem) {
+  private async generateItem(
+    sessionId: string,
+    userId: string,
+    item: SceneComposerBatchItem,
+  ) {
     const existing = await this.prisma.shot.findUnique({ where: { id: item.shotNodeId } })
     if (existing) {
       await this.shotService.update(item.shotNodeId, {
@@ -107,7 +111,11 @@ export class SceneComposerService {
       return { shotNodeId: item.shotNodeId, materialId: material.id, mediaType: 'video' }
     }
 
-    const material = await this.materialService.generateImage(item.shotNodeId, item.prompt)
+    const material = await this.materialService.generateImage({
+      userId,
+      shotId: item.shotNodeId,
+      prompt: item.prompt,
+    })
     return { shotNodeId: item.shotNodeId, materialId: material.id, mediaType: 'image' }
   }
 }

--- a/apps/server/src/canvas/scene-composer.service.ts
+++ b/apps/server/src/canvas/scene-composer.service.ts
@@ -107,7 +107,11 @@ export class SceneComposerService {
     }
 
     if (item.mediaType === 'video') {
-      const material = await this.materialService.generateVideo(item.shotNodeId, item.prompt)
+      const material = await this.materialService.generateVideo({
+        userId,
+        shotId: item.shotNodeId,
+        prompt: item.prompt,
+      })
       return { shotNodeId: item.shotNodeId, materialId: material.id, mediaType: 'video' }
     }
 

--- a/apps/server/src/canvas/scene-composer.service.ts
+++ b/apps/server/src/canvas/scene-composer.service.ts
@@ -7,6 +7,7 @@ import type {
 } from '@lnkpi/shared'
 import { MaterialService } from './material.service'
 import { ShotService } from './shot.service'
+import { PointsService } from '../points/points.service'
 import { PrismaService } from '../prisma/prisma.service'
 
 @Injectable()
@@ -15,16 +16,35 @@ export class SceneComposerService {
     @Inject(PrismaService) private readonly prisma: PrismaService,
     @Inject(ShotService) private readonly shotService: ShotService,
     @Inject(MaterialService) private readonly materialService: MaterialService,
+    @Inject(PointsService) private readonly points: PointsService,
   ) {}
 
-  private async assertSession(sessionId: string) {
-    const session = await this.prisma.session.findUnique({ where: { id: sessionId } })
+  private async assertOwnedSession(sessionId: string, userId: string) {
+    const session = await this.prisma.session.findFirst({
+      where: { id: sessionId, userId },
+    })
     if (!session) throw new NotFoundException('画布不存在')
     return session
   }
 
-  async save(dto: SceneComposerSaveRequest) {
-    await this.assertSession(dto.sessionId)
+  private itemCredits(item: SceneComposerBatchItem): number {
+    if (item.mediaType === 'video') {
+      const d = item.duration ?? 5
+      return d >= 15 ? 70 : d >= 10 ? 50 : 30
+    }
+    return 10
+  }
+
+  private async assertShotInSession(shotId: string, sessionId: string) {
+    const shot = await this.prisma.shot.findUnique({ where: { id: shotId } })
+    if (shot && shot.sessionId !== sessionId) {
+      throw new NotFoundException('画布不存在')
+    }
+    return shot
+  }
+
+  async save(userId: string, dto: SceneComposerSaveRequest) {
+    await this.assertOwnedSession(dto.sessionId, userId)
     const syncedShots: string[] = []
 
     for (const scene of dto.scenes) {
@@ -51,7 +71,7 @@ export class SceneComposerService {
     for (const [index, shot] of scene.shots.entries()) {
       if (!shot.shotNodeId) continue
       syncedShots.push(shot.shotNodeId)
-      const existing = await this.prisma.shot.findUnique({ where: { id: shot.shotNodeId } })
+      const existing = await this.assertShotInSession(shot.shotNodeId, sessionId)
       if (existing) {
         await this.shotService.update(shot.shotNodeId, {
           title: shot.title || scene.title || `镜头 ${index + 1}`,
@@ -70,12 +90,22 @@ export class SceneComposerService {
     }
   }
 
-  async batchGenerate(dto: SceneComposerBatchGenerateRequest) {
-    const session = await this.assertSession(dto.sessionId)
+  async batchGenerate(userId: string, dto: SceneComposerBatchGenerateRequest) {
+    await this.assertOwnedSession(dto.sessionId, userId)
+
+    for (const item of dto.items) {
+      await this.assertShotInSession(item.shotNodeId, dto.sessionId)
+    }
+
+    const total = dto.items.reduce((sum, item) => sum + this.itemCredits(item), 0)
+    if (total > 0) {
+      await this.points.consume(userId, total, `导演台批量生成 ×${dto.items.length}`)
+    }
+
     const results: Array<{ shotNodeId: string; materialId?: string; mediaType: string }> = []
 
     for (const item of dto.items) {
-      const result = await this.generateItem(dto.sessionId, session.userId, item)
+      const result = await this.generateItem(dto.sessionId, userId, item)
       results.push(result)
     }
 
@@ -111,6 +141,12 @@ export class SceneComposerService {
         userId,
         shotId: item.shotNodeId,
         prompt: item.prompt,
+        model: item.model,
+        duration: item.duration,
+        aspectRatio: item.aspectRatio,
+        resolution: item.resolution,
+        crop: item.crop,
+        skipCharge: true,
       })
       return { shotNodeId: item.shotNodeId, materialId: material.id, mediaType: 'video' }
     }
@@ -119,6 +155,11 @@ export class SceneComposerService {
       userId,
       shotId: item.shotNodeId,
       prompt: item.prompt,
+      model: item.model,
+      aspectRatio: item.aspectRatio,
+      resolution: item.resolution,
+      count: item.count,
+      skipCharge: true,
     })
     return { shotNodeId: item.shotNodeId, materialId: material.id, mediaType: 'image' }
   }

--- a/apps/server/src/points/points.module.ts
+++ b/apps/server/src/points/points.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common'
+import { PointsService } from './points.service'
+
+@Module({
+  providers: [PointsService],
+  exports: [PointsService],
+})
+export class PointsModule {}

--- a/apps/server/src/points/points.service.test.ts
+++ b/apps/server/src/points/points.service.test.ts
@@ -1,0 +1,58 @@
+import 'reflect-metadata'
+import { BadRequestException } from '@nestjs/common'
+import { describe, expect, it, vi } from 'vitest'
+import { Test } from '@nestjs/testing'
+import { PointsService } from './points.service'
+import { PrismaService } from '../prisma/prisma.service'
+
+describe('PointsService', () => {
+  it('decrements points and writes negative transaction when balance is enough', async () => {
+    const updateMany = vi.fn(async () => ({ count: 1 }))
+    const create = vi.fn(async (args: { data: Record<string, unknown> }) => ({ id: 'pt1', ...args.data }))
+    const $transaction = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({
+        user: { updateMany },
+        pointTransaction: { create },
+      }),
+    )
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        PointsService,
+        { provide: PrismaService, useValue: { $transaction } },
+      ],
+    }).compile()
+    const svc = moduleRef.get(PointsService)
+
+    await svc.consume('u1', 10, '图像生成')
+
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: 'u1', points: { gte: 10 } },
+      data: { points: { decrement: 10 } },
+    })
+    expect(create).toHaveBeenCalledWith({
+      data: { userId: 'u1', amount: -10, reason: '图像生成' },
+    })
+  })
+
+  it('throws 积分不足 when conditional update matches zero rows', async () => {
+    const updateMany = vi.fn(async () => ({ count: 0 }))
+    const create = vi.fn()
+    const $transaction = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({
+        user: { updateMany },
+        pointTransaction: { create },
+      }),
+    )
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        PointsService,
+        { provide: PrismaService, useValue: { $transaction } },
+      ],
+    }).compile()
+
+    await expect(moduleRef.get(PointsService).consume('u1', 10, '图像生成')).rejects.toBeInstanceOf(
+      BadRequestException,
+    )
+    expect(create).not.toHaveBeenCalled()
+  })
+})

--- a/apps/server/src/points/points.service.ts
+++ b/apps/server/src/points/points.service.ts
@@ -1,0 +1,23 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common'
+import { PrismaService } from '../prisma/prisma.service'
+
+@Injectable()
+export class PointsService {
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
+
+  async consume(userId: string, cost: number, reason: string): Promise<void> {
+    if (cost <= 0) return
+    await this.prisma.$transaction(async (tx) => {
+      const updated = await tx.user.updateMany({
+        where: { id: userId, points: { gte: cost } },
+        data: { points: { decrement: cost } },
+      })
+      if (updated.count === 0) {
+        throw new BadRequestException('积分不足')
+      }
+      await tx.pointTransaction.create({
+        data: { userId, amount: -cost, reason },
+      })
+    })
+  }
+}

--- a/apps/server/src/points/video-credits.ts
+++ b/apps/server/src/points/video-credits.ts
@@ -1,0 +1,5 @@
+export function videoCredits(duration: number): number {
+  if (duration >= 15) return 70
+  if (duration >= 10) return 50
+  return 30
+}

--- a/apps/server/src/studio/studio.module.ts
+++ b/apps/server/src/studio/studio.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common'
+import { PointsModule } from '../points/points.module'
 import { StudioController } from './studio.controller'
 import { StudioService } from './studio.service'
 
 @Module({
+  imports: [PointsModule],
   controllers: [StudioController],
   providers: [StudioService],
 })

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -13,6 +13,7 @@ import {
   type MergeTextSource,
 } from '@lnkpi/agent'
 import { resolveImageSize, resolveModelKey, type ImageResolutionTier } from '@lnkpi/shared'
+import { PointsService } from '../points/points.service'
 import { PrismaService } from '../prisma/prisma.service'
 
 const AUDIO_PLACEHOLDER = 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3'
@@ -51,7 +52,10 @@ function buildPromptWithRefImage(prompt: string, refImageUrl: string): string {
 
 @Injectable()
 export class StudioService {
-  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
+  constructor(
+    @Inject(PrismaService) private readonly prisma: PrismaService,
+    @Inject(PointsService) private readonly points: PointsService,
+  ) {}
 
   async listGenerations(userId: string, type?: string) {
     return this.prisma.generationRecord.findMany({
@@ -89,7 +93,7 @@ export class StudioService {
     refs?: StudioRefInput[],
     mentionedKeys?: string[],
   ) {
-    await this.consumePoints(userId, 5, '文本生成')
+    await this.points.consume(userId, 5, '文本生成')
     const { mergedText, skippedMerge, referenceImages } = await this.resolveMergedPrompt(
       prompt,
       refs,
@@ -131,7 +135,7 @@ export class StudioService {
   async generatePrompt(userId: string, prompt: string, model?: string) {
     const trimmed = prompt?.trim()
     if (!trimmed) throw new BadRequestException('prompt 不能为空')
-    await this.consumePoints(userId, 5, '提示词模式生成')
+    await this.points.consume(userId, 5, '提示词模式生成')
     const { modelKey: resolvedKey, entry, fallback } = resolveModelKey('text', model)
     const gatewayModelId = entry.gatewayModelId
     const { mode, content } = await generatePromptFromUserInput(trimmed, {
@@ -179,7 +183,7 @@ export class StudioService {
     count = 1,
   ) {
     const n = Math.max(1, Math.min(4, Number(count) || 1))
-    await this.consumePoints(userId, 10 * n, '图像生成')
+    await this.points.consume(userId, 10 * n, '图像生成')
     const { mergedText, skippedMerge, referenceImages } = await this.resolveMergedPrompt(
       prompt,
       refs,
@@ -220,7 +224,7 @@ export class StudioService {
   }
 
   async generateImageVariation(userId: string, prompt: string, basePrompt?: string, model?: string) {
-    await this.consumePoints(userId, 10, '图像变体')
+    await this.points.consume(userId, 10, '图像变体')
     const combined = basePrompt ? `${basePrompt}。变体要求：${prompt}` : prompt
     const { url } = await createImageProvider().generate(combined)
     return this.prisma.generationRecord.create({
@@ -248,7 +252,7 @@ export class StudioService {
     crop = 'none',
   ) {
     const durationCredits = duration >= 15 ? 70 : duration >= 10 ? 50 : 30
-    await this.consumePoints(userId, durationCredits, '视频生成')
+    await this.points.consume(userId, durationCredits, '视频生成')
     const { mergedText, skippedMerge, referenceImages } = await this.resolveMergedPrompt(
       prompt,
       refs,
@@ -309,7 +313,7 @@ export class StudioService {
     refs?: StudioRefInput[],
     mentionedKeys?: string[],
   ) {
-    await this.consumePoints(userId, 5, '音频生成')
+    await this.points.consume(userId, 5, '音频生成')
     const { mergedText, skippedMerge } = await this.resolveMergedPrompt(text, refs, 'audio', mentionedKeys)
     const built = buildAudioRequest({
       mergedText,
@@ -371,19 +375,4 @@ export class StudioService {
     }
   }
 
-  private async consumePoints(userId: string, cost: number, reason: string) {
-    const user = await this.prisma.user.findUnique({ where: { id: userId } })
-    if (!user || user.points < cost) {
-      throw new BadRequestException('积分不足')
-    }
-    await this.prisma.$transaction([
-      this.prisma.user.update({
-        where: { id: userId },
-        data: { points: { decrement: cost } },
-      }),
-      this.prisma.pointTransaction.create({
-        data: { userId, amount: -cost, reason },
-      }),
-    ])
-  }
 }

--- a/apps/server/src/studio/studio.smoke.test.ts
+++ b/apps/server/src/studio/studio.smoke.test.ts
@@ -1,38 +1,20 @@
 import 'reflect-metadata'
 import { describe, it, expect } from 'vitest'
 import { Test } from '@nestjs/testing'
+import { PointsService } from '../points/points.service'
 import { StudioService } from './studio.service'
 import { PrismaService } from '../prisma/prisma.service'
+import { createPrismaMock } from './studio.test-utils'
 
 describe('studio nest harness', () => {
   it('boots StudioService with mocked Prisma', async () => {
     const moduleRef = await Test.createTestingModule({
       providers: [
         StudioService,
+        PointsService,
         {
           provide: PrismaService,
-          useValue: {
-            user: {
-              findUnique: async () => ({ id: 'u1', points: 9999 }),
-              update: async () => ({ id: 'u1', points: 9994 }),
-            },
-            pointTransaction: {
-              create: async (args: { data: Record<string, unknown> }) => ({
-                id: 'pt1',
-                ...args.data,
-              }),
-            },
-            generationRecord: {
-              create: async (args: { data: Record<string, unknown> }) => ({
-                id: 'g1',
-                ...args.data,
-              }),
-              update: async () => ({}),
-              findFirst: async () => null,
-              findMany: async () => [],
-            },
-            $transaction: async (ops: Promise<unknown>[]) => Promise.all(ops),
-          },
+          useValue: createPrismaMock(),
         },
       ],
     }).compile()

--- a/apps/server/src/studio/studio.test-utils.ts
+++ b/apps/server/src/studio/studio.test-utils.ts
@@ -1,5 +1,6 @@
 import { Test } from '@nestjs/testing'
 import { vi } from 'vitest'
+import { PointsService } from '../points/points.service'
 import { StudioService } from './studio.service'
 import { PrismaService } from '../prisma/prisma.service'
 
@@ -8,6 +9,7 @@ export function createPrismaMock() {
     user: {
       findUnique: async () => ({ id: 'u1', points: 9999 }),
       update: async () => ({ id: 'u1', points: 9994 }),
+      updateMany: async () => ({ count: 1 }),
     },
     pointTransaction: {
       create: async (args: { data: Record<string, unknown> }) => ({
@@ -25,7 +27,19 @@ export function createPrismaMock() {
       findFirst: async () => null,
       findMany: async () => [],
     },
-    $transaction: async (ops: Promise<unknown>[]) => Promise.all(ops),
+    $transaction: async (arg: unknown) => {
+      if (typeof arg === 'function') {
+        return (arg as (tx: unknown) => Promise<unknown>)({
+          user: {
+            updateMany: async () => ({ count: 1 }),
+          },
+          pointTransaction: {
+            create: async (a: { data: Record<string, unknown> }) => ({ id: 'pt1', ...a.data }),
+          },
+        })
+      }
+      return Promise.all(arg as Promise<unknown>[])
+    },
   }
 }
 
@@ -33,6 +47,7 @@ export async function createStudioService() {
   const moduleRef = await Test.createTestingModule({
     providers: [
       StudioService,
+      PointsService,
       {
         provide: PrismaService,
         useValue: createPrismaMock(),

--- a/apps/web/src/composables/useNodeGeneration.test.ts
+++ b/apps/web/src/composables/useNodeGeneration.test.ts
@@ -5,6 +5,8 @@ import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import type { CanvasEdgeLike } from '@/composables/useUpstreamNodeContext'
 import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
 import { useNodeGeneration } from '@/composables/useNodeGeneration'
+import { defaultModelKey } from '@/constants/studioModels'
+import { canvasApi } from '@/services/canvas-api'
 import { studioApi } from '@/services/studio-api'
 
 vi.mock('@/services/studio-api', () => ({
@@ -180,5 +182,98 @@ describe('useNodeGeneration', () => {
       status: NODE_GENERATION_STATUS.error,
       errorMessage: '参考图尚未上传，请先上传后再生成',
     })
+  })
+
+  it('passes shot-linked image child params to canvasApi.generateImage', async () => {
+    const shot = createNode('shot', { title: 'Shot', prompt: 'sunset' }, 'shot-1')
+    const image = createNode('image', {
+      prompt: 'sunset',
+      imageModel: 'navo-pro',
+      imageAspect: '9:16',
+      imageResolution: '2K',
+    }, 'image-1')
+    const { api, deps } = createDeps([shot, image])
+    deps.edges.value = [{ id: 'e1', source: 'shot-1', target: 'image-1' }]
+    vi.mocked(canvasApi.generateImage).mockResolvedValue(mockAxiosResponse({ data: {} }))
+
+    await api.generateForNode(image)
+
+    expect(canvasApi.generateImage).toHaveBeenCalledWith('shot-1', 'sunset', {
+      model: 'navo-pro',
+      aspectRatio: '9:16',
+      resolution: '2K',
+      count: 1,
+    })
+    expect(studioApi.generateImage).not.toHaveBeenCalled()
+    expect(deps.startShotPolling).toHaveBeenCalledWith(['shot-1'])
+  })
+
+  it('passes shot-linked video child params to canvasApi.generateVideo', async () => {
+    const shot = createNode('shot', { title: 'Shot', prompt: 'motion' }, 'shot-1')
+    const video = createNode('video', {
+      prompt: 'motion',
+      videoModel: 'happyhose-1.1',
+      videoSettings: {
+        duration: 10,
+        aspectRatio: '9:16',
+        resolution: '1080p',
+        crop: 'center',
+      },
+    }, 'video-1')
+    const { api, deps } = createDeps([shot, video])
+    deps.edges.value = [{ id: 'e1', source: 'shot-1', target: 'video-1' }]
+    vi.mocked(canvasApi.generateVideo).mockResolvedValue(mockAxiosResponse({ data: {} }))
+
+    await api.generateForNode(video)
+
+    expect(canvasApi.generateVideo).toHaveBeenCalledWith('shot-1', 'motion', {
+      model: 'happyhose-1.1',
+      duration: 10,
+      aspectRatio: '9:16',
+      resolution: '1080p',
+      crop: 'center',
+    })
+    expect(studioApi.generateVideo).not.toHaveBeenCalled()
+    expect(deps.startShotPolling).toHaveBeenCalledWith(['shot-1'])
+  })
+
+  it('uses catalog defaults for generateShot when media child is missing', async () => {
+    const shot = createNode('shot', { title: 'Shot', prompt: 'fallback', shotGenerateMode: 'image' }, 'shot-1')
+    const { api } = createDeps([shot])
+    vi.mocked(canvasApi.editShot).mockResolvedValue(mockAxiosResponse({ data: {} }))
+    vi.mocked(canvasApi.generateImage).mockResolvedValue(mockAxiosResponse({ data: {} }))
+
+    await api.generateForNode(shot)
+
+    expect(canvasApi.generateImage).toHaveBeenCalledWith('shot-1', 'fallback', {
+      model: defaultModelKey('image'),
+      aspectRatio: '16:9',
+      resolution: '1K',
+      count: 1,
+    })
+  })
+
+  it('keeps independent studio image path on studioApi', async () => {
+    const node = createNode('image', {
+      prompt: 'standalone cat',
+      imageModel: 'seedream-5.0-pro',
+      imageAspect: '16:9',
+      imageResolution: '2K',
+      imageCount: 2,
+    })
+    const { api } = createDeps([node])
+
+    await api.generateForNode(node)
+
+    expect(studioApi.generateImage).toHaveBeenCalledWith(
+      'standalone cat',
+      'seedream-5.0-pro',
+      '16:9',
+      [],
+      [],
+      '2K',
+      2,
+    )
+    expect(canvasApi.generateImage).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -27,6 +27,8 @@ import {
   buildBatchGenerateItems,
   expandSceneComposerGraph,
   readSceneComposerFromNode,
+  resolveCanvasImageParams,
+  resolveCanvasVideoParams,
   sceneComposerToNodePatch,
 } from '@/utils/sceneComposer'
 
@@ -110,13 +112,22 @@ function findIncomingEdge(edges: CanvasEdgeLike[], targetId: string) {
   return null
 }
 
-function shotHasChildType(nodes: EditableFlowNode[], edges: CanvasEdgeLike[], shotId: string, childType: string) {
+function findShotMediaChild(
+  nodes: EditableFlowNode[],
+  edges: CanvasEdgeLike[],
+  shotId: string,
+  childType: string,
+): EditableFlowNode | null {
   for (const edge of edges) {
     if (edge.source !== shotId) continue
     const target = findNodeById(nodes, edge.target)
-    if (target?.type === childType) return true
+    if (target?.type === childType) return target
   }
-  return false
+  return null
+}
+
+function shotHasChildType(nodes: EditableFlowNode[], edges: CanvasEdgeLike[], shotId: string, childType: string) {
+  return findShotMediaChild(nodes, edges, shotId, childType) !== null
 }
 
 export function useNodeGeneration(deps: NodeGenerationDeps) {
@@ -245,10 +256,11 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating, prompt: canvasPrompt })
       deps.patchNodeData(shotId, { status: NODE_GENERATION_STATUS.generating, prompt: canvasPrompt })
       if (nodeType === 'video') {
-        const settings = data.videoSettings as VideoSettings | undefined
-        await canvasApi.generateVideo(shotId, canvasPrompt, settings)
+        const params = resolveCanvasVideoParams(data)
+        await canvasApi.generateVideo(shotId, canvasPrompt, params)
       } else {
-        await canvasApi.generateImage(shotId, canvasPrompt)
+        const params = resolveCanvasImageParams(data)
+        await canvasApi.generateImage(shotId, canvasPrompt, params)
       }
       deps.startShotPolling([shotId])
       await deps.saveCanvas()
@@ -337,12 +349,16 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     const shouldGenerateImage = mode === 'image' || (mode === 'auto' && hasImageChild && !shouldGenerateVideo)
 
     if (shouldGenerateVideo) {
-      const settings = data.videoSettings as VideoSettings | undefined
-      await canvasApi.generateVideo(node.id, prompt, settings)
+      const childNode = findShotMediaChild(deps.nodes.value, deps.edges.value, node.id, 'video')
+      const params = resolveCanvasVideoParams(childNode?.data ?? {})
+      await canvasApi.generateVideo(node.id, prompt, params)
     } else if (shouldGenerateImage) {
-      await canvasApi.generateImage(node.id, prompt)
+      const childNode = findShotMediaChild(deps.nodes.value, deps.edges.value, node.id, 'image')
+      const params = resolveCanvasImageParams(childNode?.data ?? {})
+      await canvasApi.generateImage(node.id, prompt, params)
     } else {
-      const matRes = await canvasApi.generateImage(node.id, prompt)
+      const params = resolveCanvasImageParams({})
+      const matRes = await canvasApi.generateImage(node.id, prompt, params)
       const material = matRes.data.data as { id: string }
       deps.addNode('image', { url: '', status: NODE_GENERATION_STATUS.generating, prompt }, {
         id: material.id,
@@ -409,7 +425,7 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     generating.value = true
     try {
       const payload = readSceneComposerFromNode(node)
-      const items = buildBatchGenerateItems(payload)
+      const items = buildBatchGenerateItems(payload, { nodes: deps.nodes.value })
       if (!items.length) return
 
       deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating })

--- a/apps/web/src/services/canvas-api.ts
+++ b/apps/web/src/services/canvas-api.ts
@@ -17,15 +17,32 @@ export const canvasApi = {
     api.post('/agent/canvas/shot/edit', { shotId, ...data }),
   reorderShots: (sessionId: string, shotIds: string[]) =>
     api.post('/agent/canvas/shot-order', { sessionId, shotIds }),
-  generateImage: (shotId: string, prompt: string) =>
-    api.post('/agent/canvas/material/generate-image', { shotId, prompt }),
-  generateVideo: (shotId: string, prompt: string, settings?: Partial<VideoSettings>) =>
+  generateImage: (
+    shotId: string,
+    prompt: string,
+    opts?: { model?: string; aspectRatio?: string; resolution?: string; count?: number },
+  ) =>
+    api.post('/agent/canvas/material/generate-image', {
+      shotId,
+      prompt,
+      model: opts?.model,
+      aspectRatio: opts?.aspectRatio,
+      resolution: opts?.resolution,
+      count: 1,
+    }),
+  generateVideo: (
+    shotId: string,
+    prompt: string,
+    settings?: Partial<VideoSettings> & { model?: string },
+  ) =>
     api.post('/agent/canvas/material/generate-video', {
       shotId,
       prompt,
+      model: settings?.model,
       duration: settings?.duration,
       aspectRatio: settings?.aspectRatio,
       crop: settings?.crop,
+      resolution: settings?.resolution,
     }),
   statusBatch: (ids: string[]) =>
     api.get('/agent/canvas/shot/status/batch', { params: { ids: ids.join(',') } }),

--- a/apps/web/src/utils/sceneComposer.test.ts
+++ b/apps/web/src/utils/sceneComposer.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
+import { defaultModelKey } from '@/constants/studioModels'
+import type { SceneComposerPayload } from '@lnkpi/shared'
+import { buildBatchGenerateItems } from '@/utils/sceneComposer'
+
+const payload: SceneComposerPayload = {
+  title: 'Test Composer',
+  prompt: '',
+  scenes: [
+    {
+      id: 'scene-1',
+      title: 'Scene 1',
+      shots: [
+        {
+          id: 'shot-1',
+          title: 'Shot 1',
+          prompt: 'a sunset',
+          mediaType: 'image',
+          shotNodeId: 'shot-node-1',
+          imageNodeId: 'img-1',
+        },
+      ],
+    },
+  ],
+}
+
+function node(id: string, type: string, data: Record<string, unknown>): EditableFlowNode {
+  return { id, type, position: { x: 0, y: 0 }, data }
+}
+
+describe('buildBatchGenerateItems', () => {
+  it('reads media child node model settings when expanded', () => {
+    const items = buildBatchGenerateItems(payload, {
+      nodes: [
+        node('img-1', 'image', {
+          imageModel: 'navo-pro',
+          imageAspect: '9:16',
+          imageResolution: '2K',
+        }),
+      ],
+    })
+    expect(items[0]).toMatchObject({
+      mediaType: 'image',
+      model: 'navo-pro',
+      aspectRatio: '9:16',
+      resolution: '2K',
+      count: 1,
+    })
+  })
+
+  it('falls back to catalog defaults when child missing', () => {
+    const items = buildBatchGenerateItems(payload, { nodes: [] })
+    expect(items[0].model).toBe(defaultModelKey('image'))
+  })
+})

--- a/apps/web/src/utils/sceneComposer.ts
+++ b/apps/web/src/utils/sceneComposer.ts
@@ -162,14 +162,16 @@ export function resolveCanvasImageParams(data: Record<string, unknown>) {
   }
 }
 
-export function resolveCanvasVideoParams(data: Record<string, unknown>) {
+export function resolveCanvasVideoParams(
+  data: Record<string, unknown>,
+): Partial<VideoSettings> & { model: string } {
   const settings = (data.videoSettings as Partial<VideoSettings> | undefined) ?? {}
   return {
     model: resolveModelKey('video', data.videoModel as string | undefined).modelKey,
-    duration: (settings.duration ?? DEFAULT_VIDEO_SETTINGS.duration) as 5 | 10 | 15,
-    aspectRatio: String(settings.aspectRatio ?? DEFAULT_VIDEO_SETTINGS.aspectRatio),
-    resolution: String(settings.resolution ?? DEFAULT_VIDEO_SETTINGS.resolution),
-    crop: String(settings.crop ?? DEFAULT_VIDEO_SETTINGS.crop),
+    duration: settings.duration ?? DEFAULT_VIDEO_SETTINGS.duration,
+    aspectRatio: settings.aspectRatio ?? DEFAULT_VIDEO_SETTINGS.aspectRatio,
+    resolution: settings.resolution ?? DEFAULT_VIDEO_SETTINGS.resolution,
+    crop: settings.crop ?? DEFAULT_VIDEO_SETTINGS.crop,
   }
 }
 

--- a/apps/web/src/utils/sceneComposer.ts
+++ b/apps/web/src/utils/sceneComposer.ts
@@ -1,12 +1,16 @@
 import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import type { CanvasEdgeLike } from '@/composables/useUpstreamNodeContext'
+import { defaultModelKey, resolveModelKey } from '@/constants/studioModels'
 import {
   createDefaultSceneComposerPayload,
+  DEFAULT_VIDEO_SETTINGS,
   normalizeSceneComposerPayload,
   resolveSceneComposerCoverUrl,
+  type SceneComposerBatchItem,
   type SceneComposerPayload,
   type SceneComposerScene,
   type SceneComposerShot,
+  type VideoSettings,
 } from '@lnkpi/shared'
 
 export interface SceneComposerExpandDeps {
@@ -149,24 +153,96 @@ function expandSingleShot(
   })
 }
 
-export function buildBatchGenerateItems(payload: SceneComposerPayload) {
-  const items: Array<{
-    shotNodeId: string
-    title: string
-    prompt: string
-    mediaType: 'image' | 'video'
-  }> = []
+export function resolveCanvasImageParams(data: Record<string, unknown>) {
+  return {
+    model: resolveModelKey('image', data.imageModel as string | undefined).modelKey,
+    aspectRatio: String(data.imageAspect ?? '16:9'),
+    resolution: String(data.imageResolution ?? '1K'),
+    count: 1 as const,
+  }
+}
+
+export function resolveCanvasVideoParams(data: Record<string, unknown>) {
+  const settings = (data.videoSettings as Partial<VideoSettings> | undefined) ?? {}
+  return {
+    model: resolveModelKey('video', data.videoModel as string | undefined).modelKey,
+    duration: (settings.duration ?? DEFAULT_VIDEO_SETTINGS.duration) as 5 | 10 | 15,
+    aspectRatio: String(settings.aspectRatio ?? DEFAULT_VIDEO_SETTINGS.aspectRatio),
+    resolution: String(settings.resolution ?? DEFAULT_VIDEO_SETTINGS.resolution),
+    crop: String(settings.crop ?? DEFAULT_VIDEO_SETTINGS.crop),
+  }
+}
+
+export interface BuildBatchGenerateItemsOptions {
+  nodes?: EditableFlowNode[]
+}
+
+function findMediaChildNode(
+  nodes: EditableFlowNode[],
+  shot: SceneComposerShot,
+  mediaType: 'image' | 'video',
+): EditableFlowNode | null {
+  const nodeId = mediaType === 'video' ? shot.videoNodeId : shot.imageNodeId
+  if (!nodeId) return null
+  return findNode(nodes, nodeId)
+}
+
+export function buildBatchGenerateItems(
+  payload: SceneComposerPayload,
+  options?: BuildBatchGenerateItemsOptions,
+): SceneComposerBatchItem[] {
+  const nodes = options?.nodes ?? []
+  const items: SceneComposerBatchItem[] = []
 
   for (const scene of payload.scenes) {
     for (const shot of scene.shots) {
       if (!shot.shotNodeId || !shot.prompt.trim()) continue
       if (shot.mediaType !== 'image' && shot.mediaType !== 'video') continue
-      items.push({
-        shotNodeId: shot.shotNodeId,
-        title: shot.title || scene.title,
-        prompt: shot.prompt.trim(),
-        mediaType: shot.mediaType,
-      })
+
+      const childNode = findMediaChildNode(nodes, shot, shot.mediaType)
+      const childData = childNode?.data ?? {}
+
+      if (shot.mediaType === 'image') {
+        const params = childNode
+          ? resolveCanvasImageParams(childData)
+          : {
+              model: defaultModelKey('image'),
+              aspectRatio: '16:9',
+              resolution: '1K',
+              count: 1 as const,
+            }
+        items.push({
+          shotNodeId: shot.shotNodeId,
+          title: shot.title || scene.title,
+          prompt: shot.prompt.trim(),
+          mediaType: 'image',
+          model: params.model,
+          aspectRatio: params.aspectRatio,
+          resolution: params.resolution,
+          count: params.count,
+        })
+      } else {
+        const params = childNode
+          ? resolveCanvasVideoParams(childData)
+          : {
+              model: defaultModelKey('video'),
+              duration: DEFAULT_VIDEO_SETTINGS.duration,
+              aspectRatio: DEFAULT_VIDEO_SETTINGS.aspectRatio,
+              resolution: DEFAULT_VIDEO_SETTINGS.resolution,
+              crop: DEFAULT_VIDEO_SETTINGS.crop,
+            }
+        items.push({
+          shotNodeId: shot.shotNodeId,
+          title: shot.title || scene.title,
+          prompt: shot.prompt.trim(),
+          mediaType: 'video',
+          model: params.model,
+          duration: params.duration,
+          aspectRatio: params.aspectRatio,
+          resolution: params.resolution,
+          crop: params.crop,
+        })
+      }
     }
   }
 

--- a/docs/DOCK_STUDIO_E2E_TRACKING.md
+++ b/docs/DOCK_STUDIO_E2E_TRACKING.md
@@ -3,7 +3,7 @@
 > **对标参考**：[NeoWOW Workflow](https://neowow.cn/workflow?sessionId=2074796563114016768)  
 > **UI 调研**：[NEOWOW_CANVAS_UI_RESEARCH.md](./NEOWOW_CANVAS_UI_RESEARCH.md)（§4.2 BottomToolbarWrapper / NodePanel）  
 > **创建日期**：2026-07-13  
-> **最后更新**：2026-07-18（§6.4 节点数据贯通 RefChip 验收；M3 export/sceneComposer 生产 API 验收；§0.5 P0 手测清单）
+> **最后更新**：2026-07-19（§C2 Canvas 旁路 adapter 验收；§0.5 P0 手测清单）
 
 ---
 
@@ -129,6 +129,7 @@
 | 五 | 推荐实施顺序（里程碑） | 排期与演示节点 |
 | 六 | 单节点 E2E 测试清单 | 验收标准模板 |
 | 七 | 建议优先开工的 3 个 Sprint | 近期排期 |
+| 八 | C2 Canvas 旁路 adapter 验收 | C2 实现状态与手测清单 |
 
 ---
 
@@ -727,6 +728,46 @@ Phase 0 (P0-1~P0-6)
 | UX-4 文本文件 | Dock 联动 | 文本仍走 `createFileNodeAt` → text 节点 | 可扩展 |
 | `useCanvasMedia` | 传 `MediaFilePayload` | 改为直接传 `File`，由 `ingestMediaFile` 统一持久化 | — |
 
+---
+
+## 八、C2 Canvas 旁路 adapter 验收（2026-07-19）
+
+**规格**：[2026-07-19-c2-canvas-generation-adapter-design.md](./superpowers/specs/2026-07-19-c2-canvas-generation-adapter-design.md)  
+**分支**：`feature/c2-canvas-generation-adapter`（PR 待合入）  
+**状态**：**实现完成 / 待合入** — shot、shot-linked image/video、sceneComposer batch 已接入 C1 catalog + generation adapter + PointsService 统一计费
+
+### 8.1 自动化验收
+
+| 项 | 结果 | 说明 |
+|----|------|------|
+| `pnpm install --frozen-lockfile` | ✅ | lockfile 一致 |
+| `prisma generate` | ✅ | |
+| `pnpm build` | ✅ | shared / web / agent / server |
+| `pnpm test` | ✅ | shared 7 · agent 37 · web 10 · server 14 |
+
+### 8.2 实现范围摘要
+
+| 路径 | adapter + 扣费 | 所有权校验 |
+|------|----------------|------------|
+| Material image（shot / shot-linked） | ✅ count=1 | ✅ session/shot 404 |
+| Material video（shot / shot-linked） | ✅ 按时长 30/50/70 | ✅ |
+| sceneComposer batch | ✅ 整批预检一次扣除 + skipCharge | ✅ |
+| Web 参数解析 | ✅ 媒体子节点 → canvas-api | — |
+| refs / V\* / A\* | ⏭ C2.1 / C3 / C4 | — |
+
+### 8.3 浏览器手测清单（规格 §8.3）
+
+| # | 步骤 | 预期 | 通过 |
+|---|------|------|------|
+| C2-1 | shot + **image** 子节点：选非默认模型/分辨率 → 生成 | 请求带 model/aspect/resolution；积分 -10；节点 completed | ☐ |
+| C2-2 | shot + **video** 子节点：选模型/时长/比例/分辨率 → 生成 | 请求带完整 videoSettings；积分按秒数扣费 | ☐ |
+| C2-3 | **未展开** sceneComposer → 批量生成 | 走 catalog 默认参数 | ☐ |
+| C2-4 | **已展开** sceneComposer：改子节点配置 → 批量生成 | batch items 含子节点 model/参数 | ☐ |
+| C2-5 | 积分不足 → sceneComposer 批量生成 | 整批零启动；无 shot 进入 generating | ☐ |
+| C2-6 | 非本人 session/shot 调用 generate / batch | HTTP 404；无副作用 | ☐ |
+
+---
+
 ## 附录 A：迭代记录模板
 
 复制下表到每次 Sprint 结束时的「迭代记录」区。
@@ -749,6 +790,7 @@ Phase 0 (P0-1~P0-6)
 | 2026-07-16 | M3 | sceneComposer 生产 API 手测 | — | §0.5 浏览器 UI |
 | 2026-07-16 | Deploy | PR #11 API_PUBLIC_URL + recover | GHA Wait failure | PR #12 轮询修复 ✅ |
 | 2026-07-16 | — | 节点 E2E 审计 + §0.5 P0 清单 | 真实生成待 API Key | U1–U8 浏览器手测 |
+| 2026-07-19 | C2 | Canvas 旁路 adapter + 统一计费（T1–T6） | 浏览器手测 C2-1~C2-6 待验 | C2 PR 合入 → C2.1 refs |
 
 ---
 
@@ -759,8 +801,9 @@ Phase 0 (P0-1~P0-6)
 | [NEOWOW_CANVAS_UI_RESEARCH.md](./NEOWOW_CANVAS_UI_RESEARCH.md) | NeoWOW 画布 UI 逆向调研 |
 | [NEOWOW_RESEARCH.md](./NEOWOW_RESEARCH.md) | NeoWOW 产品调研 |
 | [superpowers/plans/2026-07-09-neowow-workflow.md](./superpowers/plans/2026-07-09-neowow-workflow.md) | M1/M2 实现计划 |
+| [2026-07-19-c2-canvas-generation-adapter-design.md](./superpowers/specs/2026-07-19-c2-canvas-generation-adapter-design.md) | C2 Canvas 旁路 adapter 规格 |
 | [PRODUCT_CAPABILITY_MAP.md](./PRODUCT_CAPABILITY_MAP.md) | 产品能力地图 |
 
 ---
 
-**最后更新**：2026-07-16（§0.5 P0 手测清单；M3 ~90%；Deploy PR #12 全绿）
+**最后更新**：2026-07-19（§8 C2 Canvas 旁路 adapter 验收；M3 ~90%）

--- a/docs/superpowers/plans/2026-07-19-c2-canvas-generation-adapter.md
+++ b/docs/superpowers/plans/2026-07-19-c2-canvas-generation-adapter.md
@@ -1,0 +1,795 @@
+# C2 Canvas 旁路接入 Studio Adapter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** shot / shot 子媒体 / sceneComposer batch 走 C1 catalog + adapter，并与 Studio 同价扣费、校验资源归属。
+
+**Architecture:** 抽出共享 `PointsService`（原子条件扣减）；`MaterialService` 增量调用 `buildImageProviderOptions` / `buildVideoProviderOptions`；Controller 注入 `userId`；Web 从媒体子节点解析配置，缺失时用 catalog 默认；旁路固定 `count = 1`。
+
+**Tech Stack:** NestJS、Prisma、Vitest、`@lnkpi/shared` catalog、`@lnkpi/agent` generation-adapter、Vue composables
+
+**Spec:** `docs/superpowers/specs/2026-07-19-c2-canvas-generation-adapter-design.md`
+
+## Global Constraints
+
+- 范围仅 **C2 最小**：模型/参数/计费/所有权；**无** refs、mentionedKeys、LLM merge、多图 Material、V\*、A\*、Playwright
+- image Canvas 路径强制 `n = 1`；客户端 `count > 1` 忽略并打结构化日志
+- 计费：图 10；视频 5→30 / 10→50 / 15→70；batch 整批预检一次扣费；失败不退款
+- 非本人 / 不存在资源 → `NotFoundException`（HTTP 404）
+- Material 保持现有异步 + shot polling；不写 `GenerationRecord`
+- 独立分支 `feature/c2-canvas-generation-adapter`；提交前 `pnpm build && pnpm test` 全绿
+- C2.1 / C3 / C4 **不在本 PR**
+
+---
+
+## File Structure Map
+
+| 路径 | 职责 |
+|------|------|
+| `apps/server/src/points/points.service.ts` | 原子扣费 + PointTransaction |
+| `apps/server/src/points/points.module.ts` | 导出 PointsService |
+| `apps/server/src/points/points.service.test.ts` | 扣费单测 |
+| `apps/server/src/studio/studio.service.ts` | 改用 PointsService |
+| `apps/server/src/studio/studio.module.ts` | import PointsModule |
+| `apps/server/src/studio/studio.test-utils.ts` | mock 补 PointsService |
+| `apps/server/src/studio/studio.smoke.test.ts` | harness 补 PointsService |
+| `apps/server/src/canvas/material.service.ts` | adapter + 扣费 + 所有权 |
+| `apps/server/src/canvas/material.service.test.ts` | Material 集成测 |
+| `apps/server/src/canvas/scene-composer.service.ts` | batch 预检扣费 + 所有权 |
+| `apps/server/src/canvas/scene-composer.service.test.ts` | batch 集成测 |
+| `apps/server/src/canvas/canvas.controller.ts` | DTO 扩展 + 传 userId |
+| `apps/server/src/canvas/canvas.module.ts` | import PointsModule |
+| `packages/shared/src/sceneComposer.ts` | BatchItem 扩展字段 |
+| `apps/web/src/services/canvas-api.ts` | 传 model/params |
+| `apps/web/src/utils/sceneComposer.ts` | batch 从子节点读配置 |
+| `apps/web/src/composables/useNodeGeneration.ts` | shot/canvas 路径传配置 |
+| `apps/web/src/composables/useNodeGeneration.test.ts` | Web payload 断言 |
+| `apps/web/src/utils/sceneComposer.test.ts` | batch 解析单测 |
+| `docs/DOCK_STUDIO_E2E_TRACKING.md` | C2 状态 + 手测项 |
+| `docs/superpowers/specs/2026-07-19-test-infrastructure-design.md` | §6 T1 标已合入（顺带） |
+
+---
+
+### Task 1: PointsService + Studio 迁移
+
+**Files:**
+- Create: `apps/server/src/points/points.service.ts`
+- Create: `apps/server/src/points/points.module.ts`
+- Create: `apps/server/src/points/points.service.test.ts`
+- Modify: `apps/server/src/studio/studio.service.ts`
+- Modify: `apps/server/src/studio/studio.module.ts`
+- Modify: `apps/server/src/studio/studio.test-utils.ts`
+- Modify: `apps/server/src/studio/studio.smoke.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  class PointsService {
+    constructor(prisma: PrismaService)
+    consume(userId: string, cost: number, reason: string): Promise<void>
+  }
+  ```
+- Consumes: `PrismaService`
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+// apps/server/src/points/points.service.test.ts
+import 'reflect-metadata'
+import { BadRequestException } from '@nestjs/common'
+import { describe, expect, it, vi } from 'vitest'
+import { Test } from '@nestjs/testing'
+import { PointsService } from './points.service'
+import { PrismaService } from '../prisma/prisma.service'
+
+describe('PointsService', () => {
+  it('decrements points and writes negative transaction when balance is enough', async () => {
+    const updateMany = vi.fn(async () => ({ count: 1 }))
+    const create = vi.fn(async (args: { data: Record<string, unknown> }) => ({ id: 'pt1', ...args.data }))
+    const $transaction = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({
+        user: { updateMany },
+        pointTransaction: { create },
+      }),
+    )
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        PointsService,
+        { provide: PrismaService, useValue: { $transaction } },
+      ],
+    }).compile()
+    const svc = moduleRef.get(PointsService)
+
+    await svc.consume('u1', 10, '图像生成')
+
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: 'u1', points: { gte: 10 } },
+      data: { points: { decrement: 10 } },
+    })
+    expect(create).toHaveBeenCalledWith({
+      data: { userId: 'u1', amount: -10, reason: '图像生成' },
+    })
+  })
+
+  it('throws 积分不足 when conditional update matches zero rows', async () => {
+    const updateMany = vi.fn(async () => ({ count: 0 }))
+    const create = vi.fn()
+    const $transaction = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({
+        user: { updateMany },
+        pointTransaction: { create },
+      }),
+    )
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        PointsService,
+        { provide: PrismaService, useValue: { $transaction } },
+      ],
+    }).compile()
+
+    await expect(moduleRef.get(PointsService).consume('u1', 10, '图像生成')).rejects.toBeInstanceOf(
+      BadRequestException,
+    )
+    expect(create).not.toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Run 确认失败**
+
+```bash
+pnpm --filter @lnkpi/server test -- src/points/points.service.test.ts
+```
+
+Expected: FAIL（文件/类不存在）
+
+- [ ] **Step 3: 实现 PointsService + Module**
+
+```ts
+// points.service.ts
+import { BadRequestException, Inject, Injectable } from '@nestjs/common'
+import { PrismaService } from '../prisma/prisma.service'
+
+@Injectable()
+export class PointsService {
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
+
+  async consume(userId: string, cost: number, reason: string): Promise<void> {
+    if (cost <= 0) return
+    await this.prisma.$transaction(async (tx) => {
+      const updated = await tx.user.updateMany({
+        where: { id: userId, points: { gte: cost } },
+        data: { points: { decrement: cost } },
+      })
+      if (updated.count === 0) {
+        throw new BadRequestException('积分不足')
+      }
+      await tx.pointTransaction.create({
+        data: { userId, amount: -cost, reason },
+      })
+    })
+  }
+}
+```
+
+```ts
+// points.module.ts
+import { Module } from '@nestjs/common'
+import { PointsService } from './points.service'
+
+@Module({
+  providers: [PointsService],
+  exports: [PointsService],
+})
+export class PointsModule {}
+```
+
+- [ ] **Step 4: Studio 迁移**
+
+在 `StudioService`：
+- 注入 `PointsService`
+- 删除私有 `consumePoints`
+- 所有 `this.consumePoints(...)` → `this.points.consume(...)`
+
+`studio.module.ts`：`imports: [PointsModule]`
+
+更新 `studio.test-utils.ts` / `studio.smoke.test.ts`：providers 增加真实 `PointsService`（仍 mock Prisma），或提供 `{ provide: PointsService, useValue: { consume: vi.fn() } }`。推荐 **真实 PointsService + 扩展 Prisma mock** 的 `$transaction` 支持 callback 形式：
+
+```ts
+$transaction: async (arg: unknown) => {
+  if (typeof arg === 'function') {
+    return (arg as (tx: unknown) => Promise<unknown>)({
+      user: {
+        updateMany: async () => ({ count: 1 }),
+      },
+      pointTransaction: {
+        create: async (a: { data: Record<string, unknown> }) => ({ id: 'pt1', ...a.data }),
+      },
+    })
+  }
+  return Promise.all(arg as Promise<unknown>[])
+},
+```
+
+- [ ] **Step 5: Run 确认通过**
+
+```bash
+pnpm --filter @lnkpi/server test
+```
+
+Expected: PASS（含原 studio 测试）
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/server/src/points apps/server/src/studio
+git commit -m "feat(server): extract PointsService with atomic consume"
+```
+
+---
+
+### Task 2: MaterialService image — adapter + 扣费 + 所有权
+
+**Files:**
+- Modify: `apps/server/src/canvas/material.service.ts`
+- Create: `apps/server/src/canvas/material.service.test.ts`
+- Modify: `apps/server/src/canvas/canvas.module.ts`
+
+**Interfaces:**
+- Consumes: `PointsService.consume`, `buildImageProviderOptions`, `createImageProvider`, `resolveImageSize`
+- Produces:
+  ```ts
+  type CanvasImageGenerateInput = {
+    userId: string
+    shotId: string
+    prompt: string
+    model?: string
+    aspectRatio?: string
+    resolution?: string
+    count?: number
+  }
+  generateImage(input: CanvasImageGenerateInput): Promise<Material>
+  ```
+
+- [ ] **Step 1: 写失败测试（mock provider）**
+
+```ts
+import 'reflect-metadata'
+import { NotFoundException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Test } from '@nestjs/testing'
+import { resolveImageSize } from '@lnkpi/shared'
+import { createImageProvider } from '@lnkpi/agent'
+import { MaterialService } from './material.service'
+import { PointsService } from '../points/points.service'
+import { PrismaService } from '../prisma/prisma.service'
+
+const imageGenerate = vi.fn(async () => ({ url: 'https://example.com/a.png' }))
+vi.mock('@lnkpi/agent', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@lnkpi/agent')>()
+  return {
+    ...actual,
+    createImageProvider: vi.fn(() => ({ generate: imageGenerate })),
+  }
+})
+
+describe('MaterialService image', () => {
+  let svc: MaterialService
+  const consume = vi.fn(async () => {})
+  const materialCreate = vi.fn(async (args: { data: Record<string, unknown> }) => ({
+    id: 'm1',
+    ...args.data,
+  }))
+  const materialUpdate = vi.fn(async () => ({}))
+  const shotFindUnique = vi.fn(async () => ({
+    id: 'shot-1',
+    sessionId: 'sess-1',
+    session: { id: 'sess-1', userId: 'u1' },
+  }))
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        MaterialService,
+        { provide: PointsService, useValue: { consume } },
+        {
+          provide: PrismaService,
+          useValue: {
+            shot: { findUnique: shotFindUnique },
+            material: { create: materialCreate, update: materialUpdate },
+          },
+        },
+      ],
+    }).compile()
+    svc = moduleRef.get(MaterialService)
+  })
+
+  it('passes adapter modelId/size/n=1 and charges 10', async () => {
+    await svc.generateImage({
+      userId: 'u1',
+      shotId: 'shot-1',
+      prompt: 'a cat',
+      model: 'seedream-5.0-pro',
+      aspectRatio: '16:9',
+      resolution: '1K',
+      count: 3,
+    })
+    await vi.waitFor(() => expect(imageGenerate).toHaveBeenCalled())
+    expect(consume).toHaveBeenCalledWith('u1', 10, '图像生成')
+    expect(imageGenerate).toHaveBeenCalledWith('a cat', {
+      modelId: 'seedream-5.0-pro',
+      size: resolveImageSize('16:9', '1K'),
+      n: 1,
+    })
+  })
+
+  it('rejects foreign shot without charging', async () => {
+    shotFindUnique.mockResolvedValueOnce({
+      id: 'shot-1',
+      sessionId: 'sess-1',
+      session: { id: 'sess-1', userId: 'other' },
+    })
+    await expect(
+      svc.generateImage({ userId: 'u1', shotId: 'shot-1', prompt: 'x' }),
+    ).rejects.toBeInstanceOf(NotFoundException)
+    expect(consume).not.toHaveBeenCalled()
+    expect(materialCreate).not.toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Run 确认失败**
+
+```bash
+pnpm --filter @lnkpi/server test -- src/canvas/material.service.test.ts
+```
+
+- [ ] **Step 3: 实现 generateImage**
+
+要点：
+1. `shot.findUnique({ where: { id }, include: { session: true } })`
+2. 不存在或 `session.userId !== userId` → `NotFoundException('分镜不存在')`
+3. `count > 1` → `console.info`/`Logger` JSON：`{ event: 'canvas_image_count_clamped', requested: count, effective: 1 }`
+4. `await points.consume(userId, 10, '图像生成')`
+5. create Material `generating`
+6. async：`buildImageProviderOptions({ modelKey: model, size: resolveImageSize(...), n: 1, referenceImages: [] })` → `createImageProvider().generate(prompt, { modelId, size, n })`
+7. `canvas.module.ts` import `PointsModule`
+
+签名改为对象参数；旧位置参数调用方在 Task 4 一并改。
+
+- [ ] **Step 4: Run PASS + Commit**
+
+```bash
+pnpm --filter @lnkpi/server test -- src/canvas/material.service.test.ts
+git add apps/server/src/canvas apps/server/src/canvas/canvas.module.ts
+git commit -m "feat(server): wire Material image path to adapter and billing"
+```
+
+---
+
+### Task 3: MaterialService video — adapter + 扣费
+
+**Files:**
+- Modify: `apps/server/src/canvas/material.service.ts`
+- Modify: `apps/server/src/canvas/material.service.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  type CanvasVideoGenerateInput = {
+    userId: string
+    shotId: string
+    prompt: string
+    model?: string
+    duration?: number
+    aspectRatio?: string
+    resolution?: string
+    crop?: string
+  }
+  generateVideo(input: CanvasVideoGenerateInput): Promise<Material>
+  ```
+- Cost helper（同文件私有函数）:
+  ```ts
+  function videoCredits(duration: number): number {
+    if (duration >= 15) return 70
+    if (duration >= 10) return 50
+    return 30
+  }
+  ```
+
+- [ ] **Step 1: 追加失败测试**
+
+```ts
+it('passes video adapter options and charges by duration', async () => {
+  const videoGenerate = vi.fn(async () => ({ url: 'https://example.com/v.mp4' }))
+  vi.mocked(createVideoProvider).mockReturnValue({ generate: videoGenerate } as never)
+
+  await svc.generateVideo({
+    userId: 'u1',
+    shotId: 'shot-1',
+    prompt: 'walk',
+    model: 'seedance-2.0-min',
+    duration: 10,
+    aspectRatio: '16:9',
+    resolution: '720p',
+    crop: 'none',
+  })
+  await vi.waitFor(() => expect(videoGenerate).toHaveBeenCalled())
+  expect(consume).toHaveBeenCalledWith('u1', 50, '视频生成')
+  const [prompt, opts] = videoGenerate.mock.calls[0]
+  expect(prompt).toBe('walk')
+  expect(opts).toMatchObject({
+    model: 'seedance-2.0-min',
+    duration: 10,
+    aspectRatio: '16:9',
+    resolution: '720p',
+  })
+  // crop metadataOnly → 不应以 native 值强制出现；undefined OK
+})
+```
+
+在文件顶部 `vi.mock` 增加 `createVideoProvider`。
+
+- [ ] **Step 2: 实现**
+
+- 所有权同 image
+- `duration` 默认 5，`aspectRatio` 默认 `16:9`，`resolution` 默认 `720p`，`crop` 默认 `none`
+- `points.consume(userId, videoCredits(duration), '视频生成')`
+- `buildVideoProviderOptions({ modelKey, duration, aspectRatio, resolution, crop, referenceImages: [] })`
+- `createVideoProvider().generate(prompt, { model, duration, aspectRatio, resolution, crop: built.crop, image: built.image })`
+- **删除**手工 `[aspect:..., crop:...]` 拼 prompt
+
+- [ ] **Step 3: Run + Commit**
+
+```bash
+pnpm --filter @lnkpi/server test -- src/canvas/material.service.test.ts
+git add apps/server/src/canvas/material.service.ts apps/server/src/canvas/material.service.test.ts
+git commit -m "feat(server): wire Material video path to adapter and billing"
+```
+
+---
+
+### Task 4: CanvasController DTO + 传 userId
+
+**Files:**
+- Modify: `apps/server/src/canvas/canvas.controller.ts`
+- Modify: `packages/shared/src/sceneComposer.ts`（BatchItem 类型，供 Task 5）
+
+**Interfaces:**
+- Produces DTO 字段与规格 §4 一致
+
+- [ ] **Step 1: 扩展 shared BatchItem**
+
+```ts
+export interface SceneComposerBatchItem {
+  shotNodeId: string
+  title?: string
+  prompt: string
+  mediaType: Exclude<SceneComposerShotMediaType, 'none'>
+  model?: string
+  aspectRatio?: string
+  resolution?: string
+  duration?: 5 | 10 | 15
+  crop?: string
+  count?: number
+}
+```
+
+- [ ] **Step 2: 扩展 Controller DTO + 调用**
+
+`GenerateImageDto` 增加 optional：`model`, `aspectRatio`, `resolution`, `count`  
+`GenerateVideoDto` 增加 optional：`model`, `resolution`（已有 duration/aspect/crop）  
+`SceneComposerBatchItemDto` 同步增加上述字段  
+
+```ts
+@Post('material/generate-image')
+@UseGuards(AuthGuard)
+async generateImage(@Req() req: { user: { sub: string } }, @Body() dto: GenerateImageDto) {
+  const data = await this.materialService.generateImage({
+    userId: req.user.sub,
+    shotId: dto.shotId,
+    prompt: dto.prompt,
+    model: dto.model,
+    aspectRatio: dto.aspectRatio,
+    resolution: dto.resolution,
+    count: dto.count,
+  })
+  return { code: 0, message: 'ok', data }
+}
+```
+
+Video / `saveSceneComposer` / `batchGenerateSceneComposer` 同样传 `req.user.sub`。
+
+- [ ] **Step 3: shared + server build**
+
+```bash
+pnpm --filter @lnkpi/shared build
+pnpm --filter @lnkpi/server build
+```
+
+Expected: PASS（SceneComposerService 签名若尚未改，先只改 controller 对 material；batch 签名在 Task 5 改时一起编过）
+
+若 Task 5 未做导致类型错，本 Task 可先只改 material 两个 endpoint + DTO，batch/save 的 userId 放 Task 5。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/shared/src/sceneComposer.ts apps/server/src/canvas/canvas.controller.ts
+git commit -m "feat(api): extend canvas material DTOs with model params and userId"
+```
+
+---
+
+### Task 5: SceneComposerService — 所有权 + 整批预检扣费
+
+**Files:**
+- Modify: `apps/server/src/canvas/scene-composer.service.ts`
+- Create: `apps/server/src/canvas/scene-composer.service.test.ts`
+- Modify: `apps/server/src/canvas/canvas.controller.ts`（若 Task 4 未传 batch userId）
+
+**Interfaces:**
+- Produces:
+  ```ts
+  save(userId: string, dto: SceneComposerSaveRequest): Promise<...>
+  batchGenerate(userId: string, dto: SceneComposerBatchGenerateRequest): Promise<...>
+  ```
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+it('precomputes total cost and consumes once before starting materials', async () => {
+  // mock session owned by u1
+  // items: 1 image + 1 video(10s) → cost 10+50=60
+  // points.consume called once with 60
+  // material.generateImage/Video called with userId + model fields
+})
+
+it('rejects foreign session with zero side effects', async () => {
+  // session.userId = other → NotFoundException
+  // consume not called
+})
+```
+
+- [ ] **Step 2: 实现**
+
+```ts
+private async assertOwnedSession(sessionId: string, userId: string) {
+  const session = await this.prisma.session.findFirst({ where: { id: sessionId, userId } })
+  if (!session) throw new NotFoundException('画布不存在')
+  return session
+}
+
+private itemCredits(item: SceneComposerBatchItem): number {
+  if (item.mediaType === 'video') {
+    const d = item.duration ?? 5
+    return d >= 15 ? 70 : d >= 10 ? 50 : 30
+  }
+  return 10
+}
+```
+
+`batchGenerate` 流程：
+1. `assertOwnedSession`
+2. 校验每个已存在 shot：`shot.sessionId === dto.sessionId`，否则 404
+3. `total = sum(itemCredits)`
+4. `await points.consume(userId, total, \`导演台批量生成 ×${items.length}\`)`
+5. 逐项：upsert shot → `materialService.generateImage/Video`，但 **Material 内不再二次扣费**
+
+> **重要设计点：** batch 已一次扣费时，Material 不能再扣。两种实现选一（本计划固定 **A**）：
+>
+> **A（推荐）：** `generateImage/Video` 增加可选 `skipCharge?: boolean`；batch 传 `skipCharge: true`。  
+> **B：** 抽出 `startImageGeneration` 内部方法，charge 只在公开 API。
+
+实现 A：
+
+```ts
+generateImage(input: CanvasImageGenerateInput & { skipCharge?: boolean })
+```
+
+单测追加：`skipCharge: true` 时 `consume` 不被调用。
+
+- [ ] **Step 3: Controller 传 userId 给 save/batch**
+
+- [ ] **Step 4: Run + Commit**
+
+```bash
+pnpm --filter @lnkpi/server test
+git add apps/server/src/canvas
+git commit -m "feat(server): prepaid sceneComposer batch billing and ownership checks"
+```
+
+---
+
+### Task 6: Web canvas-api + 配置解析
+
+**Files:**
+- Modify: `apps/web/src/services/canvas-api.ts`
+- Modify: `apps/web/src/utils/sceneComposer.ts`
+- Create: `apps/web/src/utils/sceneComposer.test.ts`
+- Modify: `apps/web/src/composables/useNodeGeneration.ts`
+- Modify: `apps/web/src/composables/useNodeGeneration.test.ts`
+
+**Interfaces:**
+- Produces helpers（可放在 `sceneComposer.ts` 或 `useNodeGeneration.ts` 旁）:
+  ```ts
+  function resolveCanvasImageParams(data: Record<string, unknown>): {
+    model: string
+    aspectRatio: string
+    resolution: string
+    count: 1
+  }
+  function resolveCanvasVideoParams(data: Record<string, unknown>): {
+    model: string
+    duration: 5 | 10 | 15
+    aspectRatio: string
+    resolution: string
+    crop: string
+  }
+  ```
+
+- [ ] **Step 1: 扩展 canvas-api**
+
+```ts
+generateImage: (
+  shotId: string,
+  prompt: string,
+  opts?: { model?: string; aspectRatio?: string; resolution?: string; count?: number },
+) =>
+  api.post('/agent/canvas/material/generate-image', {
+    shotId,
+    prompt,
+    model: opts?.model,
+    aspectRatio: opts?.aspectRatio,
+    resolution: opts?.resolution,
+    count: 1,
+  }),
+
+generateVideo: (
+  shotId: string,
+  prompt: string,
+  settings?: Partial<VideoSettings> & { model?: string },
+) =>
+  api.post('/agent/canvas/material/generate-video', {
+    shotId,
+    prompt,
+    model: settings?.model,
+    duration: settings?.duration,
+    aspectRatio: settings?.aspectRatio,
+    crop: settings?.crop,
+    resolution: settings?.resolution,
+  }),
+```
+
+- [ ] **Step 2: sceneComposer batch 解析测试**
+
+```ts
+it('reads media child node model settings when expanded', () => {
+  const items = buildBatchGenerateItems(payload, {
+    nodes: [
+      { id: 'img-1', type: 'image', data: { imageModel: 'navo-pro', imageAspect: '9:16', imageResolution: '2K' } },
+    ],
+  })
+  expect(items[0]).toMatchObject({
+    mediaType: 'image',
+    model: 'navo-pro',
+    aspectRatio: '9:16',
+    resolution: '2K',
+    count: 1,
+  })
+})
+
+it('falls back to catalog defaults when child missing', () => {
+  const items = buildBatchGenerateItems(payload, { nodes: [] })
+  expect(items[0].model).toBe(defaultModelKey('image'))
+})
+```
+
+- [ ] **Step 3: 实现 buildBatchGenerateItems 扩展 + useNodeGeneration**
+
+- shot-linked image/video：传子节点解析结果
+- `generateShot`：找到出边 image/video 子节点读配置；否则 catalog 默认；video 用子节点 `videoSettings` + `videoModel`
+- `batchGenerateSceneComposer`：把 `deps.nodes.value` 传入 `buildBatchGenerateItems`
+
+- [ ] **Step 4: 扩展 useNodeGeneration.test.ts**
+
+覆盖规格 §8.2 至少 4 条：shot-linked image、shot-linked video、缺失默认、独立 studio 不回归。
+
+- [ ] **Step 5: Run + Commit**
+
+```bash
+pnpm --filter @lnkpi/web test
+git add apps/web packages/shared
+git commit -m "feat(web): pass canvas model params from media child nodes"
+```
+
+---
+
+### Task 7: 全仓验收 + 文档 + PR
+
+**Files:**
+- Modify: `docs/DOCK_STUDIO_E2E_TRACKING.md`
+- Modify: `docs/superpowers/specs/2026-07-19-c2-canvas-generation-adapter-design.md`（状态 → 实现中/已实现）
+- Modify（可选）: `docs/superpowers/specs/2026-07-19-test-infrastructure-design.md` §6 T1 行改为已合入
+
+- [ ] **Step 1: 全量**
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @lnkpi/server exec prisma generate
+pnpm build
+pnpm test
+```
+
+Expected: all green
+
+- [ ] **Step 2: 更新跟踪文档**
+
+在 `DOCK_STUDIO_E2E_TRACKING.md` 增加 C2 小节：状态、旁路已接 adapter、手测清单（规格 §8.3 六条）。
+
+规格头状态改为 **已实现**（合并前可先写「实现完成 / 待合入」）。
+
+- [ ] **Step 3: Commit + Push + PR**
+
+```bash
+git add docs
+git commit -m "docs: mark C2 canvas adapter ready for review"
+git push -u origin HEAD
+gh pr create --title "feat(canvas): C2 旁路接入 Studio adapter 与统一计费" --body "$(cat <<'EOF'
+## Summary
+- Material/shot/sceneComposer 路径接入 C1 catalog + generation adapter
+- 共享 PointsService 原子扣费；batch 整批预检一次扣除
+- Canvas 生成入口校验 session/shot 归属（404）
+- Web 从媒体子节点解析模型参数；旁路固定 count=1
+- refs / V* / A* 明确留给 C2.1 / C3 / C4
+
+## Spec
+docs/superpowers/specs/2026-07-19-c2-canvas-generation-adapter-design.md
+
+## Test plan
+- [ ] pnpm build && pnpm test
+- [ ] shot + image 子节点非默认模型生成
+- [ ] shot + video 子节点参数生成
+- [ ] sceneComposer 未展开 / 已展开 batch
+- [ ] 积分不足 batch 零启动
+- [ ] 非本人 session/shot 404
+EOF
+)"
+```
+
+---
+
+## Spec coverage
+
+| 规格要求 | Task |
+|----------|------|
+| PointsService 原子扣费 | T1 |
+| Studio 迁移 PointsService | T1 |
+| Material image adapter + n=1 + 扣费 + 所有权 | T2 |
+| Material video adapter + 按时长扣费 | T3 |
+| Controller DTO + userId | T4 |
+| shared BatchItem 扩展 | T4 |
+| sceneComposer 所有权 + 整批预检 + skipCharge | T5 |
+| Web 配置解析 + canvas-api | T6 |
+| 全量验收 + 文档 + PR | T7 |
+| 无 refs / 无多图 Material / 无 V\*A\* | Global |
+
+## Self-review
+
+- 无 TBD；`skipCharge` 在 Task 5 固定方案 A
+- 权限统一 `NotFoundException`
+- Task 接口名与规格 §3–§4 一致
+- Studio 回归由 T1 更新 harness + 现有 integration tests 覆盖
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-07-19-c2-canvas-generation-adapter.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven（推荐）** — 每任务新 subagent，任务间 review，迭代快  
+2. **Inline Execution** — 本会话按 executing-plans 批量执行，设检查点
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-07-19-c2-canvas-generation-adapter-design.md
+++ b/docs/superpowers/specs/2026-07-19-c2-canvas-generation-adapter-design.md
@@ -1,6 +1,6 @@
 # C2 Canvas 旁路接入 Studio Adapter（产品与技术规格）
 
-> 状态：**设计确认 / 待实现**  
+> 状态：**已实现**  
 > 日期：2026-07-19  
 > 范围：**C2 最小** — shot、shot 子媒体与 sceneComposer batch 接入 C1 模型目录、生成 adapter、参数透传与统一计费  
 > 前置：T0 测试地基（PR #26）、C1 Studio 模型适配层（PR #25）  

--- a/docs/superpowers/specs/2026-07-19-c2-canvas-generation-adapter-design.md
+++ b/docs/superpowers/specs/2026-07-19-c2-canvas-generation-adapter-design.md
@@ -1,0 +1,421 @@
+# C2 Canvas 旁路接入 Studio Adapter（产品与技术规格）
+
+> 状态：**设计确认 / 待实现**  
+> 日期：2026-07-19  
+> 范围：**C2 最小** — shot、shot 子媒体与 sceneComposer batch 接入 C1 模型目录、生成 adapter、参数透传与统一计费  
+> 前置：T0 测试地基（PR #26）、C1 Studio 模型适配层（PR #25）  
+> 后续：**C2.1 refs** → **C3 V\*** → **C4 A\***
+
+---
+
+## 0. 决策摘要
+
+| 项 | 结论 |
+| --- | --- |
+| 实现方案 | **增量接入 adapter**；不先重构统一生成编排器 |
+| 适用路径 | shot 生成、shot-linked image/video、sceneComposer batch |
+| 配置来源 | 优先复用媒体子节点；缺失时用 catalog 默认 |
+| 图片数量 | Canvas/Material 旁路固定 `count = 1` |
+| 计费 | 与 Studio 同价；图 10，视频按 5/10/15 秒计 30/50/70 |
+| 批量计费 | 全量预检后一次扣除；不足则整批不启动 |
+| 失败退款 | 不退款，与 Studio 当前语义一致 |
+| 权限 | 生成、导演台保存/批量均校验 session/shot 归属 |
+| 明确不做 | refs、mentionedKeys、LLM prompt 合并、多图 Material、V\*、A\*、Playwright |
+
+---
+
+## 1. 背景与问题
+
+C1 已使普通 Studio 的 text/image/video/audio 路径统一经过：
+
+```text
+studioModelCatalog
+  → buildImageProviderOptions / buildVideoProviderOptions / buildAudioRequest
+  → Provider
+```
+
+但 Canvas 仍有三条旁路：
+
+1. shot 直接生成 image/video；
+2. image/video 连接到 shot 后走 `canvasApi`；
+3. sceneComposer 批量生成 Material。
+
+这些路径当前由 `MaterialService` 裸调 `createImageProvider()` /
+`createVideoProvider()`，因此存在以下差距：
+
+- 不传用户选择的模型；
+- 图像不传比例、分辨率和数量约束；
+- 视频参数不完整，crop 仍手工拼 prompt；
+- 不经过 C1 能力表，无法获得参数降级规则；
+- Canvas 生成不扣积分；
+- 部分 Canvas 写入/生成入口只验证登录，不验证资源归属。
+
+## 2. 目标与非目标
+
+### 2.1 目标
+
+1. 三条 Canvas 旁路复用 C1 catalog + adapter。
+2. 用户在媒体子节点选择的模型和参数真实进入 provider。
+3. 没有媒体子节点或配置缺失时，使用 catalog 默认值。
+4. Material 保持现有异步生成、状态和 shot polling 模型。
+5. Canvas 图/视频与 Studio 同价扣费。
+6. sceneComposer batch 整批预检并一次扣费。
+7. 生成和导演台入口校验当前用户的资源所有权。
+8. 为 C2.1 refs 预留请求结构与 service 扩展点，但本轮不消费 refs。
+
+### 2.2 非目标
+
+| 能力 | 后续轮次 |
+| --- | --- |
+| T\*/I\* refs、`mentionedKeys`、LLM prompt 合并 | C2.1 |
+| 多图 Material 与多 URL 展示 | 独立后续能力 |
+| V\* 抽帧、视频理解 | C3 |
+| A\* ASR、音色参考 | C4 |
+| Playwright E2E | T2 工程轨 |
+| Studio/Material 统一状态机或 `GenerationRecord` | 后续架构重构 |
+| 所有 Canvas CRUD 的全面权限加固 | 独立安全加固；本轮覆盖触达的生成/导演台入口 |
+
+---
+
+## 3. 架构与数据流
+
+### 3.1 选择方案
+
+采用“MaterialService 增量接入 adapter”：
+
+```text
+Web: shot / child media / sceneComposer
+  │  modelKey + image/video params
+  ▼
+CanvasController
+  │  authenticated userId
+  ▼
+MaterialService / SceneComposerService
+  ├─ ownership validation
+  ├─ PointsService
+  ├─ buildImageProviderOptions / buildVideoProviderOptions
+  └─ Provider → Material async state
+```
+
+不采用：
+
+- **Canvas 复用 StudioService**：会产生 GenerationRecord 与 Material 双状态机；
+- **先抽统一 Orchestrator**：会重构已上线的 C1 主路径，超出 C2 最小范围。
+
+### 3.2 服务职责
+
+#### `PointsService`
+
+共享积分扣减能力：
+
+```ts
+consume(userId: string, cost: number, reason: string): Promise<void>
+```
+
+- 使用数据库事务；
+- 在事务内按 `id + points >= cost` 原子条件扣减；
+- 更新数为 0 时抛 `BadRequestException('积分不足')`；
+- 同事务写入负数 `PointTransaction`；
+- `StudioService` 改为依赖该服务，对外行为不变。
+
+#### `MaterialService`
+
+- 接收 `userId`、shotId、prompt、modelKey 和媒体参数；
+- 校验 shot 及所属 session 归当前用户；
+- 单次请求扣费后创建 Material；
+- image 调 `buildImageProviderOptions`；
+- video 调 `buildVideoProviderOptions`；
+- 保持 fire-and-forget provider 调用；
+- 成功写 `completed + url/thumbnail`，失败写 `failed`。
+
+#### `SceneComposerService`
+
+- `save`、`batchGenerate` 接收 `userId`；
+- 校验 session 归属；
+- 对已存在 shot 校验其 `sessionId` 与请求 session 一致；
+- batch 先完成全部结构、归属、参数和费用预检；
+- 一次扣除总费用后，再创建/更新 shot 并启动 Material；
+- 各 Material 异步失败相互隔离。
+
+---
+
+## 4. API 与共享类型
+
+### 4.1 Image Material
+
+`POST /agent/canvas/material/generate-image`
+
+```ts
+type GenerateCanvasImageRequest = {
+  shotId: string
+  prompt: string
+  model?: string
+  aspectRatio?: string
+  resolution?: string
+  count?: number
+}
+```
+
+规则：
+
+- `model` 是 catalog `modelKey`，缺省取 `defaultModelKey('image')`；
+- `aspectRatio` 默认 `16:9`；
+- `resolution` 默认 `1K`；
+- 服务端始终以 `n = 1` 调 provider；
+- 客户端传 `count > 1` 时忽略并输出结构化降级日志；
+- `resolveImageSize` 生成 size；
+- provider 参数为 `{ modelId, size, n: 1 }`。
+
+本轮不改 Material schema；adapter meta 不落 `GenerationRecord`。必要的降级信息写服务端结构化日志。
+
+### 4.2 Video Material
+
+`POST /agent/canvas/material/generate-video`
+
+```ts
+type GenerateCanvasVideoRequest = {
+  shotId: string
+  prompt: string
+  model?: string
+  duration?: 5 | 10 | 15
+  aspectRatio?: VideoAspectRatio
+  resolution?: VideoResolution
+  crop?: VideoCropMode
+}
+```
+
+规则：
+
+- model 缺省取 `defaultModelKey('video')`；
+- 其余缺省取 `DEFAULT_VIDEO_SETTINGS`；
+- 经 `buildVideoProviderOptions` 处理 native / metadataOnly；
+- C2 的 `referenceImages` 固定为空数组；
+- crop 不再由 MaterialService 手工拼入 prompt；
+- provider 只收到 adapter 产出的参数。
+
+### 4.3 Scene Composer Batch
+
+扩展 `SceneComposerBatchItem`：
+
+```ts
+type SceneComposerBatchItem = {
+  shotNodeId: string
+  title?: string
+  prompt: string
+  mediaType: 'image' | 'video'
+  model?: string
+  aspectRatio?: string
+  resolution?: string
+  duration?: 5 | 10 | 15
+  crop?: VideoCropMode
+  count?: number
+}
+```
+
+服务端按 `mediaType` 只读取对应字段；image 固定 `count = 1`。
+
+### 4.4 Controller
+
+以下入口都从 AuthGuard 注入的 `req.user.sub` 读取 userId，并传给 service：
+
+- `material/generate-image`
+- `material/generate-video`
+- `scene-composer/save`
+- `scene-composer/batch-generate`
+
+客户端不得传 userId。
+
+---
+
+## 5. Web 配置解析
+
+### 5.1 shot-linked media
+
+`generateImageOrVideo` 已持有当前 image/video 节点：
+
+- image 读取 `imageModel`、`imageAspect`、`imageResolution`；
+- video 读取 `videoModel` 与完整 `videoSettings`；
+- image 请求显式传 `count: 1`。
+
+### 5.2 shot 自身生成
+
+`generateShot` 查找 shot 的出边媒体子节点：
+
+1. 根据生成策略选择 image 或 video；
+2. 优先读取匹配媒体子节点配置；
+3. 未找到子节点或字段缺失时，使用 catalog 与 shared defaults；
+4. 调用扩展后的 `canvasApi.generateImage/Video`。
+
+### 5.3 sceneComposer batch
+
+`buildBatchGenerateItems` 增加 nodes/defaults 上下文：
+
+1. 根据 `imageNodeId` / `videoNodeId` 定位媒体子节点；
+2. 读取模型和参数；
+3. 若导演台未展开、ID 缺失或节点不存在，则使用 catalog 默认；
+4. 每个 batch item 都携带已解析完成的显式配置。
+
+本轮不新增导演台模型/参数 UI。需要逐镜头精细配置时，用户先展开子图并编辑媒体子节点。
+
+---
+
+## 6. 计费与失败语义
+
+### 6.1 单价
+
+| 类型 | 费用 |
+| --- | ---: |
+| image（固定 n=1） | 10 |
+| video 5 秒 | 30 |
+| video 10 秒 | 50 |
+| video 15 秒 | 70 |
+
+未知或缺失 duration 按默认 5 秒计 30。
+
+### 6.2 单次生成
+
+```text
+鉴权 → 所有权校验 → 原子扣费 → 创建 Material → 异步 provider
+```
+
+- Provider 失败时 Material 标 `failed`；
+- 已扣积分不退款，与 Studio 语义一致；
+- 扣费或权限失败时不创建 Material、不调用 provider。
+
+### 6.3 批量生成
+
+```text
+鉴权
+  → session/全部 item 预检
+  → 计算总费用
+  → 一次原子扣费
+  → 创建/更新全部 shot
+  → 启动各 Material
+```
+
+- 余额不足：整批拒绝，零 Material、零 provider 调用；
+- 扣费后单项异步失败：该项失败，其他项继续；
+- 不做失败退款或部分退款。
+
+---
+
+## 7. 权限边界
+
+### 7.1 必须校验
+
+| 入口 | 校验 |
+| --- | --- |
+| Material image/video | shot → session → `session.userId` |
+| sceneComposer save | 请求 session 属当前用户；已有 shot 必须属于该 session |
+| sceneComposer batch | 同上；全部 item 在扣费前完成校验 |
+
+不存在或非本人资源统一抛 `NotFoundException`（HTTP 404），不暴露资源是否存在。
+
+### 7.2 本轮不扩张
+
+Canvas 的 create/edit/reorder/status 等其他入口仍需单独安全审计。本规格不宣称完成全 Canvas 权限治理。
+
+---
+
+## 8. 测试策略
+
+### 8.1 Server
+
+#### PointsService
+
+- 足额扣减并写负数流水；
+- 不足时抛错且不写流水；
+- 条件更新失败回滚，不产生负余额。
+
+#### MaterialService
+
+- image modelKey → provider modelId；
+- aspectRatio + resolution → size；
+- 始终 `n: 1`；
+- video model/duration/aspectRatio/resolution 进入 provider；
+- crop 遵循 adapter，不再手工拼 prompt；
+- 5/10/15 秒费用分别为 30/50/70；
+- 非本人 shot 不扣费、不建 Material、不调 provider；
+- provider 成功/失败更新 Material 状态。
+
+#### SceneComposerService
+
+- 多项费用求和且只扣一次；
+- 积分不足时零副作用；
+- 每项配置传给 MaterialService；
+- 已存在 shot 必须属于请求 session；
+- 非本人 session 拒绝 save/batch；
+- 单项异步失败不阻止其他项启动。
+
+### 8.2 Web
+
+- shot-linked image 传子节点 model/aspect/resolution/count=1；
+- shot-linked video 传 model + 完整 videoSettings；
+- shot 自身生成优先读取媒体子节点；
+- 子节点缺失时取 catalog/shared 默认；
+- sceneComposer 已展开时按媒体 node ID 读取配置；
+- 未展开或节点丢失时使用默认；
+- 独立 Studio image/video 路径不回归。
+
+### 8.3 全量验收
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @lnkpi/server exec prisma generate
+pnpm build
+pnpm test
+```
+
+手工验收补充到 `docs/DOCK_STUDIO_E2E_TRACKING.md`：
+
+1. shot + image 子节点：选择非默认模型/分辨率后生成；
+2. shot + video 子节点：选择模型/时长/比例/分辨率后生成；
+3. 未展开 sceneComposer 批量生成走默认；
+4. 已展开 sceneComposer 修改子节点配置后批量生成；
+5. 余额不足时批量零启动；
+6. 非本人 session/shot 请求被拒绝。
+
+---
+
+## 9. 验收标准
+
+1. shot、shot-linked media、sceneComposer batch 均经过 C1 catalog + adapter。
+2. 用户媒体子节点配置进入 Canvas API 和 provider；缺失时使用默认。
+3. image Canvas 路径固定单图，不产生不可持久化的多余 URL。
+4. Canvas 图/视频与 Studio 同价。
+5. batch 整批预检并一次扣费。
+6. 触达的生成/导演台入口执行所有权校验。
+7. Material 异步状态与现有 polling 不退化。
+8. C1 普通 Studio 路径不退化。
+9. build + 全仓 tests 通过。
+10. 跟踪文档登记 C2 状态及 C2.1/C3/C4 顺序。
+
+---
+
+## 10. 后续路线
+
+```text
+C2 adapter + model/params + billing
+  → C2.1 T*/I* refs + mentionedKeys + prompt merge
+  → C3 V* frame extraction / understanding
+  → C4 A* ASR / voice reference
+```
+
+| 轮次 | 内容 | 依赖 |
+| --- | --- | --- |
+| C2 | 本规格：Canvas 旁路模型、参数、计费、权限 | C1 |
+| C2.1 | shot/sceneComposer refs 消费与 prompt 合并 | C2 |
+| C3 | V\* 抽帧/视频理解 | C2.1 |
+| C4 | A\* ASR/音色参考 | C3 可并行评估 provider |
+
+---
+
+## 11. 实现交接
+
+规格确认后：
+
+1. 使用 `writing-plans` 生成逐任务实现计划；
+2. 优先 TDD：PointsService → MaterialService → SceneComposer → Web payload；
+3. 使用 Subagent-Driven 执行并逐任务 review；
+4. 独立 PR，CI 全绿后 Squash & Merge；
+5. C2 合入后再写 C2.1 规格，不与本 PR 混做。

--- a/docs/superpowers/specs/2026-07-19-test-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-07-19-test-infrastructure-design.md
@@ -153,7 +153,7 @@ install → prisma generate → pnpm build → pnpm test → (pull_request) dock
 | 轮次 | 名称 | 内容 | 依赖 | 状态 |
 | --- | --- | --- | --- | --- |
 | **T0** | 测试地基 | 本规格：Vitest 全仓、Server 集成、Web composable、CI 全量 | — | **已实现** |
-| **T1** | C1 合入 | PR #25 rebase 到含 T0 的 main；按需补 C1 专项用例；再 Squash & Merge | T0 合入 | 暂停（#25 待 rebase） |
+| **T1** | C1 合入 | PR #25 rebase 到含 T0 的 main；按需补 C1 专项用例；再 Squash & Merge | T0 合入 | **已合入** |
 | **T2** | Playwright E2E | 起 web + api（网关 mock）；画布：选模型/参数/生成/断言请求或节点状态 | T0 | 规划中 |
 | **T3** | 可选加固 | 真库 Prisma 集成子集；部署后鉴权 API 冒烟（不止 health） | T0 / T2 | 可选 |
 | **C2** | 旁路统一 | shot / scene composer 与 studio 共用参数 + refs | C1 合入后 | 产品规格已拆 |

--- a/packages/shared/src/sceneComposer.ts
+++ b/packages/shared/src/sceneComposer.ts
@@ -36,6 +36,12 @@ export interface SceneComposerBatchItem {
   title?: string
   prompt: string
   mediaType: Exclude<SceneComposerShotMediaType, 'none'>
+  model?: string
+  aspectRatio?: string
+  resolution?: string
+  duration?: 5 | 10 | 15
+  crop?: string
+  count?: number
 }
 
 export interface SceneComposerSaveRequest {


### PR DESCRIPTION
## Summary
- Material/shot/sceneComposer 路径接入 C1 catalog + generation adapter
- 共享 PointsService 原子扣费；batch 整批预检一次扣除
- Canvas 生成入口校验 session/shot 归属（404）
- Web 从媒体子节点解析模型参数；旁路固定 count=1
- refs / V* / A* 明确留给 C2.1 / C3 / C4

## Spec
docs/superpowers/specs/2026-07-19-c2-canvas-generation-adapter-design.md

## Test plan
- [ ] pnpm build && pnpm test
- [ ] shot + image 子节点非默认模型生成
- [ ] shot + video 子节点参数生成
- [ ] sceneComposer 未展开 / 已展开 batch
- [ ] 积分不足 batch 零启动
- [ ] 非本人 session/shot 404

Made with [Cursor](https://cursor.com)