### PR TITLE
feat(canvas): C2.1 旁路接入 T*/I* refs 与 prompt merge

### DIFF
--- a/apps/server/src/canvas/canvas.controller.ts
+++ b/apps/server/src/canvas/canvas.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Get, Inject, Post, Put, Query, Req, UseGuards } from 
 import { IsArray, IsIn, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator'
 import { Type } from 'class-transformer'
 import type {
+  RefMediaType,
   SceneComposerBatchGenerateRequest,
   SceneComposerSaveRequest,
   VideoCompositionExportRequest,
@@ -44,6 +45,26 @@ class CreateShotDto {
   prompt?: string
 }
 
+class CanvasRefDto {
+  @IsString()
+  refKey!: string
+
+  @IsIn(['text', 'image', 'video', 'audio'])
+  mediaType!: RefMediaType
+
+  @IsOptional()
+  @IsString()
+  label?: string
+
+  @IsOptional()
+  @IsString()
+  text?: string
+
+  @IsOptional()
+  @IsString()
+  url?: string
+}
+
 class GenerateImageDto {
   @IsString()
   shotId!: string
@@ -66,6 +87,17 @@ class GenerateImageDto {
   @IsOptional()
   @IsNumber()
   count?: number
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CanvasRefDto)
+  refs?: CanvasRefDto[]
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  mentionedKeys?: string[]
 }
 
 class GenerateVideoDto {
@@ -95,6 +127,17 @@ class GenerateVideoDto {
   @IsOptional()
   @IsString()
   crop?: string
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CanvasRefDto)
+  refs?: CanvasRefDto[]
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  mentionedKeys?: string[]
 }
 
 class EditShotDto {
@@ -232,6 +275,17 @@ class SceneComposerBatchItemDto {
   @IsOptional()
   @IsNumber()
   count?: number
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CanvasRefDto)
+  refs?: CanvasRefDto[]
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  mentionedKeys?: string[]
 }
 
 class BatchGenerateSceneComposerDto implements SceneComposerBatchGenerateRequest {
@@ -360,6 +414,8 @@ export class CanvasController {
       aspectRatio: dto.aspectRatio,
       resolution: dto.resolution,
       count: dto.count,
+      refs: dto.refs,
+      mentionedKeys: dto.mentionedKeys,
     })
     return { code: 0, message: 'ok', data }
   }
@@ -376,6 +432,8 @@ export class CanvasController {
       aspectRatio: dto.aspectRatio,
       resolution: dto.resolution,
       crop: dto.crop,
+      refs: dto.refs,
+      mentionedKeys: dto.mentionedKeys,
     })
     return { code: 0, message: 'ok', data }
   }

--- a/apps/server/src/canvas/material.service.test.ts
+++ b/apps/server/src/canvas/material.service.test.ts
@@ -8,8 +8,12 @@ import { MaterialService } from './material.service'
 import { PointsService } from '../points/points.service'
 import { PrismaService } from '../prisma/prisma.service'
 
