### PR TITLE
fix(canvas): 渠道模型能力标注与多节点并行生成

### DIFF
--- a/apps/server/src/provider/provider.service.test.ts
+++ b/apps/server/src/provider/provider.service.test.ts
@@ -342,6 +342,37 @@ describe('ProviderService', () => {
     )
   })
 
+  it('pullModels infers capability and preserves prior tags', async () => {
+    const ch = await svc.createChannel('u1', {
+      name: 'pull-cap',
+      apiFormat: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      apiKey: 'sk-test',
+      models: [{ name: 'custom-img', capability: 'image' }],
+    })
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      json: async () => ({
+        data: [
+          { id: 'custom-img' },
+          { id: 'dall-e-3' },
+          { id: 'gpt-4o' },
+          { id: 'kling-v2' },
+        ],
+      }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const updated = await svc.pullModels('u1', ch.id)
+    const byName = Object.fromEntries(updated.models.map((m) => [m.name, m.capability]))
+    expect(byName['custom-img']).toBe('image')
+    expect(byName['dall-e-3']).toBe('image')
+    expect(byName['gpt-4o']).toBe('text')
+    expect(byName['kling-v2']).toBe('video')
+  })
+
   it('rejects intranet WebDAV URL on update and test', async () => {
     await expect(
       svc.updateWebdav('u1', { url: 'https://10.0.0.5/webdav' }),

--- a/apps/server/src/provider/provider.service.ts
+++ b/apps/server/src/provider/provider.service.ts
@@ -9,6 +9,7 @@ import {
   STUDIO_MODEL_CATALOG,
   defaultModelKey,
   encodeChannelModel,
+  resolvePulledModelCapability,
   type ApiCallFormat,
   type ModelCapability,
   type StudioModality,
@@ -337,10 +338,23 @@ export class ProviderService {
     }
 
     const body = (await response.json()) as { data?: Array<{ id?: string }> }
+    const previousByName: Record<string, ModelCapability> = {}
+    try {
+      const existing = JSON.parse(channel.models || '[]') as ChannelModelEntry[]
+      for (const entry of existing) {
+        if (entry?.name && entry.capability) previousByName[entry.name] = entry.capability
+      }
+    } catch {
+      // ignore malformed stored models
+    }
+
     const models: ChannelModelEntry[] = (body.data ?? [])
       .map((item) => item.id)
       .filter((name): name is string => typeof name === 'string' && name.length > 0)
-      .map((name) => ({ name, capability: 'text' as ModelCapability }))
+      .map((name) => ({
+        name,
+        capability: resolvePulledModelCapability(name, previousByName),
+      }))
 
     const row = await this.prisma.providerChannel.update({
       where: { id: channel.id },

--- a/apps/web/src/components/canvas/ProviderConfigDialog.vue
+++ b/apps/web/src/components/canvas/ProviderConfigDialog.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from 'vue'
 import { ElMessage } from 'element-plus'
-import { encodeChannelModel, type ApiCallFormat, type ModelCapability } from '@lnkpi/shared'
+import { encodeChannelModel, decodeChannelModel, inferModelCapability, type ApiCallFormat, type ModelCapability } from '@lnkpi/shared'
 import { useProviderBootstrap } from '@/composables/useProviderBootstrap'
 import {
   apiErrorMessage,
@@ -214,7 +214,30 @@ const modelOptionPool = computed(() => {
 })
 
 function optionsForCapability(capability: ModelCapability) {
-  return modelOptionPool.value.filter((o) => o.capability === capability)
+  // User channels may list OpenAI-compatible ids without reliable modality;
+  // include every non-platform model in all groups so they can be opted-in.
+  // Platform models stay filtered by capability.
+  return modelOptionPool.value.filter((o) => {
+    if (o.capability === capability) return true
+    const decoded = decodeChannelModel(o.value)
+    return Boolean(decoded && decoded.channelId !== 'platform')
+  })
+}
+
+function setModelCapability(draft: ChannelDraft, name: string, capability: ModelCapability) {
+  draft.modelMeta[name] = capability
+}
+
+function onModelNamesChange(draft: ChannelDraft, names: string[]) {
+  draft.modelNames = names
+  for (const name of names) {
+    if (!draft.modelMeta[name]) {
+      draft.modelMeta[name] = inferModelCapability(name)
+    }
+  }
+  for (const key of Object.keys(draft.modelMeta)) {
+    if (!names.includes(key)) delete draft.modelMeta[key]
+  }
 }
 
 function labelForModelValue(value: string) {
@@ -561,7 +584,7 @@ function apiKeyPlaceholder(draft: ChannelDraft) {
                 <label class="block md:col-span-2">
                   <span class="mb-1 block text-[11px] text-white/50">模型列表</span>
                   <el-select
-                    v-model="draft.modelNames"
+                    :model-value="draft.modelNames"
                     class="w-full"
                     multiple
                     filterable
@@ -569,7 +592,34 @@ function apiKeyPlaceholder(draft: ChannelDraft) {
                     default-first-option
                     :disabled="draft.readOnly"
                     placeholder="输入模型名，或点击拉取模型"
+                    @update:model-value="onModelNamesChange(draft, $event)"
                   />
+                  <div
+                    v-if="draft.modelNames.length && !draft.readOnly"
+                    class="mt-2 flex flex-wrap gap-2"
+                  >
+                    <div
+                      v-for="name in draft.modelNames"
+                      :key="name"
+                      class="flex items-center gap-1.5 rounded-md border border-white/10 bg-white/[0.03] px-2 py-1"
+                    >
+                      <span class="max-w-[140px] truncate text-[11px] text-white/75">{{ name }}</span>
+                      <el-select
+                        :model-value="draft.modelMeta[name] ?? 'text'"
+                        size="small"
+                        class="!w-[88px]"
+                        @update:model-value="setModelCapability(draft, name, $event)"
+                      >
+                        <el-option label="文本" value="text" />
+                        <el-option label="图像" value="image" />
+                        <el-option label="视频" value="video" />
+                        <el-option label="音频" value="audio" />
+                      </el-select>
+                    </div>
+                  </div>
+                  <p class="mt-1.5 text-[10px] leading-4 text-white/35">
+                    能力标签决定模型优先出现在哪一类可选项；自定义渠道模型也可在任意类型中勾选。
+                  </p>
                 </label>
               </div>
             </section>
@@ -582,6 +632,7 @@ function apiKeyPlaceholder(draft: ChannelDraft) {
             <div class="text-sm font-semibold text-white">默认模型和可选项</div>
             <div class="mt-1 text-xs leading-5 text-white/45">
               可选项决定各处下拉框展示哪些模型；同名模型会以括号里的渠道名区分。
+              自定义渠道模型会出现在全部类型的候选列表中，便于勾选到图像/视频/音频。
             </div>
           </div>
 

--- a/apps/web/src/components/canvas/dock-studio/shared/DockGenerateButton.vue
+++ b/apps/web/src/components/canvas/dock-studio/shared/DockGenerateButton.vue
@@ -13,9 +13,10 @@ const emit = defineEmits<{
   <button
     type="button"
     class="dock-generate-btn"
-    :disabled="disabled || generating"
-    :title="generating ? '生成中...' : '生成'"
-    aria-label="生成"
+    :class="{ 'is-generating': generating }"
+    :disabled="disabled"
+    :title="generating ? '点击取消生成' : '生成'"
+    :aria-label="generating ? '取消生成' : '生成'"
     @click="emit('generate')"
   >
     <svg
@@ -74,6 +75,15 @@ const emit = defineEmits<{
 .dock-generate-btn:disabled {
   cursor: not-allowed;
   opacity: 0.4;
+}
+
+.dock-generate-btn.is-generating {
+  background: #111;
+  color: #fff;
+}
+
+.dock-generate-btn.is-generating:hover:not(:disabled) {
+  background: #333;
 }
 
 .dock-generate-btn__spinner {

--- a/apps/web/src/composables/useGenerationPolling.ts
+++ b/apps/web/src/composables/useGenerationPolling.ts
@@ -50,6 +50,13 @@ export function useGenerationPolling(
     }, 2000)
   }
 
+  function removeByNodeId(nodeId: string) {
+    const next = tasks.value.filter((t) => t.nodeId !== nodeId)
+    if (next.length === tasks.value.length) return
+    tasks.value = next
+    if (!next.length) stop()
+  }
+
   function stop() {
     if (timer.value) clearInterval(timer.value)
     timer.value = undefined
@@ -62,7 +69,7 @@ export function useGenerationPolling(
 
   onUnmounted(stop)
 
-  return { start, stop, clearTasks }
+  return { start, stop, clearTasks, removeByNodeId }
 }
 
 export function parseRecordPromptContent(record: { metadata?: string | null; prompt: string }) {

--- a/apps/web/src/composables/useNodeGeneration.test.ts
+++ b/apps/web/src/composables/useNodeGeneration.test.ts
@@ -132,6 +132,7 @@ describe('useNodeGeneration', () => {
       },
       [],
       [],
+      expect.any(AbortSignal),
     )
   })
 
@@ -155,6 +156,7 @@ describe('useNodeGeneration', () => {
       [],
       '2K',
       3,
+      expect.any(AbortSignal),
     )
   })
 
@@ -178,6 +180,7 @@ describe('useNodeGeneration', () => {
       [],
       '1K',
       1,
+      expect.any(AbortSignal),
     )
   })
 
@@ -202,6 +205,7 @@ describe('useNodeGeneration', () => {
       [],
       '2K',
       1,
+      expect.any(AbortSignal),
     )
   })
 
@@ -527,6 +531,83 @@ describe('useNodeGeneration', () => {
     expect(deps.startShotPolling).toHaveBeenCalledWith(['shot-1'])
   })
 
+  it('allows parallel generation on two nodes', async () => {
+    let resolveA!: (v: unknown) => void
+    let resolveB!: (v: unknown) => void
+    const hangA = new Promise((r) => {
+      resolveA = r
+    })
+    const hangB = new Promise((r) => {
+      resolveB = r
+    })
+    vi.mocked(studioApi.generateImage)
+      .mockImplementationOnce(() => hangA as never)
+      .mockImplementationOnce(() => hangB as never)
+
+    const nodeA = createNode('image', { prompt: 'a' }, 'img-a')
+    const nodeB = createNode('image', { prompt: 'b' }, 'img-b')
+    const { api, deps } = createDeps([nodeA, nodeB])
+
+    const pA = api.generateForNode(nodeA)
+    const pB = api.generateForNode(nodeB)
+
+    await Promise.resolve()
+    expect(api.isNodeBusy('img-a')).toBe(true)
+    expect(api.isNodeBusy('img-b')).toBe(true)
+    expect(deps.patchNodeData).toHaveBeenCalledWith(
+      'img-a',
+      expect.objectContaining({ status: NODE_GENERATION_STATUS.generating }),
+    )
+    expect(deps.patchNodeData).toHaveBeenCalledWith(
+      'img-b',
+      expect.objectContaining({ status: NODE_GENERATION_STATUS.generating }),
+    )
+
+    resolveA(mockAxiosResponse({ data: { ...completedRecord, id: 'rec-a' } }))
+    resolveB(mockAxiosResponse({ data: { ...completedRecord, id: 'rec-b' } }))
+    await Promise.all([pA, pB])
+    expect(api.isNodeBusy('img-a')).toBe(false)
+    expect(api.isNodeBusy('img-b')).toBe(false)
+  })
+
+  it('second generate click cancels in-flight generation', async () => {
+    let rejectHang!: (err: unknown) => void
+    const hang = new Promise((_resolve, reject) => {
+      rejectHang = reject
+    })
+    vi.mocked(studioApi.generateImage).mockImplementation(
+      (_prompt, _model, _aspect, _refs, _keys, _res, _count, signal?: AbortSignal) => {
+        if (signal) {
+          signal.addEventListener('abort', () => {
+            const err = new Error('canceled')
+            ;(err as { code?: string }).code = 'ERR_CANCELED'
+            rejectHang(err)
+          })
+        }
+        return hang as never
+      },
+    )
+
+    const node = createNode('image', { prompt: 'cancel-me' }, 'img-1')
+    const { api, deps } = createDeps([node])
+
+    const pending = api.generateForNode(node)
+    await Promise.resolve()
+    expect(api.isNodeBusy('img-1')).toBe(true)
+
+    await api.generateForNode(node)
+    await pending
+
+    expect(api.isNodeBusy('img-1')).toBe(false)
+    expect(deps.patchNodeData).toHaveBeenCalledWith(
+      'img-1',
+      expect.objectContaining({
+        status: NODE_GENERATION_STATUS.draft,
+        errorMessage: null,
+      }),
+    )
+  })
+
   it('uses catalog defaults for generateShot when media child is missing', async () => {
     const shot = createNode('shot', { title: 'Shot', prompt: 'fallback', shotGenerateMode: 'image' }, 'shot-1')
     const { api } = createDeps([shot])
@@ -565,6 +646,7 @@ describe('useNodeGeneration', () => {
       [],
       '2K',
       2,
+      expect.any(AbortSignal),
     )
     expect(canvasApi.generateImage).not.toHaveBeenCalled()
   })

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -1,7 +1,7 @@
 import { ref, type Ref } from 'vue'
 import type { VideoSettings } from '@lnkpi/shared'
 import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
-import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
+import { NODE_GENERATION_STATUS, isNodeGenerating } from '@/constants/dockStudio'
 import { DEFAULT_AUDIO_VOICE } from '@/constants/dockAudio'
 import {
   mergeReferenceImageUrl,
@@ -54,6 +54,7 @@ export interface NodeGenerationDeps {
   requireLogin: () => boolean
   startShotPolling: (shotIds: string[]) => void
   startGenerationPolling: (tasks: GenerationPollTask[]) => void
+  stopGenerationPolling?: (nodeId: string) => void
   resolveProviderModels: () => { image: string; video: string; text: string }
   requestFallbackConfirm?: (req: FallbackPendingRequest) => Promise<FallbackConfirmDecision>
   isModelSelectable?: (modality: StudioModality, model: string) => boolean
@@ -168,8 +169,72 @@ function modelFieldForModality(modality: StudioModality): string {
   return 'textModel'
 }
 
+function isAbortError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const e = err as { code?: string; name?: string; message?: string }
+  return e.code === 'ERR_CANCELED' || e.name === 'CanceledError' || e.name === 'AbortError'
+}
+
 export function useNodeGeneration(deps: NodeGenerationDeps) {
+  const busyNodeIds = ref(new Set<string>())
+  const abortByNodeId = new Map<string, AbortController>()
+
+  function isNodeBusy(nodeId: string): boolean {
+    return busyNodeIds.value.has(nodeId)
+  }
+
+  function markBusy(nodeId: string) {
+    const next = new Set(busyNodeIds.value)
+    next.add(nodeId)
+    busyNodeIds.value = next
+  }
+
+  function markIdle(nodeId: string) {
+    if (!busyNodeIds.value.has(nodeId)) return
+    const next = new Set(busyNodeIds.value)
+    next.delete(nodeId)
+    busyNodeIds.value = next
+  }
+
+  /** True when any node is mid-request (legacy aggregate; prefer isNodeBusy). */
   const generating = ref(false)
+  function syncGeneratingFlag() {
+    generating.value = busyNodeIds.value.size > 0
+  }
+
+  function cancelGeneration(nodeId: string) {
+    const ac = abortByNodeId.get(nodeId)
+    if (ac) {
+      ac.abort()
+      abortByNodeId.delete(nodeId)
+    }
+    deps.stopGenerationPolling?.(nodeId)
+    markIdle(nodeId)
+    syncGeneratingFlag()
+    deps.patchNodeData(nodeId, {
+      status: NODE_GENERATION_STATUS.draft,
+      errorMessage: null,
+    })
+  }
+
+  function beginNodeWork(nodeId: string): AbortSignal {
+    const existing = abortByNodeId.get(nodeId)
+    if (existing) existing.abort()
+    const ac = new AbortController()
+    abortByNodeId.set(nodeId, ac)
+    markBusy(nodeId)
+    syncGeneratingFlag()
+    return ac.signal
+  }
+
+  function endNodeWork(nodeId: string, signal?: AbortSignal) {
+    const ac = abortByNodeId.get(nodeId)
+    if (ac && (!signal || ac.signal === signal)) {
+      abortByNodeId.delete(nodeId)
+    }
+    markIdle(nodeId)
+    syncGeneratingFlag()
+  }
 
   async function handleStudioFallback(nodeId: string, record: GenerationRecord): Promise<boolean> {
     if (record.status !== NODE_GENERATION_STATUS.fallback_pending) return false
@@ -270,6 +335,11 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
   }
 
   async function generateForNode(node: EditableFlowNode) {
+    if (isNodeBusy(node.id) || isNodeGenerating(node.data?.status)) {
+      cancelGeneration(node.id)
+      return
+    }
+
     const data = node.data ?? {}
     const nodeType = String(node.type)
     const upstream = resolveUpstreamContext(node.id, deps.nodes.value, deps.edges.value)
@@ -298,7 +368,7 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       if (!assertModelSelectable(node, modality, model)) return
     }
 
-    generating.value = true
+    const signal = beginNodeWork(node.id)
 
     try {
       if (nodeType === 'prompt') {
@@ -306,7 +376,9 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
         const { data: res } = await studioApi.generatePrompt(
           local,
           resolveGenerationModel('text', data.textModel as string | undefined),
+          signal,
         )
+        if (signal.aborted) return
         await resolveStudioRecord(node.id, res.data)
         return
       }
@@ -318,7 +390,9 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
           resolveGenerationModel('text', data.textModel as string | undefined),
           refs,
           mentionedKeys,
+          signal,
         )
+        if (signal.aborted) return
         await resolveStudioRecord(node.id, res.data)
         return
       }
@@ -333,7 +407,8 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
           speed: typeof data.audioSpeed === 'number' ? data.audioSpeed : 1,
           volume: typeof data.audioVolume === 'number' ? data.audioVolume : 1,
           pitch: typeof data.audioPitch === 'number' ? data.audioPitch : 0,
-        }, refs, mentionedKeys)
+        }, refs, mentionedKeys, signal)
+        if (signal.aborted) return
         await resolveStudioRecord(node.id, res.data)
         return
       }
@@ -344,7 +419,7 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       }
 
       if (nodeType === 'image' || nodeType === 'video') {
-        await generateImageOrVideo(node, local, data, upstream, refs, mentionedKeys)
+        await generateImageOrVideo(node, local, data, upstream, refs, mentionedKeys, signal)
         return
       }
 
@@ -352,13 +427,14 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
         await generateShot(node, local, data)
       }
     } catch (err) {
+      if (isAbortError(err) || signal.aborted) return
       console.error('[NodeGeneration]', nodeType, err)
       deps.patchNodeData(node.id, {
         status: NODE_GENERATION_STATUS.error,
         errorMessage: err instanceof Error ? err.message : '生成失败',
       })
     } finally {
-      generating.value = false
+      endNodeWork(node.id, signal)
     }
   }
 
@@ -369,6 +445,7 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     upstream: ReturnType<typeof resolveUpstreamContext>,
     refs: StudioRefPayload[],
     mentionedKeys: string[],
+    signal?: AbortSignal,
   ) {
     const nodeType = String(node.type)
     const linkedShotEdge = findIncomingEdge(deps.edges.value, node.id)
@@ -406,7 +483,9 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
         mentionedKeys,
         resolution,
         count,
+        signal,
       )
+      if (signal?.aborted) return
       deps.patchNodeData(node.id, {
         referenceImageUrl: refImage || undefined,
         imageResolution: resolution,
@@ -427,7 +506,9 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       mentionedKeys,
       settings?.resolution,
       settings?.crop,
+      signal,
     )
+    if (signal?.aborted) return
     deps.patchNodeData(node.id, {
       referenceImageUrl: refImage || undefined,
       generationRecordId: res.data.id,
@@ -556,7 +637,11 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
 
   async function expandSceneComposer(node: EditableFlowNode) {
     if (!deps.requireLogin()) return
-    generating.value = true
+    if (isNodeBusy(node.id)) {
+      cancelGeneration(node.id)
+      return
+    }
+    const signal = beginNodeWork(node.id)
     try {
       const current = readSceneComposerFromNode(node)
       const models = deps.resolveProviderModels()
@@ -577,16 +662,21 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
         scenes: expanded.scenes,
       })
       await deps.saveCanvas()
-    } catch {
+    } catch (err) {
+      if (isAbortError(err) || signal.aborted) return
       deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.error })
     } finally {
-      generating.value = false
+      endNodeWork(node.id, signal)
     }
   }
 
   async function batchGenerateSceneComposer(node: EditableFlowNode) {
     if (!deps.requireLogin()) return
-    generating.value = true
+    if (isNodeBusy(node.id) || isNodeGenerating(node.data?.status)) {
+      cancelGeneration(node.id)
+      return
+    }
+    const signal = beginNodeWork(node.id)
     try {
       const payload = readSceneComposerFromNode(node)
       const items = buildBatchGenerateItems(payload, {
@@ -620,20 +710,25 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       deps.startShotPolling(items.map((item) => item.shotNodeId))
       deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating })
       await deps.saveCanvas()
-    } catch {
+    } catch (err) {
+      if (isAbortError(err) || signal.aborted) return
       deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.error })
     } finally {
-      generating.value = false
+      endNodeWork(node.id, signal)
     }
   }
 
   async function exportVideoComposition(node: EditableFlowNode, tracks: CompositionTrack[]) {
     if (!deps.requireLogin()) return
+    if (isNodeBusy(node.id) || isNodeGenerating(node.data?.status)) {
+      cancelGeneration(node.id)
+      return
+    }
     const ordered = applyTrackOrder(tracks, node.data?.trackOrder as string[] | undefined)
     const exportTracks = ordered.filter((track) => track.url.trim())
     if (!exportTracks.length) return
 
-    generating.value = true
+    const signal = beginNodeWork(node.id)
     try {
       deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating })
       const { data: res } = await canvasApi.exportVideoComposition({
@@ -649,6 +744,7 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
           startSec: track.startSec,
         })),
       })
