### PR TITLE
fix(web): 节点任务状态反馈与文本提示词分离

### DIFF
--- a/apps/web/src/components/canvas/CanvasNodeAudio.vue
+++ b/apps/web/src/components/canvas/CanvasNodeAudio.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import NeoBaseNode from '@/components/canvas/NeoBaseNode.vue'
+import NodeTaskCornerActions from '@/components/canvas/NodeTaskCornerActions.vue'
 import { computed } from 'vue'
 import { resolveMediaUrl } from '@/services/api-base'
 import { useNodeMediaUpload } from '@/composables/useNodeMediaUpload'
@@ -7,7 +8,7 @@ import { useNodeMediaUpload } from '@/composables/useNodeMediaUpload'
 const props = defineProps<{
   id: string
   selected?: boolean
-  data: { url?: string; status: string; prompt?: string; label?: string }
+  data: { url?: string; status: string; prompt?: string; label?: string; errorMessage?: string }
 }>()
 
 const displayUrl = computed(() => resolveMediaUrl(String(props.data.url ?? '')))
@@ -91,6 +92,10 @@ const {
         @click.stop
         @change="onFileChange"
       >
+      <NodeTaskCornerActions
+        :status="data.status"
+        :error-message="data.errorMessage as string | undefined"
+      />
     </div>
   </NeoBaseNode>
 </template>

--- a/apps/web/src/components/canvas/CanvasNodeImage.vue
+++ b/apps/web/src/components/canvas/CanvasNodeImage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import NeoBaseNode from '@/components/canvas/NeoBaseNode.vue'
+import NodeTaskCornerActions from '@/components/canvas/NodeTaskCornerActions.vue'
 import { useCanvasEditorStore } from '@/stores/canvasEditor'
 import { resolveMediaUrl } from '@/services/api-base'
 import { computed } from 'vue'
@@ -8,7 +9,7 @@ import { useNodeMediaUpload } from '@/composables/useNodeMediaUpload'
 const props = defineProps<{
   id: string
   selected?: boolean
-  data: { url?: string; status: string; prompt?: string; label?: string }
+  data: { url?: string; status: string; prompt?: string; label?: string; errorMessage?: string }
 }>()
 
 const editor = useCanvasEditorStore()
@@ -108,6 +109,10 @@ function openEdit() {
         @click.stop
         @change="onFileChange"
       >
+      <NodeTaskCornerActions
+        :status="data.status"
+        :error-message="data.errorMessage as string | undefined"
+      />
     </div>
   </NeoBaseNode>
 </template>

--- a/apps/web/src/components/canvas/CanvasNodeShot.vue
+++ b/apps/web/src/components/canvas/CanvasNodeShot.vue
@@ -1,9 +1,17 @@
 <script setup lang="ts">
 import NeoBaseNode from '@/components/canvas/NeoBaseNode.vue'
+import NodeTaskCornerActions from '@/components/canvas/NodeTaskCornerActions.vue'
 
 defineProps<{
   selected?: boolean
-  data: { title?: string; prompt?: string; status?: string; coverUrl?: string; label?: string }
+  data: {
+    title?: string
+    prompt?: string
+    status?: string
+    coverUrl?: string
+    label?: string
+    errorMessage?: string
+  }
 }>()
 </script>
 
@@ -27,6 +35,10 @@ defineProps<{
           <span v-if="data.prompt" class="line-clamp-2 max-w-[220px] text-[11px] text-white/40">{{ data.prompt }}</span>
         </div>
       </div>
+      <NodeTaskCornerActions
+        :status="data.status"
+        :error-message="data.errorMessage as string | undefined"
+      />
     </div>
   </NeoBaseNode>
 </template>

--- a/apps/web/src/components/canvas/CanvasNodeText.vue
+++ b/apps/web/src/components/canvas/CanvasNodeText.vue
@@ -1,16 +1,44 @@
 <script setup lang="ts">
+import { ref } from 'vue'
+import { useNodeId, useVueFlow } from '@vue-flow/core'
 import NeoBaseNode from '@/components/canvas/NeoBaseNode.vue'
+import NodeTaskCornerActions from '@/components/canvas/NodeTaskCornerActions.vue'
+import PromptMarkdownEditor from '@/components/canvas/PromptMarkdownEditor.vue'
 
-defineProps<{
+const props = defineProps<{
   selected?: boolean
-  data: { content: string; label?: string; status?: string }
+  data: { content: string; label?: string; status?: string; errorMessage?: string }
 }>()
+
+const nodeId = useNodeId()
+const { updateNodeData } = useVueFlow()
+
+const editorOpen = ref(false)
+const draft = ref('')
+
+function openEditor() {
+  draft.value = String(props.data.content ?? '')
+  editorOpen.value = true
+}
+
+function onSave(md: string) {
+  updateNodeData(nodeId, { content: md })
+}
 </script>
 
 <template>
   <NeoBaseNode node-type="text" :selected="selected" :data="data" :status="data.status">
-    <div class="neo-text-card">
+    <div class="neo-text-card" @dblclick.stop="openEditor">
       <p>{{ data.content || '点击下方 Dock Studio 编辑...' }}</p>
+      <NodeTaskCornerActions
+        :status="data.status"
+        :error-message="data.errorMessage as string | undefined"
+      />
     </div>
+    <PromptMarkdownEditor
+      v-model:visible="editorOpen"
+      v-model="draft"
+      @save="onSave"
+    />
   </NeoBaseNode>
 </template>

--- a/apps/web/src/components/canvas/CanvasNodeVideo.vue
+++ b/apps/web/src/components/canvas/CanvasNodeVideo.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import NeoBaseNode from '@/components/canvas/NeoBaseNode.vue'
+import NodeTaskCornerActions from '@/components/canvas/NodeTaskCornerActions.vue'
 import { computed } from 'vue'
 import { resolveMediaUrl } from '@/services/api-base'
 import { useNodeMediaUpload } from '@/composables/useNodeMediaUpload'
@@ -7,7 +8,7 @@ import { useNodeMediaUpload } from '@/composables/useNodeMediaUpload'
 const props = defineProps<{
   id: string
   selected?: boolean
-  data: { url?: string; status: string; duration?: number; label?: string }
+  data: { url?: string; status: string; duration?: number; label?: string; errorMessage?: string }
 }>()
 
 const displayUrl = computed(() => resolveMediaUrl(String(props.data.url ?? '')))
@@ -91,6 +92,10 @@ const {
         @click.stop
         @change="onFileChange"
       >
+      <NodeTaskCornerActions
+        :status="data.status"
+        :error-message="data.errorMessage as string | undefined"
+      />
     </div>
   </NeoBaseNode>
 </template>

--- a/apps/web/src/components/canvas/NeoBaseNode.vue
+++ b/apps/web/src/components/canvas/NeoBaseNode.vue
@@ -7,6 +7,7 @@ import {
   resolveNeoNodeTitle,
   type NeoNodeStatus,
 } from '@/components/canvas/neoNodeMeta'
+import NodeTaskBadge from '@/components/canvas/NodeTaskBadge.vue'
 import { CANVAS_NODE_RENAME_KEY } from '@/composables/canvasNodeActions'
 
 const props = withDefaults(
@@ -127,6 +128,10 @@ function cancelRename() {
         @mousedown.stop
       >
       <span v-else class="neo-node-title">{{ displayTitle }}</span>
+      <NodeTaskBadge
+        :status="data?.status"
+        :started-at="typeof data?.generationStartedAt === 'string' ? data.generationStartedAt : undefined"
+      />
       <span class="neo-node-status" :class="nodeStatus" />
     </div>
 

--- a/apps/web/src/components/canvas/NodeTaskBadge.vue
+++ b/apps/web/src/components/canvas/NodeTaskBadge.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { computed, onUnmounted, ref, watch } from 'vue'
+import { resolveTaskBadge } from '@/components/canvas/nodeTaskChrome'
+import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
+
+const props = defineProps<{
+  status?: unknown
+  startedAt?: string
+}>()
+
+const nowMs = ref(Date.now())
+const completedFlash = ref(false)
+let tick: ReturnType<typeof setInterval> | undefined
+let flashTimer: ReturnType<typeof setTimeout> | undefined
+
+watch(
+  () => props.status,
+  (s, prev) => {
+    if (s === NODE_GENERATION_STATUS.completed && prev && prev !== NODE_GENERATION_STATUS.completed) {
+      completedFlash.value = true
+      clearTimeout(flashTimer)
+      flashTimer = setTimeout(() => {
+        completedFlash.value = false
+      }, 2000)
+    }
+  },
+)
+
+watch(
+  () => props.status,
+  (s) => {
+    clearInterval(tick)
+    if (s === NODE_GENERATION_STATUS.generating || s === NODE_GENERATION_STATUS.fallback_pending) {
+      nowMs.value = Date.now()
+      tick = setInterval(() => {
+        nowMs.value = Date.now()
+      }, 1000)
+    }
+  },
+  { immediate: true },
+)
+
+onUnmounted(() => {
+  clearInterval(tick)
+  clearTimeout(flashTimer)
+})
+
+const badge = computed(() =>
+  resolveTaskBadge({
+    status: props.status,
+    startedAt: props.startedAt,
+    nowMs: nowMs.value,
+    completedFlash: completedFlash.value,
+  }),
+)
+</script>
+
+<template>
+  <span v-if="badge" class="neo-task-badge" :class="`is-${badge.tone}`">{{ badge.text }}</span>
+</template>

--- a/apps/web/src/components/canvas/NodeTaskCornerActions.vue
+++ b/apps/web/src/components/canvas/NodeTaskCornerActions.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { computed, inject } from 'vue'
+import { useNodeId } from '@vue-flow/core'
+import { resolveCornerAction, truncateError } from '@/components/canvas/nodeTaskChrome'
+import { CANVAS_NODE_CANCEL_KEY, CANVAS_NODE_RETRY_KEY } from '@/composables/canvasNodeActions'
+import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
+
+const props = defineProps<{ status?: unknown; errorMessage?: string }>()
+const nodeId = useNodeId()
+const cancel = inject(CANVAS_NODE_CANCEL_KEY, null)
+const retry = inject(CANVAS_NODE_RETRY_KEY, null)
+const action = computed(() => resolveCornerAction(props.status))
+const err = computed(() => truncateError(props.errorMessage))
+const showError = computed(
+  () =>
+    Boolean(err.value) &&
+    (props.status === NODE_GENERATION_STATUS.error ||
+      props.status === NODE_GENERATION_STATUS.failed),
+)
+
+function onAction(e: Event) {
+  e.stopPropagation()
+  e.preventDefault()
+  if (!nodeId) return
+  if (action.value === 'cancel') cancel?.(nodeId)
+  if (action.value === 'retry') void retry?.(nodeId)
+}
+</script>
+
+<template>
+  <div class="neo-task-corner nodrag nopan" @pointerdown.stop @mousedown.stop @click.stop>
+    <p v-if="showError" class="neo-task-error">{{ err }}</p>
+    <button
+      v-if="action"
+      type="button"
+      class="neo-task-corner-btn"
+      :class="action === 'retry' ? 'is-retry' : 'is-cancel'"
+      @click="onAction"
+    >
+      {{ action === 'retry' ? '重试' : '取消' }}
+    </button>
+  </div>
+</template>

--- a/apps/web/src/components/canvas/dock-studio/panels/AudioDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/AudioDockPanel.vue
@@ -206,7 +206,7 @@ function onRefRemove(ref: NodeRef) {
         <DockCreditBadge :credits="credits" />
         <DockGenerateButton
           :generating="generating"
-          :disabled="!prompt.trim() && !upstream.textPrompt.trim()"
+          :disabled="!generating && !prompt.trim() && !upstream.textPrompt.trim()"
           @generate="onGenerate"
         />
       </div>

--- a/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
@@ -290,7 +290,7 @@ function clearReferenceImage() {
         <DockCreditBadge :credits="credits" />
         <DockGenerateButton
           :generating="generating"
-          :disabled="!prompt.trim()"
+          :disabled="!generating && !prompt.trim()"
           @generate="onGenerate"
         />
       </div>

--- a/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
@@ -168,7 +168,7 @@ function onRefRemove(ref: NodeRef) {
         <DockCreditBadge :credits="estimateTextCredits()" />
         <DockGenerateButton
           :generating="generating"
-          :disabled="!prompt.trim()"
+          :disabled="!generating && !prompt.trim()"
           @generate="onGenerate"
         />
       </div>

--- a/apps/web/src/components/canvas/dock-studio/panels/ShotDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ShotDockPanel.vue
@@ -163,7 +163,7 @@ function toggleVoice() {
         />
         <DockGenerateButton
           :generating="generating"
-          :disabled="!prompt.trim()"
+          :disabled="!generating && !prompt.trim()"
           @generate="onGenerate"
         />
       </div>

--- a/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
@@ -35,9 +35,11 @@ const emit = defineEmits<{
   removeRef: [ref: NodeRef]
 }>()
 
-/** Dock input only — never sync from generated `content`. */
+/** Dock input only — never sync from generated `content` after prompt exists. */
 const prompt = ref('')
 const textModel = ref(getConfig('text').model)
+/** One-shot legacy content→prompt seed for the current node visit. */
+const legacySeededForId = ref<string | null>(null)
 
 const speech = useSpeechRecognition()
 const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
@@ -46,21 +48,28 @@ const credits = computed(() => estimateTextCredits())
 
 function syncFromNode() {
   const data = props.node.data ?? {}
-  // Prefer explicit prompt; fall back to content only when prompt was never set (legacy nodes).
-  const storedPrompt = String(data.prompt ?? '').trim()
-  const storedContent = String(data.content ?? '').trim()
-  if (storedPrompt) {
-    prompt.value = String(data.prompt ?? '')
-  } else if (!storedContent) {
-    prompt.value = ''
-  } else if (!prompt.value.trim()) {
-    // Legacy: older nodes used content as the only field; seed dock once without coupling.
-    prompt.value = storedContent
+  const nodeId = props.node.id
+
+  // Prefer `prompt` whenever the key is present as a string — including "" after clear.
+  // Only fall back to `content` when `prompt` is truly absent (legacy nodes).
+  if (typeof data.prompt === 'string') {
+    prompt.value = data.prompt
+  } else if (legacySeededForId.value !== nodeId) {
+    prompt.value = String(data.content ?? '')
+    legacySeededForId.value = nodeId
   }
+
   textModel.value = resolveGenerationModel('text', data.textModel as string | undefined)
 }
 
-watch(() => props.node.id, syncFromNode, { immediate: true })
+watch(
+  () => props.node.id,
+  () => {
+    legacySeededForId.value = null
+    syncFromNode()
+  },
+  { immediate: true },
+)
 watch(
   () => [props.node.data?.prompt, props.node.data?.textModel] as const,
   () => syncFromNode(),

--- a/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
@@ -35,45 +35,60 @@ const emit = defineEmits<{
   removeRef: [ref: NodeRef]
 }>()
 
-const content = ref('')
+/** Dock input only — never sync from generated `content`. */
+const prompt = ref('')
 const textModel = ref(getConfig('text').model)
 
 const speech = useSpeechRecognition()
 const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
-const wordCount = computed(() => content.value.replace(/\s/g, '').length)
+const wordCount = computed(() => prompt.value.replace(/\s/g, '').length)
 const credits = computed(() => estimateTextCredits())
 
 function syncFromNode() {
   const data = props.node.data ?? {}
-  content.value = String(data.content ?? data.prompt ?? '')
+  // Prefer explicit prompt; fall back to content only when prompt was never set (legacy nodes).
+  const storedPrompt = String(data.prompt ?? '').trim()
+  const storedContent = String(data.content ?? '').trim()
+  if (storedPrompt) {
+    prompt.value = String(data.prompt ?? '')
+  } else if (!storedContent) {
+    prompt.value = ''
+  } else if (!prompt.value.trim()) {
+    // Legacy: older nodes used content as the only field; seed dock once without coupling.
+    prompt.value = storedContent
+  }
   textModel.value = resolveGenerationModel('text', data.textModel as string | undefined)
 }
 
-watch(() => props.node, syncFromNode, { immediate: true, deep: true })
+watch(() => props.node.id, syncFromNode, { immediate: true })
+watch(
+  () => [props.node.data?.prompt, props.node.data?.textModel] as const,
+  () => syncFromNode(),
+)
 
 watch(
   () => props.upstream,
   (ctx) => {
-    if (!content.value.trim() && ctx.textPrompt) {
-      content.value = ctx.textPrompt
-      emit('patch', { content: ctx.textPrompt, prompt: ctx.textPrompt })
+    if (!prompt.value.trim() && ctx.textPrompt) {
+      prompt.value = ctx.textPrompt
+      emit('patch', { prompt: ctx.textPrompt })
     }
   },
   { immediate: true },
 )
 
-function onContentInput(value: string) {
-  content.value = value
-  emit('patch', { content: value, prompt: value })
+function onPromptInput(value: string) {
+  prompt.value = value
+  emit('patch', { prompt: value })
 }
 
 function onOptimized(value: string) {
-  content.value = value
-  emit('patch', { content: value, prompt: value })
+  prompt.value = value
+  emit('patch', { prompt: value })
 }
 
 function onGenerate() {
-  emit('patch', { content: content.value, prompt: content.value, textModel: textModel.value })
+  emit('patch', { prompt: prompt.value, textModel: textModel.value })
   emit('generate')
 }
 
@@ -84,8 +99,8 @@ function toggleVoice() {
   }
   speech.start((text, isFinal) => {
     if (isFinal) {
-      const next = content.value ? `${content.value} ${text}` : text
-      onContentInput(next)
+      const next = prompt.value ? `${prompt.value} ${text}` : text
+      onPromptInput(next)
     }
   })
 }
@@ -108,10 +123,10 @@ function onRefRemove(ref: NodeRef) {
     />
 
     <DockPromptSection
-      :model-value="content"
+      :model-value="prompt"
       :mentions="mentions"
       placeholder="输入脚本、旁白或品牌文案..."
-      @update:model-value="onContentInput"
+      @update:model-value="onPromptInput"
       @submit="onGenerate"
     />
 
@@ -122,7 +137,7 @@ function onRefRemove(ref: NodeRef) {
         @update:model-value="emit('patch', { textModel: $event })"
       />
       <DockOptimizePrompt
-        :prompt="content"
+        :prompt="prompt"
         optimize-style="copywriting"
         :disabled="readonly"
         @optimized="onOptimized"
@@ -138,7 +153,7 @@ function onRefRemove(ref: NodeRef) {
         <DockCreditBadge :credits="credits" />
         <DockGenerateButton
           :generating="generating"
-          :disabled="!content.trim()"
+          :disabled="!generating && !prompt.trim()"
           @generate="onGenerate"
         />
       </div>

--- a/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
@@ -290,7 +290,7 @@ function onRefRemove(ref: NodeRef) {
         <DockCreditBadge :credits="credits" />
         <DockGenerateButton
           :generating="generating"
-          :disabled="!prompt.trim() || (videoMode === 'image_to_video' && !effectiveRefUrl)"
+          :disabled="!generating && (!prompt.trim() || (videoMode === 'image_to_video' && !effectiveRefUrl))"
           @generate="onGenerate"
         />
       </div>

--- a/apps/web/src/components/canvas/dock-studio/shared/DockGenerateButton.vue
+++ b/apps/web/src/components/canvas/dock-studio/shared/DockGenerateButton.vue
@@ -17,19 +17,18 @@ const emit = defineEmits<{
     :disabled="disabled"
     :title="generating ? '点击取消生成' : '生成'"
     :aria-label="generating ? '取消生成' : '生成'"
-    @click="emit('generate')"
+    @click.stop="emit('generate')"
   >
+    <!-- Stop square while generating — clearer cancel affordance than a spinner-only control -->
     <svg
       v-if="generating"
-      class="dock-generate-btn__spinner"
       viewBox="0 0 24 24"
-      width="14"
-      height="14"
-      fill="none"
-      stroke="currentColor"
-      stroke-width="2.5"
+      width="12"
+      height="12"
+      fill="currentColor"
+      aria-hidden="true"
     >
-      <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83" />
+      <rect x="6" y="6" width="12" height="12" rx="1.5" />
     </svg>
     <svg
       v-else
@@ -41,6 +40,7 @@ const emit = defineEmits<{
       stroke-width="2.5"
       stroke-linecap="round"
       stroke-linejoin="round"
+      aria-hidden="true"
     >
       <path d="M12 19V5" />
       <path d="m5 12 7-7 7 7" />
@@ -61,6 +61,7 @@ const emit = defineEmits<{
   background: #fff;
   color: #111;
   cursor: pointer;
+  pointer-events: auto;
   transition:
     transform 0.15s ease,
     opacity 0.15s ease,
@@ -80,19 +81,12 @@ const emit = defineEmits<{
 .dock-generate-btn.is-generating {
   background: #111;
   color: #fff;
+  opacity: 1 !important;
+  pointer-events: auto !important;
+  cursor: pointer;
 }
 
 .dock-generate-btn.is-generating:hover:not(:disabled) {
   background: #333;
-}
-
-.dock-generate-btn__spinner {
-  animation: dock-gen-spin 0.9s linear infinite;
-}
-
-@keyframes dock-gen-spin {
-  to {
-    transform: rotate(360deg);
-  }
 }
 </style>

--- a/apps/web/src/components/canvas/nodeTaskChrome.test.ts
+++ b/apps/web/src/components/canvas/nodeTaskChrome.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatElapsed,
+  resolveTaskBadge,
+  resolveCornerAction,
+  truncateError,
+} from './nodeTaskChrome'
+import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
+
+describe('nodeTaskChrome', () => {
+  it('formats elapsed as m:ss', () => {
+    const start = new Date('2026-07-20T00:00:00.000Z').toISOString()
+    expect(formatElapsed(start, Date.parse('2026-07-20T00:00:42.000Z'))).toBe('0:42')
+    expect(formatElapsed(start, Date.parse('2026-07-20T00:03:05.000Z'))).toBe('3:05')
+  })
+
+  it('badge for generating includes elapsed', () => {
+    const start = new Date('2026-07-20T00:00:00.000Z').toISOString()
+    const b = resolveTaskBadge({
+      status: NODE_GENERATION_STATUS.generating,
+      startedAt: start,
+      nowMs: Date.parse('2026-07-20T00:00:12.000Z'),
+    })
+    expect(b).toEqual({ text: '生成中 · 0:12', tone: 'running' })
+  })
+
+  it('corner cancel/retry mapping', () => {
+    expect(resolveCornerAction(NODE_GENERATION_STATUS.generating)).toBe('cancel')
+    expect(resolveCornerAction(NODE_GENERATION_STATUS.error)).toBe('retry')
+    expect(resolveCornerAction(NODE_GENERATION_STATUS.fallback_pending)).toBeNull()
+    expect(resolveCornerAction(NODE_GENERATION_STATUS.completed)).toBeNull()
+  })
+
+  it('truncates error', () => {
+    expect(truncateError('x'.repeat(50)).length).toBeLessThanOrEqual(40)
+  })
+})

--- a/apps/web/src/components/canvas/nodeTaskChrome.ts
+++ b/apps/web/src/components/canvas/nodeTaskChrome.ts
@@ -1,0 +1,72 @@
+import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
+
+export type TaskCornerAction = 'cancel' | 'retry' | null
+
+export type TaskBadgeTone = 'running' | 'error' | 'success' | 'pending'
+
+export type TaskBadge = {
+  text: string
+  tone: TaskBadgeTone
+}
+
+/** Elapsed time as m:ss. Missing/invalid startedAt → "0:00". */
+export function formatElapsed(startedAt: string | undefined, nowMs: number): string {
+  if (!startedAt) return '0:00'
+  const startMs = Date.parse(startedAt)
+  if (Number.isNaN(startMs)) return '0:00'
+  const totalSec = Math.max(0, Math.floor((nowMs - startMs) / 1000))
+  const minutes = Math.floor(totalSec / 60)
+  const seconds = totalSec % 60
+  return `${minutes}:${String(seconds).padStart(2, '0')}`
+}
+
+/**
+ * Title badge for Layout C. Status-driven (works for text/image/video/audio/shot).
+ * completed only shows while completedFlash is true.
+ */
+export function resolveTaskBadge(input: {
+  status: unknown
+  startedAt?: string
+  nowMs: number
+  completedFlash?: boolean
+}): TaskBadge | null {
+  const { status, startedAt, nowMs, completedFlash } = input
+
+  if (status === NODE_GENERATION_STATUS.generating) {
+    return {
+      text: `生成中 · ${formatElapsed(startedAt, nowMs)}`,
+      tone: 'running',
+    }
+  }
+
+  if (status === NODE_GENERATION_STATUS.error || status === NODE_GENERATION_STATUS.failed) {
+    return { text: '失败', tone: 'error' }
+  }
+
+  if (status === NODE_GENERATION_STATUS.fallback_pending) {
+    return { text: '待确认', tone: 'pending' }
+  }
+
+  if (status === NODE_GENERATION_STATUS.completed) {
+    if (completedFlash) return { text: '已完成', tone: 'success' }
+    return null
+  }
+
+  return null
+}
+
+/** Corner action: cancel while generating, retry on error/failed. */
+export function resolveCornerAction(status: unknown): TaskCornerAction {
+  if (status === NODE_GENERATION_STATUS.generating) return 'cancel'
+  if (status === NODE_GENERATION_STATUS.error || status === NODE_GENERATION_STATUS.failed) {
+    return 'retry'
+  }
+  return null
+}
+
+/** Truncate error summary for card display (default ~40 chars). */
+export function truncateError(message: string | undefined, max = 40): string {
+  if (!message) return ''
+  if (message.length <= max) return message
+  return message.slice(0, max)
+}

--- a/apps/web/src/composables/canvasNodeActions.ts
+++ b/apps/web/src/composables/canvasNodeActions.ts
@@ -5,3 +5,8 @@ export type CanvasNodePatchFn = (nodeId: string, patch: Record<string, unknown>)
 
 export const CANVAS_NODE_RENAME_KEY: InjectionKey<CanvasNodeRenameFn> = Symbol('canvasNodeRename')
 export const CANVAS_NODE_PATCH_KEY: InjectionKey<CanvasNodePatchFn> = Symbol('canvasNodePatch')
+
+export type CanvasNodeCancelFn = (nodeId: string) => void
+export type CanvasNodeRetryFn = (nodeId: string) => void | Promise<void>
+export const CANVAS_NODE_CANCEL_KEY: InjectionKey<CanvasNodeCancelFn> = Symbol('canvasNodeCancel')
+export const CANVAS_NODE_RETRY_KEY: InjectionKey<CanvasNodeRetryFn> = Symbol('canvasNodeRetry')

--- a/apps/web/src/composables/useGenerationPolling.test.ts
+++ b/apps/web/src/composables/useGenerationPolling.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { studioApi } from '@/services/studio-api'
+import { useGenerationPolling } from '@/composables/useGenerationPolling'
+
+vi.mock('@/services/studio-api', () => ({
+  studioApi: {
+    getGeneration: vi.fn(),
+  },
+}))
+
+describe('useGenerationPolling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not call onUpdate for tasks removed during poll await', async () => {
+    let resolveFetch!: (v: unknown) => void
+    const hang = new Promise((r) => {
+      resolveFetch = r
+    })
+    vi.mocked(studioApi.getGeneration).mockImplementationOnce(() => hang as never)
+
+    const onUpdate = vi.fn()
+    const polling = useGenerationPolling(onUpdate)
+    polling.start([{ recordId: 'rec-1', nodeId: 'node-1' }])
+
+    await Promise.resolve()
+    expect(studioApi.getGeneration).toHaveBeenCalledWith('rec-1')
+
+    polling.removeByNodeId('node-1')
+
+    resolveFetch({
+      data: {
+        data: {
+          id: 'rec-1',
+          type: 'image',
+          prompt: 'x',
+          status: 'completed',
+          url: 'https://example.com/late.png',
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(onUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/composables/useGenerationPolling.ts
+++ b/apps/web/src/composables/useGenerationPolling.ts
@@ -23,13 +23,17 @@ export function useGenerationPolling(
         // ignore single poll failure
       }
     }
-    if (results.length) onUpdate(results)
+    // Ignore results for tasks removed during await (e.g. cancel → removeByNodeId)
+    const active = results.filter(({ task }) =>
+      tasks.value.some((t) => t.nodeId === task.nodeId && t.recordId === task.recordId),
+    )
+    if (active.length) onUpdate(active)
 
-    const stillGenerating = results.some(
+    const stillGenerating = active.some(
       ({ record }) => record.status === 'generating' || record.status === 'pending',
     )
     // fallback_pending / completed / failed are terminal for this poll loop
-    if (!stillGenerating && results.length === tasks.value.length) {
+    if (!stillGenerating && active.length === tasks.value.length) {
       stop()
     }
   }

--- a/apps/web/src/composables/useNodeGeneration.test.ts
+++ b/apps/web/src/composables/useNodeGeneration.test.ts
@@ -621,6 +621,55 @@ describe('useNodeGeneration', () => {
     expect(api.isNodeBusy('img-b')).toBe(false)
   })
 
+  it('writes generationStartedAt when generation begins', async () => {
+    const node = createNode('image', { prompt: 'cat' }, 'img-1')
+    let resolveHang!: (v: unknown) => void
+    const hang = new Promise((r) => { resolveHang = r })
+    vi.mocked(studioApi.generateImage).mockImplementationOnce(() => hang as never)
+    const { api, deps } = createDeps([node])
+    const pending = api.generateForNode(node)
+    await Promise.resolve()
+    expect(deps.patchNodeData).toHaveBeenCalledWith(
+      'img-1',
+      expect.objectContaining({
+        status: NODE_GENERATION_STATUS.generating,
+        generationStartedAt: expect.stringMatching(/^\d{4}-/),
+      }),
+    )
+    resolveHang(mockAxiosResponse({ data: completedRecord }))
+    await pending
+  })
+
+  it('cancel keeps existing content and url', async () => {
+    const node = createNode('image', {
+      prompt: 'x',
+      url: 'https://example.com/keep.png',
+      content: 'keep-me',
+      status: NODE_GENERATION_STATUS.generating,
+    }, 'img-keep')
+    let rejectHang!: (e: unknown) => void
+    const hang = new Promise((_r, j) => { rejectHang = j })
+    vi.mocked(studioApi.generateImage).mockImplementation((_a, _b, _c, _d, _e, _f, _g, signal?: AbortSignal) => {
+      signal?.addEventListener('abort', () => {
+        const err = new Error('canceled')
+        ;(err as { code?: string }).code = 'ERR_CANCELED'
+        rejectHang(err)
+      })
+      return hang as never
+    })
+    const { api, deps } = createDeps([node])
+    const pending = api.generateForNode(node)
+    await Promise.resolve()
+    await api.generateForNode(node) // cancel
+    await pending
+    const draftPatch = deps.patchNodeData.mock.calls.find(
+      (c) => c[1]?.status === NODE_GENERATION_STATUS.draft,
+    )?.[1] as Record<string, unknown>
+    expect(draftPatch).toBeTruthy()
+    expect(draftPatch).not.toHaveProperty('url')
+    expect(draftPatch).not.toHaveProperty('content')
+  })
+
   it('second generate click cancels in-flight generation', async () => {
     let rejectHang!: (err: unknown) => void
     const hang = new Promise((_resolve, reject) => {

--- a/apps/web/src/composables/useNodeGeneration.test.ts
+++ b/apps/web/src/composables/useNodeGeneration.test.ts
@@ -531,6 +531,57 @@ describe('useNodeGeneration', () => {
     expect(deps.startShotPolling).toHaveBeenCalledWith(['shot-1'])
   })
 
+  it('text generate writes result to content without overwriting prompt', async () => {
+    const node = createNode('text', {
+      prompt: '写一句广告语',
+      content: '',
+    })
+    const { api, deps } = createDeps([node])
+    vi.mocked(studioApi.generateText).mockResolvedValue(
+      mockAxiosResponse({
+        data: {
+          ...completedRecord,
+          type: 'text',
+          prompt: '写一句广告语',
+          metadata: JSON.stringify({ text: '买它！限时优惠。' }),
+        },
+      }),
+    )
+
+    await api.generateForNode(node)
+
+    expect(studioApi.generateText).toHaveBeenCalledWith(
+      '写一句广告语',
+      expect.any(String),
+      [],
+      [],
+      expect.any(AbortSignal),
+    )
+    expect(deps.patchNodeData).toHaveBeenCalledWith(
+      'text-1',
+      expect.objectContaining({
+        status: NODE_GENERATION_STATUS.generating,
+        prompt: '写一句广告语',
+      }),
+    )
+    const generatingPatch = deps.patchNodeData.mock.calls.find(
+      (call) => call[1]?.status === NODE_GENERATION_STATUS.generating,
+    )?.[1] as Record<string, unknown>
+    expect(generatingPatch).not.toHaveProperty('content')
+
+    expect(deps.patchNodeData).toHaveBeenCalledWith(
+      'text-1',
+      expect.objectContaining({
+        status: NODE_GENERATION_STATUS.completed,
+        content: '买它！限时优惠。',
+      }),
+    )
+    const completedPatch = deps.patchNodeData.mock.calls.find(
+      (call) => call[1]?.status === NODE_GENERATION_STATUS.completed,
+    )?.[1] as Record<string, unknown>
+    expect(completedPatch).not.toHaveProperty('prompt')
+  })
+
   it('allows parallel generation on two nodes', async () => {
     let resolveA!: (v: unknown) => void
     let resolveB!: (v: unknown) => void

--- a/apps/web/src/composables/useNodeGeneration.test.ts
+++ b/apps/web/src/composables/useNodeGeneration.test.ts
@@ -62,7 +62,11 @@ function createNode(
 }
 
 function createDeps(nodes: EditableFlowNode[], overrides: Record<string, unknown> = {}) {
-  const patchNodeData = vi.fn()
+  const nodesRef = ref(nodes)
+  const patchNodeData = vi.fn((id: string, patch: Record<string, unknown>) => {
+    const node = nodesRef.value.find((n) => n.id === id)
+    if (node) node.data = { ...(node.data ?? {}), ...patch }
+  })
   const saveCanvas = vi.fn(async () => {})
   const requireLogin = vi.fn(() => true)
   const startShotPolling = vi.fn()
@@ -76,7 +80,7 @@ function createDeps(nodes: EditableFlowNode[], overrides: Record<string, unknown
   const isModelSelectable = vi.fn(() => true)
 
   const deps = {
-    nodes: ref(nodes),
+    nodes: nodesRef,
     edges: ref<CanvasEdgeLike[]>([]),
     sessionId: ref('session-1'),
     patchNodeData,
@@ -640,12 +644,73 @@ describe('useNodeGeneration', () => {
     await pending
   })
 
+  it('cancelGeneration stops generation and shot polling', () => {
+    const stopGenerationPolling = vi.fn()
+    const stopShotPolling = vi.fn()
+    const node = createNode('image', {
+      prompt: 'x',
+      status: NODE_GENERATION_STATUS.generating,
+    }, 'img-1')
+    const { api } = createDeps([node], { stopGenerationPolling, stopShotPolling })
+
+    api.cancelGeneration('img-1')
+
+    expect(stopGenerationPolling).toHaveBeenCalledWith('img-1')
+    expect(stopShotPolling).toHaveBeenCalledWith('img-1')
+  })
+
+  it('cancelGeneration stops linked shot polling for shot-linked media', () => {
+    const stopShotPolling = vi.fn()
+    const shot = createNode('shot', {
+      title: 'Shot',
+      status: NODE_GENERATION_STATUS.generating,
+    }, 'shot-1')
+    const image = createNode('image', {
+      prompt: 'x',
+      status: NODE_GENERATION_STATUS.generating,
+    }, 'image-1')
+    const { api, deps } = createDeps([shot, image], { stopShotPolling })
+    deps.edges.value = [{ id: 'e1', source: 'shot-1', target: 'image-1' }]
+
+    api.cancelGeneration('image-1')
+
+    expect(stopShotPolling).toHaveBeenCalledWith('image-1')
+    expect(stopShotPolling).toHaveBeenCalledWith('shot-1')
+  })
+
+  it('ignores late studio completed write after cancel to draft', async () => {
+    const requestFallbackConfirm = vi.fn(async () => 'confirm' as const)
+    vi.mocked(studioApi.confirmPlatformFallback).mockResolvedValue(
+      mockAxiosResponse({
+        data: {
+          ...completedRecord,
+          id: 'rec-late',
+          url: 'https://example.com/late.png',
+        },
+      }),
+    )
+    const node = createNode('image', {
+      prompt: 'x',
+      status: NODE_GENERATION_STATUS.draft,
+    }, 'img-1')
+    const { api, deps } = createDeps([node], { requestFallbackConfirm })
+
+    await api.onFallbackPending('studio', 'rec-late', 'img-1')
+
+    expect(deps.patchNodeData).not.toHaveBeenCalledWith(
+      'img-1',
+      expect.objectContaining({
+        status: NODE_GENERATION_STATUS.completed,
+        url: 'https://example.com/late.png',
+      }),
+    )
+  })
+
   it('cancel keeps existing content and url', async () => {
     const node = createNode('image', {
       prompt: 'x',
       url: 'https://example.com/keep.png',
       content: 'keep-me',
-      status: NODE_GENERATION_STATUS.generating,
     }, 'img-keep')
     let rejectHang!: (e: unknown) => void
     const hang = new Promise((_r, j) => { rejectHang = j })
@@ -660,7 +725,8 @@ describe('useNodeGeneration', () => {
     const { api, deps } = createDeps([node])
     const pending = api.generateForNode(node)
     await Promise.resolve()
-    await api.generateForNode(node) // cancel
+    expect(api.isNodeBusy('img-keep')).toBe(true)
+    await api.generateForNode(node) // cancel via second click
     await pending
     const draftPatch = deps.patchNodeData.mock.calls.find(
       (c) => c[1]?.status === NODE_GENERATION_STATUS.draft,

--- a/apps/web/src/composables/useNodeGeneration.test.ts
+++ b/apps/web/src/composables/useNodeGeneration.test.ts
@@ -676,6 +676,100 @@ describe('useNodeGeneration', () => {
 
     expect(stopShotPolling).toHaveBeenCalledWith('image-1')
     expect(stopShotPolling).toHaveBeenCalledWith('shot-1')
+    expect(deps.patchNodeData).toHaveBeenCalledWith(
+      'shot-1',
+      expect.objectContaining({
+        status: NODE_GENERATION_STATUS.draft,
+        errorMessage: null,
+      }),
+    )
+    expect(shot.data?.status).toBe(NODE_GENERATION_STATUS.draft)
+  })
+
+  it('does not restart shot polling after cancel during shot-linked generate hang', async () => {
+    let resolveHang!: (v: unknown) => void
+    const hang = new Promise((r) => { resolveHang = r })
+    vi.mocked(canvasApi.generateImage).mockImplementationOnce(() => hang as never)
+
+    const shot = createNode('shot', { title: 'Shot', prompt: 'sunset' }, 'shot-1')
+    const image = createNode('image', { prompt: 'sunset' }, 'image-1')
+    const stopShotPolling = vi.fn()
+    const { api, deps } = createDeps([shot, image], { stopShotPolling })
+    deps.edges.value = [{ id: 'e1', source: 'shot-1', target: 'image-1' }]
+
+    const pending = api.generateForNode(image)
+    await Promise.resolve()
+    expect(deps.startShotPolling).not.toHaveBeenCalled()
+
+    api.cancelGeneration('image-1')
+    expect(stopShotPolling).toHaveBeenCalledWith('shot-1')
+    expect(shot.data?.status).toBe(NODE_GENERATION_STATUS.draft)
+    expect(image.data?.status).toBe(NODE_GENERATION_STATUS.draft)
+
+    resolveHang(mockAxiosResponse({ data: {} }))
+    await pending
+
+    expect(deps.startShotPolling).not.toHaveBeenCalled()
+  })
+
+  it('does not write fallback error after cancel during confirm dialog', async () => {
+    let resolveConfirm!: (decision: 'confirm' | 'cancel') => void
+    const confirmHang = new Promise<'confirm' | 'cancel'>((r) => { resolveConfirm = r })
+    const requestFallbackConfirm = vi.fn(() => confirmHang)
+
+    const pendingRecord = {
+      id: 'rec-fb-cancel',
+      type: 'image',
+      prompt: 'fallback me',
+      status: NODE_GENERATION_STATUS.fallback_pending,
+      url: null,
+      metadata: JSON.stringify({ confirmMessage: '是否继续？' }),
+      createdAt: '2026-01-01T00:00:00.000Z',
+    }
+    vi.mocked(studioApi.generateImage).mockResolvedValue(mockAxiosResponse({ data: pendingRecord }))
+    vi.mocked(studioApi.confirmPlatformFallback).mockResolvedValue(
+      mockAxiosResponse({
+        data: {
+          ...pendingRecord,
+          status: NODE_GENERATION_STATUS.completed,
+          url: 'https://example.com/fallback.png',
+        },
+      }),
+    )
+
+    const node = createNode('image', {
+      prompt: 'fallback me',
+      imageAspect: '16:9',
+      imageResolution: '1K',
+      imageCount: 1,
+    }, 'img-fb')
+    const { api, deps } = createDeps([node], { requestFallbackConfirm })
+
+    const pending = api.generateForNode(node)
+    await Promise.resolve()
+    expect(requestFallbackConfirm).toHaveBeenCalled()
+
+    api.cancelGeneration('img-fb')
+    expect(node.data?.status).toBe(NODE_GENERATION_STATUS.draft)
+
+    resolveConfirm('confirm')
+    await pending
+
+    expect(deps.patchNodeData).not.toHaveBeenCalledWith(
+      'img-fb',
+      expect.objectContaining({
+        status: NODE_GENERATION_STATUS.error,
+        errorMessage: '平台回退仍待确认',
+      }),
+    )
+    expect(deps.patchNodeData).not.toHaveBeenCalledWith(
+      'img-fb',
+      expect.objectContaining({
+        status: NODE_GENERATION_STATUS.completed,
+        url: 'https://example.com/fallback.png',
+      }),
+    )
+    expect(node.data?.status).toBe(NODE_GENERATION_STATUS.draft)
   })
 
   it('ignores late studio completed write after cancel to draft', async () => {

--- a/apps/web/src/composables/useNodeGeneration.test.ts
+++ b/apps/web/src/composables/useNodeGeneration.test.ts
@@ -686,6 +686,31 @@ describe('useNodeGeneration', () => {
     expect(shot.data?.status).toBe(NODE_GENERATION_STATUS.draft)
   })
 
+  it('does not addNode after cancel during no-child generateShot hang', async () => {
+    let resolveHang!: (v: unknown) => void
+    const hang = new Promise((r) => { resolveHang = r })
+    vi.mocked(canvasApi.editShot).mockResolvedValue(mockAxiosResponse({ data: {} }))
+    vi.mocked(canvasApi.generateImage).mockImplementationOnce(() => hang as never)
+
+    // auto mode + no media children → else branch that addNode/addEdge
+    const shot = createNode('shot', { title: 'Shot', prompt: 'lonely', shotGenerateMode: 'auto' }, 'shot-1')
+    const { api, deps } = createDeps([shot])
+
+    const pending = api.generateForNode(shot)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    api.cancelGeneration('shot-1')
+    expect(shot.data?.status).toBe(NODE_GENERATION_STATUS.draft)
+
+    resolveHang(mockAxiosResponse({ data: { data: { id: 'mat-late' } } }))
+    await pending
+
+    expect(deps.addNode).not.toHaveBeenCalled()
+    expect(deps.addEdge).not.toHaveBeenCalled()
+    expect(deps.startShotPolling).not.toHaveBeenCalled()
+  })
+
   it('does not restart shot polling after cancel during shot-linked generate hang', async () => {
     let resolveHang!: (v: unknown) => void
     const hang = new Promise((r) => { resolveHang = r })

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -212,6 +212,11 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     generating.value = busyNodeIds.value.size > 0
   }
 
+  function nodeAcceptsWrite(nodeId: string): boolean {
+    const current = findNodeById(deps.nodes.value, nodeId)
+    return acceptsGenerationWrite(current?.data?.status)
+  }
+
   function cancelGeneration(nodeId: string) {
     const ac = abortByNodeId.get(nodeId)
     if (ac) {
@@ -227,6 +232,30 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       const shotNode = shotId ? findNodeById(deps.nodes.value, shotId) : null
       if (shotNode?.type === 'shot' && shotId) {
         deps.stopShotPolling?.(shotId)
+        deps.patchNodeData(shotId, {
+          status: NODE_GENERATION_STATUS.draft,
+          errorMessage: null,
+        })
+        markIdle(shotId)
+      }
+    }
+    if (node?.type === 'shot') {
+      for (const edge of deps.edges.value) {
+        if (edge.source !== nodeId) continue
+        const child = findNodeById(deps.nodes.value, edge.target)
+        if (!child || (child.type !== 'image' && child.type !== 'video')) continue
+        if (!isNodeGenerating(child.data?.status)) continue
+        deps.stopGenerationPolling?.(child.id)
+        const childAc = abortByNodeId.get(child.id)
+        if (childAc) {
+          childAc.abort()
+          abortByNodeId.delete(child.id)
+        }
+        markIdle(child.id)
+        deps.patchNodeData(child.id, {
+          status: NODE_GENERATION_STATUS.draft,
+          errorMessage: null,
+        })
       }
     }
     markIdle(nodeId)
@@ -273,6 +302,7 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     }
 
     await studioApi.cancelPlatformFallback(record.id)
+    if (!nodeAcceptsWrite(nodeId)) return false
     deps.patchNodeData(nodeId, {
       status: NODE_GENERATION_STATUS.error,
       errorMessage: '已取消平台回退',
@@ -336,6 +366,7 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     if (record.status === NODE_GENERATION_STATUS.fallback_pending) {
       const handled = await handleStudioFallback(nodeId, record)
       if (!handled) {
+        if (!nodeAcceptsWrite(nodeId)) return
         deps.patchNodeData(nodeId, {
           status: NODE_GENERATION_STATUS.error,
           errorMessage: '平台回退仍待确认',
@@ -456,7 +487,7 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       }
 
       if (nodeType === 'shot') {
-        await generateShot(node, local, data)
+        await generateShot(node, local, data, signal)
       }
     } catch (err) {
       if (isAbortError(err) || signal.aborted) return
@@ -502,6 +533,7 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
         const params = resolveCanvasImageParams(data)
         await canvasApi.generateImage(shotId, prompt, { ...params, refs, mentionedKeys })
       }
+      if (signal?.aborted || !nodeAcceptsWrite(node.id) || !nodeAcceptsWrite(shotId)) return
       deps.startShotPolling([shotId])
       await deps.saveCanvas()
       return
@@ -572,6 +604,7 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
 
     if (decision === 'confirm') {
       await canvasApi.confirmMaterialPlatformFallback(materialId)
+      if (!nodeAcceptsWrite(nodeId)) return
       deps.patchNodeData(nodeId, { status: NODE_GENERATION_STATUS.generating })
       const shotEdge = findIncomingEdge(deps.edges.value, nodeId)
       if (shotEdge?.source) deps.startShotPolling([shotEdge.source])
@@ -579,6 +612,7 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     }
 
     await canvasApi.cancelMaterialPlatformFallback(materialId)
+    if (!nodeAcceptsWrite(nodeId)) return
     deps.patchNodeData(nodeId, {
       status: NODE_GENERATION_STATUS.error,
       errorMessage: '已取消平台回退',
@@ -607,6 +641,8 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       }
       await deps.saveCanvas()
     } catch (err) {
+      const current = findNodeById(deps.nodes.value, nodeId)
+      if (current && !acceptsGenerationWrite(current.data?.status)) return
       deps.patchNodeData(nodeId, {
         status: NODE_GENERATION_STATUS.error,
         errorMessage: err instanceof Error ? err.message : '平台回退处理失败',
@@ -615,7 +651,12 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     }
   }
 
-  async function generateShot(node: EditableFlowNode, prompt: string, data: Record<string, unknown>) {
+  async function generateShot(
+    node: EditableFlowNode,
+    prompt: string,
+    data: Record<string, unknown>,
+    signal?: AbortSignal,
+  ) {
     const refs = resolveStudioRefs(node, deps.nodes.value, deps.edges.value)
     const mentionedKeys = parseRefMentions(prompt)
     deps.patchNodeData(node.id, {
@@ -674,6 +715,7 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
         style: { stroke: '#6366f1' },
       })
     }
+    if (signal?.aborted || !nodeAcceptsWrite(node.id)) return
     deps.startShotPolling([node.id])
     await deps.saveCanvas()
   }
@@ -769,6 +811,13 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
         items,
       })
 
+      if (
+        signal.aborted
+        || !nodeAcceptsWrite(node.id)
+        || items.some((item) => !nodeAcceptsWrite(item.shotNodeId))
+      ) {
+        return
+      }
       deps.startShotPolling(items.map((item) => item.shotNodeId))
       deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating })
       await deps.saveCanvas()

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -280,7 +280,7 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
         } else {
           const content = parseRecordText(record)
           patch.content = content
-          patch.prompt = content
+          // Keep dock prompt intact — result lives on the node card via `content`.
         }
       } else {
         patch.url = urls[0] ?? parseRecordUrl(record)
@@ -384,7 +384,7 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       }
 
       if (nodeType === 'text') {
-        deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating, content: local, prompt: local })
+        deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating, prompt: local })
         const { data: res } = await studioApi.generateText(
           local,
           resolveGenerationModel('text', data.textModel as string | undefined),

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -668,8 +668,10 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     try {
       await canvasApi.editShot(node.id, { title, prompt })
     } catch {
+      if (signal?.aborted || !nodeAcceptsWrite(node.id)) return
       const shotRes = await canvasApi.createShot(deps.sessionId.value, { title, prompt })
       const shot = shotRes.data.data as { id: string }
+      if (signal?.aborted || !nodeAcceptsWrite(node.id)) return
       if (shot.id !== node.id) {
         deps.patchNodeData(node.id, {
           ...startedAtPatch(),
@@ -679,6 +681,8 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
         })
       }
     }
+
+    if (signal?.aborted || !nodeAcceptsWrite(node.id)) return
 
     const hasVideoChild = shotHasChildType(deps.nodes.value, deps.edges.value, node.id, 'video')
     const hasImageChild = shotHasChildType(deps.nodes.value, deps.edges.value, node.id, 'image')
@@ -698,6 +702,7 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     } else {
       const params = resolveCanvasImageParams({})
       const matRes = await canvasApi.generateImage(node.id, prompt, { ...params, refs, mentionedKeys })
+      if (signal?.aborted || !nodeAcceptsWrite(node.id)) return
       const material = matRes.data.data as { id: string }
       deps.addNode('image', {
         url: '',

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -64,6 +64,10 @@ function localPrompt(data: Record<string, unknown>): string {
   return String(data.prompt ?? data.content ?? '').trim()
 }
 
+function startedAtPatch(): Record<string, unknown> {
+  return { generationStartedAt: new Date().toISOString() }
+}
+
 function normalizeEdges(edges: CanvasEdgeLike[]) {
   return edges.map((edge) => ({
     id: edge.id ?? `${edge.source}->${edge.target}`,
@@ -372,7 +376,7 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
 
     try {
       if (nodeType === 'prompt') {
-        deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating })
+        deps.patchNodeData(node.id, { ...startedAtPatch(), status: NODE_GENERATION_STATUS.generating })
         const { data: res } = await studioApi.generatePrompt(
           local,
           resolveGenerationModel('text', data.textModel as string | undefined),
@@ -384,7 +388,11 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       }
 
       if (nodeType === 'text') {
-        deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating, prompt: local })
+        deps.patchNodeData(node.id, {
+          ...startedAtPatch(),
+          status: NODE_GENERATION_STATUS.generating,
+          prompt: local,
+        })
         const { data: res } = await studioApi.generateText(
           local,
           resolveGenerationModel('text', data.textModel as string | undefined),
@@ -398,7 +406,11 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       }
 
       if (nodeType === 'audio') {
-        deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating, prompt: local })
+        deps.patchNodeData(node.id, {
+          ...startedAtPatch(),
+          status: NODE_GENERATION_STATUS.generating,
+          prompt: local,
+        })
         const { data: res } = await studioApi.generateAudio(local, {
           model: resolveGenerationModel('audio', data.audioModel as string | undefined),
           voice: String(data.audioVoice ?? DEFAULT_AUDIO_VOICE),
@@ -453,8 +465,16 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     const shotNode = shotId ? findNodeById(deps.nodes.value, shotId) : null
 
     if (shotNode?.type === 'shot' && shotId) {
-      deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating, prompt })
-      deps.patchNodeData(shotId, { status: NODE_GENERATION_STATUS.generating, prompt })
+      deps.patchNodeData(node.id, {
+        ...startedAtPatch(),
+        status: NODE_GENERATION_STATUS.generating,
+        prompt,
+      })
+      deps.patchNodeData(shotId, {
+        ...startedAtPatch(),
+        status: NODE_GENERATION_STATUS.generating,
+        prompt,
+      })
       if (nodeType === 'video') {
         const params = resolveCanvasVideoParams(data)
         await canvasApi.generateVideo(shotId, prompt, { ...params, refs, mentionedKeys })
@@ -467,7 +487,11 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       return
     }
 
-    deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating, prompt })
+    deps.patchNodeData(node.id, {
+      ...startedAtPatch(),
+      status: NODE_GENERATION_STATUS.generating,
+      prompt,
+    })
 
     const refImage = firstImageRefUrl(refs) || mergeReferenceImageUrl(data, upstream)
 
@@ -574,7 +598,11 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
   async function generateShot(node: EditableFlowNode, prompt: string, data: Record<string, unknown>) {
     const refs = resolveStudioRefs(node, deps.nodes.value, deps.edges.value)
     const mentionedKeys = parseRefMentions(prompt)
-    deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating, prompt })
+    deps.patchNodeData(node.id, {
+      ...startedAtPatch(),
+      status: NODE_GENERATION_STATUS.generating,
+      prompt,
+    })
     const title = String(data.title ?? (prompt.slice(0, 24) || '新分镜'))
     try {
       await canvasApi.editShot(node.id, { title, prompt })
@@ -582,7 +610,12 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       const shotRes = await canvasApi.createShot(deps.sessionId.value, { title, prompt })
       const shot = shotRes.data.data as { id: string }
       if (shot.id !== node.id) {
-        deps.patchNodeData(node.id, { title, prompt, status: NODE_GENERATION_STATUS.generating })
+        deps.patchNodeData(node.id, {
+          ...startedAtPatch(),
+          title,
+          prompt,
+          status: NODE_GENERATION_STATUS.generating,
+        })
       }
     }
 
@@ -605,7 +638,12 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       const params = resolveCanvasImageParams({})
       const matRes = await canvasApi.generateImage(node.id, prompt, { ...params, refs, mentionedKeys })
       const material = matRes.data.data as { id: string }
-      deps.addNode('image', { url: '', status: NODE_GENERATION_STATUS.generating, prompt }, {
+      deps.addNode('image', {
+        url: '',
+        ...startedAtPatch(),
+        status: NODE_GENERATION_STATUS.generating,
+        prompt,
+      }, {
         id: material.id,
         position: { x: node.position.x + 280, y: node.position.y },
       })
@@ -696,9 +734,13 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
         }
       }
 
-      deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating })
+      deps.patchNodeData(node.id, { ...startedAtPatch(), status: NODE_GENERATION_STATUS.generating })
       for (const item of items) {
-        deps.patchNodeData(item.shotNodeId, { status: NODE_GENERATION_STATUS.generating, prompt: item.prompt })
+        deps.patchNodeData(item.shotNodeId, {
+          ...startedAtPatch(),
+          status: NODE_GENERATION_STATUS.generating,
+          prompt: item.prompt,
+        })
       }
 
       await canvasApi.batchGenerateSceneComposer({

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -55,9 +55,15 @@ export interface NodeGenerationDeps {
   startShotPolling: (shotIds: string[]) => void
   startGenerationPolling: (tasks: GenerationPollTask[]) => void
   stopGenerationPolling?: (nodeId: string) => void
+  stopShotPolling?: (nodeId: string) => void
   resolveProviderModels: () => { image: string; video: string; text: string }
   requestFallbackConfirm?: (req: FallbackPendingRequest) => Promise<FallbackConfirmDecision>
   isModelSelectable?: (modality: StudioModality, model: string) => boolean
+}
+
+/** Node still accepts poll / resolve writes (not cancelled to draft). */
+function acceptsGenerationWrite(status: unknown): boolean {
+  return isNodeGenerating(status) || status === 'pending'
 }
 
 function localPrompt(data: Record<string, unknown>): string {
@@ -213,6 +219,16 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       abortByNodeId.delete(nodeId)
     }
     deps.stopGenerationPolling?.(nodeId)
+    deps.stopShotPolling?.(nodeId)
+    const node = findNodeById(deps.nodes.value, nodeId)
+    if (node && (node.type === 'image' || node.type === 'video')) {
+      const linkedShotEdge = findIncomingEdge(deps.edges.value, nodeId)
+      const shotId = linkedShotEdge?.source
+      const shotNode = shotId ? findNodeById(deps.nodes.value, shotId) : null
+      if (shotNode?.type === 'shot' && shotId) {
+        deps.stopShotPolling?.(shotId)
+      }
+    }
     markIdle(nodeId)
     syncGeneratingFlag()
     deps.patchNodeData(nodeId, {
@@ -266,6 +282,8 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
   }
 
   function applyStudioRecord(nodeId: string, record: GenerationRecord): boolean {
+    const current = findNodeById(deps.nodes.value, nodeId)
+    if (!acceptsGenerationWrite(current?.data?.status)) return false
     if (record.status === NODE_GENERATION_STATUS.fallback_pending) {
       return false
     }
@@ -313,6 +331,8 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
   }
 
   async function resolveStudioRecord(nodeId: string, record: GenerationRecord) {
+    const current = findNodeById(deps.nodes.value, nodeId)
+    if (!acceptsGenerationWrite(current?.data?.status)) return
     if (record.status === NODE_GENERATION_STATUS.fallback_pending) {
       const handled = await handleStudioFallback(nodeId, record)
       if (!handled) {

--- a/apps/web/src/composables/useShotPolling.ts
+++ b/apps/web/src/composables/useShotPolling.ts
@@ -24,11 +24,14 @@ export function useShotPolling(onUpdate: (shots: ShotStatus[]) => void) {
     if (!shotIds.length) return
     timer.value = setInterval(async () => {
       if (!ids.value.length) return
+      const requestedIds = [...ids.value]
       try {
-        const { data } = await canvasApi.statusBatch(ids.value)
+        const { data } = await canvasApi.statusBatch(requestedIds)
         const shots = (data.data ?? data) as ShotStatus[]
-        onUpdate(shots)
-        const stillGenerating = shots.some((s) =>
+        // Ignore shots removed during await (e.g. cancel → removeById)
+        const active = shots.filter((s) => ids.value.includes(s.id))
+        if (active.length) onUpdate(active)
+        const stillGenerating = active.some((s) =>
           s.materials.some((m) => m.status === 'generating' || m.status === 'pending'),
         )
         if (!stillGenerating) stop()
@@ -38,11 +41,18 @@ export function useShotPolling(onUpdate: (shots: ShotStatus[]) => void) {
     }, 2000)
   }
 
+  function removeById(shotId: string) {
+    const next = ids.value.filter((id) => id !== shotId)
+    if (next.length === ids.value.length) return
+    ids.value = next
+    if (!next.length) stop()
+  }
+
   function stop() {
     if (timer.value) clearInterval(timer.value)
     timer.value = undefined
   }
 
   onUnmounted(stop)
-  return { start, stop }
+  return { start, stop, removeById }
 }

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -1422,10 +1422,21 @@ function handleRemoveRef(ref: NodeRef) {
 }
 
 async function handleNodeGenerate() {
-  await debouncedNodePatch.flush()
   const node = editorNode.value
   if (!node) return
-  await generateForNode(node)
+  // Cancel before flush so a second click isn't delayed by pending patches.
+  if (isNodeBusy(node.id) || isNodeGenerating(node.data?.status)) {
+    cancelGeneration(node.id)
+    return
+  }
+  await debouncedNodePatch.flush()
+  const fresh = editorNode.value
+  if (!fresh) return
+  if (isNodeBusy(fresh.id) || isNodeGenerating(fresh.data?.status)) {
+    cancelGeneration(fresh.id)
+    return
+  }
+  await generateForNode(fresh)
 }
 
 async function handleSceneComposerSave() {
@@ -1603,6 +1614,7 @@ async function saveCanvas() {
 
 const {
   isNodeBusy,
+  cancelGeneration,
   generateForNode,
   saveSceneComposer,
   expandSceneComposer,

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -81,7 +81,12 @@ import { useCanvasKeyboard } from '@/composables/useCanvasKeyboard'
 import { downloadMediaPackage, setupCanvasMediaHandlers, type MediaFilePayload } from '@/composables/useCanvasMedia'
 import { fileToPersistedPayload, inferMediaInputKind } from '@/composables/useMediaUpload'
 import { useDebouncedNodePatch } from '@/composables/useDebouncedNodePatch'
-import { CANVAS_NODE_PATCH_KEY, CANVAS_NODE_RENAME_KEY } from '@/composables/canvasNodeActions'
+import {
+  CANVAS_NODE_CANCEL_KEY,
+  CANVAS_NODE_PATCH_KEY,
+  CANVAS_NODE_RENAME_KEY,
+  CANVAS_NODE_RETRY_KEY,
+} from '@/composables/canvasNodeActions'
 import type { CanvasAssetItem } from '@/components/canvas/CanvasAssetPanel.vue'
 import AIImageEditor from '@/components/canvas/AIImageEditor.vue'
 import CanvasContextMenu from '@/components/canvas/CanvasContextMenu.vue'
@@ -1647,6 +1652,25 @@ const {
   requestFallbackConfirm,
   isModelSelectable,
 })
+
+function retryNodeGeneration(nodeId: string) {
+  const node = nodes.value.find((n) => n.id === nodeId)
+  if (!node) return
+  const data = node.data ?? {}
+  const prompt = String(data.prompt ?? '').trim()
+  if (!prompt && String(node.type) !== 'sceneComposer') {
+    patchNodeData(nodeId, {
+      status: NODE_GENERATION_STATUS.error,
+      errorMessage: '请先填写提示词',
+    })
+    return
+  }
+  patchNodeData(nodeId, { errorMessage: null })
+  return generateForNode(node as EditableFlowNode)
+}
+
+provide(CANVAS_NODE_CANCEL_KEY, (id) => cancelGeneration(id))
+provide(CANVAS_NODE_RETRY_KEY, (id) => { void retryNodeGeneration(id) })
 
 const selectedNodeGenerating = computed(() => {
   const node = editorNode.value

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -315,8 +315,15 @@ function parseFallbackMessage(metadata?: string | null): string | undefined {
   }
 }
 
+/** Cancelled (draft) nodes must ignore late poll writes. */
+function acceptsPollWrite(status: unknown): boolean {
+  return isNodeGenerating(status) || status === 'pending'
+}
+
 const shotPolling = useShotPolling((shots) => {
   for (const shot of shots) {
+    const shotNode = nodes.value.find((n) => n.id === shot.id)
+    if (!acceptsPollWrite(shotNode?.data?.status)) continue
     for (const material of shot.materials) {
       if (material.status === NODE_GENERATION_STATUS.fallback_pending) {
         const nodeId = findLinkedMediaNodeId(shot.id, material.id)
@@ -338,6 +345,7 @@ const shotPolling = useShotPolling((shots) => {
         }
       }
       if (linked) {
+        if (!acceptsPollWrite(n.data?.status)) continue
         patchNodeData(n.id, { url: material.url, status: NODE_GENERATION_STATUS.completed })
       }
     }
@@ -347,6 +355,8 @@ const shotPolling = useShotPolling((shots) => {
 
 const generationPolling = useGenerationPolling((results) => {
   for (const { task, record } of results) {
+    const node = nodes.value.find((n) => n.id === task.nodeId)
+    if (!acceptsPollWrite(node?.data?.status)) continue
     if (record.status === NODE_GENERATION_STATUS.fallback_pending) {
       patchNodeData(task.nodeId, {
         status: NODE_GENERATION_STATUS.fallback_pending,
@@ -1644,6 +1654,7 @@ const {
   startShotPolling: (ids) => shotPolling.start(ids),
   startGenerationPolling: (tasks) => generationPolling.start(tasks),
   stopGenerationPolling: (nodeId) => generationPolling.removeByNodeId(nodeId),
+  stopShotPolling: (id) => shotPolling.removeById(id),
   resolveProviderModels: () => ({
     text: getProviderConfig('text').model,
     image: getProviderConfig('image').model,

--- a/apps/web/src/styles/neo-node.css
+++ b/apps/web/src/styles/neo-node.css
@@ -56,6 +56,22 @@
   white-space: nowrap;
 }
 
+.neo-task-badge {
+  margin-left: 6px;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border-radius: 999px;
+  padding: 1px 7px;
+  font-size: 10px;
+  font-weight: 600;
+}
+.neo-task-badge.is-running { background: rgba(59,130,246,0.2); color: #93c5fd; }
+.neo-task-badge.is-error { background: rgba(239,68,68,0.2); color: #fca5a5; }
+.neo-task-badge.is-success { background: rgba(34,197,94,0.2); color: #86efac; }
+.neo-task-badge.is-pending { background: rgba(245,158,11,0.2); color: #fcd34d; }
+
 .neo-node-rename-input {
   min-width: 80px;
   max-width: 200px;

--- a/apps/web/src/styles/neo-node.css
+++ b/apps/web/src/styles/neo-node.css
@@ -72,6 +72,49 @@
 .neo-task-badge.is-success { background: rgba(34,197,94,0.2); color: #86efac; }
 .neo-task-badge.is-pending { background: rgba(245,158,11,0.2); color: #fcd34d; }
 
+.neo-task-corner {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  max-width: 70%;
+}
+
+.neo-task-corner-btn {
+  border: none;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+}
+
+.neo-task-corner-btn.is-cancel {
+  background: #fff;
+  color: #111;
+}
+
+.neo-task-corner-btn.is-retry {
+  background: #ef4444;
+  color: #fff;
+}
+
+.neo-task-error {
+  margin: 0;
+  padding: 4px 6px;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.65);
+  color: #fca5a5;
+  font-size: 10px;
+  line-height: 1.3;
+  text-align: right;
+}
+
 .neo-node-rename-input {
   min-width: 80px;
   max-width: 200px;
@@ -137,6 +180,7 @@
 }
 
 .neo-gen-card {
+  position: relative;
   display: flex;
   width: 100%;
   height: 100%;
@@ -258,6 +302,7 @@
 }
 
 .neo-text-card {
+  position: relative;
   display: flex;
   width: 100%;
   height: 100%;
@@ -279,6 +324,7 @@
 }
 
 .neo-audio-card {
+  position: relative;
   display: flex;
   width: 100%;
   height: 100%;

--- a/apps/web/src/styles/neo-node.css
+++ b/apps/web/src/styles/neo-node.css
@@ -645,6 +645,12 @@
   opacity: 0.55;
 }
 
+.dock-studio-toolbar.is-dock-locked .dock-generate-btn,
+.bottom-toolbar-container.is-dock-readonly .dock-generate-btn {
+  pointer-events: auto !important;
+  opacity: 1 !important;
+}
+
 .bottom-toolbar-container.is-dock-readonly .bottom-toolbar-actions :not(.bottom-toolbar-close):not(.dock-generate-btn) {
   pointer-events: none;
   opacity: 0.55;

--- a/docs/superpowers/plans/2026-07-20-node-task-status-feedback.md
+++ b/docs/superpowers/plans/2026-07-20-node-task-status-feedback.md
@@ -1,0 +1,663 @@
+# 节点任务状态反馈（布局 C）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 文本生成不覆盖 Dock 提示词；Dock/卡片可取消；节点标题徽章显示生成中耗时/失败/完成，角标提供取消与重试。
+
+**Architecture:** 共享 `NodeTaskChrome`（徽章挂 `NeoBaseNode` 标题行，角标叠在卡片内容右上）。`CanvasPage` 通过 `provide` 注入 `cancelGeneration` / `retryGeneration`。`useNodeGeneration` 在开始任务时写入 `generationStartedAt`，完成只写 `content` 不改 `prompt`。
+
+**Tech Stack:** Vue 3、Vitest、现有 `NeoBaseNode` / `useNodeGeneration` / `canvasNodeActions` provide 模式
+
+**Spec:** `docs/superpowers/specs/2026-07-20-node-task-status-feedback-design.md`
+
+## Global Constraints
+
+- 布局锁定 **C**：标题徽章 + 角标操作；不做底部条 / 全卡遮罩
+- 进度仅 **已用时 m:ss**；无假百分比
+- 取消 = 客户端 abort + 停轮询；**不清空**已有 `url`/`content`；无上游 cancel API
+- 覆盖节点：`text` / `image` / `video` / `audio` / `shot`
+- 分支：`fix/text-prompt-result-separation`（已有部分改动，勿另开无关分支）
+- 提交前相关单测绿；最终 `pnpm --filter @lnkpi/web exec vitest run` 与 `pnpm build` 通过
+- 不把 `.superpowers/` 加入 commit
+
+---
+
+## File Structure Map
+
+| 路径 | 职责 |
+|------|------|
+| `apps/web/src/composables/useNodeGeneration.ts` | prompt/content 分离；`generationStartedAt`；cancel 保留结果 |
+| `apps/web/src/composables/useNodeGeneration.test.ts` | 文本/耗时/取消断言 |
+| `apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue` | Dock 只绑定 `prompt` |
+| `apps/web/src/components/canvas/dock-studio/shared/DockGenerateButton.vue` | 停止图标可取消 |
+| `apps/web/src/pages/CanvasPage.vue` | flush 前取消；provide cancel/retry |
+| `apps/web/src/styles/neo-node.css` | 生成按钮可点；徽章/角标样式 |
+| `apps/web/src/composables/canvasNodeActions.ts` | 新增 InjectionKey |
+| `apps/web/src/components/canvas/nodeTaskChrome.ts` | 徽章文案 / 角标模式 / 耗时格式纯函数 |
+| `apps/web/src/components/canvas/nodeTaskChrome.test.ts` | 纯函数单测 |
+| `apps/web/src/components/canvas/NodeTaskBadge.vue` | 标题徽章（含 tick 刷新） |
+| `apps/web/src/components/canvas/NodeTaskCornerActions.vue` | 角标取消/重试 |
+| `apps/web/src/components/canvas/NeoBaseNode.vue` | 标题行挂徽章 slot/prop |
+| `apps/web/src/components/canvas/CanvasNode{Text,Image,Video,Audio,Shot}.vue` | 挂角标 + 错误摘要 |
+| `apps/web/src/components/canvas/CanvasNodeText.vue` | 双击编辑 content（对齐 Prompt 节点） |
+
+---
+
+### Task 1: 固化文本 prompt/content 分离 + Dock 取消（分支已有改动）
+
+**Files:**
+- Modify（若未完成则补齐）: `useNodeGeneration.ts`、`TextDockPanel.vue`、`DockGenerateButton.vue`、`CanvasPage.vue`、`neo-node.css`、各 Dock `DockGenerateButton` `:disabled`
+- Test: `useNodeGeneration.test.ts`
+
+**Interfaces:**
+- Produces: 文本完成 patch **不含** `prompt`；生成中 patch **不含** `content`；`cancelGeneration(nodeId)`；`isNodeBusy(nodeId)`
+
+- [ ] **Step 1: 确认失败测试存在并失败于旧行为（若已绿则跳到 Step 3）**
+
+已有用例名：`text generate writes result to content without overwriting prompt`
+
+Run:
+
+```bash
+pnpm --filter @lnkpi/web exec vitest run src/composables/useNodeGeneration.test.ts -t "text generate writes"
+```
+
+Expected: PASS（分支已实现）或 FAIL 指出仍写入 `prompt`/`content` 混用
+
+- [ ] **Step 2: 若 FAIL，最小修复**
+
+`applyStudioRecord` 文本完成分支：
+
+```ts
+} else {
+  const content = parseRecordText(record)
+  patch.content = content
+  // do NOT set patch.prompt
+}
+```
+
+文本开始：
+
+```ts
+deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating, prompt: local })
+```
+
+`TextDockPanel`：本地 `prompt` ref，只 watch `node.id` / `data.prompt` / `data.textModel`，勿 deep-watch 整个 node。
+
+- [ ] **Step 3: 跑相关测试**
+
+```bash
+pnpm --filter @lnkpi/web exec vitest run src/composables/useNodeGeneration.test.ts
+```
+
+Expected: 全部 PASS（含 parallel / cancel）
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/composables/useNodeGeneration.ts \
+  apps/web/src/composables/useNodeGeneration.test.ts \
+  apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue \
+  apps/web/src/components/canvas/dock-studio/shared/DockGenerateButton.vue \
+  apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue \
+  apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue \
+  apps/web/src/components/canvas/dock-studio/panels/AudioDockPanel.vue \
+  apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue \
+  apps/web/src/components/canvas/dock-studio/panels/ShotDockPanel.vue \
+  apps/web/src/pages/CanvasPage.vue \
+  apps/web/src/styles/neo-node.css
+git commit -m "$(cat <<'EOF'
+fix(web): 文本结果与 Dock 提示词分离，生成中可取消
+
+EOF
+)"
+```
+
+---
+
+### Task 2: `generationStartedAt` 写入与取消保留结果
+
+**Files:**
+- Modify: `apps/web/src/composables/useNodeGeneration.ts`
+- Test: `apps/web/src/composables/useNodeGeneration.test.ts`
+
+**Interfaces:**
+- Consumes: `beginNodeWork` / `patchNodeData`
+- Produces: 进入 generating 时 patch 含 `generationStartedAt: string`（ISO）；`cancelGeneration` 不删除 `url`/`content`
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+it('writes generationStartedAt when generation begins', async () => {
+  const node = createNode('image', { prompt: 'cat' }, 'img-1')
+  let resolveHang!: (v: unknown) => void
+  const hang = new Promise((r) => { resolveHang = r })
+  vi.mocked(studioApi.generateImage).mockImplementationOnce(() => hang as never)
+  const { api, deps } = createDeps([node])
+  const pending = api.generateForNode(node)
+  await Promise.resolve()
+  expect(deps.patchNodeData).toHaveBeenCalledWith(
+    'img-1',
+    expect.objectContaining({
+      status: NODE_GENERATION_STATUS.generating,
+      generationStartedAt: expect.stringMatching(/^\d{4}-/),
+    }),
+  )
+  resolveHang(mockAxiosResponse({ data: completedRecord }))
+  await pending
+})
+
+it('cancel keeps existing content and url', async () => {
+  const node = createNode('image', {
+    prompt: 'x',
+    url: 'https://example.com/keep.png',
+    content: 'keep-me',
+    status: NODE_GENERATION_STATUS.generating,
+  }, 'img-keep')
+  // make busy then cancel
+  let rejectHang!: (e: unknown) => void
+  const hang = new Promise((_r, j) => { rejectHang = j })
+  vi.mocked(studioApi.generateImage).mockImplementation((_a, _b, _c, _d, _e, _f, _g, signal?: AbortSignal) => {
+    signal?.addEventListener('abort', () => {
+      const err = new Error('canceled')
+      ;(err as { code?: string }).code = 'ERR_CANCELED'
+      rejectHang(err)
+    })
+    return hang as never
+  })
+  const { api, deps } = createDeps([node])
+  const pending = api.generateForNode(node)
+  await Promise.resolve()
+  await api.generateForNode(node) // cancel
+  await pending
+  const draftPatch = deps.patchNodeData.mock.calls.find(
+    (c) => c[1]?.status === NODE_GENERATION_STATUS.draft,
+  )?.[1] as Record<string, unknown>
+  expect(draftPatch).toBeTruthy()
+  expect(draftPatch).not.toHaveProperty('url')
+  expect(draftPatch).not.toHaveProperty('content')
+})
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+pnpm --filter @lnkpi/web exec vitest run src/composables/useNodeGeneration.test.ts -t "generationStartedAt|cancel keeps"
+```
+
+- [ ] **Step 3: 实现**
+
+在首次进入 generating 的 patch（text/image/video/audio/shot 及 `beginNodeWork` 后的统一辅助）合并：
+
+```ts
+function startedAtPatch(): Record<string, unknown> {
+  return { generationStartedAt: new Date().toISOString() }
+}
+```
+
+`cancelGeneration` 仅：
+
+```ts
+deps.patchNodeData(nodeId, {
+  status: NODE_GENERATION_STATUS.draft,
+  errorMessage: null,
+})
+```
+
+不要 patch `url`/`content` 为 null。
+
+- [ ] **Step 4: Run — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/composables/useNodeGeneration.ts apps/web/src/composables/useNodeGeneration.test.ts
+git commit -m "feat(web): record generationStartedAt and preserve results on cancel"
+```
+
+---
+
+### Task 3: `nodeTaskChrome` 纯函数
+
+**Files:**
+- Create: `apps/web/src/components/canvas/nodeTaskChrome.ts`
+- Create: `apps/web/src/components/canvas/nodeTaskChrome.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export type TaskCornerAction = 'cancel' | 'retry' | null
+  export function formatElapsed(startedAt: string | undefined, nowMs: number): string // "0:42"
+  export function resolveTaskBadge(input: {
+    status: unknown
+    startedAt?: string
+    nowMs: number
+    completedFlash?: boolean
+  }): { text: string; tone: 'running' | 'error' | 'success' | 'pending' } | null
+  export function resolveCornerAction(status: unknown): TaskCornerAction
+  export function truncateError(message: string | undefined, max = 40): string
+  ```
+
+- [ ] **Step 1: 写失败测试**
+
+```ts
+import { describe, expect, it } from 'vitest'
+import {
+  formatElapsed,
+  resolveTaskBadge,
+  resolveCornerAction,
+  truncateError,
+} from './nodeTaskChrome'
+import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
+
+describe('nodeTaskChrome', () => {
+  it('formats elapsed as m:ss', () => {
+    const start = new Date('2026-07-20T00:00:00.000Z').toISOString()
+    expect(formatElapsed(start, Date.parse('2026-07-20T00:00:42.000Z'))).toBe('0:42')
+    expect(formatElapsed(start, Date.parse('2026-07-20T00:03:05.000Z'))).toBe('3:05')
+  })
+
+  it('badge for generating includes elapsed', () => {
+    const start = new Date('2026-07-20T00:00:00.000Z').toISOString()
+    const b = resolveTaskBadge({
+      status: NODE_GENERATION_STATUS.generating,
+      startedAt: start,
+      nowMs: Date.parse('2026-07-20T00:00:12.000Z'),
+    })
+    expect(b).toEqual({ text: '生成中 · 0:12', tone: 'running' })
+  })
+
+  it('corner cancel/retry mapping', () => {
+    expect(resolveCornerAction(NODE_GENERATION_STATUS.generating)).toBe('cancel')
+    expect(resolveCornerAction(NODE_GENERATION_STATUS.error)).toBe('retry')
+    expect(resolveCornerAction(NODE_GENERATION_STATUS.fallback_pending)).toBeNull()
+    expect(resolveCornerAction(NODE_GENERATION_STATUS.completed)).toBeNull()
+  })
+
+  it('truncates error', () => {
+    expect(truncateError('x'.repeat(50)).length).toBeLessThanOrEqual(40)
+  })
+})
+```
+
+- [ ] **Step 2: Run — expect FAIL（module missing）**
+
+```bash
+pnpm --filter @lnkpi/web exec vitest run src/components/canvas/nodeTaskChrome.test.ts
+```
+
+- [ ] **Step 3: 实现纯函数**（`formatElapsed`：缺 `startedAt` 时用 `0:00`）
+
+- [ ] **Step 4: Run — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/canvas/nodeTaskChrome.ts apps/web/src/components/canvas/nodeTaskChrome.test.ts
+git commit -m "feat(web): add nodeTaskChrome badge and corner helpers"
+```
+
+---
+
+### Task 4: InjectionKey + CanvasPage provide cancel/retry
+
+**Files:**
+- Modify: `apps/web/src/composables/canvasNodeActions.ts`
+- Modify: `apps/web/src/pages/CanvasPage.vue`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  export type CanvasNodeCancelFn = (nodeId: string) => void
+  export type CanvasNodeRetryFn = (nodeId: string) => void | Promise<void>
+  export const CANVAS_NODE_CANCEL_KEY: InjectionKey<CanvasNodeCancelFn>
+  export const CANVAS_NODE_RETRY_KEY: InjectionKey<CanvasNodeRetryFn>
+  ```
+- `retryGeneration(nodeId)`：找节点 → 若无 prompt（`prompt`/`content` 按类型）则 `patchNodeData` 短暂错误或 no-op；否则 `generateForNode(node)`
+
+- [ ] **Step 1: 扩展 keys**
+
+```ts
+// canvasNodeActions.ts — append
+export type CanvasNodeCancelFn = (nodeId: string) => void
+export type CanvasNodeRetryFn = (nodeId: string) => void | Promise<void>
+export const CANVAS_NODE_CANCEL_KEY: InjectionKey<CanvasNodeCancelFn> = Symbol('canvasNodeCancel')
+export const CANVAS_NODE_RETRY_KEY: InjectionKey<CanvasNodeRetryFn> = Symbol('canvasNodeRetry')
+```
+
+- [ ] **Step 2: CanvasPage provide**
+
+在已有 `cancelGeneration` / `generateForNode` / `nodes` 处：
+
+```ts
+function retryNodeGeneration(nodeId: string) {
+  const node = nodes.value.find((n) => n.id === nodeId)
+  if (!node) return
+  const data = node.data ?? {}
+  const prompt = String(data.prompt ?? '').trim()
+  if (!prompt && String(node.type) !== 'sceneComposer') {
+    patchNodeData(nodeId, {
+      status: NODE_GENERATION_STATUS.error,
+      errorMessage: '请先填写提示词',
+    })
+    return
+  }
+  patchNodeData(nodeId, { errorMessage: null })
+  return generateForNode(node as EditableFlowNode)
+}
+
+provide(CANVAS_NODE_CANCEL_KEY, (id) => cancelGeneration(id))
+provide(CANVAS_NODE_RETRY_KEY, (id) => { void retryNodeGeneration(id) })
+```
+
+- [ ] **Step 3: 手动类型检查**
+
+```bash
+pnpm --filter @lnkpi/web exec vue-tsc --noEmit
+```
+
+Expected: 无新增错误
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/composables/canvasNodeActions.ts apps/web/src/pages/CanvasPage.vue
+git commit -m "feat(web): provide canvas node cancel and retry actions"
+```
+
+---
+
+### Task 5: `NodeTaskBadge` + `NeoBaseNode` 标题徽章
+
+**Files:**
+- Create: `apps/web/src/components/canvas/NodeTaskBadge.vue`
+- Modify: `apps/web/src/components/canvas/NeoBaseNode.vue`
+- Modify: `apps/web/src/styles/neo-node.css`
+
+**Interfaces:**
+- Consumes: `resolveTaskBadge` / `formatElapsed`
+- `NeoBaseNode` 增加从 `data.status` / `data.generationStartedAt` 自动渲染徽章（默认开启）；`completed` 进入后本地 `flash` 2s
+
+- [ ] **Step 1: 实现 `NodeTaskBadge.vue`**
+
+```vue
+<script setup lang="ts">
+import { computed, onUnmounted, ref, watch } from 'vue'
+import { resolveTaskBadge } from '@/components/canvas/nodeTaskChrome'
+
+const props = defineProps<{
+  status?: unknown
+  startedAt?: string
+}>()
+
+const nowMs = ref(Date.now())
+const completedFlash = ref(false)
+let tick: ReturnType<typeof setInterval> | undefined
+let flashTimer: ReturnType<typeof setTimeout> | undefined
+
+watch(
+  () => props.status,
+  (s, prev) => {
+    if (s === 'completed' && prev && prev !== 'completed') {
+      completedFlash.value = true
+      clearTimeout(flashTimer)
+      flashTimer = setTimeout(() => { completedFlash.value = false }, 2000)
+    }
+  },
+)
+
+watch(
+  () => props.status,
+  (s) => {
+    clearInterval(tick)
+    if (s === 'generating' || s === 'pending') {
+      nowMs.value = Date.now()
+      tick = setInterval(() => { nowMs.value = Date.now() }, 1000)
+    }
+  },
+  { immediate: true },
+)
+
+onUnmounted(() => {
+  clearInterval(tick)
+  clearTimeout(flashTimer)
+})
+
+const badge = computed(() =>
+  resolveTaskBadge({
+    status: props.status,
+    startedAt: props.startedAt,
+    nowMs: nowMs.value,
+    completedFlash: completedFlash.value,
+  }),
+)
+</script>
+
+<template>
+  <span v-if="badge" class="neo-task-badge" :class="`is-${badge.tone}`">{{ badge.text }}</span>
+</template>
+```
+
+`resolveTaskBadge` 对 `completedFlash===true` 返回 `{ text: '已完成', tone: 'success' }`；否则 completed 返回 `null`。
+
+- [ ] **Step 2: NeoBaseNode 标题行插入徽章**
+
+在 `neo-node-title` 与 `neo-node-status` 之间：
+
+```vue
+<NodeTaskBadge
+  :status="data?.status"
+  :started-at="typeof data?.generationStartedAt === 'string' ? data.generationStartedAt : undefined"
+/>
+```
+
+- [ ] **Step 3: CSS**
+
+```css
+.neo-task-badge {
+  margin-left: 6px;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border-radius: 999px;
+  padding: 1px 7px;
+  font-size: 10px;
+  font-weight: 600;
+}
+.neo-task-badge.is-running { background: rgba(59,130,246,0.2); color: #93c5fd; }
+.neo-task-badge.is-error { background: rgba(239,68,68,0.2); color: #fca5a5; }
+.neo-task-badge.is-success { background: rgba(34,197,94,0.2); color: #86efac; }
+.neo-task-badge.is-pending { background: rgba(245,158,11,0.2); color: #fcd34d; }
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/canvas/NodeTaskBadge.vue \
+  apps/web/src/components/canvas/NeoBaseNode.vue \
+  apps/web/src/components/canvas/nodeTaskChrome.ts \
+  apps/web/src/styles/neo-node.css
+git commit -m "feat(web): show generation status badge on NeoBaseNode title"
+```
+
+---
+
+### Task 6: `NodeTaskCornerActions` + 五类节点接入
+
+**Files:**
+- Create: `apps/web/src/components/canvas/NodeTaskCornerActions.vue`
+- Modify: `CanvasNodeText.vue`、`CanvasNodeImage.vue`、`CanvasNodeVideo.vue`、`CanvasNodeAudio.vue`、`CanvasNodeShot.vue`
+- Modify: `neo-node.css`
+
+**Interfaces:**
+- Consumes: `CANVAS_NODE_CANCEL_KEY` / `CANVAS_NODE_RETRY_KEY` / `resolveCornerAction` / `truncateError`
+- Props: `status`、`errorMessage?`
+
+- [ ] **Step 1: Corner 组件**
+
+```vue
+<script setup lang="ts">
+import { computed, inject } from 'vue'
+import { useNodeId } from '@vue-flow/core'
+import { resolveCornerAction, truncateError } from '@/components/canvas/nodeTaskChrome'
+import { CANVAS_NODE_CANCEL_KEY, CANVAS_NODE_RETRY_KEY } from '@/composables/canvasNodeActions'
+
+const props = defineProps<{ status?: unknown; errorMessage?: string }>()
+const nodeId = useNodeId()
+const cancel = inject(CANVAS_NODE_CANCEL_KEY, null)
+const retry = inject(CANVAS_NODE_RETRY_KEY, null)
+const action = computed(() => resolveCornerAction(props.status))
+const err = computed(() => truncateError(props.errorMessage))
+
+function onAction(e: Event) {
+  e.stopPropagation()
+  e.preventDefault()
+  if (!nodeId) return
+  if (action.value === 'cancel') cancel?.(nodeId)
+  if (action.value === 'retry') void retry?.(nodeId)
+}
+</script>
+
+<template>
+  <div class="neo-task-corner nodrag nopan" @pointerdown.stop @mousedown.stop @click.stop>
+    <p v-if="err && (status === 'error' || status === 'failed')" class="neo-task-error">{{ err }}</p>
+    <button
+      v-if="action"
+      type="button"
+      class="neo-task-corner-btn"
+      :class="action === 'retry' ? 'is-retry' : 'is-cancel'"
+      @click="onAction"
+    >
+      {{ action === 'retry' ? '重试' : '取消' }}
+    </button>
+  </div>
+</template>
+```
+
+- [ ] **Step 2: 各 CanvasNode 在卡片根内加入**
+
+```vue
+<NodeTaskCornerActions :status="data.status" :error-message="data.errorMessage as string | undefined" />
+```
+
+父级需 `position: relative`（`neo-gen-card` / `neo-text-card` 已有或补上）。
+
+- [ ] **Step 3: Text 节点双击编辑 content（对齐 Prompt）** — 可选同 Task：用现有 `PromptMarkdownEditor` 或简单 textarea；最小实现：双击打开编辑 `content`，不改 `prompt`。
+
+- [ ] **Step 4: CSS 角标**
+
+```css
+.neo-task-corner {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  max-width: 70%;
+}
+.neo-task-corner-btn {
+  border: none;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.35);
+}
+.neo-task-corner-btn.is-cancel { background: #fff; color: #111; }
+.neo-task-corner-btn.is-retry { background: #ef4444; color: #fff; }
+.neo-task-error {
+  margin: 0;
+  padding: 4px 6px;
+  border-radius: 6px;
+  background: rgba(0,0,0,0.65);
+  color: #fca5a5;
+  font-size: 10px;
+  line-height: 1.3;
+  text-align: right;
+}
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/canvas/NodeTaskCornerActions.vue \
+  apps/web/src/components/canvas/CanvasNodeText.vue \
+  apps/web/src/components/canvas/CanvasNodeImage.vue \
+  apps/web/src/components/canvas/CanvasNodeVideo.vue \
+  apps/web/src/components/canvas/CanvasNodeAudio.vue \
+  apps/web/src/components/canvas/CanvasNodeShot.vue \
+  apps/web/src/styles/neo-node.css
+git commit -m "feat(web): add corner cancel/retry actions on generation nodes"
+```
+
+---
+
+### Task 7: 验收与 PR
+
+**Files:** 无新文件；验证 + 开 PR
+
+- [ ] **Step 1: 测试**
+
+```bash
+pnpm --filter @lnkpi/web exec vitest run \
+  src/composables/useNodeGeneration.test.ts \
+  src/components/canvas/nodeTaskChrome.test.ts
+pnpm --filter @lnkpi/web exec vue-tsc --noEmit
+pnpm build
+```
+
+Expected: 全绿
+
+- [ ] **Step 2: 手测清单（本地或 Preview）**
+
+按 spec §6.2 勾选 text + image
+
+- [ ] **Step 3: Push + PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --base main --title "fix(web): 节点任务状态反馈与文本提示词分离" --body "$(cat <<'EOF'
+## Summary
+- 文本 Dock 提示词与生成结果分离
+- Dock / 卡片可取消生成；标题徽章显示耗时；角标取消/重试
+- 覆盖 text/image/video/audio/shot
+
+## Spec
+docs/superpowers/specs/2026-07-20-node-task-status-feedback-design.md
+
+## Test plan
+- [ ] text：生成后 Dock 提示词不变
+- [ ] 生成中徽章「生成中 · m:ss」，角标可取消
+- [ ] 失败摘要 + 重试
+- [ ] pnpm build / vitest 相关套件
+
+EOF
+)"
+```
+
+---
+
+## Spec Coverage Checklist
+
+| Spec 项 | Task |
+|---------|------|
+| 文本 prompt/content 分离 | T1 |
+| Dock 可取消 | T1 |
+| `generationStartedAt` | T2 |
+| 取消保留结果 | T2 |
+| 徽章文案/耗时/完成闪 | T3 + T5 |
+| 角标取消/重试映射 | T3 + T6 |
+| provide 注入 | T4 |
+| 五类节点 | T6 |
+| 失败摘要截断 | T3 + T6 |
+| fallback_pending 无角标 | T3 |
+| PR / 验收 | T7 |
+
+## Placeholder Scan
+
+无 TBD /「类似 Task N」占位；函数名与 InjectionKey 在全文一致。

--- a/docs/superpowers/specs/2026-07-20-node-task-status-feedback-design.md
+++ b/docs/superpowers/specs/2026-07-20-node-task-status-feedback-design.md
@@ -1,0 +1,161 @@
+# 节点任务状态反馈（布局 C）设计规格
+
+**日期**：2026-07-20  
+**状态**：已确认，待实现  
+**分支建议**：`fix/text-prompt-result-separation`（已含文本 prompt/content 分离与 Dock 取消加固）  
+**布局决策**：C — 标题徽章 + 角标操作  
+
+---
+
+## 1. 背景与问题
+
+1. **文本节点**：生成结果回写 `prompt`，Dock Studio 输入被覆盖；期望 Dock 保留提示词，结果只在节点卡片。
+2. **取消 / 状态**：生成按钮转圈后难以取消；节点上任务状态几乎不可感知（仅标题旁小点）。
+3. **结果反馈**：用户无法直观看到进行中、耗时、失败原因，也无法在卡片上取消/重试。
+
+已锁定产品范围：**完整反馈（原选项 B）** = 状态 + 进度/耗时 + 失败摘要 + 卡片取消/重试。  
+视觉布局锁定为 **C**。
+
+---
+
+## 2. 已锁定决策
+
+| 决策 | 结论 |
+|------|------|
+| 架构 | 共享 `NodeTaskChrome`（方案 1），非每节点各自一套 UI |
+| 布局 | **C**：标题旁状态徽章 + 内容区右上角操作 |
+| 进度 | 仅「已用时 m:ss」，不做假百分比条 |
+| 取消语义 | 客户端 abort + 停轮询；不清空已有结果；不上游强制取消 API（本版） |
+| 重试 | 用当前节点 `prompt` + 模型参数再调 `generateForNode` |
+| 覆盖节点 | `text` / `image` / `video` / `audio` / `shot` |
+| 同 PR 附带 | 文本 prompt/content 分离；Dock 生成中可取消 |
+
+---
+
+## 3. 结构与数据
+
+### 3.1 组件
+
+- **`NodeTaskChrome`**（新）
+  - **徽章**：挂在 `NeoBaseNode` 标题行（节点名旁）
+  - **角标**：绝对定位于卡片内容区右上角
+- Dock 停止按钮与卡片「取消」共用 `cancelGeneration`
+- 卡片「重试」调用 `generateForNode`（不要求 Dock 打开）
+
+### 3.2 节点 `data` 字段
+
+| 字段 | 说明 |
+|------|------|
+| `status` | 已有：`draft` / `generating` / `completed` / `error` / `fallback_pending` |
+| `errorMessage` | 已有：失败摘要；卡片截断约 40 字 |
+| `generationStartedAt` | **新增**：ISO 时间戳，用于已用时 |
+| `generationModel` | **可选**：模型短名，徽章副文案 |
+| `generationRecordId` | 已有：轮询恢复 |
+
+### 3.3 文本 prompt / content 分离（附带修复）
+
+| 字段 | 职责 |
+|------|------|
+| `prompt` | Dock 输入；生成请求用 |
+| `content` | 生成结果；仅卡片展示 |
+
+- 生成开始：只更新 `status` + 保留 `prompt`，**不**把 prompt 写入 `content`
+- 生成完成：只写 `content`（及 status），**不**覆盖 `prompt`
+- Dock `TextDockPanel` 只同步 `prompt` / `textModel`，不 deep-watch `content`
+
+---
+
+## 4. 视觉与文案（布局 C）
+
+### 4.1 徽章
+
+| 状态 | 徽章 |
+|------|------|
+| `generating` | `生成中 · 0:42`（每秒刷新）；可选副文案模型短名 |
+| `error` / `failed` | `失败` |
+| `completed`（刚完成） | `已完成`，约 2s 后淡出，仅留标题绿点 |
+| `fallback_pending` | `待确认` |
+| `draft` / 空闲 | 无徽章 |
+
+### 4.2 角标
+
+| 状态 | 角标 |
+|------|------|
+| `generating` | 「取消」 |
+| `error` / `failed` | 「重试」 |
+| `fallback_pending` | 无（走费用确认弹窗） |
+| 其他 | 无 |
+
+- 角标 `pointerdown`/`click` 须 `stopPropagation`，避免拖拽/误选中
+- 失败时卡片内另有一行错误摘要（`errorMessage` 截断）
+
+### 4.3 Dock 生成按钮（附带）
+
+- 生成中显示停止方块（非仅转圈），可点击取消
+- 锁定态 CSS 不得禁用生成按钮的 pointer-events
+- `handleNodeGenerate` 在 `flush` **之前**处理取消
+
+---
+
+## 5. 交互与边界
+
+### 5.1 取消
+
+1. abort 进行中的请求（AbortSignal）
+2. `stopGenerationPolling(nodeId)`
+3. `status → draft`，清除 busy；**保留**已有 `url` / `content`
+4. 清除或忽略后续 poll 结果对该节点的写入
+
+### 5.2 重试
+
+1. 若 `prompt`（及该类型必要参数）为空：不发起；短暂提示「请先填写提示词」
+2. 否则清 `errorMessage`，写入新的 `generationStartedAt`，再 `generateForNode`
+
+### 5.3 耗时
+
+- 客户端根据 `generationStartedAt` 计算；无后端进度
+- 刷新后仍为 `generating` 且有 `generationRecordId`：恢复轮询；若无 `generationStartedAt`，从恢复时刻起算
+
+### 5.4 与 Dock
+
+- 未选中节点也可在卡片上取消/重试
+- 与 Dock 同时操作时依赖现有 per-node busy 守卫，禁止双开同节点任务
+
+### 5.5 本版明确不做
+
+- 全局任务列表 / 批量取消
+- 服务端取消上游供应商任务
+- 真实百分比进度条
+
+---
+
+## 6. 落地范围与验收
+
+### 6.1 交付物
+
+1. 文本 prompt/content 分离 + TextDockPanel 同步修复  
+2. Dock 可取消加固  
+3. `NodeTaskChrome` 布局 C + 五类节点接入  
+4. `generationStartedAt`（及可选 model）在开始生成时写入  
+
+### 6.2 验收
+
+- [ ] 文本生成后 Dock 提示词不变，卡片显示结果  
+- [ ] 生成中：标题徽章「生成中 · m:ss」，右上可取消  
+- [ ] 取消后回草稿，已有媒体/正文保留  
+- [ ] 失败：徽章「失败」+ 摘要 + 角标重试可再跑  
+- [ ] 完成：短暂「已完成」后徽章消失  
+- [ ] 不打开 Dock 时，仅角标可取消/重试  
+
+### 6.3 测试
+
+- 单测：文本不覆盖 prompt；取消路径；`generationStartedAt` 写入  
+- 手测：text + image 各走 生成 → 取消 →（模拟）失败重试  
+
+---
+
+## 7. 实现提示（非阻塞）
+
+- 在 `useNodeGeneration.beginNodeWork` / 首次 `patchNodeData(..., generating)` 时写入 `generationStartedAt: new Date().toISOString()`
+- `CanvasPage` 向节点组件注入 cancel/retry 回调（与现有 `patchNodeData` / `generateForNode` 对齐），避免每个 CanvasNode 直接依赖 composable 实例细节
+- 标题徽章可扩 `NeoBaseNode` slot 或 props，避免复制五套标题 DOM


### PR DESCRIPTION
## Summary
- 文本 Dock 提示词与生成结果分离
- Dock / 卡片可取消生成；标题徽章显示耗时；角标取消/重试
- 取消后停 generation/shot 轮询并忽略迟到写入，保留已有 url/content
- 覆盖 text/image/video/audio/shot

## Spec
docs/superpowers/specs/2026-07-20-node-task-status-feedback-design.md

## Test plan
- [ ] text：生成后 Dock 提示词不变
- [ ] 生成中徽章「生成中 · m:ss」，角标可取消
- [ ] 失败摘要 + 重试
- [ ] 取消后节点不会被迟到 poll 写回 completed
- [ ] pnpm build / vitest 相关套件


Made with [Cursor](https://cursor.com)