-const imageGenerate = vi.fn(async () => ({ url: 'https://example.com/a.png' }))
-const videoGenerate = vi.fn(async () => ({ url: 'https://example.com/v.mp4' }))
+const imageGenerate = vi.fn(
+  async (_prompt: string, _opts?: Record<string, unknown>) => ({ url: 'https://example.com/a.png' }),
+)
+const videoGenerate = vi.fn(
+  async (_prompt: string, _opts?: Record<string, unknown>) => ({ url: 'https://example.com/v.mp4' }),
+)
 vi.mock('@lnkpi/agent', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@lnkpi/agent')>()
   return {

--- a/apps/server/src/canvas/material.service.test.ts
+++ b/apps/server/src/canvas/material.service.test.ts
@@ -1,9 +1,9 @@
 import 'reflect-metadata'
-import { NotFoundException } from '@nestjs/common'
+import { BadRequestException, NotFoundException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Test } from '@nestjs/testing'
 import { resolveImageSize } from '@lnkpi/shared'
-import { createImageProvider, createVideoProvider } from '@lnkpi/agent'
+import { createImageProvider, createVideoProvider, mergeRefsToPrompt } from '@lnkpi/agent'
 import { MaterialService } from './material.service'
 import { PointsService } from '../points/points.service'
 import { PrismaService } from '../prisma/prisma.service'
@@ -14,6 +14,10 @@ vi.mock('@lnkpi/agent', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@lnkpi/agent')>()
   return {
     ...actual,
+    mergeRefsToPrompt: vi.fn(async (input: { localPrompt?: string }) => ({
+      mergedText: input.localPrompt ?? 'merged',
+      skippedMerge: true,
+    })),
     createImageProvider: vi.fn(() => ({ generate: imageGenerate })),
     createVideoProvider: vi.fn(() => ({ generate: videoGenerate })),
   }
@@ -93,6 +97,38 @@ describe('MaterialService image', () => {
     expect(consume).not.toHaveBeenCalled()
     expect(materialCreate).toHaveBeenCalled()
   })
+
+  it('rejects blob refs before charging', async () => {
+    await expect(
+      svc.generateImage({
+        userId: 'u1',
+        shotId: 'shot-1',
+        prompt: 'x',
+        refs: [{ refKey: 'I1', mediaType: 'image', url: 'blob:http://localhost/x' }],
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException)
+    expect(consume).not.toHaveBeenCalled()
+    expect(materialCreate).not.toHaveBeenCalled()
+  })
+
+  it('passes I* into image adapter and merges T*', async () => {
+    await svc.generateImage({
+      userId: 'u1',
+      shotId: 'shot-1',
+      prompt: 'local',
+      model: 'seedream-5.0-pro',
+      refs: [
+        { refKey: 'T1', mediaType: 'text', text: 'style soft' },
+        { refKey: 'I1', mediaType: 'image', url: 'https://example.com/a.png' },
+      ],
+      mentionedKeys: ['T1'],
+    })
+    await vi.waitFor(() => expect(imageGenerate).toHaveBeenCalled())
+    expect(mergeRefsToPrompt).toHaveBeenCalled()
+    const [prompt, opts] = imageGenerate.mock.calls[0]
+    expect(String(prompt)).toContain('[ref-image:https://example.com/a.png]')
+    expect(opts).toMatchObject({ n: 1, modelId: 'seedream-5.0-pro' })
+  })
 })
 
 describe('MaterialService video', () => {
@@ -162,5 +198,19 @@ describe('MaterialService video', () => {
     ).rejects.toBeInstanceOf(NotFoundException)
     expect(consume).not.toHaveBeenCalled()
     expect(materialCreate).not.toHaveBeenCalled()
+  })
+
+  it('passes I1 as video options.image', async () => {
+    await svc.generateVideo({
+      userId: 'u1',
+      shotId: 'shot-1',
+      prompt: 'walk',
+      model: 'seedance-2.0-min',
+      duration: 5,
+      refs: [{ refKey: 'I1', mediaType: 'image', url: 'https://example.com/ref.png' }],
+    })
+    await vi.waitFor(() => expect(videoGenerate).toHaveBeenCalled())
+    const [, opts] = videoGenerate.mock.calls[0]
+    expect(opts).toMatchObject({ image: 'https://example.com/ref.png' })
   })
 })

--- a/apps/server/src/canvas/material.service.ts
+++ b/apps/server/src/canvas/material.service.ts
@@ -1,11 +1,19 @@
-import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common'
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common'
 import {
   buildImageProviderOptions,
   buildVideoProviderOptions,
   createImageProvider,
   createVideoProvider,
+  mergeRefsToPrompt,
+  type MergeTextSource,
 } from '@lnkpi/agent'
-import { resolveImageSize, type ImageResolutionTier } from '@lnkpi/shared'
+import { resolveImageSize, type GenerationRefPayload, type ImageResolutionTier } from '@lnkpi/shared'
 import { PrismaService } from '../prisma/prisma.service'
 import { PointsService } from '../points/points.service'
 import { videoCredits } from '../points/video-credits'
@@ -19,6 +27,8 @@ export type CanvasImageGenerateInput = {
   resolution?: string
   count?: number
   skipCharge?: boolean
+  refs?: GenerationRefPayload[]
+  mentionedKeys?: string[]
 }
 
 export type CanvasVideoGenerateInput = {
@@ -31,6 +41,40 @@ export type CanvasVideoGenerateInput = {
   resolution?: string
   crop?: string
   skipCharge?: boolean
+  refs?: GenerationRefPayload[]
+  mentionedKeys?: string[]
+}
+
+function assertNoBlobRefs(refs?: GenerationRefPayload[]): void {
+  for (const ref of refs ?? []) {
+    const url = ref.url?.trim()
+    if (url?.startsWith('blob:')) {
+      throw new BadRequestException('参考图尚未上传')
+    }
+  }
+}
+
+function extractTextSources(refs?: GenerationRefPayload[]): MergeTextSource[] {
+  return (refs ?? [])
+    .filter((r) => r.mediaType === 'text' && r.text?.trim())
+    .map((r) => ({
+      refKey: r.refKey,
+      label: r.label?.trim() || r.refKey,
+      text: r.text!.trim(),
+    }))
+}
+
+function extractReferenceImages(refs?: GenerationRefPayload[]): string[] {
+  return (refs ?? [])
+    .filter((r) => r.mediaType === 'image' && r.url?.trim())
+    .map((r) => r.url!.trim())
+}
+
+function buildPromptWithRefImage(prompt: string, refImageUrl: string): string {
+  const trimmed = prompt.trim()
+  const ref = refImageUrl.trim()
+  if (!ref) return trimmed
+  return `${trimmed} [ref-image:${ref}]`
 }
 
 @Injectable()
@@ -64,7 +108,18 @@ export class MaterialService {
   }
 
   async generateImage(input: CanvasImageGenerateInput) {
-    const { userId, shotId, prompt, model, aspectRatio, resolution, count, skipCharge } = input
+    const {
+      userId,
+      shotId,
+      prompt,
+      model,
+      aspectRatio,
+      resolution,
+      count,
+      skipCharge,
+      refs,
+      mentionedKeys,
+    } = input
 
     const shot = await this.prisma.shot.findUnique({
       where: { id: shotId },
@@ -73,6 +128,8 @@ export class MaterialService {
     if (!shot || shot.session.userId !== userId) {
       throw new NotFoundException('分镜不存在')
     }
+
+    assertNoBlobRefs(refs)
 
     const requested = count ?? 1
     if (requested > 1) {
@@ -92,9 +149,15 @@ export class MaterialService {
     const material = await this.prisma.material.create({
       data: { shotId, type: 'image', prompt, status: 'generating' },
     })
-    this.runImageGeneration(material.id, prompt, model, aspectRatio, resolution).catch(
-      console.error,
-    )
+    this.runImageGeneration(
+      material.id,
+      prompt,
+      model,
+      aspectRatio,
+      resolution,
+      refs,
+      mentionedKeys,
+    ).catch(console.error)
     return material
   }
 
@@ -109,6 +172,8 @@ export class MaterialService {
       resolution = '720p',
       crop = 'none',
       skipCharge,
+      refs,
+      mentionedKeys,
     } = input
 
     const shot = await this.prisma.shot.findUnique({
@@ -118,6 +183,8 @@ export class MaterialService {
     if (!shot || shot.session.userId !== userId) {
       throw new NotFoundException('分镜不存在')
     }
+
+    assertNoBlobRefs(refs)
 
     if (!skipCharge) {
       await this.points.consume(userId, videoCredits(duration), '视频生成')
@@ -134,8 +201,31 @@ export class MaterialService {
       aspectRatio,
       resolution,
       crop,
+      refs,
+      mentionedKeys,
     ).catch(console.error)
     return material
+  }
+
+  private async resolveMergedPrompt(
+    localPrompt: string,
+    refs: GenerationRefPayload[] | undefined,
+    downstreamType: 'image' | 'video',
+    mentionedKeys?: string[],
+  ) {
+    const { mergedText, skippedMerge } = await mergeRefsToPrompt({
+      sources: extractTextSources(refs),
+      localPrompt: localPrompt.trim() || undefined,
+      downstreamType,
+      mentionedKeys: mentionedKeys?.length ? mentionedKeys : undefined,
+      apiKey: process.env.OPENAI_API_KEY,
+      baseUrl: process.env.OPENAI_BASE_URL,
+    })
+    return {
+      mergedText,
+      skippedMerge,
+      referenceImages: extractReferenceImages(refs),
+    }
   }
 
   private async runImageGeneration(
@@ -144,8 +234,24 @@ export class MaterialService {
     model?: string,
     aspectRatio?: string,
     resolution?: string,
+    refs?: GenerationRefPayload[],
+    mentionedKeys?: string[],
   ) {
     try {
+      const { mergedText, skippedMerge, referenceImages } = await this.resolveMergedPrompt(
+        prompt,
+        refs,
+        'image',
+        mentionedKeys,
+      )
+      this.logger.log(
+        JSON.stringify({
+          event: 'canvas_material_merge',
+          skippedMerge,
+          refsCount: refs?.length ?? 0,
+          referenceImages: referenceImages.length,
+        }),
+      )
       const size = resolveImageSize(
         aspectRatio ?? '16:9',
         (resolution ?? '1K') as ImageResolutionTier,
@@ -154,9 +260,11 @@ export class MaterialService {
         modelKey: model,
         size,
         n: 1,
-        referenceImages: [],
+        referenceImages,
       })
-      const effectivePrompt = [prompt, built.effectivePromptSuffix].filter(Boolean).join('\n')
+      const primary = built.referenceImages[0]
+      const base = primary ? buildPromptWithRefImage(mergedText, primary) : mergedText
+      const effectivePrompt = [base, built.effectivePromptSuffix].filter(Boolean).join('\n')
       const provider = createImageProvider()
       const { url } = await provider.generate(effectivePrompt, {
         modelId: built.modelId,
@@ -165,7 +273,7 @@ export class MaterialService {
       })
       await this.prisma.material.update({
         where: { id: materialId },
-        data: { url, thumbnail: url, status: 'completed' },
+        data: { url, thumbnail: url, status: 'completed', prompt: effectivePrompt },
       })
     } catch (err) {
       console.error('Image generation failed:', err)
@@ -184,17 +292,33 @@ export class MaterialService {
     aspectRatio: string,
     resolution: string,
     crop: string,
+    refs?: GenerationRefPayload[],
+    mentionedKeys?: string[],
   ) {
     try {
+      const { mergedText, skippedMerge, referenceImages } = await this.resolveMergedPrompt(
+        prompt,
+        refs,
+        'video',
+        mentionedKeys,
+      )
+      this.logger.log(
+        JSON.stringify({
+          event: 'canvas_material_merge',
+          skippedMerge,
+          refsCount: refs?.length ?? 0,
+          referenceImages: referenceImages.length,
+        }),
+      )
       const built = buildVideoProviderOptions({
         modelKey: model,
         duration,
         aspectRatio,
         resolution,
         crop,
-        referenceImages: [],
+        referenceImages,
       })
-      const effectivePrompt = [prompt, built.effectivePromptSuffix].filter(Boolean).join('\n')
+      const effectivePrompt = [mergedText, built.effectivePromptSuffix].filter(Boolean).join('\n')
       const { url } = await createVideoProvider().generate(effectivePrompt, {
         model: built.model,
         duration: built.duration,
@@ -205,7 +329,7 @@ export class MaterialService {
       })
       await this.prisma.material.update({
         where: { id: materialId },
-        data: { url, thumbnail: url, status: 'completed' },
+        data: { url, thumbnail: url, status: 'completed', prompt: effectivePrompt },
       })
     } catch (err) {
       console.error('Video generation failed:', err)

--- a/apps/server/src/canvas/scene-composer.service.test.ts
+++ b/apps/server/src/canvas/scene-composer.service.test.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata'
-import { NotFoundException } from '@nestjs/common'
+import { BadRequestException, NotFoundException } from '@nestjs/common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Test } from '@nestjs/testing'
 import { SceneComposerService } from './scene-composer.service'
@@ -156,6 +156,52 @@ describe('SceneComposerService batchGenerate', () => {
     expect(generateVideo).not.toHaveBeenCalled()
     expect(shotUpdate).not.toHaveBeenCalled()
     expect(shotCreate).not.toHaveBeenCalled()
+  })
+
+  it('rejects batch when any item has blob ref before charging', async () => {
+    await expect(
+      svc.batchGenerate('u1', {
+        sessionId: 'sess-1',
+        composerNodeId: 'composer-1',
+        items: [
+          {
+            shotNodeId: 'shot-img',
+            prompt: 'a cat',
+            mediaType: 'image',
+            refs: [{ refKey: 'I1', mediaType: 'image', url: 'blob:x' }],
+          },
+        ],
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException)
+
+    expect(consume).not.toHaveBeenCalled()
+    expect(generateImage).not.toHaveBeenCalled()
+    expect(generateVideo).not.toHaveBeenCalled()
+  })
+
+  it('passes refs and mentionedKeys to material with skipCharge', async () => {
+    await svc.batchGenerate('u1', {
+      sessionId: 'sess-1',
+      composerNodeId: 'composer-1',
+      items: [
+        {
+          shotNodeId: 'shot-img',
+          prompt: 'a cat @I1',
+          mediaType: 'image',
+          model: 'seedream-5.0-pro',
+          refs: [{ refKey: 'I1', mediaType: 'image', url: 'https://example.com/a.png' }],
+          mentionedKeys: ['I1'],
+        },
+      ],
+    })
+
+    expect(generateImage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skipCharge: true,
+        refs: expect.arrayContaining([expect.objectContaining({ refKey: 'I1' })]),
+        mentionedKeys: ['I1'],
+      }),
+    )
   })
 
   it('does not create shots or materials when consume throws', async () => {

--- a/apps/server/src/canvas/scene-composer.service.ts
+++ b/apps/server/src/canvas/scene-composer.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, NotFoundException } from '@nestjs/common'
+import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common'
 import type {
   SceneComposerBatchGenerateRequest,
   SceneComposerBatchItem,
@@ -41,6 +41,16 @@ export class SceneComposerService {
       throw new NotFoundException('画布不存在')
     }
     return shot
+  }
+
+  private assertNoBlobRefsInBatch(items: SceneComposerBatchItem[]) {
+    for (const item of items) {
+      for (const ref of item.refs ?? []) {
+        if (ref.url?.trim().startsWith('blob:')) {
+          throw new BadRequestException('参考图尚未上传')
+        }
+      }
+    }
   }
 
   async save(userId: string, dto: SceneComposerSaveRequest) {
@@ -97,6 +107,8 @@ export class SceneComposerService {
       await this.assertShotInSession(item.shotNodeId, dto.sessionId)
     }
 
+    this.assertNoBlobRefsInBatch(dto.items)
+
     const total = dto.items.reduce((sum, item) => sum + this.itemCredits(item), 0)
     if (total > 0) {
       await this.points.consume(userId, total, `导演台批量生成 ×${dto.items.length}`)
@@ -146,6 +158,8 @@ export class SceneComposerService {
         aspectRatio: item.aspectRatio,
         resolution: item.resolution,
         crop: item.crop,
+        refs: item.refs,
+        mentionedKeys: item.mentionedKeys,
         skipCharge: true,
       })
       return { shotNodeId: item.shotNodeId, materialId: material.id, mediaType: 'video' }
@@ -159,6 +173,8 @@ export class SceneComposerService {
       aspectRatio: item.aspectRatio,
       resolution: item.resolution,
       count: item.count,
+      refs: item.refs,
+      mentionedKeys: item.mentionedKeys,
       skipCharge: true,
     })
     return { shotNodeId: item.shotNodeId, materialId: material.id, mediaType: 'image' }

--- a/apps/web/src/composables/useNodeGeneration.test.ts
+++ b/apps/web/src/composables/useNodeGeneration.test.ts
@@ -203,9 +203,88 @@ describe('useNodeGeneration', () => {
       aspectRatio: '9:16',
       resolution: '2K',
       count: 1,
+      refs: [],
+      mentionedKeys: [],
     })
     expect(studioApi.generateImage).not.toHaveBeenCalled()
     expect(deps.startShotPolling).toHaveBeenCalledWith(['shot-1'])
+  })
+
+  it('shot-linked image sends media local prompt and refs, not canvasPrompt', async () => {
+    const textUpstream = createNode('text', { content: 'upstream style', prompt: 'upstream style' }, 'text-1')
+    const shot = createNode('shot', { title: 'Shot', prompt: 'shot prompt' }, 'shot-1')
+    const image = createNode('image', {
+      prompt: '',
+      imageModel: 'navo-pro',
+      imageAspect: '9:16',
+      imageResolution: '2K',
+    }, 'image-1')
+    const { api, deps } = createDeps([textUpstream, shot, image])
+    deps.edges.value = [
+      { id: 'e-shot-image', source: 'shot-1', target: 'image-1' },
+      { id: 'e-text-image', source: 'text-1', target: 'image-1' },
+    ]
+    vi.mocked(canvasApi.generateImage).mockResolvedValue(mockAxiosResponse({ data: {} }))
+
+    await api.generateForNode(image)
+
+    expect(canvasApi.generateImage).toHaveBeenCalledWith(
+      'shot-1',
+      '',
+      expect.objectContaining({
+        refs: expect.arrayContaining([
+          expect.objectContaining({ refKey: 'T1', mediaType: 'text', text: 'upstream style' }),
+        ]),
+        mentionedKeys: [],
+      }),
+    )
+    expect(canvasApi.generateImage).not.toHaveBeenCalledWith('shot-1', 'upstream style', expect.anything())
+  })
+
+  it('blocks canvas image when blob ref present', async () => {
+    const refNode = createNode('image', { url: 'blob:http://localhost/ref-456' }, 'ref-1')
+    const shot = createNode('shot', { title: 'Shot', prompt: 'sunset' }, 'shot-1')
+    const image = createNode('image', {
+      prompt: 'sunset',
+      localRefs: [{ id: 'r1', mediaType: 'image', sourceKind: 'upload', label: 'ref', url: 'blob:http://localhost/ref-456' }],
+      refOrder: ['r1'],
+    }, 'image-1')
+    const { api, deps } = createDeps([refNode, shot, image])
+    deps.edges.value = [{ id: 'e1', source: 'shot-1', target: 'image-1' }]
+
+    await api.generateForNode(image)
+
+    expect(canvasApi.generateImage).not.toHaveBeenCalled()
+    expect(deps.patchNodeData).toHaveBeenCalledWith('image-1', {
+      status: NODE_GENERATION_STATUS.error,
+      errorMessage: '参考图尚未上传，请先上传后再生成',
+    })
+  })
+
+  it('generateShot uses shot local prompt with shot refs', async () => {
+    const textUpstream = createNode('text', { content: 'cinematic', prompt: 'cinematic' }, 'text-1')
+    const shot = createNode('shot', {
+      title: 'Shot',
+      prompt: 'local shot @T1',
+      shotGenerateMode: 'image',
+    }, 'shot-1')
+    const { api, deps } = createDeps([textUpstream, shot])
+    deps.edges.value = [{ id: 'e-text-shot', source: 'text-1', target: 'shot-1' }]
+    vi.mocked(canvasApi.editShot).mockResolvedValue(mockAxiosResponse({ data: {} }))
+    vi.mocked(canvasApi.generateImage).mockResolvedValue(mockAxiosResponse({ data: {} }))
+
+    await api.generateForNode(shot)
+
+    expect(canvasApi.generateImage).toHaveBeenCalledWith(
+      'shot-1',
+      'local shot @T1',
+      expect.objectContaining({
+        refs: expect.arrayContaining([
+          expect.objectContaining({ refKey: 'T1', mediaType: 'text', text: 'cinematic' }),
+        ]),
+        mentionedKeys: ['T1'],
+      }),
+    )
   })
 
   it('passes shot-linked video child params to canvasApi.generateVideo', async () => {
@@ -232,6 +311,8 @@ describe('useNodeGeneration', () => {
       aspectRatio: '9:16',
       resolution: '1080p',
       crop: 'center',
+      refs: [],
+      mentionedKeys: [],
     })
     expect(studioApi.generateVideo).not.toHaveBeenCalled()
     expect(deps.startShotPolling).toHaveBeenCalledWith(['shot-1'])
@@ -250,6 +331,8 @@ describe('useNodeGeneration', () => {
       aspectRatio: '16:9',
       resolution: '1K',
       count: 1,
+      refs: [],
+      mentionedKeys: [],
     })
   })
 

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -4,7 +4,6 @@ import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
 import { DEFAULT_AUDIO_VOICE } from '@/constants/dockAudio'
 import {
-  mergePromptWithUpstream,
   mergeReferenceImageUrl,
   resolveUpstreamContext,
   type CanvasEdgeLike,
@@ -140,7 +139,6 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     const local = localPrompt(data)
     const refs = resolveStudioRefs(node, deps.nodes.value, deps.edges.value)
     const mentionedKeys = parseRefMentions(local)
-    const canvasPrompt = mergePromptWithUpstream(data, upstream)
     if (!deps.requireLogin()) return
     if (nodeType === 'prompt') {
       if (!local) return
@@ -225,7 +223,7 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       }
 
       if (nodeType === 'shot') {
-        await generateShot(node, canvasPrompt, data)
+        await generateShot(node, local, data)
       }
     } catch (err) {
       console.error('[NodeGeneration]', nodeType, err)
@@ -250,17 +248,16 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     const linkedShotEdge = findIncomingEdge(deps.edges.value, node.id)
     const shotId = linkedShotEdge?.source
     const shotNode = shotId ? findNodeById(deps.nodes.value, shotId) : null
-    const canvasPrompt = mergePromptWithUpstream(data, upstream)
 
     if (shotNode?.type === 'shot' && shotId) {
-      deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating, prompt: canvasPrompt })
-      deps.patchNodeData(shotId, { status: NODE_GENERATION_STATUS.generating, prompt: canvasPrompt })
+      deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating, prompt })
+      deps.patchNodeData(shotId, { status: NODE_GENERATION_STATUS.generating, prompt })
       if (nodeType === 'video') {
         const params = resolveCanvasVideoParams(data)
-        await canvasApi.generateVideo(shotId, canvasPrompt, params)
+        await canvasApi.generateVideo(shotId, prompt, { ...params, refs, mentionedKeys })
       } else {
         const params = resolveCanvasImageParams(data)
-        await canvasApi.generateImage(shotId, canvasPrompt, params)
+        await canvasApi.generateImage(shotId, prompt, { ...params, refs, mentionedKeys })
       }
       deps.startShotPolling([shotId])
       await deps.saveCanvas()
@@ -329,6 +326,8 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
   }
 
   async function generateShot(node: EditableFlowNode, prompt: string, data: Record<string, unknown>) {
+    const refs = resolveStudioRefs(node, deps.nodes.value, deps.edges.value)
+    const mentionedKeys = parseRefMentions(prompt)
     deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating, prompt })
     const title = String(data.title ?? (prompt.slice(0, 24) || '新分镜'))
     try {
@@ -351,14 +350,14 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     if (shouldGenerateVideo) {
       const childNode = findShotMediaChild(deps.nodes.value, deps.edges.value, node.id, 'video')
       const params = resolveCanvasVideoParams(childNode?.data ?? {})
-      await canvasApi.generateVideo(node.id, prompt, params)
+      await canvasApi.generateVideo(node.id, prompt, { ...params, refs, mentionedKeys })
     } else if (shouldGenerateImage) {
       const childNode = findShotMediaChild(deps.nodes.value, deps.edges.value, node.id, 'image')
       const params = resolveCanvasImageParams(childNode?.data ?? {})
-      await canvasApi.generateImage(node.id, prompt, params)
+      await canvasApi.generateImage(node.id, prompt, { ...params, refs, mentionedKeys })
     } else {
       const params = resolveCanvasImageParams({})
-      const matRes = await canvasApi.generateImage(node.id, prompt, params)
+      const matRes = await canvasApi.generateImage(node.id, prompt, { ...params, refs, mentionedKeys })
       const material = matRes.data.data as { id: string }
       deps.addNode('image', { url: '', status: NODE_GENERATION_STATUS.generating, prompt }, {
         id: material.id,
@@ -425,8 +424,22 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     generating.value = true
     try {
       const payload = readSceneComposerFromNode(node)
-      const items = buildBatchGenerateItems(payload, { nodes: deps.nodes.value })
+      const items = buildBatchGenerateItems(payload, {
+        nodes: deps.nodes.value,
+        edges: deps.edges.value,
+        composerNodeId: node.id,
+      })
       if (!items.length) return
+
+      for (const item of items) {
+        if (hasBlobReference(item.refs ?? [], {})) {
+          deps.patchNodeData(node.id, {
+            status: NODE_GENERATION_STATUS.error,
+            errorMessage: '参考图尚未上传，请先上传后再生成',
+          })
+          return
+        }
+      }
 
       deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating })
       for (const item of items) {

--- a/apps/web/src/services/canvas-api.ts
+++ b/apps/web/src/services/canvas-api.ts
@@ -1,5 +1,5 @@
 import { api } from './api'
-import type { VideoSettings } from '@lnkpi/shared'
+import type { GenerationRefPayload, VideoSettings } from '@lnkpi/shared'
 import type {
   SceneComposerBatchGenerateRequest,
   SceneComposerSaveRequest,
@@ -20,7 +20,14 @@ export const canvasApi = {
   generateImage: (
     shotId: string,
     prompt: string,
-    opts?: { model?: string; aspectRatio?: string; resolution?: string; count?: number },
+    opts?: {
+      model?: string
+      aspectRatio?: string
+      resolution?: string
+      count?: number
+      refs?: GenerationRefPayload[]
+      mentionedKeys?: string[]
+    },
   ) =>
     api.post('/agent/canvas/material/generate-image', {
       shotId,
@@ -29,11 +36,17 @@ export const canvasApi = {
       aspectRatio: opts?.aspectRatio,
       resolution: opts?.resolution,
       count: 1,
+      refs: opts?.refs,
+      mentionedKeys: opts?.mentionedKeys,
     }),
   generateVideo: (
     shotId: string,
     prompt: string,
-    settings?: Partial<VideoSettings> & { model?: string },
+    settings?: Partial<VideoSettings> & {
+      model?: string
+      refs?: GenerationRefPayload[]
+      mentionedKeys?: string[]
+    },
   ) =>
     api.post('/agent/canvas/material/generate-video', {
       shotId,
@@ -43,6 +56,8 @@ export const canvasApi = {
       aspectRatio: settings?.aspectRatio,
       crop: settings?.crop,
       resolution: settings?.resolution,
+      refs: settings?.refs,
+      mentionedKeys: settings?.mentionedKeys,
     }),
   statusBatch: (ids: string[]) =>
     api.get('/agent/canvas/shot/status/batch', { params: { ids: ids.join(',') } }),

--- a/apps/web/src/services/studio-api.ts
+++ b/apps/web/src/services/studio-api.ts
@@ -1,4 +1,7 @@
 import { api } from './api'
+import type { GenerationRefPayload } from '@lnkpi/shared'
+
+export type StudioRefPayload = GenerationRefPayload
 
 export interface GenerationRecord {
   id: string
@@ -19,14 +22,6 @@ export interface AudioGenerateOptions {
   volume?: number
   pitch?: number
   model?: string
-}
-
-export type StudioRefPayload = {
-  refKey: string
-  mediaType: string
-  label?: string
-  text?: string
-  url?: string
 }
 
 export const studioApi = {

--- a/apps/web/src/utils/sceneComposer.test.ts
+++ b/apps/web/src/utils/sceneComposer.test.ts
@@ -53,4 +53,54 @@ describe('buildBatchGenerateItems', () => {
     const items = buildBatchGenerateItems(payload, { nodes: [] })
     expect(items[0].model).toBe(defaultModelKey('image'))
   })
+
+  it('uses media child prompt and refs when expanded', () => {
+    const textNode = node('text-1', 'text', { content: 'soft lighting', prompt: 'soft lighting' })
+    const childNode = node('img-1', 'image', {
+      prompt: 'child prompt @T1',
+      imageModel: 'navo-pro',
+      imageAspect: '16:9',
+      imageResolution: '1K',
+    })
+    const composerNode = node('composer-1', 'sceneComposer', { prompt: 'composer prompt' })
+    const items = buildBatchGenerateItems(payload, {
+      nodes: [composerNode, childNode, textNode],
+      edges: [{ id: 'e-text-child', source: 'text-1', target: 'img-1' }],
+      composerNodeId: 'composer-1',
+    })
+    expect(items[0].prompt).toBe('child prompt @T1')
+    expect(items[0].refs).toEqual(
+      expect.arrayContaining([expect.objectContaining({ refKey: 'T1', mediaType: 'text', text: 'soft lighting' })]),
+    )
+    expect(items[0].mentionedKeys).toEqual(['T1'])
+  })
+
+  it('falls back to shot prompt and composer refs when child missing', () => {
+    const payloadNoChild: SceneComposerPayload = {
+      ...payload,
+      scenes: [
+        {
+          ...payload.scenes[0],
+          shots: [
+            {
+              ...payload.scenes[0].shots[0],
+              imageNodeId: undefined,
+            },
+          ],
+        },
+      ],
+    }
+    const textNode = node('text-1', 'text', { content: 'composer style', prompt: 'composer style' })
+    const composerNode = node('composer-1', 'sceneComposer', { prompt: 'composer prompt' })
+    const items = buildBatchGenerateItems(payloadNoChild, {
+      nodes: [composerNode, textNode],
+      edges: [{ id: 'e-text-composer', source: 'text-1', target: 'composer-1' }],
+      composerNodeId: 'composer-1',
+    })
+    expect(items[0].prompt).toBe('a sunset')
+    expect(items[0].refs).toEqual(
+      expect.arrayContaining([expect.objectContaining({ refKey: 'T1', mediaType: 'text', text: 'composer style' })]),
+    )
+    expect(items[0].mentionedKeys).toEqual([])
+  })
 })

--- a/apps/web/src/utils/sceneComposer.ts
+++ b/apps/web/src/utils/sceneComposer.ts
@@ -1,11 +1,14 @@
 import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import type { CanvasEdgeLike } from '@/composables/useUpstreamNodeContext'
+import { resolveNodeRefs, type LocalRefBinding } from '@/composables/useNodeRefs'
+import { parseRefMentions } from '@/composables/useRefMentions'
 import { defaultModelKey, resolveModelKey } from '@/constants/studioModels'
 import {
   createDefaultSceneComposerPayload,
   DEFAULT_VIDEO_SETTINGS,
   normalizeSceneComposerPayload,
   resolveSceneComposerCoverUrl,
+  type GenerationRefPayload,
   type SceneComposerBatchItem,
   type SceneComposerPayload,
   type SceneComposerScene,
@@ -177,6 +180,44 @@ export function resolveCanvasVideoParams(
 
 export interface BuildBatchGenerateItemsOptions {
   nodes?: EditableFlowNode[]
+  edges?: CanvasEdgeLike[]
+  composerNodeId?: string
+}
+
+function normalizeEdges(edges: CanvasEdgeLike[]) {
+  return edges.map((edge) => ({
+    id: edge.id ?? `${edge.source}->${edge.target}`,
+    source: edge.source,
+    target: edge.target,
+  }))
+}
+
+function nodeLocalPrompt(data: Record<string, unknown>): string {
+  return String(data.prompt ?? data.content ?? '').trim()
+}
+
+export function toGenerationRefs(
+  node: EditableFlowNode,
+  nodes: EditableFlowNode[],
+  edges: CanvasEdgeLike[],
+): GenerationRefPayload[] {
+  const data = node.data ?? {}
+  return resolveNodeRefs({
+    targetNodeId: node.id,
+    targetType: String(node.type),
+    nodes,
+    edges: normalizeEdges(edges),
+    localRefs: (data.localRefs as LocalRefBinding[]) ?? [],
+    refOrder: (data.refOrder as string[]) ?? [],
+  })
+    .filter((ref) => !ref.stale)
+    .map((ref) => ({
+      refKey: ref.refKey,
+      mediaType: ref.mediaType,
+      label: ref.label,
+      text: ref.payload.text,
+      url: ref.payload.url,
+    }))
 }
 
 function findMediaChildNode(
@@ -194,6 +235,10 @@ export function buildBatchGenerateItems(
   options?: BuildBatchGenerateItemsOptions,
 ): SceneComposerBatchItem[] {
   const nodes = options?.nodes ?? []
+  const edges = options?.edges ?? []
+  const composerNode = options?.composerNodeId
+    ? findNode(nodes, options.composerNodeId)
+    : null
   const items: SceneComposerBatchItem[] = []
 
   for (const scene of payload.scenes) {
@@ -203,6 +248,12 @@ export function buildBatchGenerateItems(
 
       const childNode = findMediaChildNode(nodes, shot, shot.mediaType)
       const childData = childNode?.data ?? {}
+      const refsTarget = childNode ?? composerNode
+      const refs = refsTarget ? toGenerationRefs(refsTarget, nodes, edges) : []
+      const finalPrompt = childNode
+        ? nodeLocalPrompt(childData) || shot.prompt.trim()
+        : shot.prompt.trim()
+      const mentionedKeys = parseRefMentions(finalPrompt)
 
       if (shot.mediaType === 'image') {
         const params = childNode
@@ -216,12 +267,14 @@ export function buildBatchGenerateItems(
         items.push({
           shotNodeId: shot.shotNodeId,
           title: shot.title || scene.title,
-          prompt: shot.prompt.trim(),
+          prompt: finalPrompt,
           mediaType: 'image',
           model: params.model,
           aspectRatio: params.aspectRatio,
           resolution: params.resolution,
           count: params.count,
+          refs,
+          mentionedKeys,
         })
       } else {
         const params = childNode
@@ -236,13 +289,15 @@ export function buildBatchGenerateItems(
         items.push({
           shotNodeId: shot.shotNodeId,
           title: shot.title || scene.title,
-          prompt: shot.prompt.trim(),
+          prompt: finalPrompt,
           mediaType: 'video',
           model: params.model,
           duration: params.duration,
           aspectRatio: params.aspectRatio,
           resolution: params.resolution,
           crop: params.crop,
+          refs,
+          mentionedKeys,
         })
       }
     }

--- a/docs/DOCK_STUDIO_E2E_TRACKING.md
+++ b/docs/DOCK_STUDIO_E2E_TRACKING.md
@@ -3,7 +3,7 @@
 > **对标参考**：[NeoWOW Workflow](https://neowow.cn/workflow?sessionId=2074796563114016768)  
 > **UI 调研**：[NEOWOW_CANVAS_UI_RESEARCH.md](./NEOWOW_CANVAS_UI_RESEARCH.md)（§4.2 BottomToolbarWrapper / NodePanel）  
 > **创建日期**：2026-07-13  
-> **最后更新**：2026-07-19（§C2 Canvas 旁路 adapter 验收；§0.5 P0 手测清单）
+> **最后更新**：2026-07-19（§C2.1 Canvas T*/I* refs 验收；§0.5 P0 手测清单）
 
 ---
 
@@ -130,6 +130,7 @@
 | 六 | 单节点 E2E 测试清单 | 验收标准模板 |
 | 七 | 建议优先开工的 3 个 Sprint | 近期排期 |
 | 八 | C2 Canvas 旁路 adapter 验收 | C2 实现状态与手测清单 |
+| 九 | C2.1 Canvas T*/I* refs 验收 | C2.1 实现状态与手测清单 |
 
 ---
 
@@ -753,7 +754,7 @@ Phase 0 (P0-1~P0-6)
 | Material video（shot / shot-linked） | ✅ 按时长 30/50/70 | ✅ |
 | sceneComposer batch | ✅ 整批预检一次扣除 + skipCharge | ✅ |
 | Web 参数解析 | ✅ 媒体子节点 → canvas-api | — |
-| refs / V\* / A\* | ⏭ C2.1 / C3 / C4 | — |
+| refs / V\* / A\* | ⏭ C2.1（见 §九）/ C3 / C4 | — |
 
 ### 8.3 浏览器手测清单（规格 §8.3）
 
@@ -765,6 +766,49 @@ Phase 0 (P0-1~P0-6)
 | C2-4 | **已展开** sceneComposer：改子节点配置 → 批量生成 | batch items 含子节点 model/参数 | ☐ |
 | C2-5 | 积分不足 → sceneComposer 批量生成 | 整批零启动；无 shot 进入 generating | ☐ |
 | C2-6 | 非本人 session/shot 调用 generate / batch | HTTP 404；无副作用 | ☐ |
+
+---
+
+## 九、C2.1 Canvas T*/I* refs 验收（2026-07-19）
+
+**规格**：[2026-07-19-c21-canvas-refs-design.md](./superpowers/specs/2026-07-19-c21-canvas-refs-design.md)  
+**分支**：`feature/c21-canvas-refs`（PR 待合入）  
+**状态**：**实现完成 / 待合入** — shot、shot-linked image/video、sceneComposer batch 传递并消费 `refs` + `mentionedKeys`；Material 走与 Studio 同款 `mergeRefsToPrompt` + adapter `referenceImages`
+
+### 9.1 自动化验收
+
+| 项 | 结果 | 说明 |
+|----|------|------|
+| `pnpm install --frozen-lockfile` | ✅ | lockfile 一致 |
+| `prisma generate` | ✅ | |
+| `pnpm build` | ✅ | shared / web / agent / server |
+| `pnpm test` | ✅ | shared 8 · agent 37 · web 15 · server 23 |
+
+### 9.2 实现范围摘要
+
+| 路径 | T\*/I\* merge | 目标节点语义 | blob 护栏 |
+|------|---------------|--------------|-----------|
+| 直接 shot 生成 | ✅ merge 不另计费 | local prompt + shot refs | ✅ Web + Server 扣费前 |
+| shot-linked image/video | ✅ I\* → referenceImages | 媒体节点 prompt/refs | ✅ |
+| sceneComposer batch 已展开 | ✅ 按项独立 merge | 媒体子节点 prompt/refs；空则 shot prompt | ✅ batch 预检 |
+| sceneComposer batch 未展开 | ✅ composer refs | shot prompt + composer refs | ✅ |
+| `canvasPrompt` 双重合并 | ✅ 已停用 | 上游文案走 T\* edge refs | — |
+| V\* / A\* | ⏭ 不消费 | 可展示 | — |
+
+**目标节点语义（§3.2）**：refs 归属目标节点，不做 composer→shot→child 三层隐式合并；batch 已展开用媒体子节点 refs，未展开/子节点缺失用 composer refs。
+
+**后续路线**：C3 V\* 抽帧/视频理解 → C4 A\* ASR/音色参考。
+
+### 9.3 浏览器手测清单（规格 §8.3）
+
+| # | 步骤 | 预期 | 通过 |
+|---|------|------|------|
+| C2.1-1 | **text** → **shot** → 生成 | T\* 合并文案进入 Material；无 `canvasPrompt` 重复 | ☐ |
+| C2.1-2 | **image** → shot-linked **video** → 生成 | I\* 进入图生视频 referenceImages | ☐ |
+| C2.1-3 | **已展开** sceneComposer：改媒体 prompt/@mention → 批量生成 | batch items 含媒体子节点 prompt/refs | ☐ |
+| C2.1-4 | **未展开** sceneComposer batch | composer 上 T\*/I\* 生效 | ☐ |
+| C2.1-5 | refs 含 `blob:` | Web 拦截不发请求；直打 API Server 扣费前拒绝 | ☐ |
+| C2.1-6 | 积分不足 → sceneComposer 批量生成 | 整批零启动；无 shot 进入 generating | ☐ |
 
 ---
 
@@ -791,6 +835,7 @@ Phase 0 (P0-1~P0-6)
 | 2026-07-16 | Deploy | PR #11 API_PUBLIC_URL + recover | GHA Wait failure | PR #12 轮询修复 ✅ |
 | 2026-07-16 | — | 节点 E2E 审计 + §0.5 P0 清单 | 真实生成待 API Key | U1–U8 浏览器手测 |
 | 2026-07-19 | C2 | Canvas 旁路 adapter + 统一计费（T1–T6） | 浏览器手测 C2-1~C2-6 待验 | C2 PR 合入 → C2.1 refs |
+| 2026-07-19 | C2.1 | Canvas T\*/I\* refs + prompt merge（T1–T6） | 浏览器手测 C2.1-1~C2.1-6 待验 | C2.1 PR 合入 → C3 V\* |
 
 ---
 
@@ -802,8 +847,9 @@ Phase 0 (P0-1~P0-6)
 | [NEOWOW_RESEARCH.md](./NEOWOW_RESEARCH.md) | NeoWOW 产品调研 |
 | [superpowers/plans/2026-07-09-neowow-workflow.md](./superpowers/plans/2026-07-09-neowow-workflow.md) | M1/M2 实现计划 |
 | [2026-07-19-c2-canvas-generation-adapter-design.md](./superpowers/specs/2026-07-19-c2-canvas-generation-adapter-design.md) | C2 Canvas 旁路 adapter 规格 |
+| [2026-07-19-c21-canvas-refs-design.md](./superpowers/specs/2026-07-19-c21-canvas-refs-design.md) | C2.1 Canvas T\*/I\* refs 规格 |
 | [PRODUCT_CAPABILITY_MAP.md](./PRODUCT_CAPABILITY_MAP.md) | 产品能力地图 |
 
 ---
 
-**最后更新**：2026-07-19（§8 C2 Canvas 旁路 adapter 验收；M3 ~90%）
+**最后更新**：2026-07-19（§9 C2.1 Canvas T*/I* refs 验收；M3 ~90%）

--- a/docs/superpowers/plans/2026-07-19-c21-canvas-refs.md
+++ b/docs/superpowers/plans/2026-07-19-c21-canvas-refs.md
@@ -1,0 +1,513 @@
+# C2.1 Canvas T*/I* Refs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Canvas shot / shot-linked / sceneComposer batch 传递并消费 `refs` + `mentionedKeys`，Material 与 Studio 同款 T* merge + I* referenceImages。
+
+**Architecture:** MaterialService 增量接入 `mergeRefsToPrompt` 与 adapter `referenceImages`；Web 按目标节点语义解析 refs；禁止 `canvasPrompt` 双重合并；blob 在扣费前拒绝。
+
+**Tech Stack:** NestJS、Vitest、`@lnkpi/shared` nodeRefs、`@lnkpi/agent` mergeRefsToPrompt / generation-adapter、Vue composables
+
+**Spec:** `docs/superpowers/specs/2026-07-19-c21-canvas-refs-design.md`
+
+## Global Constraints
+
+- 仅消费 **T\*** / **I\***；V\*/A\* 不消费
+- Prompt = 目标节点 **local prompt**；禁止把 `mergePromptWithUpstream` 结果二次喂给 merge
+- Refs = **目标节点语义**；未展开 batch 用 composer refs；已展开用媒体子节点 refs
+- Batch prompt：媒体子节点优先，空则 shot prompt
+- Merge **不另计费**；batch 预检仍按图 10 / 视频 30|50|70
+- blob：Web 拦截 + Server **扣费前** `BadRequestException`
+- 不抽共享 GenerationRefResolver；不改 StudioService 行为
+- 分支 `feature/c21-canvas-refs`；提交前 `pnpm build && pnpm test` 全绿
+
+---
+
+## File Structure Map
+
+| 路径 | 职责 |
+|------|------|
+| `packages/shared/src/nodeRefs.ts` | `GenerationRefPayload` |
+| `packages/shared/src/sceneComposer.ts` | BatchItem `refs`/`mentionedKeys` |
+| `apps/server/src/canvas/material.service.ts` | blob 校验、resolveMergedPrompt、adapter refs |
+| `apps/server/src/canvas/material.service.test.ts` | Material refs 测试 |
+| `apps/server/src/canvas/canvas.controller.ts` | DTO 嵌套 refs |
+| `apps/server/src/canvas/scene-composer.service.ts` | batch blob 预检 + 透传 refs |
+| `apps/server/src/canvas/scene-composer.service.test.ts` | batch refs 测试 |
+| `apps/web/src/services/canvas-api.ts` | 传 refs/mentionedKeys |
+| `apps/web/src/services/studio-api.ts` | 可选：`StudioRefPayload` 对齐 shared 类型（别名即可） |
+| `apps/web/src/utils/sceneComposer.ts` | batch 解析 prompt/refs |
+| `apps/web/src/utils/sceneComposer.test.ts` | batch refs 规则 |
+| `apps/web/src/composables/useNodeGeneration.ts` | shot/shot-linked 传 refs；停用 canvasPrompt |
+| `apps/web/src/composables/useNodeGeneration.test.ts` | Web payload 断言 |
+| `docs/DOCK_STUDIO_E2E_TRACKING.md` | C2.1 章节 |
+
+---
+
+### Task 1: Shared `GenerationRefPayload` + BatchItem 字段
+
+**Files:**
+- Modify: `packages/shared/src/nodeRefs.ts`
+- Modify: `packages/shared/src/sceneComposer.ts`
+- Create: `packages/shared/src/nodeRefs.generation.test.ts`（可选最小导出断言）
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export interface GenerationRefPayload {
+    refKey: string
+    mediaType: RefMediaType
+    label?: string
+    text?: string
+    url?: string
+  }
+  ```
+- SceneComposerBatchItem 增加 `refs?: GenerationRefPayload[]`、`mentionedKeys?: string[]`
+
+- [ ] **Step 1: 写最小测试**
+
+```ts
+// packages/shared/src/nodeRefs.generation.test.ts
+import { describe, expect, it } from 'vitest'
+import type { GenerationRefPayload } from './nodeRefs'
+
+describe('GenerationRefPayload', () => {
+  it('accepts T* and I* shapes', () => {
+    const refs: GenerationRefPayload[] = [
+      { refKey: 'T1', mediaType: 'text', text: 'hello' },
+      { refKey: 'I1', mediaType: 'image', url: 'https://example.com/a.png' },
+    ]
+    expect(refs).toHaveLength(2)
+  })
+})
+```
+
+- [ ] **Step 2: 实现类型并扩展 BatchItem**
+
+在 `nodeRefs.ts` 末尾增加 `GenerationRefPayload`。  
+在 `sceneComposer.ts` 的 `SceneComposerBatchItem` 增加 `refs?`、`mentionedKeys?`（import 类型）。
+
+- [ ] **Step 3: Build shared**
+
+```bash
+pnpm --filter @lnkpi/shared test
+pnpm --filter @lnkpi/shared build
+```
+
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/shared
+git commit -m "feat(shared): add GenerationRefPayload for canvas refs"
+```
+
+---
+
+### Task 2: MaterialService — blob 校验 + resolveMergedPrompt + image/video
+
+**Files:**
+- Modify: `apps/server/src/canvas/material.service.ts`
+- Modify: `apps/server/src/canvas/material.service.test.ts`
+
+**Interfaces:**
+- Extends inputs:
+  ```ts
+  refs?: Array<{ refKey: string; mediaType: string; label?: string; text?: string; url?: string }>
+  mentionedKeys?: string[]
+  ```
+- Helpers（同文件私有，对齐 Studio，本轮不抽共享）:
+  ```ts
+  function assertNoBlobRefs(refs?: ...): void  // BadRequestException
+  function extractTextSources(refs?): MergeTextSource[]
+  function extractReferenceImages(refs?): string[]
+  function buildPromptWithRefImage(prompt: string, refImageUrl: string): string
+  private resolveMergedPrompt(local, refs, 'image'|'video', mentionedKeys?)
+  ```
+
+- [ ] **Step 1: 写失败测试（mock mergeRefsToPrompt）**
+
+```ts
+vi.mock('@lnkpi/agent', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@lnkpi/agent')>()
+  return {
+    ...actual,
+    mergeRefsToPrompt: vi.fn(async (input: { localPrompt?: string }) => ({
+      mergedText: input.localPrompt ?? 'merged',
+      skippedMerge: true,
+    })),
+    createImageProvider: vi.fn(() => ({ generate: imageGenerate })),
+    createVideoProvider: vi.fn(() => ({ generate: videoGenerate })),
+  }
+})
+
+it('rejects blob refs before charging', async () => {
+  await expect(
+    svc.generateImage({
+      userId: 'u1',
+      shotId: 'shot-1',
+      prompt: 'x',
+      refs: [{ refKey: 'I1', mediaType: 'image', url: 'blob:http://localhost/x' }],
+    }),
+  ).rejects.toBeInstanceOf(BadRequestException)
+  expect(consume).not.toHaveBeenCalled()
+  expect(materialCreate).not.toHaveBeenCalled()
+})
+
+it('passes I* into image adapter and merges T*', async () => {
+  await svc.generateImage({
+    userId: 'u1',
+    shotId: 'shot-1',
+    prompt: 'local',
+    model: 'seedream-5.0-pro',
+    refs: [
+      { refKey: 'T1', mediaType: 'text', text: 'style soft' },
+      { refKey: 'I1', mediaType: 'image', url: 'https://example.com/a.png' },
+    ],
+    mentionedKeys: ['T1'],
+  })
+  await vi.waitFor(() => expect(imageGenerate).toHaveBeenCalled())
+  expect(mergeRefsToPrompt).toHaveBeenCalled()
+  const [prompt, opts] = imageGenerate.mock.calls[0]
+  expect(String(prompt)).toContain('[ref-image:https://example.com/a.png]')
+  expect(opts).toMatchObject({ n: 1, modelId: 'seedream-5.0-pro' })
+})
+
+it('passes I1 as video options.image', async () => {
+  await svc.generateVideo({
+    userId: 'u1',
+    shotId: 'shot-1',
+    prompt: 'walk',
+    model: 'seedance-2.0-min',
+    duration: 5,
+    refs: [{ refKey: 'I1', mediaType: 'image', url: 'https://example.com/ref.png' }],
+  })
+  await vi.waitFor(() => expect(videoGenerate).toHaveBeenCalled())
+  const [, opts] = videoGenerate.mock.calls[0]
+  expect(opts).toMatchObject({ image: 'https://example.com/ref.png' })
+})
+```
+
+- [ ] **Step 2: Run FAIL**
+
+```bash
+pnpm --filter @lnkpi/server test -- src/canvas/material.service.test.ts
+```
+
+- [ ] **Step 3: 实现**
+
+顺序（同步路径）：
+
+1. ownership  
+2. `assertNoBlobRefs(refs)` — 任一 `url?.trim().startsWith('blob:')` → `BadRequestException('参考图尚未上传')`  
+3. charge（除非 skipCharge）  
+4. create Material with **raw local prompt** 先写入亦可；异步更新为 effective（推荐异步完成后 `update` prompt 为 effectivePrompt，或 create 时先用 local，完成时覆盖）
+
+异步 `runImageGeneration` / `runVideoGeneration` 增加 `refs`、`mentionedKeys` 参数：
+
+```ts
+const { mergedText, skippedMerge, referenceImages } = await this.resolveMergedPrompt(...)
+this.logger.log(JSON.stringify({ event: 'canvas_material_merge', skippedMerge, refsCount: refs?.length ?? 0, referenceImages: referenceImages.length }))
+const built = buildImageProviderOptions({ modelKey, size, n: 1, referenceImages })
+const primary = built.referenceImages[0]
+const base = primary ? buildPromptWithRefImage(mergedText, primary) : mergedText
+const effectivePrompt = [base, built.effectivePromptSuffix].filter(Boolean).join('\n')
+// generate + update material { url, prompt: effectivePrompt, status }
+```
+
+Video 同理：`buildVideoProviderOptions({ referenceImages })`，`image: built.image`。
+
+V*/A* refs 留在数组中但不进入 extract*（filter 仅 text/image）。
+
+- [ ] **Step 4: Run PASS + Commit**
+
+```bash
+pnpm --filter @lnkpi/server test -- src/canvas/material.service.test.ts
+git add apps/server/src/canvas/material.service.ts apps/server/src/canvas/material.service.test.ts
+git commit -m "feat(server): merge canvas material refs like Studio"
+```
+
+---
+
+### Task 3: Controller DTO — 嵌套 refs
+
+**Files:**
+- Modify: `apps/server/src/canvas/canvas.controller.ts`
+
+**Interfaces:**
+- Produces nested DTO:
+
+```ts
+class CanvasRefDto {
+  @IsString() refKey!: string
+  @IsString() mediaType!: string
+  @IsOptional() @IsString() label?: string
+  @IsOptional() @IsString() text?: string
+  @IsOptional() @IsString() url?: string
+}
+```
+
+挂到 `GenerateImageDto`、`GenerateVideoDto`、`SceneComposerBatchItemDto`：
+
+```ts
+@IsOptional()
+@IsArray()
+@ValidateNested({ each: true })
+@Type(() => CanvasRefDto)
+refs?: CanvasRefDto[]
+
+@IsOptional()
+@IsArray()
+@IsString({ each: true })
+mentionedKeys?: string[]
+```
+
+Controller 调用 material 时透传 `refs`、`mentionedKeys`。
+
+- [ ] **Step 1: 改 DTO + 透传**
+
+- [ ] **Step 2: Build**
+
+```bash
+pnpm --filter @lnkpi/server build
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/server/src/canvas/canvas.controller.ts
+git commit -m "feat(api): accept refs and mentionedKeys on canvas material DTOs"
+```
+
+---
+
+### Task 4: SceneComposer — batch blob 预检 + 透传 refs
+
+**Files:**
+- Modify: `apps/server/src/canvas/scene-composer.service.ts`
+- Modify: `apps/server/src/canvas/scene-composer.service.test.ts`
+
+**Interfaces:**
+- `generateItem` 把 `item.refs` / `item.mentionedKeys` 传给 Material
+- 新增：
+
+```ts
+private assertNoBlobRefsInBatch(items: SceneComposerBatchItem[]) {
+  for (const item of items) {
+    for (const ref of item.refs ?? []) {
+      if (ref.url?.trim().startsWith('blob:')) {
+        throw new BadRequestException('参考图尚未上传')
+      }
+    }
+  }
+}
+```
+
+在 `points.consume` **之前**、所有权校验之后调用。
+
+- [ ] **Step 1: 测试**
+
+```ts
+it('rejects batch when any item has blob ref before charging', async () => {
+  // owned session
+  // items[0].refs = [{ refKey:'I1', mediaType:'image', url:'blob:x' }]
+  await expect(svc.batchGenerate('u1', dto)).rejects.toBeInstanceOf(BadRequestException)
+  expect(consume).not.toHaveBeenCalled()
+  expect(materialGenerateImage).not.toHaveBeenCalled()
+})
+
+it('passes refs to material with skipCharge', async () => {
+  // item with https I1
+  await svc.batchGenerate('u1', dto)
+  expect(materialGenerateImage).toHaveBeenCalledWith(
+    expect.objectContaining({
+      skipCharge: true,
+      refs: expect.arrayContaining([expect.objectContaining({ refKey: 'I1' })]),
+    }),
+  )
+})
+```
+
+- [ ] **Step 2: 实现 + Run + Commit**
+
+```bash
+pnpm --filter @lnkpi/server test
+git add apps/server/src/canvas/scene-composer.service.ts apps/server/src/canvas/scene-composer.service.test.ts
+git commit -m "feat(server): validate and forward refs in sceneComposer batch"
+```
+
+---
+
+### Task 5: Web — canvas-api + 目标节点 refs 解析
+
+**Files:**
+- Modify: `apps/web/src/services/canvas-api.ts`
+- Modify: `apps/web/src/utils/sceneComposer.ts`
+- Modify: `apps/web/src/utils/sceneComposer.test.ts`
+- Modify: `apps/web/src/composables/useNodeGeneration.ts`
+- Modify: `apps/web/src/composables/useNodeGeneration.test.ts`
+
+**Interfaces:**
+- canvas-api:
+
+```ts
+generateImage(shotId, prompt, opts?: {
+  model?, aspectRatio?, resolution?, count?,
+  refs?: GenerationRefPayload[],
+  mentionedKeys?: string[],
+})
+generateVideo(shotId, prompt, settings?: Partial<VideoSettings> & {
+  model?, refs?, mentionedKeys?,
+})
+```
+
+- `BuildBatchGenerateItemsOptions`:
+
+```ts
+{
+  nodes: EditableFlowNode[]
+  edges: CanvasEdgeLike[]
+  composerNodeId: string
+}
+```
+
+- Helper（可放 sceneComposer.ts 或 useNodeGeneration 旁）:
+
+```ts
+function toGenerationRefs(node, nodes, edges): GenerationRefPayload[]
+// wrap resolveNodeRefs → filter !stale → map {refKey,mediaType,label,text,url}
+```
+
+- [ ] **Step 1: sceneComposer 测试**
+
+```ts
+it('uses media child prompt and refs when expanded', () => {
+  // child has prompt 'child' and edge from text node
+  // expect item.prompt === 'child'
+  // expect item.refs some T1
+})
+
+it('falls back to shot prompt and composer refs when child missing', () => {
+  // no imageNodeId
+  // composer has localRefs/edges → refs from composer
+  // prompt === shot.prompt
+})
+```
+
+- [ ] **Step 2: useNodeGeneration 测试**
+
+```ts
+it('shot-linked image sends media local prompt and refs, not canvasPrompt', async () => {
+  // image linked to shot; image.prompt='local'; upstream text exists
+  // expect canvasApi.generateImage called with 'local' and refs including T*
+  // expect call prompt NOT to equal mergePromptWithUpstream result if different
+})
+
+it('blocks canvas image when blob ref present', async () => {
+  // same as studio blob guard but path is canvasApi
+  expect(canvasApi.generateImage).not.toHaveBeenCalled()
+})
+
+it('generateShot uses shot local prompt with shot refs', async () => { ... })
+```
+
+- [ ] **Step 3: 实现**
+
+1. 扩展 canvas-api body 字段。  
+2. `buildBatchGenerateItems`：按规格 §3.2 选 prompt 目标与 refs 目标；`mentionedKeys = parseRefMentions(finalPrompt)`。  
+3. `generateImageOrVideo` shot-linked：传 `local` + `refs` + `mentionedKeys`（函数已有参数），**不要**传 `canvasPrompt`。  
+4. `generateShot(node, localPrompt, data)`：签名改为 local；内部 `resolveStudioRefs(node,...)` + `parseRefMentions(local)`；调用 canvasApi 带 refs。  
+5. `batchGenerateSceneComposer`：传入 `{ nodes, edges, composerNodeId: node.id }`。  
+6. blob：shot / shot-linked / batch 组装前检查 `hasBlobReference`。
+
+注意：`generateForNode` 里对 shot 调用改为 `generateShot(node, local, data)`，不再传 `canvasPrompt`。`canvasPrompt` 变量若仅 shot 使用可删除该路径的计算；其他路径若仍引用 upstream 展示可保留 `resolveUpstreamContext` 仅作非生成用途（YAGNI：生成路径不用即可）。
+
+- [ ] **Step 4: Run + Commit**
+
+```bash
+pnpm --filter @lnkpi/web test
+git add apps/web
+git commit -m "feat(web): pass target-node refs on canvas generation paths"
+```
+
+---
+
+### Task 6: 全仓验收 + 文档 + PR
+
+**Files:**
+- Modify: `docs/DOCK_STUDIO_E2E_TRACKING.md`
+- Modify: `docs/superpowers/specs/2026-07-19-c21-canvas-refs-design.md`（状态 → 已实现 / 待合入）
+
+- [ ] **Step 1: 全量**
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @lnkpi/server exec prisma generate
+pnpm build
+pnpm test
+```
+
+- [ ] **Step 2: 文档**
+
+在跟踪文档新增 C2.1 小节：范围、目标节点语义、手工清单（规格 §8.3 六条）、后续 C3/C4。
+
+- [ ] **Step 3: Push + PR**
+
+```bash
+git add docs
+git commit -m "docs: mark C2.1 canvas refs ready for review"
+git push -u origin HEAD
+gh pr create --title "feat(canvas): C2.1 旁路接入 T*/I* refs 与 prompt merge" --body "$(cat <<'EOF'
+## Summary
+- Material/shot/sceneComposer 消费 T*/I* refs + mentionedKeys（对齐 Studio merge）
+- 目标节点语义；禁止 canvasPrompt 双重合并
+- Web + Server blob 拦截；merge 不另计费
+- V*/A* 明确留给 C3/C4
+
+## Spec
+docs/superpowers/specs/2026-07-19-c21-canvas-refs-design.md
+
+## Test plan
+- [ ] pnpm build && pnpm test
+- [ ] text→shot 合并文案
+- [ ] image→shot-linked video I*
+- [ ] sceneComposer 已展开/未展开 batch refs
+- [ ] blob Web + API 拒绝
+- [ ] 积分不足 batch 零启动
+EOF
+)"
+```
+
+---
+
+## Spec coverage
+
+| 规格要求 | Task |
+|----------|------|
+| GenerationRefPayload + BatchItem 字段 | T1 |
+| Material merge + I* adapter + blob 扣费前拒绝 | T2 |
+| Controller DTO | T3 |
+| Batch blob 预检 + 透传 | T4 |
+| Web 目标节点解析 + 停用 canvasPrompt | T5 |
+| 验收 + 文档 + PR | T6 |
+| 无 V*/A* / 无共享 resolver / 无另计费 | Global |
+
+## Self-review
+
+- 无 TBD；blob 文案统一 `参考图尚未上传`
+- Material helpers 刻意重复 Studio（规格禁止本轮抽取）
+- Task 5 明确 `generateShot(node, local, data)` 签名变更
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-07-19-c21-canvas-refs.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven（推荐）** — 每任务新 subagent，任务间 review  
+2. **Inline Execution** — 本会话连续执行，设检查点  
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-07-19-c21-canvas-refs-design.md
+++ b/docs/superpowers/specs/2026-07-19-c21-canvas-refs-design.md
@@ -191,7 +191,7 @@ export interface SceneComposerBatchItem {
 
 ### 5.3 `buildBatchGenerateItems`
 
-签名扩展为接收 `nodes` + `edges` + `composerNodeId`（或等价上下文），以便：
+签名扩展为接收 `{ nodes, edges, composerNodeId }`，以便：
 
 - 定位媒体子节点 / composer；
 - 解析目标 refs；

--- a/docs/superpowers/specs/2026-07-19-c21-canvas-refs-design.md
+++ b/docs/superpowers/specs/2026-07-19-c21-canvas-refs-design.md
@@ -1,0 +1,342 @@
+# C2.1 Canvas 旁路接入 T*/I* Refs（产品与技术规格）
+
+> 状态：**设计确认 / 待实现**  
+> 日期：2026-07-19  
+> 范围：**C2.1 最小对齐** — shot、shot-linked image/video、sceneComposer batch 传递并消费 `refs` + `mentionedKeys`；Material 走与 Studio 同款 `mergeRefsToPrompt` + `referenceImages`  
+> 前置：C2 Canvas adapter/计费（PR #27）、C1 Studio 模型适配层（PR #25）、节点数据贯通 refs（2026-07-18）  
+> 后续：**C3 V\*** → **C4 A\***
+
+---
+
+## 0. 决策摘要
+
+| 项 | 结论 |
+| --- | --- |
+| 实现方案 | **Material 增量接入 refs**；不先抽共享 GenerationRefResolver；不经 StudioService |
+| 适用路径 | shot 生成、shot-linked image/video、sceneComposer batch |
+| Prompt 来源 | **目标节点 local prompt**；禁止把 `mergePromptWithUpstream` 长拼接二次喂给 merge |
+| Refs 归属 | **目标节点语义**；不做 composer→shot→child 隐式层级合并 |
+| Batch prompt | 已展开：媒体子节点 prompt 优先，空则 shot prompt；未展开：shot prompt |
+| Batch refs | 已展开：媒体子节点 refs；未展开/子节点缺失：composer 节点 refs |
+| 消费能力 | 仅 **T\*** 文本合并 + **I\*** 图片参考；V\*/A\* 可展示但不消费 |
+| Merge 计费 | 与 Studio 一致：**不另计费**；batch 预检仍只按图/视频单价 |
+| blob | Web 拦截 + Server 扣费前拒绝；允许持久化/外部 HTTPS |
+| URL 归属 | 本轮不做资产归属查库（与 Studio 对齐） |
+| 明确不做 | 共享 resolver 抽取、V\*/A\* 消费、多图 Material、Playwright、GenerationRecord 统一 |
+
+---
+
+## 1. 背景与问题
+
+C2 已使 Canvas 旁路接入 catalog + adapter + 统一计费 + 所有权校验，但生成仍是 **prompt-only**：
+
+```text
+Web → canvasApi({ prompt, model, params })
+  → MaterialService
+  → build*ProviderOptions({ referenceImages: [] })
+```
+
+Studio 独立节点已具备完整链路：
+
+```text
+resolveNodeRefs + parseRefMentions
+  → studioApi({ prompt, refs, mentionedKeys, ... })
+  → resolveMergedPrompt
+  → mergeRefsToPrompt(T*) + extractReferenceImages(I*)
+  → adapter → provider
+```
+
+因此一旦 image/video **连到 shot** 或走 sceneComposer batch，用户在 Dock 上配置的 T*/I* 芯片会静默失效。
+
+另有 **双重合并风险**：Canvas 历史使用 `mergePromptWithUpstream`（简单拼接上游文案）生成 `canvasPrompt`；若再把该结果当 `localPrompt` 送入 `mergeRefsToPrompt`，且同时传 edge T* refs，文本会重复。
+
+---
+
+## 2. 目标与非目标
+
+### 2.1 目标
+
+1. Canvas 三条旁路与 Studio 同款消费 **T\*** / **I\***。
+2. Web 按目标节点语义解析并传递 `refs` + `mentionedKeys`。
+3. Material 使用 `mergeRefsToPrompt` 与 adapter `referenceImages`，替换硬编码空数组。
+4. Prompt 单一来源：local prompt + refs merge；不再二次喂 `canvasPrompt`。
+5. Web + Server 均拦截 `blob:`；扣费前完成校验。
+6. C2 的 adapter、计费、`skipCharge`、所有权、`count=1` 不退化。
+7. 为 C3/C4 预留 V*/A* 展示位，本轮不消费。
+
+### 2.2 非目标
+
+| 能力 | 后续 |
+| --- | --- |
+| 抽共享 `GenerationRefResolver` / Studio 迁移 | 独立清理 PR |
+| V\* 抽帧 / 视频理解 | C3 |
+| A\* ASR / 音色参考 | C4 |
+| 多图 Material 持久化与展示 | 独立能力 |
+| refs URL 必须映射当前用户资产 | 安全加固 |
+| LLM merge 单独计费 | 产品另议 |
+| Playwright E2E | T2 |
+
+---
+
+## 3. 架构与数据流
+
+### 3.1 选择方案 A
+
+```text
+目标节点 local prompt
+  + resolveNodeRefs(target)
+  + parseRefMentions(local)
+        │
+        ▼
+Canvas API / batch item
+  { prompt, refs, mentionedKeys, model/params }
+        │
+        ▼
+MaterialService
+  ├─ ownership
+  ├─ reject blob refs (before charge)
+  ├─ PointsService (unless skipCharge)
+  ├─ resolveMergedPrompt → T* merge + I* urls
+  └─ buildImage/VideoProviderOptions → Provider
+        │
+        ▼
+Material async state + shot polling
+```
+
+不采用：先抽共享编排器、Canvas 调用 StudioService 再同步 Material。
+
+### 3.2 Prompt 与 Refs 解析表
+
+| 路径 | local prompt | refs 来源 | mentionedKeys |
+| --- | --- | --- | --- |
+| 直接 shot 生成 | `shot.data.prompt` | shot 节点 | 从 shot local prompt 解析 |
+| shot-linked image/video | 媒体节点 prompt | 媒体节点 | 从媒体 local prompt 解析 |
+| batch 已展开且有媒体子节点 | 媒体子节点 prompt；空则 shot prompt | 媒体子节点 | 从最终 local prompt 解析 |
+| batch 未展开 / 子节点缺失 | shot prompt | **composer** 节点 | 从最终 local prompt 解析 |
+
+规则：
+
+- 不做 composer + shot + child 三层 refs 隐式合并。
+- Canvas 路径**停止**将 `mergePromptWithUpstream` 结果作为生成 prompt。
+- 上游文本应作为 T* edge refs 进入 merge；上游图片作为 I* edge refs。
+
+---
+
+## 4. API 与共享类型
+
+### 4.1 `GenerationRefPayload`
+
+建议放在 `packages/shared/src/nodeRefs.ts` 并 re-export：
+
+```ts
+export interface GenerationRefPayload {
+  refKey: string
+  mediaType: RefMediaType
+  label?: string
+  text?: string
+  url?: string
+}
+```
+
+Web `StudioRefPayload` 与 Server DTO 对齐该形状（可保留别名）。
+
+### 4.2 Material 请求
+
+`POST material/generate-image` / `generate-video` 增加：
+
+```ts
+refs?: GenerationRefPayload[]
+mentionedKeys?: string[]
+```
+
+其余 C2 字段不变（model、aspectRatio、resolution、duration、crop；image `count` 仍服务端强制 1）。
+
+### 4.3 SceneComposer BatchItem
+
+```ts
+export interface SceneComposerBatchItem {
+  // ...existing C2 fields
+  refs?: GenerationRefPayload[]
+  mentionedKeys?: string[]
+}
+```
+
+每项独立携带；服务端按项 merge，互不影响。
+
+### 4.4 Controller
+
+- 继续从 `req.user.sub` 注入 `userId`。
+- Image/Video/BatchItemDto 增加嵌套 refs 校验：`refKey`、`mediaType` 必填；其余可选。
+- `mentionedKeys` 为可选字符串数组。
+
+---
+
+## 5. Web 行为
+
+### 5.1 公共解析
+
+复用 `resolveNodeRefs`：
+
+1. 选定目标节点（见 §3.2）。
+2. 解析 edge + local refs，过滤 stale。
+3. 映射为 `GenerationRefPayload`。
+4. `mentionedKeys = parseRefMentions(localPrompt)`。
+5. 若 `hasBlobReference(refs, data)` → patch error，不发请求。
+
+### 5.2 `useNodeGeneration` 变更
+
+- `generateShot`：传 shot local prompt + shot refs/mentions + 媒体子节点 model/params（C2 已有）。
+- shot-linked 分支：传媒体节点 local prompt + 其 refs/mentions（不再传 `canvasPrompt`）。
+- `batchGenerateSceneComposer`：`buildBatchGenerateItems` 按 §3.2 填充每项 prompt/refs/mentions。
+
+### 5.3 `buildBatchGenerateItems`
+
+签名扩展为接收 `nodes` + `edges` + `composerNodeId`（或等价上下文），以便：
+
+- 定位媒体子节点 / composer；
+- 解析目标 refs；
+- 计算最终 local prompt。
+
+---
+
+## 6. Material merge 与 provider
+
+### 6.1 私有 `resolveMergedPrompt`
+
+语义对齐 `StudioService.resolveMergedPrompt`：
+
+- T* → `mergeRefsToPrompt({ sources, localPrompt, downstreamType, mentionedKeys, apiKey, baseUrl })`
+- I* → URL 列表（顺序与 refs 一致；仅非空 url）
+- V*/A* 忽略
+- 返回 `{ mergedText, skippedMerge, referenceImages }`
+
+### 6.2 Image
+
+1. 所有权校验 → blob 校验 → 扣费（除非 `skipCharge`）→ 创建 Material。
+2. 异步：`resolveMergedPrompt(..., 'image')`。
+3. `buildImageProviderOptions({ referenceImages, n: 1, ... })`。
+4. 主图：`buildPromptWithRefImage(mergedText, primaryRef)`（有 primary 时）。
+5. 拼接 `effectivePromptSuffix`。
+6. Provider 生成；Material.`prompt` 存 **effectivePrompt**；失败标 `failed`，不退款。
+
+### 6.3 Video
+
+1. 同上前序校验与扣费。
+2. `resolveMergedPrompt(..., 'video')`。
+3. `buildVideoProviderOptions({ referenceImages, ... })`。
+4. `effectivePrompt = [mergedText, built.effectivePromptSuffix].filter(Boolean).join('\n')`。
+5. Provider options 含 `image: built.image`。
+6. Material.`prompt` 存 effectivePrompt。
+
+### 6.4 日志
+
+Material 表不新增列。结构化日志记录：
+
+- `skippedMerge`
+- `refsCount`
+- `referenceImages.length`
+- `event: canvas_blob_ref_rejected`（若触发）
+
+---
+
+## 7. blob、batch 与计费
+
+### 7.1 blob
+
+| 层 | 行为 |
+| --- | --- |
+| Web | 生成前拦截；错误文案与现有一致（参考图尚未上传） |
+| Server | **扣费前**扫描全部 refs 的 `url`；任一以 `blob:` 开头 → `BadRequestException` |
+
+允许：已持久化的相对/绝对业务 URL、`https://` 外链（与 Studio 一致）。
+
+### 7.2 Batch
+
+1. `assertOwnedSession` + 每项 shot 属 session。
+2. 预检全部 item 的 refs（blob）。
+3. 任一项非法 → 整批拒绝，零扣费、零 Material、零 provider。
+4. `sum(itemCredits)` → 一次 `points.consume`。
+5. 各 item `skipCharge: true` + 完整 `refs`/`mentionedKeys`/model params 调用 Material。
+6. 每项独立异步 merge/generate；单项失败不退款、不阻断其他项。
+
+### 7.3 Merge 计费
+
+- LLM merge **不另计费**（与 Studio 一致）。
+- Batch 预检总额仍仅为图 10 + 视频 30/50/70。
+
+---
+
+## 8. 测试策略
+
+### 8.1 Server
+
+- image：T* 进入 merge；I* 进入 `referenceImages`；主图走 `buildPromptWithRefImage`；`n=1`
+- video：I1 → `options.image`；其余图 → prompt suffix
+- blob → 扣费前拒绝，无 Material
+- foreign shot → 404，不扣费
+- `skipCharge: true` 仍 merge，不二次扣费
+- batch：透传 refs；blob 整批零副作用；积分不足零副作用
+
+### 8.2 Web
+
+- shot：local + shot refs；不使用 `canvasPrompt`
+- shot-linked image/video：媒体节点 prompt/refs + model params
+- blob 护栏覆盖 Canvas 路径
+- batch 已展开 / 未展开 的 prompt+refs 规则
+- `mentionedKeys` 来自最终 local prompt
+- Studio 独立路径不回归
+
+### 8.3 全量验收
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @lnkpi/server exec prisma generate
+pnpm build
+pnpm test
+```
+
+手工清单写入 `docs/DOCK_STUDIO_E2E_TRACKING.md`：
+
+1. text → shot → 生成：合并文案进入 Material  
+2. image → shot-linked video：I\* 进入图生视频  
+3. 已展开 sceneComposer：改媒体 prompt/@mention 后 batch 生效  
+4. 未展开 batch：composer 上 T\*/I\* 生效  
+5. blob：Web 拦截；直打 API 也被 Server 拒绝  
+6. 积分不足 batch 零启动  
+
+---
+
+## 9. 验收标准
+
+1. Canvas 三条路径消费 T\*/I\*，行为对齐 Studio merge + adapter。  
+2. 无 `canvasPrompt` 双重合并。  
+3. 目标节点 refs 语义成立；未展开 batch 使用 composer refs。  
+4. Web + Server 拦截 `blob:`。  
+5. Merge 不另计费；C2 计费/`skipCharge`/所有权/`count=1` 不退化。  
+6. V\*/A\* 不消费。  
+7. `pnpm build && pnpm test` 通过。  
+8. 跟踪文档登记 C2.1 状态与 C3/C4 顺序。  
+
+---
+
+## 10. 后续路线
+
+```text
+C2.1 T*/I* refs on Canvas
+  → C3 V* frame extraction / understanding
+  → C4 A* ASR / voice reference
+```
+
+可选并行：抽共享 `resolveMergedPrompt` 清理 Studio/Material 重复（非本 PR 阻塞项）。
+
+---
+
+## 11. 实现交接
+
+规格确认后：
+
+1. `writing-plans` → `docs/superpowers/plans/2026-07-19-c21-canvas-refs.md`  
+2. 分支 `feature/c21-canvas-refs`  
+3. TDD：shared 类型 → Material merge → Controller/DTO → Web 解析 → batch → 全量验收  
+4. Subagent-Driven 或 Inline 执行  
+5. 独立 PR，CI 绿后 Squash & Merge  

--- a/docs/superpowers/specs/2026-07-19-c21-canvas-refs-design.md
+++ b/docs/superpowers/specs/2026-07-19-c21-canvas-refs-design.md
@@ -1,6 +1,6 @@
 # C2.1 Canvas 旁路接入 T*/I* Refs（产品与技术规格）
 
-> 状态：**设计确认 / 待实现**  
+> 状态：**已实现 / 待合入**  
 > 日期：2026-07-19  
 > 范围：**C2.1 最小对齐** — shot、shot-linked image/video、sceneComposer batch 传递并消费 `refs` + `mentionedKeys`；Material 走与 Studio 同款 `mergeRefsToPrompt` + `referenceImages`  
 > 前置：C2 Canvas adapter/计费（PR #27）、C1 Studio 模型适配层（PR #25）、节点数据贯通 refs（2026-07-18）  

--- a/packages/shared/src/nodeRefs.generation.test.ts
+++ b/packages/shared/src/nodeRefs.generation.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import type { GenerationRefPayload } from './nodeRefs'
+
+describe('GenerationRefPayload', () => {
+  it('accepts T* and I* shapes', () => {
+    const refs: GenerationRefPayload[] = [
+      { refKey: 'T1', mediaType: 'text', text: 'hello' },
+      { refKey: 'I1', mediaType: 'image', url: 'https://example.com/a.png' },
+    ]
+    expect(refs).toHaveLength(2)
+  })
+})

--- a/packages/shared/src/nodeRefs.ts
+++ b/packages/shared/src/nodeRefs.ts
@@ -211,3 +211,11 @@ export function resolveNodeRefs(input: ResolveNodeRefsInput): NodeRef[] {
 
   return assignRefKeys(applyRefOrder(visible, input.refOrder))
 }
+
+export interface GenerationRefPayload {
+  refKey: string
+  mediaType: RefMediaType
+  label?: string
+  text?: string
+  url?: string
+}

--- a/packages/shared/src/sceneComposer.ts
+++ b/packages/shared/src/sceneComposer.ts
@@ -1,5 +1,7 @@
 /** 导演台 sceneComposer 节点编排数据结构（D-2） */
 
+import type { GenerationRefPayload } from './nodeRefs'
+
 export type SceneComposerShotMediaType = 'image' | 'video' | 'none'
 
 export interface SceneComposerShot {
@@ -42,6 +44,8 @@ export interface SceneComposerBatchItem {
   duration?: 5 | 10 | 15
   crop?: string
   count?: number
+  refs?: GenerationRefPayload[]
+  mentionedKeys?: string[]
 }
 
 export interface SceneComposerSaveRequest {


### PR DESCRIPTION
## Summary
- Material/shot/sceneComposer 消费 T*/I* refs + mentionedKeys（对齐 Studio merge）
- 目标节点语义；禁止 canvasPrompt 双重合并
- Web + Server blob 拦截；merge 不另计费
- V*/A* 明确留给 C3/C4

## Spec
docs/superpowers/specs/2026-07-19-c21-canvas-refs-design.md

## Test plan
- [ ] pnpm build && pnpm test
- [ ] text→shot 合并文案
- [ ] image→shot-linked video I*
- [ ] sceneComposer 已展开/未展开 batch refs
- [ ] blob Web + API 拒绝
- [ ] 积分不足 batch 零启动

Made with [Cursor](https://cursor.com)