+      if (signal.aborted) return
       const result = res.data as { url: string; durationSec: number }
       deps.patchNodeData(node.id, {
         url: result.url,
@@ -657,15 +753,18 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
         exportedAt: new Date().toISOString(),
       })
       await deps.saveCanvas()
-    } catch {
+    } catch (err) {
+      if (isAbortError(err) || signal.aborted) return
       deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.error })
     } finally {
-      generating.value = false
+      endNodeWork(node.id, signal)
     }
   }
 
   return {
     generating,
+    isNodeBusy,
+    cancelGeneration,
     generateForNode,
     saveSceneComposer,
     expandSceneComposer,

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -33,7 +33,7 @@ import { createInitialSceneComposerNodeData } from '@/utils/sceneComposer'
 import { resolveCompositionTracks, mergeCompositionTracks, compositionTracksToNodePatch } from '@/utils/compositionUpstream'
 import { resolveUpstreamContext } from '@/composables/useUpstreamNodeContext'
 import { resolveNodeRefs, type LocalRefBinding, type NodeRef } from '@/composables/useNodeRefs'
-import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
+import { NODE_GENERATION_STATUS, isNodeGenerating } from '@/constants/dockStudio'
 import CanvasNodePrompt from '@/components/canvas/CanvasNodePrompt.vue'
 import CanvasNodeImage from '@/components/canvas/CanvasNodeImage.vue'
 import CanvasNodeVideo from '@/components/canvas/CanvasNodeVideo.vue'
@@ -1602,7 +1602,7 @@ async function saveCanvas() {
 }
 
 const {
-  generating: nodeGenerating,
+  isNodeBusy,
   generateForNode,
   saveSceneComposer,
   expandSceneComposer,
@@ -1626,6 +1626,7 @@ const {
   },
   startShotPolling: (ids) => shotPolling.start(ids),
   startGenerationPolling: (tasks) => generationPolling.start(tasks),
+  stopGenerationPolling: (nodeId) => generationPolling.removeByNodeId(nodeId),
   resolveProviderModels: () => ({
     text: getProviderConfig('text').model,
     image: getProviderConfig('image').model,
@@ -1633,6 +1634,12 @@ const {
   }),
   requestFallbackConfirm,
   isModelSelectable,
+})
+
+const selectedNodeGenerating = computed(() => {
+  const node = editorNode.value
+  if (!node) return false
+  return isNodeBusy(node.id) || isNodeGenerating(node.data?.status)
 })
 
 onFallbackPendingFromPoll = onFallbackPending
@@ -1895,7 +1902,7 @@ onMounted(() => {
           :refs="selectedRefs"
           :composition-tracks="editorCompositionTracks"
           :mentions="mentionOptions"
-          :generating="nodeGenerating"
+          :generating="selectedNodeGenerating"
           :scale="viewportSettings.bottomToolbarScale"
           @patch="patchSelectedNode"
           @remove-ref="handleRemoveRef"

--- a/apps/web/src/services/studio-api.ts
+++ b/apps/web/src/services/studio-api.ts
@@ -37,22 +37,23 @@ export const studioApi = {
     mentionedKeys?: string[],
     resolution?: string,
     count?: number,
+    signal?: AbortSignal,
   ) =>
     api.post<{ data: GenerationRecord }>(
       '/studio/image/generate',
       { prompt, model, aspectRatio, refs, mentionedKeys, resolution, count },
-      { timeout: 120_000 },
+      { timeout: 120_000, signal },
     ),
-  generateImageVariation: (prompt: string, basePrompt?: string, model?: string) =>
-    api.post<{ data: GenerationRecord }>('/studio/image/variation', { prompt, basePrompt, model }, { timeout: 120_000 }),
-  generateText: (prompt: string, model?: string, refs?: StudioRefPayload[], mentionedKeys?: string[]) =>
+  generateImageVariation: (prompt: string, basePrompt?: string, model?: string, signal?: AbortSignal) =>
+    api.post<{ data: GenerationRecord }>('/studio/image/variation', { prompt, basePrompt, model }, { timeout: 120_000, signal }),
+  generateText: (prompt: string, model?: string, refs?: StudioRefPayload[], mentionedKeys?: string[], signal?: AbortSignal) =>
     api.post<{ data: GenerationRecord }>(
       '/studio/text/generate',
       { prompt, model, refs, mentionedKeys },
-      { timeout: 90_000 },
+      { timeout: 90_000, signal },
     ),
-  generatePrompt: (prompt: string, model?: string) =>
-    api.post<{ data: GenerationRecord }>('/studio/prompt/generate', { prompt, model }, { timeout: 90_000 }),
+  generatePrompt: (prompt: string, model?: string, signal?: AbortSignal) =>
+    api.post<{ data: GenerationRecord }>('/studio/prompt/generate', { prompt, model }, { timeout: 90_000, signal }),
   generateVideo: (
     prompt: string,
     model?: string,
@@ -62,17 +63,18 @@ export const studioApi = {
     mentionedKeys?: string[],
     resolution?: string,
     crop?: string,
+    signal?: AbortSignal,
   ) =>
     api.post<{ data: GenerationRecord }>(
       '/studio/video/generate',
       { prompt, model, duration, aspectRatio, refs, mentionedKeys, resolution, crop },
-      { timeout: 60_000 },
+      { timeout: 60_000, signal },
     ),
-  generateAudio: (text: string, options?: AudioGenerateOptions, refs?: StudioRefPayload[], mentionedKeys?: string[]) =>
+  generateAudio: (text: string, options?: AudioGenerateOptions, refs?: StudioRefPayload[], mentionedKeys?: string[], signal?: AbortSignal) =>
     api.post<{ data: GenerationRecord & { url?: string } }>(
       '/studio/audio/generate',
       { text, ...options, refs, mentionedKeys },
-      { timeout: 60_000 },
+      { timeout: 60_000, signal },
     ),
   confirmPlatformFallback: (id: string) =>
     api.post<{ data: GenerationRecord }>(`/studio/generations/${id}/confirm-platform-fallback`, {}, {

--- a/apps/web/src/styles/neo-node.css
+++ b/apps/web/src/styles/neo-node.css
@@ -77,8 +77,11 @@
 }
 
 .neo-node-status.running {
+  width: 8px;
+  height: 8px;
   background: #3b82f6;
-  animation: neo-node-pulse 1.5s ease-in-out infinite;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.28);
+  animation: neo-node-pulse 1.2s ease-in-out infinite;
 }
 
 .neo-node-status.success {
@@ -637,12 +640,12 @@
   opacity: 0.88;
 }
 
-.bottom-toolbar-container.is-dock-readonly .bottom-toolbar-actions :not(.bottom-toolbar-close) {
+.dock-studio-toolbar.is-dock-locked .bottom-toolbar-actions button:not(.bottom-toolbar-close):not(.dock-generate-btn) {
   pointer-events: none;
   opacity: 0.55;
 }
 
-.dock-studio-toolbar.is-dock-locked .bottom-toolbar-actions button:not(.bottom-toolbar-close) {
+.bottom-toolbar-container.is-dock-readonly .bottom-toolbar-actions :not(.bottom-toolbar-close):not(.dock-generate-btn) {
   pointer-events: none;
   opacity: 0.55;
 }

--- a/packages/shared/src/providerChannels.test.ts
+++ b/packages/shared/src/providerChannels.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { encodeChannelModel, decodeChannelModel, modelOptionName } from './providerChannels'
+import {
+  encodeChannelModel,
+  decodeChannelModel,
+  modelOptionName,
+  inferModelCapability,
+  resolvePulledModelCapability,
+} from './providerChannels'
 
 describe('providerChannels', () => {
   it('round-trips channel::model', () => {
@@ -12,5 +18,25 @@ describe('providerChannels', () => {
   it('returns null for legacy bare model keys', () => {
     expect(decodeChannelModel('seedream-5.0-pro')).toBeNull()
     expect(modelOptionName('seedream-5.0-pro')).toBe('seedream-5.0-pro')
+  })
+
+  it('infers modality from common model name patterns', () => {
+    expect(inferModelCapability('dall-e-3')).toBe('image')
+    expect(inferModelCapability('flux-kontext-pro')).toBe('image')
+    expect(inferModelCapability('seedream-5.0-pro')).toBe('image')
+    expect(inferModelCapability('kling-v2')).toBe('video')
+    expect(inferModelCapability('seedance-1.0')).toBe('video')
+    expect(inferModelCapability('sora-2')).toBe('video')
+    expect(inferModelCapability('whisper-1')).toBe('audio')
+    expect(inferModelCapability('tts-1-hd')).toBe('audio')
+    expect(inferModelCapability('gpt-4o')).toBe('text')
+  })
+
+  it('preserves previously tagged capability when re-pulling models', () => {
+    expect(
+      resolvePulledModelCapability('my-custom-img', { 'my-custom-img': 'image' }),
+    ).toBe('image')
+    expect(resolvePulledModelCapability('brand-new-model', {})).toBe('text')
+    expect(resolvePulledModelCapability('dall-e-3', {})).toBe('image')
   })
 })

--- a/packages/shared/src/providerChannels.ts
+++ b/packages/shared/src/providerChannels.ts
@@ -26,3 +26,31 @@ export function modelOptionName(value: string): string {
   const decoded = decodeChannelModel(value)
   return decoded?.modelName ?? value
 }
+
+const IMAGE_MODEL_RE =
+  /(dall-?e|flux|seedream|imagen|midjourney|stable-?diffusion|sdxl|gpt-image|ideogram|recraft|banana)/i
+const VIDEO_MODEL_RE =
+  /(kling|seedance|sora|runway|luma|pika|hailuo|vidu|veo|wan2|cogvideo|happyhose)/i
+const AUDIO_MODEL_RE = /(whisper|tts|audio|suno|fish-speech|cosyvoice|speech|voice)/i
+
+/** Best-effort modality guess from OpenAI-compatible model ids (no modality in /models). */
+export function inferModelCapability(modelName: string): ModelCapability {
+  const name = modelName.trim()
+  if (!name) return 'text'
+  if (IMAGE_MODEL_RE.test(name)) return 'image'
+  if (VIDEO_MODEL_RE.test(name)) return 'video'
+  if (AUDIO_MODEL_RE.test(name)) return 'audio'
+  return 'text'
+}
+
+/**
+ * When re-pulling models: keep user/previous tags, else infer from name, else text.
+ */
+export function resolvePulledModelCapability(
+  modelName: string,
+  previousByName: Record<string, ModelCapability>,
+): ModelCapability {
+  const prev = previousByName[modelName]
+  if (prev === 'text' || prev === 'image' || prev === 'video' || prev === 'audio') return prev
+  return inferModelCapability(modelName)
+}


### PR DESCRIPTION
## Summary
- 拉取渠道模型时按名称推断 modality，并保留用户已标注的 capability；配置弹窗可为每个模型设置能力标签
- 自定义渠道模型会出现在图像/视频/音频可选项候选中（平台模型仍按能力过滤）
- Dock 生成改为按节点忙碌跟踪：支持多节点并行生成；生成中可再点一次取消；节点 running 状态更明显

## Test plan
- [ ] `pnpm build` 已通过
- [ ] 新增渠道 → 拉取模型 → 到「模型」Tab 确认图像/视频/音频可选项能勾选自定义渠道模型 → 保存后 Dock 可见
- [ ] 选中节点 A 点击生成：按钮转圈且可再点取消；节点标题旁状态点为 running
- [ ] A 生成过程中选中节点 B，可同时发起生成（并行）
- [ ] 相关单测：`providerChannels` / `provider.service` / `useNodeGeneration`


Made with [Cursor](https://cursor.com)