### PR TITLE
feat: points refund, canvas account chrome, dock/node UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ coverage
 *.tsbuildinfo
 uploads/
 
+# Superpowers / worktrees
+.superpowers/
+.worktrees/
+
 # Prisma
 apps/server/prisma/*.db
 apps/server/prisma/*.db-journal

--- a/apps/server/src/canvas/canvas.controller.ts
+++ b/apps/server/src/canvas/canvas.controller.ts
@@ -8,6 +8,7 @@ import type {
   VideoCompositionExportRequest,
 } from '@lnkpi/shared'
 import { AuthGuard } from '../auth/auth.guard'
+import { createCancelFlag } from '../points/charge-session'
 import { CanvasService } from './canvas.service'
 import { MaterialService } from './material.service'
 import { SceneComposerService } from './scene-composer.service'
@@ -441,10 +442,11 @@ export class CanvasController {
   @Post('material/:id/confirm-platform-fallback')
   @UseGuards(AuthGuard)
   async confirmMaterialPlatformFallback(
-    @Req() req: { user: { sub: string } },
+    @Req() req: { user: { sub: string }; on(event: string, cb: () => void): void; aborted?: boolean },
     @Param('id') id: string,
   ) {
-    const data = await this.materialService.confirmPlatformFallback(req.user.sub, id)
+    const cancel = createCancelFlag(req)
+    const data = await this.materialService.confirmPlatformFallback(req.user.sub, id, cancel)
     return { code: 0, message: 'ok', data }
   }
 

--- a/apps/server/src/canvas/canvas.controller.ts
+++ b/apps/server/src/canvas/canvas.controller.ts
@@ -460,6 +460,16 @@ export class CanvasController {
     return { code: 0, message: 'ok', data }
   }
 
+  @Post('material/:id/cancel')
+  @UseGuards(AuthGuard)
+  async cancelMaterialGeneration(
+    @Req() req: { user: { sub: string } },
+    @Param('id') id: string,
+  ) {
+    const data = await this.materialService.cancelGeneration(req.user.sub, id)
+    return { code: 0, message: 'ok', data }
+  }
+
   @Get('shot/status/batch')
   @UseGuards(AuthGuard)
   async statusBatch(@Query('ids') ids: string) {

--- a/apps/server/src/canvas/material.fallback.test.ts
+++ b/apps/server/src/canvas/material.fallback.test.ts
@@ -46,6 +46,7 @@ describe('MaterialService BYOK fallback_pending', () => {
   let svc: MaterialService
   let resolveForGeneration: ReturnType<typeof vi.fn>
   let materialUpdate: ReturnType<typeof vi.fn>
+  let materialUpdateMany: ReturnType<typeof vi.fn>
   let materialFindFirst: ReturnType<typeof vi.fn>
   let pointsConsume: ReturnType<typeof vi.fn>
   let pointsRefund: ReturnType<typeof vi.fn>
@@ -60,6 +61,11 @@ describe('MaterialService BYOK fallback_pending', () => {
     materialUpdate = vi.fn(async (args: { where: { id: string }; data: Record<string, unknown> }) => {
       stored = { ...stored, ...args.data, id: args.where.id }
       return stored
+    })
+    materialUpdateMany = vi.fn(async (args: { where: { id: string; status: string }; data: Record<string, unknown> }) => {
+      if (stored.status !== args.where.status) return { count: 0 }
+      stored = { ...stored, ...args.data }
+      return { count: 1 }
     })
     materialFindFirst = vi.fn(async () => ({
       ...stored,
@@ -92,6 +98,7 @@ describe('MaterialService BYOK fallback_pending', () => {
                 return stored
               }),
               update: materialUpdate,
+              updateMany: materialUpdateMany,
               findFirst: materialFindFirst,
             },
           },
@@ -358,5 +365,52 @@ describe('MaterialService BYOK fallback_pending', () => {
     const meta = JSON.parse(String(failedUpdate![0].data.metadata))
     expect(meta.refundReason).toBe('cancelled')
     expect(meta.refundedPoints).toBe(10)
+  })
+
+  it('cancelGeneration on generating image → refund once and failed metadata', async () => {
+    stored = {
+      id: 'm1',
+      shotId: 'shot-1',
+      type: 'image',
+      prompt: 'a cat',
+      status: 'generating',
+      metadata: JSON.stringify({ chargedPoints: 10 }),
+    }
+    materialFindFirst.mockResolvedValue({
+      ...stored,
+      shot: { session: { userId: 'u1' } },
+    })
+    const result = await svc.cancelGeneration('u1', 'm1')
+    expect(result.status).toBe('failed')
+    expect(pointsRefund).toHaveBeenCalledWith('u1', 10, '图像生成-取消退款')
+    const meta = JSON.parse(String(materialUpdate.mock.calls.at(-1)?.[0].data.metadata))
+    expect(meta.cancelled).toBe(true)
+    expect(meta.refundedPoints).toBe(10)
+  })
+
+  it('image: cancel before runImageGeneration success → ignore late completed write', async () => {
+    resolveForGeneration.mockResolvedValue(platformResolved)
+    let resolveImage!: (v: { url: string }) => void
+    imageGenerate.mockImplementationOnce(
+      () =>
+        new Promise((r) => {
+          resolveImage = r
+        }),
+    )
+    await svc.generateImage({
+      userId: 'u1',
+      shotId: 'shot-1',
+      prompt: 'a cat',
+    })
+    await vi.waitFor(() => expect(imageGenerate).toHaveBeenCalled())
+    stored = {
+      ...stored,
+      status: 'failed',
+      metadata: JSON.stringify({ chargedPoints: 10, cancelled: true, refundedPoints: 10 }),
+    }
+    resolveImage({ url: 'https://example.com/late.png' })
+    await new Promise((r) => setTimeout(r, 30))
+    expect(materialUpdateMany).not.toHaveBeenCalled()
+    expect(stored.status).toBe('failed')
   })
 })

--- a/apps/server/src/canvas/material.fallback.test.ts
+++ b/apps/server/src/canvas/material.fallback.test.ts
@@ -32,16 +32,28 @@ const userResolved = {
   source: 'user' as const,
 }
 
+const platformResolved = {
+  channelId: 'platform',
+  modelName: 'seedream-5.0-pro',
+  apiFormat: 'openai' as const,
+  credentials: { apiKey: 'plat-key', baseUrl: 'https://platform.example.com/v1' },
+  source: 'platform' as const,
+}
+
 describe('MaterialService BYOK fallback_pending', () => {
   let svc: MaterialService
   let resolveForGeneration: ReturnType<typeof vi.fn>
   let materialUpdate: ReturnType<typeof vi.fn>
   let materialFindFirst: ReturnType<typeof vi.fn>
+  let pointsConsume: ReturnType<typeof vi.fn>
+  let pointsRefund: ReturnType<typeof vi.fn>
   let stored: Record<string, unknown>
 
   beforeEach(async () => {
     vi.clearAllMocks()
     stored = { id: 'm1', shotId: 'shot-1', type: 'image', prompt: 'a cat', status: 'generating' }
+    pointsConsume = vi.fn(async () => {})
+    pointsRefund = vi.fn(async () => {})
     resolveForGeneration = vi.fn(async () => userResolved)
     materialUpdate = vi.fn(async (args: { where: { id: string }; data: Record<string, unknown> }) => {
       stored = { ...stored, ...args.data, id: args.where.id }
@@ -55,7 +67,13 @@ describe('MaterialService BYOK fallback_pending', () => {
     const moduleRef = await Test.createTestingModule({
       providers: [
         MaterialService,
-        { provide: PointsService, useValue: { consume: vi.fn(async () => {}) } },
+        {
+          provide: PointsService,
+          useValue: {
+            consume: pointsConsume,
+            refund: pointsRefund,
+          },
+        },
         {
           provide: PrismaService,
           useValue: {
@@ -85,7 +103,7 @@ describe('MaterialService BYOK fallback_pending', () => {
     svc = moduleRef.get(MaterialService)
   })
 
-  it('image: user fail → fallback_pending retains effectivePrompt/refs', async () => {
+  it('image: user fail → fallback_pending retains effectivePrompt/refs and refunds', async () => {
     vi.mocked(mergeRefsToPrompt).mockResolvedValueOnce({
       mergedText: 'merged cat prompt',
       skippedMerge: false,
@@ -117,6 +135,10 @@ describe('MaterialService BYOK fallback_pending', () => {
     expect(meta.effectivePrompt).toContain('merged cat prompt')
     expect(meta.effectivePrompt).toContain('https://cdn.example.com/ref.png')
     expect(meta.referenceImages).toEqual(['https://cdn.example.com/ref.png'])
+    expect(meta.chargedPoints).toBe(10)
+    expect(meta.refundedPoints).toBe(10)
+    expect(meta.refundReason).toBe('byok_failed')
+    expect(pointsRefund).toHaveBeenCalledWith('u1', 10, '图像生成-BYOK失败退款')
     expect(call.data.prompt).toBe(meta.effectivePrompt)
     expect(createImageProvider).toHaveBeenCalledTimes(1)
     expect(createImageProvider).toHaveBeenCalledWith({
@@ -125,7 +147,7 @@ describe('MaterialService BYOK fallback_pending', () => {
     })
   })
 
-  it('video: user fail → fallback_pending retains effectivePrompt/refs', async () => {
+  it('video: user fail → fallback_pending retains effectivePrompt/refs and refunds', async () => {
     vi.mocked(mergeRefsToPrompt).mockResolvedValueOnce({
       mergedText: 'merged walk prompt',
       skippedMerge: false,
@@ -155,6 +177,8 @@ describe('MaterialService BYOK fallback_pending', () => {
     expect(meta.effectivePrompt).toBe('merged walk prompt')
     expect(meta.referenceImages).toEqual(['https://cdn.example.com/frame.png'])
     expect(meta.image).toBe('https://cdn.example.com/frame.png')
+    expect(meta.refundedPoints).toBe(30)
+    expect(pointsRefund).toHaveBeenCalledWith('u1', 30, '视频生成-BYOK失败退款')
     expect(call.data.prompt).toBe('merged walk prompt')
     expect(createVideoProvider).toHaveBeenCalledTimes(1)
     expect(createVideoProvider).toHaveBeenCalledWith({
@@ -163,7 +187,7 @@ describe('MaterialService BYOK fallback_pending', () => {
     })
   })
 
-  it('image confirm → platform generate called', async () => {
+  it('image confirm → platform generate called and consumes points', async () => {
     imageGenerate.mockRejectedValueOnce(new Error('upstream 502'))
     await svc.generateImage({
       userId: 'u1',
@@ -189,11 +213,14 @@ describe('MaterialService BYOK fallback_pending', () => {
     expect(result.status).toBe('completed')
     expect(createImageProvider).toHaveBeenCalledWith(undefined)
     expect(imageGenerate).toHaveBeenCalled()
+    expect(pointsConsume).toHaveBeenCalledWith('u1', 10, '平台回退生成')
     const meta = JSON.parse(String(result.metadata))
     expect(meta.providerFallback).toBe(true)
+    expect(meta.chargedPoints).toBe(10)
+    expect(meta.priorByokRefunded).toBe(true)
   })
 
-  it('video confirm → platform generate called with catalog model', async () => {
+  it('video confirm → platform generate called with catalog model and consumes points', async () => {
     videoGenerate.mockRejectedValueOnce(new Error('upstream 502'))
     await svc.generateVideo({
       userId: 'u1',
@@ -231,11 +258,55 @@ describe('MaterialService BYOK fallback_pending', () => {
         image: 'https://cdn.example.com/frame.png',
       }),
     )
+    expect(pointsConsume).toHaveBeenCalledWith('u1', 30, '平台回退生成')
     const meta = JSON.parse(String(result.metadata))
     expect(meta.providerFallback).toBe(true)
   })
 
-  it('cancel → failed', async () => {
+  it('image: platform source failure → refund after consume', async () => {
+    resolveForGeneration.mockResolvedValue(platformResolved)
+    imageGenerate.mockRejectedValueOnce(new Error('platform upstream 502'))
+    await svc.generateImage({
+      userId: 'u1',
+      shotId: 'shot-1',
+      prompt: 'a cat',
+    })
+    await vi.waitFor(() =>
+      expect(materialUpdate.mock.calls.some((c) => c[0].data.status === 'failed')).toBe(true),
+    )
+    expect(pointsConsume).toHaveBeenCalledWith('u1', 10, '图像生成')
+    expect(pointsRefund).toHaveBeenCalledWith('u1', 10, '图像生成-失败退款')
+    const failedUpdate = materialUpdate.mock.calls.find((c) => c[0].data.status === 'failed')!
+    const meta = JSON.parse(String(failedUpdate[0].data.metadata))
+    expect(meta.refundedPoints).toBe(10)
+    expect(meta.refundReason).toBe('platform_failed')
+  })
+
+  it('confirmPlatformFallback: platform generate failure → refund, failed, refundedPoints', async () => {
+    imageGenerate.mockRejectedValueOnce(new Error('upstream 502'))
+    await svc.generateImage({
+      userId: 'u1',
+      shotId: 'shot-1',
+      prompt: 'a cat',
+      model: 'ch_user::custom-model',
+    })
+    await vi.waitFor(() => expect(stored.status).toBe('fallback_pending'))
+    vi.clearAllMocks()
+    imageGenerate.mockRejectedValueOnce(new Error('platform confirm failed'))
+
+    await expect(svc.confirmPlatformFallback('u1', 'm1')).rejects.toThrow('platform confirm failed')
+
+    expect(pointsConsume).toHaveBeenCalledWith('u1', 10, '平台回退生成')
+    expect(pointsRefund).toHaveBeenCalledWith('u1', 10, '平台回退失败退款')
+    const failedUpdate = materialUpdate.mock.calls.find((c) => c[0].data.status === 'failed')
+    expect(failedUpdate).toBeTruthy()
+    const meta = JSON.parse(String(failedUpdate![0].data.metadata))
+    expect(meta.refundedPoints).toBe(10)
+    expect(meta.refundReason).toBe('platform_fallback_failed')
+    expect(meta.priorByokRefunded).toBe(true)
+  })
+
+  it('cancel → failed without double refund', async () => {
     imageGenerate.mockRejectedValueOnce(new Error('fail'))
     await svc.generateImage({
       userId: 'u1',
@@ -244,7 +315,10 @@ describe('MaterialService BYOK fallback_pending', () => {
       model: 'ch_user::custom-model',
     })
     await vi.waitFor(() => expect(stored.status).toBe('fallback_pending'))
+    expect(pointsRefund).toHaveBeenCalledTimes(1)
+    pointsRefund.mockClear()
     const result = await svc.cancelPlatformFallback('u1', 'm1')
     expect(result.status).toBe('failed')
+    expect(pointsRefund).not.toHaveBeenCalled()
   })
 })

--- a/apps/server/src/canvas/material.fallback.test.ts
+++ b/apps/server/src/canvas/material.fallback.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Test } from '@nestjs/testing'
 import { createImageProvider, createVideoProvider, mergeRefsToPrompt } from '@lnkpi/agent'
 import { BYOK_FALLBACK_CONFIRM_MESSAGE } from '@lnkpi/shared'
+import { BadRequestException } from '@nestjs/common'
+import { createCancelFlag } from '../points/charge-session'
 import { MaterialService } from './material.service'
 import { PointsService } from '../points/points.service'
 import { PrismaService } from '../prisma/prisma.service'
@@ -320,5 +322,39 @@ describe('MaterialService BYOK fallback_pending', () => {
     const result = await svc.cancelPlatformFallback('u1', 'm1')
     expect(result.status).toBe('failed')
     expect(pointsRefund).not.toHaveBeenCalled()
+  })
+
+  it('confirmPlatformFallback: client abort after generate → refund once, failed', async () => {
+    imageGenerate.mockRejectedValueOnce(new Error('upstream 502'))
+    await svc.generateImage({
+      userId: 'u1',
+      shotId: 'shot-1',
+      prompt: 'a cat',
+      model: 'ch_user::custom-model',
+    })
+    await vi.waitFor(() => expect(stored.status).toBe('fallback_pending'))
+    vi.clearAllMocks()
+    imageGenerate.mockResolvedValueOnce({ url: 'https://example.com/plat.png' })
+
+    const listeners: Record<string, (() => void)[]> = {}
+    const cancel = createCancelFlag({
+      aborted: false,
+      on(event: string, cb: () => void) {
+        listeners[event] = listeners[event] ?? []
+        listeners[event].push(cb)
+      },
+    })
+    const promise = svc.confirmPlatformFallback('u1', 'm1', cancel)
+    listeners.close?.forEach((cb) => cb())
+    await expect(promise).rejects.toThrow(BadRequestException)
+    await expect(promise).rejects.toThrow('已取消')
+    expect(pointsConsume).toHaveBeenCalledWith('u1', 10, '平台回退生成')
+    expect(pointsRefund).toHaveBeenCalledTimes(1)
+    expect(pointsRefund).toHaveBeenCalledWith('u1', 10, '平台回退-取消退款')
+    const failedUpdate = materialUpdate.mock.calls.find((c) => c[0].data.status === 'failed')
+    expect(failedUpdate).toBeTruthy()
+    const meta = JSON.parse(String(failedUpdate![0].data.metadata))
+    expect(meta.refundReason).toBe('cancelled')
+    expect(meta.refundedPoints).toBe(10)
   })
 })

--- a/apps/server/src/canvas/material.fallback.test.ts
+++ b/apps/server/src/canvas/material.fallback.test.ts
@@ -346,8 +346,10 @@ describe('MaterialService BYOK fallback_pending', () => {
     })
     const promise = svc.confirmPlatformFallback('u1', 'm1', cancel)
     listeners.close?.forEach((cb) => cb())
-    await expect(promise).rejects.toThrow(BadRequestException)
-    await expect(promise).rejects.toThrow('已取消')
+    await expect(promise).rejects.toBeInstanceOf(BadRequestException)
+    await expect(promise).rejects.toMatchObject({
+      response: { message: '已取消', refundedPoints: 10 },
+    })
     expect(pointsConsume).toHaveBeenCalledWith('u1', 10, '平台回退生成')
     expect(pointsRefund).toHaveBeenCalledTimes(1)
     expect(pointsRefund).toHaveBeenCalledWith('u1', 10, '平台回退-取消退款')

--- a/apps/server/src/canvas/material.service.ts
+++ b/apps/server/src/canvas/material.service.ts
@@ -20,6 +20,11 @@ import {
   type GenerationRefPayload,
   type ImageResolutionTier,
 } from '@lnkpi/shared'
+import {
+  alreadyRefunded,
+  applyChargeMeta,
+  applyRefundMeta,
+} from '../points/charge-session'
 import { PrismaService } from '../prisma/prisma.service'
 import { PointsService } from '../points/points.service'
 import { videoCredits } from '../points/video-credits'
@@ -105,6 +110,8 @@ function parseMeta(raw: string | null | undefined): Record<string, unknown> {
   }
 }
 
+type CancelFlag = { isCancelled(): boolean }
+
 @Injectable()
 export class MaterialService {
   private readonly logger = new Logger(MaterialService.name)
@@ -134,6 +141,41 @@ export class MaterialService {
         status: data.status ?? 'completed',
       },
     })
+  }
+
+  private pendingMeta(
+    resolved: ResolvedGenerationProvider,
+    err: unknown,
+    extra: Record<string, unknown> = {},
+  ) {
+    return {
+      ...extra,
+      channelId: resolved.channelId,
+      failureClass: classifyByokFailure(err),
+      confirmMessage: BYOK_FALLBACK_CONFIRM_MESSAGE,
+    }
+  }
+
+  private byokPendingMeta(
+    resolved: ResolvedGenerationProvider,
+    err: unknown,
+    cost: number,
+    extra: Record<string, unknown> = {},
+  ) {
+    return applyRefundMeta(
+      applyChargeMeta(this.pendingMeta(resolved, err, extra), cost),
+      cost,
+      'byok_failed',
+    )
+  }
+
+  private platformFallbackCost(type: string, meta: Record<string, unknown>): number {
+    if (type === 'image') return 10
+    if (type === 'video') {
+      const duration = Number(meta.duration ?? 5)
+      return videoCredits(duration)
+    }
+    throw new BadRequestException('不支持的素材类型')
   }
 
   async generateImage(input: CanvasImageGenerateInput) {
@@ -171,8 +213,10 @@ export class MaterialService {
       )
     }
 
+    const cost = 10
+    const chargeReason = '图像生成'
     if (!skipCharge) {
-      await this.points.consume(userId, 10, '图像生成')
+      await this.points.consume(userId, cost, chargeReason)
     }
 
     const resolved = await this.resolver.resolveForGeneration(userId, model, 'image')
@@ -182,18 +226,25 @@ export class MaterialService {
         type: 'image',
         prompt,
         status: 'generating',
-        metadata: JSON.stringify({
-          model,
-          aspectRatio,
-          resolution,
-          channelId: resolved.channelId,
-          providerSource: resolved.source,
-        }),
+        metadata: JSON.stringify(
+          applyChargeMeta(
+            {
+              model,
+              aspectRatio,
+              resolution,
+              channelId: resolved.channelId,
+              providerSource: resolved.source,
+            },
+            skipCharge ? 0 : cost,
+          ),
+        ),
       },
     })
     this.runImageGeneration(
       material.id,
       userId,
+      cost,
+      chargeReason,
       prompt,
       model,
       aspectRatio,
@@ -201,6 +252,7 @@ export class MaterialService {
       refs,
       mentionedKeys,
       resolved,
+      skipCharge,
     ).catch(console.error)
     return material
   }
@@ -230,8 +282,10 @@ export class MaterialService {
 
     assertNoBlobRefs(refs)
 
+    const cost = videoCredits(duration)
+    const chargeReason = '视频生成'
     if (!skipCharge) {
-      await this.points.consume(userId, videoCredits(duration), '视频生成')
+      await this.points.consume(userId, cost, chargeReason)
     }
 
     const resolved = await this.resolver.resolveForGeneration(userId, model, 'video')
@@ -241,20 +295,27 @@ export class MaterialService {
         type: 'video',
         prompt,
         status: 'generating',
-        metadata: JSON.stringify({
-          model,
-          duration,
-          aspectRatio,
-          resolution,
-          crop,
-          channelId: resolved.channelId,
-          providerSource: resolved.source,
-        }),
+        metadata: JSON.stringify(
+          applyChargeMeta(
+            {
+              model,
+              duration,
+              aspectRatio,
+              resolution,
+              crop,
+              channelId: resolved.channelId,
+              providerSource: resolved.source,
+            },
+            skipCharge ? 0 : cost,
+          ),
+        ),
       },
     })
     this.runVideoGeneration(
       material.id,
       userId,
+      cost,
+      chargeReason,
       prompt,
       model,
       duration,
@@ -264,11 +325,12 @@ export class MaterialService {
       refs,
       mentionedKeys,
       resolved,
+      skipCharge,
     ).catch(console.error)
     return material
   }
 
-  async confirmPlatformFallback(userId: string, materialId: string) {
+  async confirmPlatformFallback(userId: string, materialId: string, cancel?: CancelFlag) {
     const material = await this.prisma.material.findFirst({
       where: { id: materialId, shot: { session: { userId } } },
       include: { shot: { include: { session: true } } },
@@ -278,80 +340,122 @@ export class MaterialService {
       throw new BadRequestException('当前状态不可确认平台回退')
     }
     const meta = parseMeta(material.metadata)
-    await this.resolver.resolveForGeneration(
-      userId,
-      String(meta.modelKey ?? meta.gatewayModelId ?? meta.model ?? ''),
-      material.type === 'video' ? 'video' : 'image',
-    )
+    const platformCost = this.platformFallbackCost(material.type, meta)
+    await this.points.consume(userId, platformCost, '平台回退生成')
+    const chargedMeta = { ...meta, chargedPoints: platformCost, priorByokRefunded: true }
 
-    if (material.type === 'image') {
-      const size = String(meta.size ?? resolveImageSize('16:9', '1K'))
-      const modelKey =
-        typeof meta.modelKey === 'string' && meta.modelKey.trim()
-          ? meta.modelKey
-          : undefined
-      const modelId = resolveModelKey('image', modelKey).entry.gatewayModelId
-      const prompt = String(meta.effectivePrompt ?? material.prompt ?? '')
-      const { url } = await createImageProvider(undefined).generate(prompt, {
-        modelId,
-        size,
-        n: 1,
-      })
-      return this.prisma.material.update({
+    try {
+      await this.resolver.resolveForGeneration(
+        userId,
+        String(meta.modelKey ?? meta.gatewayModelId ?? meta.model ?? ''),
+        material.type === 'video' ? 'video' : 'image',
+      )
+
+      if (material.type === 'image') {
+        const size = String(meta.size ?? resolveImageSize('16:9', '1K'))
+        const modelKey =
+          typeof meta.modelKey === 'string' && meta.modelKey.trim()
+            ? meta.modelKey
+            : undefined
+        const modelId = resolveModelKey('image', modelKey).entry.gatewayModelId
+        const prompt = String(meta.effectivePrompt ?? material.prompt ?? '')
+        const { url } = await createImageProvider(undefined).generate(prompt, {
+          modelId,
+          size,
+          n: 1,
+        })
+        if (cancel?.isCancelled()) {
+          await this.points.refund(userId, platformCost, '平台回退-取消退款')
+          throw new BadRequestException('已取消')
+        }
+        return this.prisma.material.update({
+          where: { id: material.id },
+          data: {
+            url,
+            thumbnail: url,
+            status: 'completed',
+            prompt,
+            metadata: JSON.stringify({
+              ...chargedMeta,
+              gatewayModelId: modelId,
+              providerFallback: true,
+              channelId: 'platform',
+            }),
+          },
+        })
+      }
+
+      if (material.type === 'video') {
+        const prompt = String(meta.effectivePrompt ?? material.prompt ?? '')
+        const modelKey =
+          typeof meta.modelKey === 'string' && meta.modelKey.trim()
+            ? meta.modelKey
+            : undefined
+        const platformModel = resolveModelKey('video', modelKey).entry.gatewayModelId
+        const { url } = await createVideoProvider(undefined).generate(prompt, {
+          model: platformModel,
+          duration: Number(meta.duration ?? 5),
+          aspectRatio: String(meta.aspectRatio ?? '16:9'),
+          resolution: String(meta.resolution ?? '720p'),
+          crop: meta.crop === undefined ? undefined : String(meta.crop),
+          image:
+            typeof meta.image === 'string'
+              ? meta.image
+              : Array.isArray(meta.referenceImages)
+                ? (meta.referenceImages as string[])[0]
+                : undefined,
+        })
+        if (cancel?.isCancelled()) {
+          await this.points.refund(userId, platformCost, '平台回退-取消退款')
+          throw new BadRequestException('已取消')
+        }
+        return this.prisma.material.update({
+          where: { id: material.id },
+          data: {
+            url,
+            thumbnail: url,
+            status: 'completed',
+            prompt,
+            metadata: JSON.stringify({
+              ...chargedMeta,
+              gatewayModelId: platformModel,
+              providerFallback: true,
+              channelId: 'platform',
+            }),
+          },
+        })
+      }
+
+      throw new BadRequestException('不支持的素材类型')
+    } catch (err) {
+      if (err instanceof BadRequestException && err.message === '已取消') {
+        await this.prisma.material.update({
+          where: { id: material.id },
+          data: {
+            status: 'failed',
+            metadata: JSON.stringify(
+              applyRefundMeta(chargedMeta, platformCost, 'cancelled'),
+            ),
+          },
+        })
+        throw err
+      }
+      if (err instanceof BadRequestException && err.message === '不支持的素材类型') {
+        await this.points.refund(userId, platformCost, '平台回退失败退款')
+        throw err
+      }
+      await this.points.refund(userId, platformCost, '平台回退失败退款')
+      await this.prisma.material.update({
         where: { id: material.id },
         data: {
-          url,
-          thumbnail: url,
-          status: 'completed',
-          prompt,
-          metadata: JSON.stringify({
-            ...meta,
-            gatewayModelId: modelId,
-            providerFallback: true,
-            channelId: 'platform',
-          }),
+          status: 'failed',
+          metadata: JSON.stringify(
+            applyRefundMeta(chargedMeta, platformCost, 'platform_fallback_failed'),
+          ),
         },
       })
+      throw err
     }
-
-    if (material.type === 'video') {
-      const prompt = String(meta.effectivePrompt ?? material.prompt ?? '')
-      const modelKey =
-        typeof meta.modelKey === 'string' && meta.modelKey.trim()
-          ? meta.modelKey
-          : undefined
-      const platformModel = resolveModelKey('video', modelKey).entry.gatewayModelId
-      const { url } = await createVideoProvider(undefined).generate(prompt, {
-        model: platformModel,
-        duration: Number(meta.duration ?? 5),
-        aspectRatio: String(meta.aspectRatio ?? '16:9'),
-        resolution: String(meta.resolution ?? '720p'),
-        crop: meta.crop === undefined ? undefined : String(meta.crop),
-        image:
-          typeof meta.image === 'string'
-            ? meta.image
-            : Array.isArray(meta.referenceImages)
-              ? (meta.referenceImages as string[])[0]
-              : undefined,
-      })
-      return this.prisma.material.update({
-        where: { id: material.id },
-        data: {
-          url,
-          thumbnail: url,
-          status: 'completed',
-          prompt,
-          metadata: JSON.stringify({
-            ...meta,
-            gatewayModelId: platformModel,
-            providerFallback: true,
-            channelId: 'platform',
-          }),
-        },
-      })
-    }
-
-    throw new BadRequestException('不支持的素材类型')
   }
 
   async cancelPlatformFallback(userId: string, materialId: string) {
@@ -361,6 +465,14 @@ export class MaterialService {
     if (!material) throw new NotFoundException('素材不存在')
     if (material.status !== 'fallback_pending') {
       throw new BadRequestException('当前状态不可取消平台回退')
+    }
+    const meta = parseMeta(material.metadata)
+    if (!alreadyRefunded(meta)) {
+      const cost =
+        typeof meta.chargedPoints === 'number'
+          ? meta.chargedPoints
+          : this.platformFallbackCost(material.type, meta)
+      await this.points.refund(userId, cost, '平台回退取消退款')
     }
     return this.prisma.material.update({
       where: { id: material.id },
@@ -393,6 +505,8 @@ export class MaterialService {
   private async runImageGeneration(
     materialId: string,
     userId: string,
+    cost: number,
+    chargeReason: string,
     prompt: string,
     model: string | undefined,
     aspectRatio: string | undefined,
@@ -400,6 +514,7 @@ export class MaterialService {
     refs: GenerationRefPayload[] | undefined,
     mentionedKeys: string[] | undefined,
     resolved: ResolvedGenerationProvider,
+    skipCharge?: boolean,
   ) {
     const { mergedText, skippedMerge, referenceImages } = await this.resolveMergedPrompt(
       prompt,
@@ -448,23 +563,31 @@ export class MaterialService {
           thumbnail: url,
           status: 'completed',
           prompt: effectivePrompt,
-          metadata: JSON.stringify({
-            ...built.meta,
-            modelId,
-            model,
-            aspectRatio,
-            resolution,
-            size: built.size,
-            referenceImages,
-            skippedMerge,
-            channelId: resolved.channelId,
-            effectivePrompt,
-          }),
+          metadata: JSON.stringify(
+            applyChargeMeta(
+              {
+                ...built.meta,
+                modelId,
+                model,
+                aspectRatio,
+                resolution,
+                size: built.size,
+                referenceImages,
+                skippedMerge,
+                channelId: resolved.channelId,
+                effectivePrompt,
+              },
+              skipCharge ? 0 : cost,
+            ),
+          ),
         },
       })
     } catch (err) {
       console.error('Image generation failed:', err)
       if (resolved.source === 'user') {
+        if (!skipCharge) {
+          await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
+        }
         const existing = await this.prisma.material.findFirst({ where: { id: materialId } })
         const prev = parseMeta(existing?.metadata)
         await this.prisma.material.update({
@@ -472,30 +595,39 @@ export class MaterialService {
           data: {
             status: 'fallback_pending',
             prompt: effectivePrompt,
-            metadata: JSON.stringify({
-              ...prev,
-              ...built.meta,
-              modelId,
-              model,
-              originalModel: model,
-              aspectRatio,
-              resolution,
-              size: built.size,
-              referenceImages,
-              skippedMerge,
-              effectivePrompt,
-              channelId: resolved.channelId,
-              failureClass: classifyByokFailure(err),
-              confirmMessage: BYOK_FALLBACK_CONFIRM_MESSAGE,
-              userId,
-            }),
+            metadata: JSON.stringify(
+              this.byokPendingMeta(resolved, err, skipCharge ? 0 : cost, {
+                ...prev,
+                ...built.meta,
+                modelId,
+                model,
+                originalModel: model,
+                aspectRatio,
+                resolution,
+                size: built.size,
+                referenceImages,
+                skippedMerge,
+                effectivePrompt,
+                userId,
+              }),
+            ),
           },
         })
         return
       }
+      if (!skipCharge) {
+        await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
+      }
+      const existing = await this.prisma.material.findFirst({ where: { id: materialId } })
+      const prev = parseMeta(existing?.metadata)
       await this.prisma.material.update({
         where: { id: materialId },
-        data: { status: 'failed' },
+        data: {
+          status: 'failed',
+          metadata: JSON.stringify(
+            applyRefundMeta(prev, skipCharge ? 0 : cost, 'platform_failed'),
+          ),
+        },
       })
     }
   }
@@ -503,6 +635,8 @@ export class MaterialService {
   private async runVideoGeneration(
     materialId: string,
     userId: string,
+    cost: number,
+    chargeReason: string,
     prompt: string,
     model: string | undefined,
     duration: number,
@@ -512,6 +646,7 @@ export class MaterialService {
     refs: GenerationRefPayload[] | undefined,
     mentionedKeys: string[] | undefined,
     resolved: ResolvedGenerationProvider,
+    skipCharge?: boolean,
   ) {
     const { mergedText, skippedMerge, referenceImages } = await this.resolveMergedPrompt(
       prompt,
@@ -561,24 +696,32 @@ export class MaterialService {
           thumbnail: url,
           status: 'completed',
           prompt: effectivePrompt,
-          metadata: JSON.stringify({
-            ...built.meta,
-            model,
-            duration,
-            aspectRatio,
-            resolution,
-            crop,
-            image: built.image,
-            referenceImages,
-            skippedMerge,
-            channelId: resolved.channelId,
-            effectivePrompt,
-          }),
+          metadata: JSON.stringify(
+            applyChargeMeta(
+              {
+                ...built.meta,
+                model,
+                duration,
+                aspectRatio,
+                resolution,
+                crop,
+                image: built.image,
+                referenceImages,
+                skippedMerge,
+                channelId: resolved.channelId,
+                effectivePrompt,
+              },
+              skipCharge ? 0 : cost,
+            ),
+          ),
         },
       })
     } catch (err) {
       console.error('Video generation failed:', err)
       if (resolved.source === 'user') {
+        if (!skipCharge) {
+          await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
+        }
         const existing = await this.prisma.material.findFirst({ where: { id: materialId } })
         const prev = parseMeta(existing?.metadata)
         await this.prisma.material.update({
@@ -586,32 +729,41 @@ export class MaterialService {
           data: {
             status: 'fallback_pending',
             prompt: effectivePrompt,
-            metadata: JSON.stringify({
-              ...prev,
-              ...built.meta,
-              model,
-              originalModel: model,
-              modelName: resolved.modelName,
-              duration,
-              aspectRatio,
-              resolution,
-              crop,
-              image: built.image,
-              referenceImages,
-              skippedMerge,
-              effectivePrompt,
-              channelId: resolved.channelId,
-              failureClass: classifyByokFailure(err),
-              confirmMessage: BYOK_FALLBACK_CONFIRM_MESSAGE,
-              userId,
-            }),
+            metadata: JSON.stringify(
+              this.byokPendingMeta(resolved, err, skipCharge ? 0 : cost, {
+                ...prev,
+                ...built.meta,
+                model,
+                originalModel: model,
+                modelName: resolved.modelName,
+                duration,
+                aspectRatio,
+                resolution,
+                crop,
+                image: built.image,
+                referenceImages,
+                skippedMerge,
+                effectivePrompt,
+                userId,
+              }),
+            ),
           },
         })
         return
       }
+      if (!skipCharge) {
+        await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
+      }
+      const existing = await this.prisma.material.findFirst({ where: { id: materialId } })
+      const prev = parseMeta(existing?.metadata)
       await this.prisma.material.update({
         where: { id: materialId },
-        data: { status: 'failed' },
+        data: {
+          status: 'failed',
+          metadata: JSON.stringify(
+            applyRefundMeta(prev, skipCharge ? 0 : cost, 'platform_failed'),
+          ),
+        },
       })
     }
   }

--- a/apps/server/src/canvas/material.service.ts
+++ b/apps/server/src/canvas/material.service.ts
@@ -25,6 +25,7 @@ import {
   applyChargeMeta,
   applyRefundMeta,
   isCancelledException,
+  isCancelledMeta,
   rethrowWithRefundedPoints,
   throwCancelledException,
 } from '../points/charge-session'
@@ -483,6 +484,31 @@ export class MaterialService {
     })
   }
 
+  async cancelGeneration(userId: string, materialId: string) {
+    const material = await this.prisma.material.findFirst({
+      where: { id: materialId, shot: { session: { userId } } },
+    })
+    if (!material) throw new NotFoundException('素材不存在')
+    if (material.status !== 'generating') {
+      throw new BadRequestException('当前状态不可取消')
+    }
+    const meta = parseMeta(material.metadata)
+    const cost = typeof meta.chargedPoints === 'number' ? meta.chargedPoints : 0
+    const chargeReason = material.type === 'video' ? '视频生成' : '图像生成'
+    let updatedMeta: Record<string, unknown> = { ...meta, cancelled: true }
+    if (cost > 0 && !alreadyRefunded(meta)) {
+      await this.points.refund(userId, cost, `${chargeReason}-取消退款`)
+      updatedMeta = applyRefundMeta(updatedMeta, cost, 'cancelled')
+    }
+    return this.prisma.material.update({
+      where: { id: material.id },
+      data: {
+        status: 'failed',
+        metadata: JSON.stringify(updatedMeta),
+      },
+    })
+  }
+
   private async resolveMergedPrompt(
     localPrompt: string,
     refs: GenerationRefPayload[] | undefined,
@@ -559,8 +585,12 @@ export class MaterialService {
         size: built.size,
         n: built.n,
       })
-      await this.prisma.material.update({
-        where: { id: materialId },
+      const existing = await this.prisma.material.findFirst({ where: { id: materialId } })
+      if (!existing || existing.status !== 'generating') return
+      const prev = parseMeta(existing.metadata)
+      if (isCancelledMeta(prev) || alreadyRefunded(prev)) return
+      const updated = await this.prisma.material.updateMany({
+        where: { id: materialId, status: 'generating' },
         data: {
           url,
           thumbnail: url,
@@ -585,6 +615,7 @@ export class MaterialService {
           ),
         },
       })
+      if (updated.count === 0) return
     } catch (err) {
       console.error('Image generation failed:', err)
       if (resolved.source === 'user') {
@@ -592,7 +623,9 @@ export class MaterialService {
           await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
         }
         const existing = await this.prisma.material.findFirst({ where: { id: materialId } })
-        const prev = parseMeta(existing?.metadata)
+        if (!existing || existing.status !== 'generating') return
+        const prev = parseMeta(existing.metadata)
+        if (isCancelledMeta(prev) || alreadyRefunded(prev)) return
         await this.prisma.material.update({
           where: { id: materialId },
           data: {
@@ -621,14 +654,16 @@ export class MaterialService {
       if (!skipCharge) {
         await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
       }
-      const existing = await this.prisma.material.findFirst({ where: { id: materialId } })
-      const prev = parseMeta(existing?.metadata)
+      const existingFailed = await this.prisma.material.findFirst({ where: { id: materialId } })
+      if (!existingFailed || existingFailed.status !== 'generating') return
+      const prevFailed = parseMeta(existingFailed.metadata)
+      if (isCancelledMeta(prevFailed) || alreadyRefunded(prevFailed)) return
       await this.prisma.material.update({
         where: { id: materialId },
         data: {
           status: 'failed',
           metadata: JSON.stringify(
-            applyRefundMeta(prev, skipCharge ? 0 : cost, 'platform_failed'),
+            applyRefundMeta(prevFailed, skipCharge ? 0 : cost, 'platform_failed'),
           ),
         },
       })
@@ -692,8 +727,12 @@ export class MaterialService {
           image: built.image,
         },
       )
-      await this.prisma.material.update({
-        where: { id: materialId },
+      const existing = await this.prisma.material.findFirst({ where: { id: materialId } })
+      if (!existing || existing.status !== 'generating') return
+      const prev = parseMeta(existing.metadata)
+      if (isCancelledMeta(prev) || alreadyRefunded(prev)) return
+      const updated = await this.prisma.material.updateMany({
+        where: { id: materialId, status: 'generating' },
         data: {
           url,
           thumbnail: url,
@@ -719,6 +758,7 @@ export class MaterialService {
           ),
         },
       })
+      if (updated.count === 0) return
     } catch (err) {
       console.error('Video generation failed:', err)
       if (resolved.source === 'user') {
@@ -726,7 +766,9 @@ export class MaterialService {
           await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
         }
         const existing = await this.prisma.material.findFirst({ where: { id: materialId } })
-        const prev = parseMeta(existing?.metadata)
+        if (!existing || existing.status !== 'generating') return
+        const prev = parseMeta(existing.metadata)
+        if (isCancelledMeta(prev) || alreadyRefunded(prev)) return
         await this.prisma.material.update({
           where: { id: materialId },
           data: {
@@ -757,14 +799,16 @@ export class MaterialService {
       if (!skipCharge) {
         await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
       }
-      const existing = await this.prisma.material.findFirst({ where: { id: materialId } })
-      const prev = parseMeta(existing?.metadata)
+      const existingFailed = await this.prisma.material.findFirst({ where: { id: materialId } })
+      if (!existingFailed || existingFailed.status !== 'generating') return
+      const prevFailed = parseMeta(existingFailed.metadata)
+      if (isCancelledMeta(prevFailed) || alreadyRefunded(prevFailed)) return
       await this.prisma.material.update({
         where: { id: materialId },
         data: {
           status: 'failed',
           metadata: JSON.stringify(
-            applyRefundMeta(prev, skipCharge ? 0 : cost, 'platform_failed'),
+            applyRefundMeta(prevFailed, skipCharge ? 0 : cost, 'platform_failed'),
           ),
         },
       })

--- a/apps/server/src/canvas/material.service.ts
+++ b/apps/server/src/canvas/material.service.ts
@@ -24,6 +24,9 @@ import {
   alreadyRefunded,
   applyChargeMeta,
   applyRefundMeta,
+  isCancelledException,
+  rethrowWithRefundedPoints,
+  throwCancelledException,
 } from '../points/charge-session'
 import { PrismaService } from '../prisma/prisma.service'
 import { PointsService } from '../points/points.service'
@@ -366,7 +369,7 @@ export class MaterialService {
         })
         if (cancel?.isCancelled()) {
           await this.points.refund(userId, platformCost, '平台回退-取消退款')
-          throw new BadRequestException('已取消')
+          throwCancelledException(platformCost)
         }
         return this.prisma.material.update({
           where: { id: material.id },
@@ -407,7 +410,7 @@ export class MaterialService {
         })
         if (cancel?.isCancelled()) {
           await this.points.refund(userId, platformCost, '平台回退-取消退款')
-          throw new BadRequestException('已取消')
+          throwCancelledException(platformCost)
         }
         return this.prisma.material.update({
           where: { id: material.id },
@@ -428,7 +431,7 @@ export class MaterialService {
 
       throw new BadRequestException('不支持的素材类型')
     } catch (err) {
-      if (err instanceof BadRequestException && err.message === '已取消') {
+      if (isCancelledException(err)) {
         await this.prisma.material.update({
           where: { id: material.id },
           data: {
@@ -442,7 +445,7 @@ export class MaterialService {
       }
       if (err instanceof BadRequestException && err.message === '不支持的素材类型') {
         await this.points.refund(userId, platformCost, '平台回退失败退款')
-        throw err
+        rethrowWithRefundedPoints(err, platformCost)
       }
       await this.points.refund(userId, platformCost, '平台回退失败退款')
       await this.prisma.material.update({
@@ -454,7 +457,7 @@ export class MaterialService {
           ),
         },
       })
-      throw err
+      rethrowWithRefundedPoints(err, platformCost)
     }
   }
 

--- a/apps/server/src/points/charge-session.test.ts
+++ b/apps/server/src/points/charge-session.test.ts
@@ -1,5 +1,13 @@
+import { BadRequestException } from '@nestjs/common'
 import { describe, expect, it } from 'vitest'
-import { alreadyRefunded, applyChargeMeta, applyRefundMeta } from './charge-session'
+import {
+  alreadyRefunded,
+  applyChargeMeta,
+  applyRefundMeta,
+  isCancelledException,
+  rethrowWithRefundedPoints,
+  throwCancelledException,
+} from './charge-session'
 
 describe('charge-session', () => {
   it('applyChargeMeta adds chargedPoints to meta', () => {
@@ -22,5 +30,31 @@ describe('charge-session', () => {
     expect(alreadyRefunded({})).toBe(false)
     expect(alreadyRefunded({ refundedPoints: 0 })).toBe(false)
     expect(alreadyRefunded({ refundedPoints: '5' })).toBe(false)
+  })
+
+  it('throwCancelledException includes refundedPoints in response body', () => {
+    try {
+      throwCancelledException(10)
+      expect.fail('should throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(BadRequestException)
+      expect((err as BadRequestException).getResponse()).toMatchObject({
+        message: '已取消',
+        refundedPoints: 10,
+      })
+      expect(isCancelledException(err)).toBe(true)
+    }
+  })
+
+  it('rethrowWithRefundedPoints attaches refundedPoints to existing BadRequestException', () => {
+    try {
+      rethrowWithRefundedPoints(new BadRequestException('upstream failed'), 10)
+      expect.fail('should throw')
+    } catch (err) {
+      expect((err as BadRequestException).getResponse()).toMatchObject({
+        message: 'upstream failed',
+        refundedPoints: 10,
+      })
+    }
   })
 })

--- a/apps/server/src/points/charge-session.test.ts
+++ b/apps/server/src/points/charge-session.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { alreadyRefunded, applyChargeMeta, applyRefundMeta } from './charge-session'
+
+describe('charge-session', () => {
+  it('applyChargeMeta adds chargedPoints to meta', () => {
+    expect(applyChargeMeta({ foo: 'bar' }, 10)).toEqual({ foo: 'bar', chargedPoints: 10 })
+  })
+
+  it('applyRefundMeta adds refundedPoints and refundReason to meta', () => {
+    expect(applyRefundMeta({ chargedPoints: 10 }, 10, '文本生成退款')).toEqual({
+      chargedPoints: 10,
+      refundedPoints: 10,
+      refundReason: '文本生成退款',
+    })
+  })
+
+  it('alreadyRefunded returns true when refundedPoints > 0', () => {
+    expect(alreadyRefunded({ refundedPoints: 5 })).toBe(true)
+  })
+
+  it('alreadyRefunded returns false when refundedPoints is missing or not positive', () => {
+    expect(alreadyRefunded({})).toBe(false)
+    expect(alreadyRefunded({ refundedPoints: 0 })).toBe(false)
+    expect(alreadyRefunded({ refundedPoints: '5' })).toBe(false)
+  })
+})

--- a/apps/server/src/points/charge-session.test.ts
+++ b/apps/server/src/points/charge-session.test.ts
@@ -5,6 +5,7 @@ import {
   applyChargeMeta,
   applyRefundMeta,
   isCancelledException,
+  isCancelledMeta,
   rethrowWithRefundedPoints,
   throwCancelledException,
 } from './charge-session'
@@ -30,6 +31,12 @@ describe('charge-session', () => {
     expect(alreadyRefunded({})).toBe(false)
     expect(alreadyRefunded({ refundedPoints: 0 })).toBe(false)
     expect(alreadyRefunded({ refundedPoints: '5' })).toBe(false)
+  })
+
+  it('isCancelledMeta returns true when cancelled flag is set', () => {
+    expect(isCancelledMeta({ cancelled: true })).toBe(true)
+    expect(isCancelledMeta({ cancelled: false })).toBe(false)
+    expect(isCancelledMeta({})).toBe(false)
   })
 
   it('throwCancelledException includes refundedPoints in response body', () => {

--- a/apps/server/src/points/charge-session.ts
+++ b/apps/server/src/points/charge-session.ts
@@ -1,3 +1,5 @@
+import { BadRequestException } from '@nestjs/common'
+
 export function createCancelFlag(req: {
   on(event: string, cb: () => void): void
   aborted?: boolean
@@ -23,4 +25,31 @@ export function applyRefundMeta(
   refundReason: string,
 ) {
   return { ...meta, refundedPoints, refundReason }
+}
+
+export function throwCancelledException(refundedPoints: number): never {
+  throw new BadRequestException({ message: '已取消', refundedPoints })
+}
+
+export function isCancelledException(err: unknown): boolean {
+  if (!(err instanceof BadRequestException)) return false
+  const response = err.getResponse()
+  if (typeof response === 'string') return response === '已取消'
+  if (response && typeof response === 'object') {
+    return (response as { message?: unknown }).message === '已取消'
+  }
+  return false
+}
+
+export function rethrowWithRefundedPoints(err: unknown, refundedPoints: number): never {
+  if (err instanceof BadRequestException) {
+    const response = err.getResponse()
+    if (typeof response === 'object' && response !== null && !Array.isArray(response)) {
+      throw new BadRequestException({ ...(response as Record<string, unknown>), refundedPoints })
+    }
+    const message = typeof response === 'string' ? response : '请求失败'
+    throw new BadRequestException({ message, refundedPoints })
+  }
+  const message = err instanceof Error ? err.message : '生成失败'
+  throw new BadRequestException({ message, refundedPoints })
 }

--- a/apps/server/src/points/charge-session.ts
+++ b/apps/server/src/points/charge-session.ts
@@ -1,3 +1,14 @@
+export function createCancelFlag(req: {
+  on(event: string, cb: () => void): void
+  aborted?: boolean
+}) {
+  let cancelled = Boolean(req.aborted)
+  req.on('close', () => {
+    cancelled = true
+  })
+  return { isCancelled: () => cancelled }
+}
+
 export function applyChargeMeta(meta: Record<string, unknown>, chargedPoints: number) {
   return { ...meta, chargedPoints }
 }

--- a/apps/server/src/points/charge-session.ts
+++ b/apps/server/src/points/charge-session.ts
@@ -19,6 +19,10 @@ export function alreadyRefunded(meta: Record<string, unknown>): boolean {
   return typeof meta.refundedPoints === 'number' && meta.refundedPoints > 0
 }
 
+export function isCancelledMeta(meta: Record<string, unknown>): boolean {
+  return meta.cancelled === true
+}
+
 export function applyRefundMeta(
   meta: Record<string, unknown>,
   refundedPoints: number,

--- a/apps/server/src/points/charge-session.ts
+++ b/apps/server/src/points/charge-session.ts
@@ -1,0 +1,15 @@
+export function applyChargeMeta(meta: Record<string, unknown>, chargedPoints: number) {
+  return { ...meta, chargedPoints }
+}
+
+export function alreadyRefunded(meta: Record<string, unknown>): boolean {
+  return typeof meta.refundedPoints === 'number' && meta.refundedPoints > 0
+}
+
+export function applyRefundMeta(
+  meta: Record<string, unknown>,
+  refundedPoints: number,
+  refundReason: string,
+) {
+  return { ...meta, refundedPoints, refundReason }
+}

--- a/apps/server/src/points/points.service.test.ts
+++ b/apps/server/src/points/points.service.test.ts
@@ -55,4 +55,40 @@ describe('PointsService', () => {
     )
     expect(create).not.toHaveBeenCalled()
   })
+
+  it('increments points and writes positive transaction on refund', async () => {
+    const updateMany = vi.fn(async () => ({ count: 1 }))
+    const create = vi.fn(async (args: { data: Record<string, unknown> }) => ({ id: 'pt2', ...args.data }))
+    const $transaction = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({ user: { updateMany }, pointTransaction: { create } }),
+    )
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        PointsService,
+        { provide: PrismaService, useValue: { $transaction } },
+      ],
+    }).compile()
+
+    await moduleRef.get(PointsService).refund('u1', 5, '文本生成退款')
+
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: 'u1' },
+      data: { points: { increment: 5 } },
+    })
+    expect(create).toHaveBeenCalledWith({
+      data: { userId: 'u1', amount: 5, reason: '文本生成退款' },
+    })
+  })
+
+  it('no-ops when refund amount <= 0', async () => {
+    const $transaction = vi.fn()
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        PointsService,
+        { provide: PrismaService, useValue: { $transaction } },
+      ],
+    }).compile()
+    await moduleRef.get(PointsService).refund('u1', 0, 'x')
+    expect($transaction).not.toHaveBeenCalled()
+  })
 })

--- a/apps/server/src/points/points.service.ts
+++ b/apps/server/src/points/points.service.ts
@@ -20,4 +20,17 @@ export class PointsService {
       })
     })
   }
+
+  async refund(userId: string, amount: number, reason: string): Promise<void> {
+    if (amount <= 0) return
+    await this.prisma.$transaction(async (tx) => {
+      await tx.user.updateMany({
+        where: { id: userId },
+        data: { points: { increment: amount } },
+      })
+      await tx.pointTransaction.create({
+        data: { userId, amount, reason },
+      })
+    })
+  }
 }

--- a/apps/server/src/studio/studio.controller.ts
+++ b/apps/server/src/studio/studio.controller.ts
@@ -310,10 +310,11 @@ export class StudioController {
   @Post('generations/:id/confirm-platform-fallback')
   @UseGuards(AuthGuard)
   async confirmPlatformFallback(
-    @Req() req: { user: { sub: string } },
+    @Req() req: { user: { sub: string }; on(event: string, cb: () => void): void; aborted?: boolean },
     @Param('id') id: string,
   ) {
-    const data = await this.studioService.confirmPlatformFallback(req.user.sub, id)
+    const cancel = createCancelFlag(req)
+    const data = await this.studioService.confirmPlatformFallback(req.user.sub, id, cancel)
     return { code: 0, message: 'ok', data }
   }
 

--- a/apps/server/src/studio/studio.controller.ts
+++ b/apps/server/src/studio/studio.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Get, Inject, Param, Post, Query, Req, UseGuards } fro
 import { Type } from 'class-transformer'
 import { IsArray, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator'
 import { AuthGuard } from '../auth/auth.guard'
+import { createCancelFlag } from '../points/charge-session'
 import { StudioService } from './studio.service'
 
 class StudioRefDto {
@@ -191,32 +192,46 @@ export class StudioController {
 
   @Post('text/generate')
   @UseGuards(AuthGuard)
-  async generateText(@Req() req: { user: { sub: string } }, @Body() dto: GenerateTextDto) {
+  async generateText(
+    @Req() req: { user: { sub: string }; on(event: string, cb: () => void): void; aborted?: boolean },
+    @Body() dto: GenerateTextDto,
+  ) {
+    const cancel = createCancelFlag(req)
     const data = await this.studioService.generateText(
       req.user.sub,
       dto.prompt,
       dto.model,
       dto.refs,
       dto.mentionedKeys,
+      cancel,
     )
     return { code: 0, message: 'ok', data }
   }
 
   @Post('prompt/generate')
   @UseGuards(AuthGuard)
-  async generatePrompt(@Req() req: { user: { sub: string } }, @Body() dto: GeneratePromptDto) {
-    const data = await this.studioService.generatePrompt(req.user.sub, dto.prompt, dto.model)
+  async generatePrompt(
+    @Req() req: { user: { sub: string }; on(event: string, cb: () => void): void; aborted?: boolean },
+    @Body() dto: GeneratePromptDto,
+  ) {
+    const cancel = createCancelFlag(req)
+    const data = await this.studioService.generatePrompt(req.user.sub, dto.prompt, dto.model, cancel)
     return { code: 0, message: 'ok', data }
   }
 
   @Post('image/variation')
   @UseGuards(AuthGuard)
-  async imageVariation(@Req() req: { user: { sub: string } }, @Body() dto: ImageVariationDto) {
+  async imageVariation(
+    @Req() req: { user: { sub: string }; on(event: string, cb: () => void): void; aborted?: boolean },
+    @Body() dto: ImageVariationDto,
+  ) {
+    const cancel = createCancelFlag(req)
     const data = await this.studioService.generateImageVariation(
       req.user.sub,
       dto.prompt,
       dto.basePrompt,
       dto.model,
+      cancel,
     )
     return { code: 0, message: 'ok', data }
   }
@@ -230,7 +245,11 @@ export class StudioController {
 
   @Post('image/generate')
   @UseGuards(AuthGuard)
-  async generateImage(@Req() req: { user: { sub: string } }, @Body() dto: GenerateImageDto) {
+  async generateImage(
+    @Req() req: { user: { sub: string }; on(event: string, cb: () => void): void; aborted?: boolean },
+    @Body() dto: GenerateImageDto,
+  ) {
+    const cancel = createCancelFlag(req)
     const data = await this.studioService.generateImage(
       req.user.sub,
       dto.prompt,
@@ -240,6 +259,7 @@ export class StudioController {
       dto.mentionedKeys,
       dto.resolution,
       dto.count,
+      cancel,
     )
     return { code: 0, message: 'ok', data }
   }
@@ -263,7 +283,11 @@ export class StudioController {
 
   @Post('audio/generate')
   @UseGuards(AuthGuard)
-  async generateAudio(@Req() req: { user: { sub: string } }, @Body() dto: GenerateAudioDto) {
+  async generateAudio(
+    @Req() req: { user: { sub: string }; on(event: string, cb: () => void): void; aborted?: boolean },
+    @Body() dto: GenerateAudioDto,
+  ) {
+    const cancel = createCancelFlag(req)
     const data = await this.studioService.generateAudio(
       req.user.sub,
       dto.text,
@@ -278,6 +302,7 @@ export class StudioController {
       },
       dto.refs,
       dto.mentionedKeys,
+      cancel,
     )
     return { code: 0, message: 'ok', data }
   }

--- a/apps/server/src/studio/studio.controller.ts
+++ b/apps/server/src/studio/studio.controller.ts
@@ -327,4 +327,11 @@ export class StudioController {
     const data = await this.studioService.cancelPlatformFallback(req.user.sub, id)
     return { code: 0, message: 'ok', data }
   }
+
+  @Post('generations/:id/cancel')
+  @UseGuards(AuthGuard)
+  async cancelGeneration(@Req() req: { user: { sub: string } }, @Param('id') id: string) {
+    const data = await this.studioService.cancelGeneration(req.user.sub, id)
+    return { code: 0, message: 'ok', data }
+  }
 }

--- a/apps/server/src/studio/studio.fallback.test.ts
+++ b/apps/server/src/studio/studio.fallback.test.ts
@@ -58,6 +58,7 @@ describe('StudioService BYOK fallback_pending', () => {
   let resolveForGeneration: ReturnType<typeof vi.fn>
   let generationCreate: ReturnType<typeof vi.fn>
   let generationUpdate: ReturnType<typeof vi.fn>
+  let generationUpdateMany: ReturnType<typeof vi.fn>
   let generationFindFirst: ReturnType<typeof vi.fn>
   let pointsConsume: ReturnType<typeof vi.fn>
   let pointsRefund: ReturnType<typeof vi.fn>
@@ -76,6 +77,11 @@ describe('StudioService BYOK fallback_pending', () => {
     generationUpdate = vi.fn(async (args: { where: { id: string }; data: Record<string, unknown> }) => {
       stored = { ...stored, ...args.data, id: args.where.id }
       return stored
+    })
+    generationUpdateMany = vi.fn(async (args: { where: { id: string; status: string }; data: Record<string, unknown> }) => {
+      if (stored.status !== args.where.status) return { count: 0 }
+      stored = { ...stored, ...args.data }
+      return { count: 1 }
     })
     generationFindFirst = vi.fn(async () => stored)
 
@@ -100,6 +106,7 @@ describe('StudioService BYOK fallback_pending', () => {
             generationRecord: {
               create: generationCreate,
               update: generationUpdate,
+              updateMany: generationUpdateMany,
               findFirst: generationFindFirst,
               findMany: vi.fn(async () => []),
             },
@@ -420,6 +427,44 @@ describe('StudioService BYOK fallback_pending', () => {
     const result = await svc.cancelPlatformFallback('u1', 'g1')
     expect(result.status).toBe('failed')
     expect(pointsRefund).not.toHaveBeenCalled()
+  })
+
+  it('cancelGeneration on generating video → refund once and failed metadata', async () => {
+    stored = {
+      id: 'g-vid',
+      type: 'video',
+      status: 'generating',
+      metadata: JSON.stringify({ chargedPoints: 30, duration: 5 }),
+    }
+    generationFindFirst.mockResolvedValue(stored)
+    const result = await svc.cancelGeneration('u1', 'g-vid')
+    expect(result.status).toBe('failed')
+    expect(pointsRefund).toHaveBeenCalledWith('u1', 30, '视频生成-取消退款')
+    const meta = JSON.parse(String(generationUpdate.mock.calls.at(-1)?.[0].data.metadata))
+    expect(meta.cancelled).toBe(true)
+    expect(meta.refundedPoints).toBe(30)
+  })
+
+  it('video: cancel before completeVideo success → ignore late completed write', async () => {
+    resolveForGeneration.mockResolvedValue(platformResolved)
+    let resolveVideo!: (v: { url: string }) => void
+    videoGenerate.mockImplementationOnce(
+      () =>
+        new Promise((r) => {
+          resolveVideo = r
+        }),
+    )
+    await svc.generateVideo('u1', 'walk')
+    await vi.waitFor(() => expect(videoGenerate).toHaveBeenCalled())
+    stored = {
+      ...stored,
+      status: 'failed',
+      metadata: JSON.stringify({ chargedPoints: 30, cancelled: true, refundedPoints: 30 }),
+    }
+    resolveVideo({ url: 'https://example.com/v.mp4' })
+    await new Promise((r) => setTimeout(r, 30))
+    expect(generationUpdateMany).not.toHaveBeenCalled()
+    expect(stored.status).toBe('failed')
   })
 
   it('text: client abort after generate → refund once and throw 已取消', async () => {

--- a/apps/server/src/studio/studio.fallback.test.ts
+++ b/apps/server/src/studio/studio.fallback.test.ts
@@ -344,6 +344,72 @@ describe('StudioService BYOK fallback_pending', () => {
     expect((opts as { modelId?: string }).modelId).toBeTruthy()
   })
 
+  it.each([
+    {
+      name: 'image',
+      cost: 10,
+      refundReason: '图像生成-失败退款',
+      run: () => svc.generateImage('u1', 'a cat', undefined),
+      failOnce: () => imageGenerate.mockRejectedValueOnce(new Error('platform upstream 502')),
+    },
+    {
+      name: 'text',
+      cost: 5,
+      refundReason: '文本生成-失败退款',
+      run: () => svc.generateText('u1', 'hello'),
+      failOnce: () => textGenerate.mockRejectedValueOnce(new Error('platform upstream 502')),
+    },
+  ] as const)(
+    '$name: platform source failure → refund after consume',
+    async ({ run, failOnce, cost, refundReason }) => {
+      resolveForGeneration.mockResolvedValue(platformResolved)
+      failOnce()
+      await expect(run()).rejects.toThrow('platform upstream 502')
+      expect(pointsConsume).toHaveBeenCalledWith('u1', cost, expect.any(String))
+      expect(pointsRefund).toHaveBeenCalledWith('u1', cost, refundReason)
+    },
+  )
+
+  it('confirmPlatformFallback: platform generate failure → refund, failed, refundedPoints', async () => {
+    imageGenerate.mockRejectedValueOnce(new Error('upstream 502'))
+    await svc.generateImage('u1', 'a cat', 'ch_user::custom-model')
+    vi.clearAllMocks()
+    resolveForGeneration.mockImplementation(async (_uid: string, model?: string) => ({
+      ...platformResolved,
+      modelName: model?.includes('::') ? model.split('::')[1]! : (model ?? platformResolved.modelName),
+    }))
+    imageGenerate.mockRejectedValueOnce(new Error('platform confirm failed'))
+    pointsConsume.mockResolvedValue(undefined)
+
+    await expect(svc.confirmPlatformFallback('u1', 'g1')).rejects.toThrow('platform confirm failed')
+
+    expect(pointsConsume).toHaveBeenCalledWith('u1', 10, '平台回退生成')
+    expect(pointsRefund).toHaveBeenCalledWith('u1', 10, '平台回退失败退款')
+    const failedUpdate = generationUpdate.mock.calls.find((c) => c[0].data.status === 'failed')
+    expect(failedUpdate).toBeTruthy()
+    const meta = JSON.parse(String(failedUpdate![0].data.metadata))
+    expect(meta.refundedPoints).toBe(10)
+    expect(meta.refundReason).toBe('platform_fallback_failed')
+    expect(meta.chargedPoints).toBe(10)
+    expect(meta.priorByokRefunded).toBe(true)
+  })
+
+  it('video: platform source failure → refund and failed metadata', async () => {
+    resolveForGeneration.mockResolvedValue(platformResolved)
+    videoGenerate.mockRejectedValueOnce(new Error('platform upstream 502'))
+    const record = await svc.generateVideo('u1', 'walk')
+    expect(record.status).toBe('generating')
+
+    await vi.waitFor(() =>
+      expect(generationUpdate.mock.calls.some((c) => c[0].data.status === 'failed')).toBe(true),
+    )
+    const failedUpdate = generationUpdate.mock.calls.find((c) => c[0].data.status === 'failed')!
+    const meta = JSON.parse(String(failedUpdate[0].data.metadata))
+    expect(meta.refundedPoints).toBe(30)
+    expect(meta.refundReason).toBe('platform_failed')
+    expect(pointsRefund).toHaveBeenCalledWith('u1', 30, '视频生成-失败退款')
+  })
+
   it('cancel-platform-fallback → failed without double refund', async () => {
     imageGenerate.mockRejectedValueOnce(new Error('fail'))
     await svc.generateImage('u1', 'a cat', 'ch_user::custom-model')

--- a/apps/server/src/studio/studio.fallback.test.ts
+++ b/apps/server/src/studio/studio.fallback.test.ts
@@ -422,7 +422,7 @@ describe('StudioService BYOK fallback_pending', () => {
     expect(pointsRefund).not.toHaveBeenCalled()
   })
 
-  it('text: client abort after generate → refund and throw 已取消', async () => {
+  it('text: client abort after generate → refund once and throw 已取消', async () => {
     resolveForGeneration.mockResolvedValue(platformResolved)
     textGenerate.mockReset()
     textGenerate.mockResolvedValue({ text: 'done' })
@@ -439,6 +439,68 @@ describe('StudioService BYOK fallback_pending', () => {
     listeners.close?.forEach((cb) => cb())
     await expect(promise).rejects.toThrow(BadRequestException)
     await expect(promise).rejects.toThrow('已取消')
+    expect(pointsRefund).toHaveBeenCalledTimes(1)
     expect(pointsRefund).toHaveBeenCalledWith('u1', 5, '文本生成-取消退款')
+    expect(generationCreate).not.toHaveBeenCalled()
+  })
+
+  it('image: BYOK client abort after generate → refund once, no fallback_pending', async () => {
+    imageGenerate.mockResolvedValueOnce({
+      url: 'https://example.com/i.png',
+      urls: ['https://example.com/i.png'],
+    })
+    const listeners: Record<string, (() => void)[]> = {}
+    const cancel = createCancelFlag({
+      aborted: false,
+      on(event: string, cb: () => void) {
+        listeners[event] = listeners[event] ?? []
+        listeners[event].push(cb)
+      },
+    })
+    const promise = svc.generateImage(
+      'u1',
+      'a cat',
+      'ch_user::custom-model',
+      '16:9',
+      [],
+      [],
+      '1K',
+      1,
+      cancel,
+    )
+    listeners.close?.forEach((cb) => cb())
+    await expect(promise).rejects.toThrow('已取消')
+    expect(pointsRefund).toHaveBeenCalledTimes(1)
+    expect(pointsRefund).toHaveBeenCalledWith('u1', 10, '图像生成-取消退款')
+    expect(generationCreate).not.toHaveBeenCalled()
+  })
+
+  it('confirmPlatformFallback: client abort after generate → refund once, failed', async () => {
+    imageGenerate.mockRejectedValueOnce(new Error('upstream 502'))
+    await svc.generateImage('u1', 'a cat', 'ch_user::custom-model')
+    vi.clearAllMocks()
+    imageGenerate.mockResolvedValueOnce({
+      url: 'https://example.com/plat.png',
+      urls: ['https://example.com/plat.png'],
+    })
+    const listeners: Record<string, (() => void)[]> = {}
+    const cancel = createCancelFlag({
+      aborted: false,
+      on(event: string, cb: () => void) {
+        listeners[event] = listeners[event] ?? []
+        listeners[event].push(cb)
+      },
+    })
+    const promise = svc.confirmPlatformFallback('u1', 'g1', cancel)
+    listeners.close?.forEach((cb) => cb())
+    await expect(promise).rejects.toThrow('已取消')
+    expect(pointsConsume).toHaveBeenCalledWith('u1', 10, '平台回退生成')
+    expect(pointsRefund).toHaveBeenCalledTimes(1)
+    expect(pointsRefund).toHaveBeenCalledWith('u1', 10, '平台回退-取消退款')
+    const failedUpdate = generationUpdate.mock.calls.find((c) => c[0].data.status === 'failed')
+    expect(failedUpdate).toBeTruthy()
+    const meta = JSON.parse(String(failedUpdate![0].data.metadata))
+    expect(meta.refundReason).toBe('cancelled')
+    expect(meta.refundedPoints).toBe(10)
   })
 })

--- a/apps/server/src/studio/studio.fallback.test.ts
+++ b/apps/server/src/studio/studio.fallback.test.ts
@@ -437,8 +437,10 @@ describe('StudioService BYOK fallback_pending', () => {
     const cancel = createCancelFlag(req)
     const promise = svc.generateText('u1', 'hello', undefined, undefined, undefined, cancel)
     listeners.close?.forEach((cb) => cb())
-    await expect(promise).rejects.toThrow(BadRequestException)
-    await expect(promise).rejects.toThrow('已取消')
+    await expect(promise).rejects.toBeInstanceOf(BadRequestException)
+    await expect(promise).rejects.toMatchObject({
+      response: { message: '已取消', refundedPoints: 5 },
+    })
     expect(pointsRefund).toHaveBeenCalledTimes(1)
     expect(pointsRefund).toHaveBeenCalledWith('u1', 5, '文本生成-取消退款')
     expect(generationCreate).not.toHaveBeenCalled()
@@ -469,7 +471,9 @@ describe('StudioService BYOK fallback_pending', () => {
       cancel,
     )
     listeners.close?.forEach((cb) => cb())
-    await expect(promise).rejects.toThrow('已取消')
+    await expect(promise).rejects.toMatchObject({
+      response: { message: '已取消', refundedPoints: 10 },
+    })
     expect(pointsRefund).toHaveBeenCalledTimes(1)
     expect(pointsRefund).toHaveBeenCalledWith('u1', 10, '图像生成-取消退款')
     expect(generationCreate).not.toHaveBeenCalled()
@@ -493,7 +497,9 @@ describe('StudioService BYOK fallback_pending', () => {
     })
     const promise = svc.confirmPlatformFallback('u1', 'g1', cancel)
     listeners.close?.forEach((cb) => cb())
-    await expect(promise).rejects.toThrow('已取消')
+    await expect(promise).rejects.toMatchObject({
+      response: { message: '已取消', refundedPoints: 10 },
+    })
     expect(pointsConsume).toHaveBeenCalledWith('u1', 10, '平台回退生成')
     expect(pointsRefund).toHaveBeenCalledTimes(1)
     expect(pointsRefund).toHaveBeenCalledWith('u1', 10, '平台回退-取消退款')

--- a/apps/server/src/studio/studio.fallback.test.ts
+++ b/apps/server/src/studio/studio.fallback.test.ts
@@ -8,7 +8,9 @@ import {
   createVideoProvider,
   mergeRefsToPrompt,
 } from '@lnkpi/agent'
+import { BadRequestException } from '@nestjs/common'
 import { BYOK_FALLBACK_CONFIRM_MESSAGE } from '@lnkpi/shared'
+import { createCancelFlag } from '../points/charge-session'
 import { PointsService } from '../points/points.service'
 import { PrismaService } from '../prisma/prisma.service'
 import { ProviderResolverService } from '../provider/provider-resolver.service'
@@ -418,5 +420,25 @@ describe('StudioService BYOK fallback_pending', () => {
     const result = await svc.cancelPlatformFallback('u1', 'g1')
     expect(result.status).toBe('failed')
     expect(pointsRefund).not.toHaveBeenCalled()
+  })
+
+  it('text: client abort after generate → refund and throw 已取消', async () => {
+    resolveForGeneration.mockResolvedValue(platformResolved)
+    textGenerate.mockReset()
+    textGenerate.mockResolvedValue({ text: 'done' })
+    const listeners: Record<string, (() => void)[]> = {}
+    const req = {
+      aborted: false,
+      on(event: string, cb: () => void) {
+        listeners[event] = listeners[event] ?? []
+        listeners[event].push(cb)
+      },
+    }
+    const cancel = createCancelFlag(req)
+    const promise = svc.generateText('u1', 'hello', undefined, undefined, undefined, cancel)
+    listeners.close?.forEach((cb) => cb())
+    await expect(promise).rejects.toThrow(BadRequestException)
+    await expect(promise).rejects.toThrow('已取消')
+    expect(pointsRefund).toHaveBeenCalledWith('u1', 5, '文本生成-取消退款')
   })
 })

--- a/apps/server/src/studio/studio.fallback.test.ts
+++ b/apps/server/src/studio/studio.fallback.test.ts
@@ -57,11 +57,15 @@ describe('StudioService BYOK fallback_pending', () => {
   let generationCreate: ReturnType<typeof vi.fn>
   let generationUpdate: ReturnType<typeof vi.fn>
   let generationFindFirst: ReturnType<typeof vi.fn>
+  let pointsConsume: ReturnType<typeof vi.fn>
+  let pointsRefund: ReturnType<typeof vi.fn>
   let stored: Record<string, unknown>
 
   beforeEach(async () => {
     vi.clearAllMocks()
     stored = {}
+    pointsConsume = vi.fn(async () => {})
+    pointsRefund = vi.fn(async () => {})
     resolveForGeneration = vi.fn(async () => userResolved)
     generationCreate = vi.fn(async (args: { data: Record<string, unknown> }) => {
       stored = { id: 'g1', createdAt: new Date(), ...args.data }
@@ -84,7 +88,8 @@ describe('StudioService BYOK fallback_pending', () => {
         {
           provide: PointsService,
           useValue: {
-            consume: vi.fn(async () => {}),
+            consume: pointsConsume,
+            refund: pointsRefund,
           },
         },
         {
@@ -111,6 +116,8 @@ describe('StudioService BYOK fallback_pending', () => {
   it.each([
     {
       name: 'image',
+      cost: 10,
+      refundReason: '图像生成-BYOK失败退款',
       failOnce: () => imageGenerate.mockRejectedValueOnce(new Error('upstream 502')),
       run: () => svc.generateImage('u1', 'a cat', 'ch_user::custom-model'),
       createProvider: createImageProvider,
@@ -119,6 +126,8 @@ describe('StudioService BYOK fallback_pending', () => {
     },
     {
       name: 'text',
+      cost: 5,
+      refundReason: '文本生成-BYOK失败退款',
       failOnce: () => textGenerate.mockRejectedValueOnce(new Error('unauthorized api key')),
       run: () => svc.generateText('u1', 'hello', 'ch_user::custom-model'),
       createProvider: createTextProvider,
@@ -127,6 +136,8 @@ describe('StudioService BYOK fallback_pending', () => {
     },
     {
       name: 'audio',
+      cost: 5,
+      refundReason: '音频生成-BYOK失败退款',
       failOnce: () => audioGenerate.mockRejectedValueOnce(new Error('network timeout')),
       run: () => svc.generateAudio('u1', 'hi', { model: 'ch_user::custom-model' }),
       createProvider: createAudioProvider,
@@ -135,7 +146,7 @@ describe('StudioService BYOK fallback_pending', () => {
     },
   ] as const)(
     '$name: user channel failure → fallback_pending without platform provider',
-    async ({ failOnce, run, createProvider, generate }) => {
+    async ({ failOnce, run, createProvider, generate, cost, refundReason }) => {
       failOnce()
       const record = await run()
 
@@ -144,6 +155,10 @@ describe('StudioService BYOK fallback_pending', () => {
       expect(meta.channelId).toBe('ch_user')
       expect(meta.failureClass).toBeTruthy()
       expect(meta.confirmMessage).toBe(BYOK_FALLBACK_CONFIRM_MESSAGE)
+      expect(meta.chargedPoints).toBe(cost)
+      expect(meta.refundedPoints).toBe(cost)
+      expect(meta.refundReason).toBe('byok_failed')
+      expect(pointsRefund).toHaveBeenCalledWith('u1', cost, refundReason)
       expect(createProvider).toHaveBeenCalledTimes(1)
       expect(createProvider).toHaveBeenCalledWith({
         apiKey: 'user-key',
@@ -168,6 +183,8 @@ describe('StudioService BYOK fallback_pending', () => {
     const meta = JSON.parse(String(updateData.metadata))
     expect(meta.channelId).toBe('ch_user')
     expect(meta.failureClass).toBeTruthy()
+    expect(meta.refundedPoints).toBe(30)
+    expect(pointsRefund).toHaveBeenCalledWith('u1', 30, '视频生成-BYOK失败退款')
 
     expect(createVideoProvider).toHaveBeenCalledTimes(1)
     expect(createVideoProvider).toHaveBeenCalledWith({
@@ -179,6 +196,7 @@ describe('StudioService BYOK fallback_pending', () => {
   it.each([
     {
       name: 'image',
+      platformCost: 10,
       setupPending: async () => {
         imageGenerate.mockRejectedValueOnce(new Error('upstream 502'))
         await svc.generateImage('u1', 'a cat', 'ch_user::custom-model', '16:9', [], [], '1K', 1)
@@ -192,6 +210,7 @@ describe('StudioService BYOK fallback_pending', () => {
     },
     {
       name: 'text',
+      platformCost: 5,
       setupPending: async () => {
         textGenerate.mockRejectedValueOnce(new Error('unauthorized'))
         await svc.generateText('u1', 'hello', 'ch_user::custom-model')
@@ -202,6 +221,7 @@ describe('StudioService BYOK fallback_pending', () => {
     },
     {
       name: 'audio',
+      platformCost: 5,
       setupPending: async () => {
         audioGenerate.mockRejectedValueOnce(new Error('network'))
         await svc.generateAudio('u1', 'hi', { model: 'ch_user::custom-model' })
@@ -210,7 +230,7 @@ describe('StudioService BYOK fallback_pending', () => {
       createProvider: createAudioProvider,
       generate: audioGenerate,
     },
-  ] as const)('$name: confirm → platform generate called', async ({ setupPending, createProvider, generate }) => {
+  ] as const)('$name: confirm → platform generate called', async ({ setupPending, createProvider, generate, platformCost }) => {
     await setupPending()
     vi.clearAllMocks()
     resolveForGeneration.mockImplementation(async (_uid: string, model?: string) => ({
@@ -222,6 +242,9 @@ describe('StudioService BYOK fallback_pending', () => {
     expect(result.status).toBe('completed')
     const meta = JSON.parse(String(result.metadata))
     expect(meta.providerFallback).toBe(true)
+    expect(meta.chargedPoints).toBe(platformCost)
+    expect(meta.priorByokRefunded).toBe(true)
+    expect(pointsConsume).toHaveBeenCalledWith('u1', platformCost, '平台回退生成')
 
     expect(createProvider).toHaveBeenCalled()
     const credCall = vi.mocked(createProvider).mock.calls.find((c) => c[0] == null || c.length === 0 || !c[0]?.apiKey)
@@ -321,10 +344,13 @@ describe('StudioService BYOK fallback_pending', () => {
     expect((opts as { modelId?: string }).modelId).toBeTruthy()
   })
 
-  it('cancel-platform-fallback → failed', async () => {
+  it('cancel-platform-fallback → failed without double refund', async () => {
     imageGenerate.mockRejectedValueOnce(new Error('fail'))
     await svc.generateImage('u1', 'a cat', 'ch_user::custom-model')
+    expect(pointsRefund).toHaveBeenCalledTimes(1)
+    pointsRefund.mockClear()
     const result = await svc.cancelPlatformFallback('u1', 'g1')
     expect(result.status).toBe('failed')
+    expect(pointsRefund).not.toHaveBeenCalled()
   })
 })

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -239,6 +239,7 @@ export class StudioService {
         },
       })
     } catch (err) {
+      if (err instanceof BadRequestException && err.message === '已取消') throw err
       if (resolved.source !== 'user') {
         await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
         throw err
@@ -307,6 +308,7 @@ export class StudioService {
         },
       })
     } catch (err) {
+      if (err instanceof BadRequestException && err.message === '已取消') throw err
       if (resolved.source !== 'user') {
         await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
         throw err
@@ -423,6 +425,7 @@ export class StudioService {
         },
       })
     } catch (err) {
+      if (err instanceof BadRequestException && err.message === '已取消') throw err
       if (resolved.source !== 'user') {
         await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
         throw err
@@ -498,6 +501,7 @@ export class StudioService {
         },
       })
     } catch (err) {
+      if (err instanceof BadRequestException && err.message === '已取消') throw err
       if (resolved.source !== 'user') {
         await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
         throw err
@@ -690,6 +694,7 @@ export class StudioService {
       })
       return { ...record, url }
     } catch (err) {
+      if (err instanceof BadRequestException && err.message === '已取消') throw err
       if (resolved.source !== 'user') {
         await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
         throw err
@@ -723,7 +728,7 @@ export class StudioService {
     }
   }
 
-  async confirmPlatformFallback(userId: string, recordId: string) {
+  async confirmPlatformFallback(userId: string, recordId: string, cancel?: CancelFlag) {
     const record = await this.getGeneration(userId, recordId)
     if (record.status !== 'fallback_pending') {
       throw new BadRequestException('当前状态不可确认平台回退')
@@ -744,6 +749,10 @@ export class StudioService {
           modelId,
         })
         const imageUrls = urls?.length ? urls : [url]
+        if (cancel?.isCancelled()) {
+          await this.points.refund(userId, platformCost, '平台回退-取消退款')
+          throw new BadRequestException('已取消')
+        }
         return this.prisma.generationRecord.update({
           where: { id: record.id },
           data: {
@@ -786,6 +795,10 @@ export class StudioService {
           const result = await createTextProvider(undefined).generate(record.prompt, gatewayModelId)
           text = result.text
         }
+        if (cancel?.isCancelled()) {
+          await this.points.refund(userId, platformCost, '平台回退-取消退款')
+          throw new BadRequestException('已取消')
+        }
         return this.prisma.generationRecord.update({
           where: { id: record.id },
           data: {
@@ -818,6 +831,10 @@ export class StudioService {
           audioOptions as { model?: string; voice?: string; speed?: number; volume?: number; pitch?: number },
         )
         const storeUrl = url.startsWith('data:') ? AUDIO_PLACEHOLDER : url
+        if (cancel?.isCancelled()) {
+          await this.points.refund(userId, platformCost, '平台回退-取消退款')
+          throw new BadRequestException('已取消')
+        }
         return this.prisma.generationRecord.update({
           where: { id: record.id },
           data: {
@@ -847,6 +864,10 @@ export class StudioService {
             ? (meta.referenceImages as string[])[0]
             : undefined,
         })
+        if (cancel?.isCancelled()) {
+          await this.points.refund(userId, platformCost, '平台回退-取消退款')
+          throw new BadRequestException('已取消')
+        }
         return this.prisma.generationRecord.update({
           where: { id: record.id },
           data: {
@@ -864,6 +885,18 @@ export class StudioService {
 
       throw new BadRequestException('不支持的生成类型')
     } catch (err) {
+      if (err instanceof BadRequestException && err.message === '已取消') {
+        await this.prisma.generationRecord.update({
+          where: { id: record.id },
+          data: {
+            status: 'failed',
+            metadata: JSON.stringify(
+              applyRefundMeta(chargedMeta, platformCost, 'cancelled'),
+            ),
+          },
+        })
+        throw err
+      }
       if (err instanceof BadRequestException && err.message === '不支持的生成类型') {
         await this.points.refund(userId, platformCost, '平台回退失败退款')
         throw err

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -24,6 +24,7 @@ import {
   applyChargeMeta,
   applyRefundMeta,
   isCancelledException,
+  isCancelledMeta,
   rethrowWithRefundedPoints,
   throwCancelledException,
 } from '../points/charge-session'
@@ -937,6 +938,29 @@ export class StudioService {
     })
   }
 
+  async cancelGeneration(userId: string, recordId: string) {
+    const record = await this.getGeneration(userId, recordId)
+    if (record.status !== 'generating') {
+      throw new BadRequestException('当前状态不可取消')
+    }
+    const meta = parseMeta(record.metadata)
+    const cost = typeof meta.chargedPoints === 'number' ? meta.chargedPoints : 0
+    const chargeReason =
+      record.type === 'video' ? '视频生成' : record.type === 'image' ? '图像生成' : '生成'
+    let updatedMeta: Record<string, unknown> = { ...meta, cancelled: true }
+    if (cost > 0 && !alreadyRefunded(meta)) {
+      await this.points.refund(userId, cost, `${chargeReason}-取消退款`)
+      updatedMeta = applyRefundMeta(updatedMeta, cost, 'cancelled')
+    }
+    return this.prisma.generationRecord.update({
+      where: { id: record.id },
+      data: {
+        status: 'failed',
+        metadata: JSON.stringify(updatedMeta),
+      },
+    })
+  }
+
   private async completeVideo(
     id: string,
     userId: string,
@@ -961,16 +985,23 @@ export class StudioService {
         prompt,
         options,
       )
-      await this.prisma.generationRecord.update({
-        where: { id },
+      const existing = await this.prisma.generationRecord.findFirst({ where: { id } })
+      if (!existing || existing.status !== 'generating') return
+      const meta = parseMeta(existing.metadata)
+      if (isCancelledMeta(meta) || alreadyRefunded(meta)) return
+      const updated = await this.prisma.generationRecord.updateMany({
+        where: { id, status: 'generating' },
         data: { url, status: 'completed' },
       })
+      if (updated.count === 0) return
     } catch (err) {
       console.error('Video generation failed:', err)
+      const existing = await this.prisma.generationRecord.findFirst({ where: { id } })
+      if (!existing || existing.status !== 'generating') return
+      const meta = parseMeta(existing.metadata)
+      if (isCancelledMeta(meta) || alreadyRefunded(meta)) return
       if (resolved.source === 'user') {
         await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
-        const existing = await this.prisma.generationRecord.findFirst({ where: { id } })
-        const meta = parseMeta(existing?.metadata)
         await this.prisma.generationRecord.update({
           where: { id },
           data: {
@@ -981,8 +1012,6 @@ export class StudioService {
         return
       }
       await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
-      const existing = await this.prisma.generationRecord.findFirst({ where: { id } })
-      const meta = parseMeta(existing?.metadata)
       await this.prisma.generationRecord.update({
         where: { id },
         data: {

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -83,6 +83,8 @@ function parseMeta(raw: string | null | undefined): Record<string, unknown> {
   }
 }
 
+type CancelFlag = { isCancelled(): boolean }
+
 @Injectable()
 export class StudioService {
   constructor(
@@ -180,6 +182,7 @@ export class StudioService {
     model?: string,
     refs?: StudioRefInput[],
     mentionedKeys?: string[],
+    cancel?: CancelFlag,
   ) {
     const cost = 5
     const chargeReason = '文本生成'
@@ -220,6 +223,10 @@ export class StudioService {
               baseUrl: opts?.baseUrl ?? process.env.OPENAI_BASE_URL,
             })
           : await createTextProvider(opts).generate(mergedText, gatewayModelId)
+      if (cancel?.isCancelled()) {
+        await this.points.refund(userId, cost, `${chargeReason}-取消退款`)
+        throw new BadRequestException('已取消')
+      }
       return this.prisma.generationRecord.create({
         data: {
           userId,
@@ -256,7 +263,7 @@ export class StudioService {
     }
   }
 
-  async generatePrompt(userId: string, prompt: string, model?: string) {
+  async generatePrompt(userId: string, prompt: string, model?: string, cancel?: CancelFlag) {
     const trimmed = prompt?.trim()
     if (!trimmed) throw new BadRequestException('prompt 不能为空')
     const cost = 5
@@ -284,6 +291,10 @@ export class StudioService {
         apiKey: opts?.apiKey ?? process.env.OPENAI_API_KEY,
         baseUrl: opts?.baseUrl ?? process.env.OPENAI_BASE_URL,
       })
+      if (cancel?.isCancelled()) {
+        await this.points.refund(userId, cost, `${chargeReason}-取消退款`)
+        throw new BadRequestException('已取消')
+      }
       return this.prisma.generationRecord.create({
         data: {
           userId,
@@ -339,6 +350,7 @@ export class StudioService {
     mentionedKeys?: string[],
     resolution = '1K',
     count = 1,
+    cancel?: CancelFlag,
   ) {
     const n = Math.max(1, Math.min(4, Number(count) || 1))
     const cost = 10 * n
@@ -379,6 +391,10 @@ export class StudioService {
         },
       )
       const imageUrls = urls?.length ? urls : [url]
+      if (cancel?.isCancelled()) {
+        await this.points.refund(userId, cost, `${chargeReason}-取消退款`)
+        throw new BadRequestException('已取消')
+      }
       return this.prisma.generationRecord.create({
         data: {
           userId,
@@ -438,7 +454,13 @@ export class StudioService {
     }
   }
 
-  async generateImageVariation(userId: string, prompt: string, basePrompt?: string, model?: string) {
+  async generateImageVariation(
+    userId: string,
+    prompt: string,
+    basePrompt?: string,
+    model?: string,
+    cancel?: CancelFlag,
+  ) {
     const cost = 10
     const chargeReason = '图像变体'
     await this.points.consume(userId, cost, chargeReason)
@@ -451,6 +473,10 @@ export class StudioService {
       const { url } = await createImageProvider(userProviderOpts(resolved)).generate(combined, {
         modelId: resolved.modelName || undefined,
       })
+      if (cancel?.isCancelled()) {
+        await this.points.refund(userId, cost, `${chargeReason}-取消退款`)
+        throw new BadRequestException('已取消')
+      }
       return this.prisma.generationRecord.create({
         data: {
           userId,
@@ -592,6 +618,7 @@ export class StudioService {
     } = {},
     refs?: StudioRefInput[],
     mentionedKeys?: string[],
+    cancel?: CancelFlag,
   ) {
     const cost = 5
     const chargeReason = '音频生成'
@@ -630,6 +657,10 @@ export class StudioService {
         audioOpts,
       )
       const storeUrl = url.startsWith('data:') ? AUDIO_PLACEHOLDER : url
+      if (cancel?.isCancelled()) {
+        await this.points.refund(userId, cost, `${chargeReason}-取消退款`)
+        throw new BadRequestException('已取消')
+      }
       const record = await this.prisma.generationRecord.create({
         data: {
           userId,

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -19,6 +19,11 @@ import {
   type ImageResolutionTier,
   type StudioModality,
 } from '@lnkpi/shared'
+import {
+  alreadyRefunded,
+  applyChargeMeta,
+  applyRefundMeta,
+} from '../points/charge-session'
 import { PointsService } from '../points/points.service'
 import { PrismaService } from '../prisma/prisma.service'
 import { classifyByokFailure } from '../provider/byok-fallback'
@@ -130,6 +135,33 @@ export class StudioService {
     }
   }
 
+  private byokPendingMeta(
+    resolved: ResolvedGenerationProvider,
+    err: unknown,
+    cost: number,
+    extra: Record<string, unknown> = {},
+  ) {
+    return applyRefundMeta(
+      applyChargeMeta(this.pendingMeta(resolved, err, extra), cost),
+      cost,
+      'byok_failed',
+    )
+  }
+
+  private platformFallbackCost(type: string, meta: Record<string, unknown>): number {
+    if (type === 'text' || type === 'prompt' || type === 'audio') return 5
+    if (type === 'image') return 10 * (Number(meta.count ?? 1) || 1)
+    if (type === 'video') {
+      const duration = Number(meta.duration ?? 5)
+      return duration >= 15 ? 70 : duration >= 10 ? 50 : 30
+    }
+    throw new BadRequestException('不支持的生成类型')
+  }
+
+  private videoDurationCredits(duration: number): number {
+    return duration >= 15 ? 70 : duration >= 10 ? 50 : 30
+  }
+
   /** Catalog gateway id for platform confirm — never reuse user-channel modelName. */
   private platformGatewayModelId(
     modality: StudioModality,
@@ -149,7 +181,9 @@ export class StudioService {
     refs?: StudioRefInput[],
     mentionedKeys?: string[],
   ) {
-    await this.points.consume(userId, 5, '文本生成')
+    const cost = 5
+    const chargeReason = '文本生成'
+    await this.points.consume(userId, cost, chargeReason)
     const resolved = await this.resolver.resolveForGeneration(userId, model, 'text')
     const { mergedText, skippedMerge, referenceImages } = await this.resolveMergedPrompt(
       prompt,
@@ -162,6 +196,16 @@ export class StudioService {
     const gatewayModelId =
       resolved.source === 'user' ? resolved.modelName : entry.gatewayModelId
     const storeModel = resolved.source === 'user' ? model ?? resolvedKey : resolvedKey
+    const baseMeta = {
+      modelKey: resolvedKey,
+      gatewayModelId,
+      channelId: resolved.channelId,
+      skippedMerge,
+      refsCount: refs?.length ?? 0,
+      visionUsed: referenceImages.length > 0,
+      referenceImages,
+      ...(fallback && resolved.source === 'platform' ? { modelFallback: true } : {}),
+    }
 
     try {
       if (resolved.source === 'user' && !resolved.credentials.apiKey) {
@@ -184,21 +228,15 @@ export class StudioService {
           model: storeModel,
           url: null,
           status: 'completed',
-          metadata: JSON.stringify({
-            text,
-            modelKey: resolvedKey,
-            gatewayModelId,
-            channelId: resolved.channelId,
-            ...(fallback && resolved.source === 'platform' ? { modelFallback: true } : {}),
-            skippedMerge,
-            refsCount: refs?.length ?? 0,
-            visionUsed: referenceImages.length > 0,
-            referenceImages,
-          }),
+          metadata: JSON.stringify(applyChargeMeta({ ...baseMeta, text }, cost)),
         },
       })
     } catch (err) {
-      if (resolved.source !== 'user') throw err
+      if (resolved.source !== 'user') {
+        await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
+        throw err
+      }
+      await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
       return this.prisma.generationRecord.create({
         data: {
           userId,
@@ -208,14 +246,9 @@ export class StudioService {
           url: null,
           status: 'fallback_pending',
           metadata: JSON.stringify(
-            this.pendingMeta(resolved, err, {
+            this.byokPendingMeta(resolved, err, cost, {
               originalModel: model,
-              modelKey: resolvedKey,
-              gatewayModelId,
-              skippedMerge,
-              refsCount: refs?.length ?? 0,
-              visionUsed: referenceImages.length > 0,
-              referenceImages,
+              ...baseMeta,
             }),
           ),
         },
@@ -226,13 +259,21 @@ export class StudioService {
   async generatePrompt(userId: string, prompt: string, model?: string) {
     const trimmed = prompt?.trim()
     if (!trimmed) throw new BadRequestException('prompt 不能为空')
-    await this.points.consume(userId, 5, '提示词模式生成')
+    const cost = 5
+    const chargeReason = '提示词模式生成'
+    await this.points.consume(userId, cost, chargeReason)
     const resolved = await this.resolver.resolveForGeneration(userId, model, 'text')
     const { modelKey: resolvedKey, entry, fallback } = resolveModelKey('text', resolved.modelName)
     const gatewayModelId =
       resolved.source === 'user' ? resolved.modelName : entry.gatewayModelId
     const storeModel = resolved.source === 'user' ? model ?? resolvedKey : resolvedKey
     const opts = userProviderOpts(resolved)
+    const baseMeta = {
+      modelKey: resolvedKey,
+      gatewayModelId,
+      channelId: resolved.channelId,
+      ...(fallback && resolved.source === 'platform' ? { modelFallback: true } : {}),
+    }
 
     try {
       if (resolved.source === 'user' && !resolved.credentials.apiKey) {
@@ -251,18 +292,15 @@ export class StudioService {
           model: storeModel,
           url: null,
           status: 'completed',
-          metadata: JSON.stringify({
-            mode,
-            content,
-            modelKey: resolvedKey,
-            gatewayModelId,
-            channelId: resolved.channelId,
-            ...(fallback && resolved.source === 'platform' ? { modelFallback: true } : {}),
-          }),
+          metadata: JSON.stringify(applyChargeMeta({ ...baseMeta, mode, content }, cost)),
         },
       })
     } catch (err) {
-      if (resolved.source !== 'user') throw err
+      if (resolved.source !== 'user') {
+        await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
+        throw err
+      }
+      await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
       return this.prisma.generationRecord.create({
         data: {
           userId,
@@ -272,10 +310,9 @@ export class StudioService {
           url: null,
           status: 'fallback_pending',
           metadata: JSON.stringify(
-            this.pendingMeta(resolved, err, {
+            this.byokPendingMeta(resolved, err, cost, {
               originalModel: model,
-              modelKey: resolvedKey,
-              gatewayModelId,
+              ...baseMeta,
             }),
           ),
         },
@@ -304,7 +341,9 @@ export class StudioService {
     count = 1,
   ) {
     const n = Math.max(1, Math.min(4, Number(count) || 1))
-    await this.points.consume(userId, 10 * n, '图像生成')
+    const cost = 10 * n
+    const chargeReason = '图像生成'
+    await this.points.consume(userId, cost, chargeReason)
     const resolved = await this.resolver.resolveForGeneration(userId, model, 'image')
     const { mergedText, skippedMerge, referenceImages } = await this.resolveMergedPrompt(
       prompt,
@@ -348,22 +387,31 @@ export class StudioService {
           model: storeModel,
           url: imageUrls[0],
           status: 'completed',
-          metadata: JSON.stringify({
-            ...built.meta,
-            modelId,
-            aspectRatio,
-            resolution,
-            count: n,
-            size: built.size,
-            urls: imageUrls,
-            referenceImages,
-            skippedMerge,
-            channelId: resolved.channelId,
-          }),
+          metadata: JSON.stringify(
+            applyChargeMeta(
+              {
+                ...built.meta,
+                modelId,
+                aspectRatio,
+                resolution,
+                count: n,
+                size: built.size,
+                urls: imageUrls,
+                referenceImages,
+                skippedMerge,
+                channelId: resolved.channelId,
+              },
+              cost,
+            ),
+          ),
         },
       })
     } catch (err) {
-      if (resolved.source !== 'user') throw err
+      if (resolved.source !== 'user') {
+        await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
+        throw err
+      }
+      await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
       return this.prisma.generationRecord.create({
         data: {
           userId,
@@ -373,7 +421,7 @@ export class StudioService {
           url: null,
           status: 'fallback_pending',
           metadata: JSON.stringify(
-            this.pendingMeta(resolved, err, {
+            this.byokPendingMeta(resolved, err, cost, {
               ...built.meta,
               modelId,
               originalModel: model,
@@ -391,7 +439,9 @@ export class StudioService {
   }
 
   async generateImageVariation(userId: string, prompt: string, basePrompt?: string, model?: string) {
-    await this.points.consume(userId, 10, '图像变体')
+    const cost = 10
+    const chargeReason = '图像变体'
+    await this.points.consume(userId, cost, chargeReason)
     const resolved = await this.resolver.resolveForGeneration(userId, model, 'image')
     const combined = basePrompt ? `${basePrompt}。变体要求：${prompt}` : prompt
     try {
@@ -409,15 +459,24 @@ export class StudioService {
           model: model ?? resolved.modelName,
           url,
           status: 'completed',
-          metadata: JSON.stringify({
-            variation: true,
-            basePrompt,
-            channelId: resolved.channelId,
-          }),
+          metadata: JSON.stringify(
+            applyChargeMeta(
+              {
+                variation: true,
+                basePrompt,
+                channelId: resolved.channelId,
+              },
+              cost,
+            ),
+          ),
         },
       })
     } catch (err) {
-      if (resolved.source !== 'user') throw err
+      if (resolved.source !== 'user') {
+        await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
+        throw err
+      }
+      await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
       return this.prisma.generationRecord.create({
         data: {
           userId,
@@ -427,7 +486,7 @@ export class StudioService {
           url: null,
           status: 'fallback_pending',
           metadata: JSON.stringify(
-            this.pendingMeta(resolved, err, {
+            this.byokPendingMeta(resolved, err, cost, {
               originalModel: model,
               variation: true,
               basePrompt,
@@ -449,8 +508,9 @@ export class StudioService {
     resolution = '720p',
     crop = 'none',
   ) {
-    const durationCredits = duration >= 15 ? 70 : duration >= 10 ? 50 : 30
-    await this.points.consume(userId, durationCredits, '视频生成')
+    const durationCredits = this.videoDurationCredits(duration)
+    const chargeReason = '视频生成'
+    await this.points.consume(userId, durationCredits, chargeReason)
     const resolved = await this.resolver.resolveForGeneration(userId, model, 'video')
     const { mergedText, skippedMerge, referenceImages } = await this.resolveMergedPrompt(
       prompt,
@@ -479,23 +539,31 @@ export class StudioService {
         prompt: effectivePrompt,
         model: storeModel,
         status: 'generating',
-        metadata: JSON.stringify({
-          ...built.meta,
-          duration,
-          aspectRatio,
-          resolution,
-          crop,
-          referenceImages,
-          skippedMerge,
-          mergedText,
-          channelId: resolved.channelId,
-          originalModel: model,
-          providerSource: resolved.source,
-        }),
+        metadata: JSON.stringify(
+          applyChargeMeta(
+            {
+              ...built.meta,
+              duration,
+              aspectRatio,
+              resolution,
+              crop,
+              referenceImages,
+              skippedMerge,
+              mergedText,
+              channelId: resolved.channelId,
+              originalModel: model,
+              providerSource: resolved.source,
+            },
+            durationCredits,
+          ),
+        ),
       },
     })
     this.completeVideo(
       record.id,
+      userId,
+      durationCredits,
+      chargeReason,
       effectivePrompt,
       {
         model: gatewayModel,
@@ -525,7 +593,9 @@ export class StudioService {
     refs?: StudioRefInput[],
     mentionedKeys?: string[],
   ) {
-    await this.points.consume(userId, 5, '音频生成')
+    const cost = 5
+    const chargeReason = '音频生成'
+    await this.points.consume(userId, cost, chargeReason)
     const resolved = await this.resolver.resolveForGeneration(userId, options.model, 'audio')
     const { mergedText, skippedMerge } = await this.resolveMergedPrompt(
       text,
@@ -568,23 +638,32 @@ export class StudioService {
           model: storeModel,
           url: storeUrl,
           status: 'completed',
-          metadata: JSON.stringify({
-            ...built.meta,
-            skippedMerge,
-            voice: built.options.voice ?? options.voice ?? 'default',
-            emotion: options.emotion ?? 'neutral',
-            language: options.language ?? 'zh',
-            speed: options.speed ?? 1,
-            volume: options.volume,
-            pitch: options.pitch,
-            hasTtsData: url.startsWith('data:'),
-            channelId: resolved.channelId,
-          }),
+          metadata: JSON.stringify(
+            applyChargeMeta(
+              {
+                ...built.meta,
+                skippedMerge,
+                voice: built.options.voice ?? options.voice ?? 'default',
+                emotion: options.emotion ?? 'neutral',
+                language: options.language ?? 'zh',
+                speed: options.speed ?? 1,
+                volume: options.volume,
+                pitch: options.pitch,
+                hasTtsData: url.startsWith('data:'),
+                channelId: resolved.channelId,
+              },
+              cost,
+            ),
+          ),
         },
       })
       return { ...record, url }
     } catch (err) {
-      if (resolved.source !== 'user') throw err
+      if (resolved.source !== 'user') {
+        await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
+        throw err
+      }
+      await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
       const record = await this.prisma.generationRecord.create({
         data: {
           userId,
@@ -594,7 +673,7 @@ export class StudioService {
           url: null,
           status: 'fallback_pending',
           metadata: JSON.stringify(
-            this.pendingMeta(resolved, err, {
+            this.byokPendingMeta(resolved, err, cost, {
               ...built.meta,
               originalModel: options.model,
               skippedMerge,
@@ -619,144 +698,171 @@ export class StudioService {
       throw new BadRequestException('当前状态不可确认平台回退')
     }
     const meta = parseMeta(record.metadata)
+    const platformCost = this.platformFallbackCost(record.type, meta)
+    await this.points.consume(userId, platformCost, '平台回退生成')
+    const chargedMeta = { ...meta, chargedPoints: platformCost, priorByokRefunded: true }
 
-    if (record.type === 'image') {
-      const size = String(meta.size ?? '1024x1024')
-      const n = Number(meta.count ?? 1) || 1
-      // Never reuse user-channel modelName against platform credentials.
-      const modelId = this.platformGatewayModelId('image', meta)
-      const { url, urls } = await createImageProvider(undefined).generate(record.prompt, {
-        size,
-        n,
-        modelId,
-      })
-      const imageUrls = urls?.length ? urls : [url]
-      return this.prisma.generationRecord.update({
-        where: { id: record.id },
-        data: {
-          url: imageUrls[0],
-          status: 'completed',
-          metadata: JSON.stringify({
-            ...meta,
-            urls: imageUrls,
-            gatewayModelId: modelId,
-            providerFallback: true,
-            channelId: 'platform',
-          }),
-        },
-      })
-    }
-
-    if (record.type === 'text' || record.type === 'prompt') {
-      // Never reuse user-channel modelName against platform credentials.
-      const gatewayModelId = this.platformGatewayModelId('text', meta)
-      const referenceImages = Array.isArray(meta.referenceImages)
-        ? (meta.referenceImages as string[])
-        : []
-      let text: string
-      let promptMeta: Record<string, unknown> = {}
-      if (record.type === 'prompt') {
-        const { mode, content } = await generatePromptFromUserInput(record.prompt, {
-          model: gatewayModelId,
-          apiKey: process.env.OPENAI_API_KEY,
-          baseUrl: process.env.OPENAI_BASE_URL,
+    try {
+      if (record.type === 'image') {
+        const size = String(meta.size ?? '1024x1024')
+        const n = Number(meta.count ?? 1) || 1
+        const modelId = this.platformGatewayModelId('image', meta)
+        const { url, urls } = await createImageProvider(undefined).generate(record.prompt, {
+          size,
+          n,
+          modelId,
         })
-        text = content
-        promptMeta = { mode, content }
-      } else if (referenceImages.length > 0) {
-        const result = await generateTextWithImages(record.prompt, referenceImages, {
-          model: gatewayModelId,
-          apiKey: process.env.OPENAI_API_KEY,
-          baseUrl: process.env.OPENAI_BASE_URL,
+        const imageUrls = urls?.length ? urls : [url]
+        return this.prisma.generationRecord.update({
+          where: { id: record.id },
+          data: {
+            url: imageUrls[0],
+            status: 'completed',
+            metadata: JSON.stringify({
+              ...chargedMeta,
+              urls: imageUrls,
+              gatewayModelId: modelId,
+              providerFallback: true,
+              channelId: 'platform',
+            }),
+          },
         })
-        text = result.text
-      } else {
-        const result = await createTextProvider(undefined).generate(record.prompt, gatewayModelId)
-        text = result.text
       }
-      return this.prisma.generationRecord.update({
-        where: { id: record.id },
-        data: {
-          status: 'completed',
-          metadata: JSON.stringify({
-            ...meta,
-            ...promptMeta,
-            text: record.type === 'text' ? text : meta.text,
-            gatewayModelId,
-            providerFallback: true,
-            channelId: 'platform',
-          }),
-        },
-      })
-    }
 
-    if (record.type === 'audio') {
-      const platformModel = this.platformGatewayModelId('audio', meta)
-      const prevAudio = (meta.audioOptions as Record<string, unknown> | undefined) ?? {}
-      const audioOptions = {
-        ...prevAudio,
-        model: platformModel,
-        voice: prevAudio.voice ?? meta.voice,
-        speed: prevAudio.speed ?? meta.speed,
-        volume: prevAudio.volume ?? meta.volume,
-        pitch: prevAudio.pitch ?? meta.pitch,
+      if (record.type === 'text' || record.type === 'prompt') {
+        const gatewayModelId = this.platformGatewayModelId('text', meta)
+        const referenceImages = Array.isArray(meta.referenceImages)
+          ? (meta.referenceImages as string[])
+          : []
+        let text: string
+        let promptMeta: Record<string, unknown> = {}
+        if (record.type === 'prompt') {
+          const { mode, content } = await generatePromptFromUserInput(record.prompt, {
+            model: gatewayModelId,
+            apiKey: process.env.OPENAI_API_KEY,
+            baseUrl: process.env.OPENAI_BASE_URL,
+          })
+          text = content
+          promptMeta = { mode, content }
+        } else if (referenceImages.length > 0) {
+          const result = await generateTextWithImages(record.prompt, referenceImages, {
+            model: gatewayModelId,
+            apiKey: process.env.OPENAI_API_KEY,
+            baseUrl: process.env.OPENAI_BASE_URL,
+          })
+          text = result.text
+        } else {
+          const result = await createTextProvider(undefined).generate(record.prompt, gatewayModelId)
+          text = result.text
+        }
+        return this.prisma.generationRecord.update({
+          where: { id: record.id },
+          data: {
+            status: 'completed',
+            metadata: JSON.stringify({
+              ...chargedMeta,
+              ...promptMeta,
+              text: record.type === 'text' ? text : meta.text,
+              gatewayModelId,
+              providerFallback: true,
+              channelId: 'platform',
+            }),
+          },
+        })
       }
-      const { url } = await createAudioProvider(undefined).generate(
-        record.prompt,
-        audioOptions as { model?: string; voice?: string; speed?: number; volume?: number; pitch?: number },
-      )
-      const storeUrl = url.startsWith('data:') ? AUDIO_PLACEHOLDER : url
-      return this.prisma.generationRecord.update({
+
+      if (record.type === 'audio') {
+        const platformModel = this.platformGatewayModelId('audio', meta)
+        const prevAudio = (meta.audioOptions as Record<string, unknown> | undefined) ?? {}
+        const audioOptions = {
+          ...prevAudio,
+          model: platformModel,
+          voice: prevAudio.voice ?? meta.voice,
+          speed: prevAudio.speed ?? meta.speed,
+          volume: prevAudio.volume ?? meta.volume,
+          pitch: prevAudio.pitch ?? meta.pitch,
+        }
+        const { url } = await createAudioProvider(undefined).generate(
+          record.prompt,
+          audioOptions as { model?: string; voice?: string; speed?: number; volume?: number; pitch?: number },
+        )
+        const storeUrl = url.startsWith('data:') ? AUDIO_PLACEHOLDER : url
+        return this.prisma.generationRecord.update({
+          where: { id: record.id },
+          data: {
+            url: storeUrl,
+            status: 'completed',
+            metadata: JSON.stringify({
+              ...chargedMeta,
+              audioOptions,
+              gatewayModelId: platformModel,
+              hasTtsData: url.startsWith('data:'),
+              providerFallback: true,
+              channelId: 'platform',
+            }),
+          },
+        })
+      }
+
+      if (record.type === 'video') {
+        const platformModel = this.platformGatewayModelId('video', meta)
+        const { url } = await createVideoProvider(undefined).generate(record.prompt, {
+          model: platformModel,
+          duration: Number(meta.duration ?? 5),
+          aspectRatio: String(meta.aspectRatio ?? '16:9'),
+          resolution: String(meta.resolution ?? '720p'),
+          crop: meta.crop === undefined ? undefined : String(meta.crop),
+          image: Array.isArray(meta.referenceImages)
+            ? (meta.referenceImages as string[])[0]
+            : undefined,
+        })
+        return this.prisma.generationRecord.update({
+          where: { id: record.id },
+          data: {
+            url,
+            status: 'completed',
+            metadata: JSON.stringify({
+              ...chargedMeta,
+              gatewayModelId: platformModel,
+              providerFallback: true,
+              channelId: 'platform',
+            }),
+          },
+        })
+      }
+
+      throw new BadRequestException('不支持的生成类型')
+    } catch (err) {
+      if (err instanceof BadRequestException && err.message === '不支持的生成类型') {
+        await this.points.refund(userId, platformCost, '平台回退失败退款')
+        throw err
+      }
+      await this.points.refund(userId, platformCost, '平台回退失败退款')
+      await this.prisma.generationRecord.update({
         where: { id: record.id },
         data: {
-          url: storeUrl,
-          status: 'completed',
-          metadata: JSON.stringify({
-            ...meta,
-            audioOptions,
-            gatewayModelId: platformModel,
-            hasTtsData: url.startsWith('data:'),
-            providerFallback: true,
-            channelId: 'platform',
-          }),
+          status: 'failed',
+          metadata: JSON.stringify(
+            applyRefundMeta(chargedMeta, platformCost, 'platform_fallback_failed'),
+          ),
         },
       })
+      throw err
     }
-
-    if (record.type === 'video') {
-      const platformModel = this.platformGatewayModelId('video', meta)
-      const { url } = await createVideoProvider(undefined).generate(record.prompt, {
-        model: platformModel,
-        duration: Number(meta.duration ?? 5),
-        aspectRatio: String(meta.aspectRatio ?? '16:9'),
-        resolution: String(meta.resolution ?? '720p'),
-        crop: meta.crop === undefined ? undefined : String(meta.crop),
-        image: Array.isArray(meta.referenceImages)
-          ? (meta.referenceImages as string[])[0]
-          : undefined,
-      })
-      return this.prisma.generationRecord.update({
-        where: { id: record.id },
-        data: {
-          url,
-          status: 'completed',
-          metadata: JSON.stringify({
-            ...meta,
-            gatewayModelId: platformModel,
-            providerFallback: true,
-            channelId: 'platform',
-          }),
-        },
-      })
-    }
-
-    throw new BadRequestException('不支持的生成类型')
   }
 
   async cancelPlatformFallback(userId: string, recordId: string) {
     const record = await this.getGeneration(userId, recordId)
     if (record.status !== 'fallback_pending') {
       throw new BadRequestException('当前状态不可取消平台回退')
+    }
+    const meta = parseMeta(record.metadata)
+    if (!alreadyRefunded(meta)) {
+      const cost =
+        typeof meta.chargedPoints === 'number'
+          ? meta.chargedPoints
+          : this.platformFallbackCost(record.type, meta)
+      await this.points.refund(userId, cost, '平台回退取消退款')
     }
     return this.prisma.generationRecord.update({
       where: { id: record.id },
@@ -766,6 +872,9 @@ export class StudioService {
 
   private async completeVideo(
     id: string,
+    userId: string,
+    cost: number,
+    chargeReason: string,
     prompt: string,
     options: {
       model?: string
@@ -792,17 +901,19 @@ export class StudioService {
     } catch (err) {
       console.error('Video generation failed:', err)
       if (resolved.source === 'user') {
+        await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
         const existing = await this.prisma.generationRecord.findFirst({ where: { id } })
         const meta = parseMeta(existing?.metadata)
         await this.prisma.generationRecord.update({
           where: { id },
           data: {
             status: 'fallback_pending',
-            metadata: JSON.stringify(this.pendingMeta(resolved, err, meta)),
+            metadata: JSON.stringify(this.byokPendingMeta(resolved, err, cost, meta)),
           },
         })
         return
       }
+      await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
       await this.prisma.generationRecord.update({ where: { id }, data: { status: 'failed' } })
     }
   }

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -914,7 +914,15 @@ export class StudioService {
         return
       }
       await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
-      await this.prisma.generationRecord.update({ where: { id }, data: { status: 'failed' } })
+      const existing = await this.prisma.generationRecord.findFirst({ where: { id } })
+      const meta = parseMeta(existing?.metadata)
+      await this.prisma.generationRecord.update({
+        where: { id },
+        data: {
+          status: 'failed',
+          metadata: JSON.stringify(applyRefundMeta(meta, cost, 'platform_failed')),
+        },
+      })
     }
   }
 }

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -23,6 +23,9 @@ import {
   alreadyRefunded,
   applyChargeMeta,
   applyRefundMeta,
+  isCancelledException,
+  rethrowWithRefundedPoints,
+  throwCancelledException,
 } from '../points/charge-session'
 import { PointsService } from '../points/points.service'
 import { PrismaService } from '../prisma/prisma.service'
@@ -225,7 +228,7 @@ export class StudioService {
           : await createTextProvider(opts).generate(mergedText, gatewayModelId)
       if (cancel?.isCancelled()) {
         await this.points.refund(userId, cost, `${chargeReason}-取消退款`)
-        throw new BadRequestException('已取消')
+        throwCancelledException(cost)
       }
       return this.prisma.generationRecord.create({
         data: {
@@ -239,10 +242,10 @@ export class StudioService {
         },
       })
     } catch (err) {
-      if (err instanceof BadRequestException && err.message === '已取消') throw err
+      if (isCancelledException(err)) throw err
       if (resolved.source !== 'user') {
         await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
-        throw err
+        rethrowWithRefundedPoints(err, cost)
       }
       await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
       return this.prisma.generationRecord.create({
@@ -294,7 +297,7 @@ export class StudioService {
       })
       if (cancel?.isCancelled()) {
         await this.points.refund(userId, cost, `${chargeReason}-取消退款`)
-        throw new BadRequestException('已取消')
+        throwCancelledException(cost)
       }
       return this.prisma.generationRecord.create({
         data: {
@@ -308,10 +311,10 @@ export class StudioService {
         },
       })
     } catch (err) {
-      if (err instanceof BadRequestException && err.message === '已取消') throw err
+      if (isCancelledException(err)) throw err
       if (resolved.source !== 'user') {
         await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
-        throw err
+        rethrowWithRefundedPoints(err, cost)
       }
       await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
       return this.prisma.generationRecord.create({
@@ -395,7 +398,7 @@ export class StudioService {
       const imageUrls = urls?.length ? urls : [url]
       if (cancel?.isCancelled()) {
         await this.points.refund(userId, cost, `${chargeReason}-取消退款`)
-        throw new BadRequestException('已取消')
+        throwCancelledException(cost)
       }
       return this.prisma.generationRecord.create({
         data: {
@@ -425,10 +428,10 @@ export class StudioService {
         },
       })
     } catch (err) {
-      if (err instanceof BadRequestException && err.message === '已取消') throw err
+      if (isCancelledException(err)) throw err
       if (resolved.source !== 'user') {
         await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
-        throw err
+        rethrowWithRefundedPoints(err, cost)
       }
       await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
       return this.prisma.generationRecord.create({
@@ -478,7 +481,7 @@ export class StudioService {
       })
       if (cancel?.isCancelled()) {
         await this.points.refund(userId, cost, `${chargeReason}-取消退款`)
-        throw new BadRequestException('已取消')
+        throwCancelledException(cost)
       }
       return this.prisma.generationRecord.create({
         data: {
@@ -501,10 +504,10 @@ export class StudioService {
         },
       })
     } catch (err) {
-      if (err instanceof BadRequestException && err.message === '已取消') throw err
+      if (isCancelledException(err)) throw err
       if (resolved.source !== 'user') {
         await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
-        throw err
+        rethrowWithRefundedPoints(err, cost)
       }
       await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
       return this.prisma.generationRecord.create({
@@ -663,7 +666,7 @@ export class StudioService {
       const storeUrl = url.startsWith('data:') ? AUDIO_PLACEHOLDER : url
       if (cancel?.isCancelled()) {
         await this.points.refund(userId, cost, `${chargeReason}-取消退款`)
-        throw new BadRequestException('已取消')
+        throwCancelledException(cost)
       }
       const record = await this.prisma.generationRecord.create({
         data: {
@@ -694,10 +697,10 @@ export class StudioService {
       })
       return { ...record, url }
     } catch (err) {
-      if (err instanceof BadRequestException && err.message === '已取消') throw err
+      if (isCancelledException(err)) throw err
       if (resolved.source !== 'user') {
         await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
-        throw err
+        rethrowWithRefundedPoints(err, cost)
       }
       await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
       const record = await this.prisma.generationRecord.create({
@@ -751,7 +754,7 @@ export class StudioService {
         const imageUrls = urls?.length ? urls : [url]
         if (cancel?.isCancelled()) {
           await this.points.refund(userId, platformCost, '平台回退-取消退款')
-          throw new BadRequestException('已取消')
+          throwCancelledException(platformCost)
         }
         return this.prisma.generationRecord.update({
           where: { id: record.id },
@@ -797,7 +800,7 @@ export class StudioService {
         }
         if (cancel?.isCancelled()) {
           await this.points.refund(userId, platformCost, '平台回退-取消退款')
-          throw new BadRequestException('已取消')
+          throwCancelledException(platformCost)
         }
         return this.prisma.generationRecord.update({
           where: { id: record.id },
@@ -833,7 +836,7 @@ export class StudioService {
         const storeUrl = url.startsWith('data:') ? AUDIO_PLACEHOLDER : url
         if (cancel?.isCancelled()) {
           await this.points.refund(userId, platformCost, '平台回退-取消退款')
-          throw new BadRequestException('已取消')
+          throwCancelledException(platformCost)
         }
         return this.prisma.generationRecord.update({
           where: { id: record.id },
@@ -866,7 +869,7 @@ export class StudioService {
         })
         if (cancel?.isCancelled()) {
           await this.points.refund(userId, platformCost, '平台回退-取消退款')
-          throw new BadRequestException('已取消')
+          throwCancelledException(platformCost)
         }
         return this.prisma.generationRecord.update({
           where: { id: record.id },
@@ -885,7 +888,7 @@ export class StudioService {
 
       throw new BadRequestException('不支持的生成类型')
     } catch (err) {
-      if (err instanceof BadRequestException && err.message === '已取消') {
+      if (isCancelledException(err)) {
         await this.prisma.generationRecord.update({
           where: { id: record.id },
           data: {
@@ -899,7 +902,7 @@ export class StudioService {
       }
       if (err instanceof BadRequestException && err.message === '不支持的生成类型') {
         await this.points.refund(userId, platformCost, '平台回退失败退款')
-        throw err
+        rethrowWithRefundedPoints(err, platformCost)
       }
       await this.points.refund(userId, platformCost, '平台回退失败退款')
       await this.prisma.generationRecord.update({
@@ -911,7 +914,7 @@ export class StudioService {
           ),
         },
       })
-      throw err
+      rethrowWithRefundedPoints(err, platformCost)
     }
   }
 

--- a/apps/web/src/components/canvas/CanvasAccountChrome.test.ts
+++ b/apps/web/src/components/canvas/CanvasAccountChrome.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import { useAuthStore } from '@/stores/auth'
+import CanvasAccountChrome from './CanvasAccountChrome.vue'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@/components/membership/MembershipModal.vue', () => ({
+  default: { template: '<div class="membership-modal-stub" />' },
+}))
+
+describe('CanvasAccountChrome', () => {
+  it('renders points from auth store', () => {
+    const pinia = createPinia()
+    const auth = useAuthStore(pinia)
+    auth.user = { id: '1', phone: '13800000000', nickname: 'Neo', points: 420, membership: 'free' } as never
+    auth.token = 'tok'
+
+    const wrapper = mount(CanvasAccountChrome, {
+      global: { plugins: [pinia] },
+    })
+
+    expect(wrapper.find('.canvas-points-pill').text()).toContain('420 积分')
+  })
+})

--- a/apps/web/src/components/canvas/CanvasAccountChrome.vue
+++ b/apps/web/src/components/canvas/CanvasAccountChrome.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+import { useClickOutside } from '@/composables/useClickOutside'
+import MembershipModal from '@/components/membership/MembershipModal.vue'
+
+const showMembership = defineModel<boolean>('showMembership', { default: false })
+
+const auth = useAuthStore()
+const router = useRouter()
+const menuOpen = ref(false)
+const menuRef = ref<HTMLElement | null>(null)
+
+function closeMenu() {
+  menuOpen.value = false
+}
+
+useClickOutside(menuRef, closeMenu)
+
+function openProfile() {
+  closeMenu()
+  void router.push('/profile')
+}
+
+function logout() {
+  closeMenu()
+  auth.logout()
+}
+</script>
+
+<template>
+  <div v-if="auth.isLoggedIn" class="canvas-account-chrome pointer-events-auto flex items-center gap-2">
+    <button
+      type="button"
+      class="canvas-points-pill rounded-xl border border-white/[0.08] bg-[rgba(22,22,22,0.88)] px-3 py-1.5 text-xs text-[#818cf8] shadow-lg backdrop-blur-xl transition hover:bg-white/[0.06]"
+      @click="showMembership = true"
+    >
+      {{ auth.user?.points ?? 0 }} 积分
+    </button>
+
+    <div ref="menuRef" class="canvas-user-menu relative">
+      <button
+        type="button"
+        class="flex items-center gap-2 rounded-xl border border-white/[0.08] bg-[rgba(22,22,22,0.88)] px-2 py-1 shadow-lg backdrop-blur-xl transition hover:bg-white/[0.06]"
+        @click.stop="menuOpen = !menuOpen"
+      >
+        <div
+          class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[#6366f1] text-xs font-medium text-white"
+        >
+          {{ auth.user?.nickname?.[0] ?? 'U' }}
+        </div>
+        <span class="max-w-[88px] truncate text-sm text-white/80">{{ auth.user?.nickname }}</span>
+        <svg
+          class="h-3.5 w-3.5 shrink-0 text-white/40 transition"
+          :class="menuOpen ? 'rotate-180' : ''"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      <div
+        v-if="menuOpen"
+        class="absolute right-0 top-full z-10 mt-1.5 min-w-[120px] rounded-xl border border-white/10 bg-[#242424] py-1 shadow-2xl"
+        @click.stop
+      >
+        <button
+          type="button"
+          class="flex w-full px-3 py-2 text-left text-xs text-white/70 hover:bg-white/5 hover:text-white"
+          @click="openProfile"
+        >
+          资料
+        </button>
+        <button
+          type="button"
+          class="flex w-full px-3 py-2 text-left text-xs text-white/70 hover:bg-white/5 hover:text-white"
+          @click="logout"
+        >
+          退出
+        </button>
+      </div>
+    </div>
+
+    <MembershipModal v-model="showMembership" />
+  </div>
+  <button
+    v-else
+    type="button"
+    class="canvas-account-chrome pointer-events-auto rounded-xl border border-white/[0.08] bg-[rgba(22,22,22,0.88)] px-3 py-1.5 text-xs text-white/70 shadow-lg backdrop-blur-xl transition hover:bg-white/[0.06] hover:text-white"
+    @click="auth.openLogin()"
+  >
+    登录
+  </button>
+</template>

--- a/apps/web/src/components/canvas/CanvasNodeAudio.vue
+++ b/apps/web/src/components/canvas/CanvasNodeAudio.vue
@@ -8,7 +8,7 @@ import { useNodeMediaUpload } from '@/composables/useNodeMediaUpload'
 const props = defineProps<{
   id: string
   selected?: boolean
-  data: { url?: string; status: string; prompt?: string; label?: string; errorMessage?: string }
+  data: { url?: string; status: string; prompt?: string; label?: string; errorMessage?: string; generationStartedAt?: string }
 }>()
 
 const displayUrl = computed(() => resolveMediaUrl(String(props.data.url ?? '')))

--- a/apps/web/src/components/canvas/CanvasNodeAudio.vue
+++ b/apps/web/src/components/canvas/CanvasNodeAudio.vue
@@ -94,6 +94,7 @@ const {
       >
       <NodeTaskCornerActions
         :status="data.status"
+        :started-at="typeof data.generationStartedAt === 'string' ? data.generationStartedAt : undefined"
         :error-message="data.errorMessage as string | undefined"
       />
     </div>

--- a/apps/web/src/components/canvas/CanvasNodeImage.vue
+++ b/apps/web/src/components/canvas/CanvasNodeImage.vue
@@ -9,7 +9,7 @@ import { useNodeMediaUpload } from '@/composables/useNodeMediaUpload'
 const props = defineProps<{
   id: string
   selected?: boolean
-  data: { url?: string; status: string; prompt?: string; label?: string; errorMessage?: string }
+  data: { url?: string; status: string; prompt?: string; label?: string; errorMessage?: string; generationStartedAt?: string }
 }>()
 
 const editor = useCanvasEditorStore()

--- a/apps/web/src/components/canvas/CanvasNodeImage.vue
+++ b/apps/web/src/components/canvas/CanvasNodeImage.vue
@@ -111,6 +111,7 @@ function openEdit() {
       >
       <NodeTaskCornerActions
         :status="data.status"
+        :started-at="typeof data.generationStartedAt === 'string' ? data.generationStartedAt : undefined"
         :error-message="data.errorMessage as string | undefined"
       />
     </div>

--- a/apps/web/src/components/canvas/CanvasNodeShot.vue
+++ b/apps/web/src/components/canvas/CanvasNodeShot.vue
@@ -11,6 +11,7 @@ defineProps<{
     coverUrl?: string
     label?: string
     errorMessage?: string
+    generationStartedAt?: string
   }
 }>()
 </script>

--- a/apps/web/src/components/canvas/CanvasNodeShot.vue
+++ b/apps/web/src/components/canvas/CanvasNodeShot.vue
@@ -37,6 +37,7 @@ defineProps<{
       </div>
       <NodeTaskCornerActions
         :status="data.status"
+        :started-at="typeof data.generationStartedAt === 'string' ? data.generationStartedAt : undefined"
         :error-message="data.errorMessage as string | undefined"
       />
     </div>

--- a/apps/web/src/components/canvas/CanvasNodeText.vue
+++ b/apps/web/src/components/canvas/CanvasNodeText.vue
@@ -32,6 +32,7 @@ function onSave(md: string) {
       <p>{{ data.content || '点击下方 Dock Studio 编辑...' }}</p>
       <NodeTaskCornerActions
         :status="data.status"
+        :started-at="typeof data.generationStartedAt === 'string' ? data.generationStartedAt : undefined"
         :error-message="data.errorMessage as string | undefined"
       />
     </div>

--- a/apps/web/src/components/canvas/CanvasNodeText.vue
+++ b/apps/web/src/components/canvas/CanvasNodeText.vue
@@ -7,7 +7,7 @@ import PromptMarkdownEditor from '@/components/canvas/PromptMarkdownEditor.vue'
 
 const props = defineProps<{
   selected?: boolean
-  data: { content: string; label?: string; status?: string; errorMessage?: string }
+  data: { content: string; label?: string; status?: string; errorMessage?: string; generationStartedAt?: string }
 }>()
 
 const nodeId = useNodeId()

--- a/apps/web/src/components/canvas/CanvasNodeVideo.vue
+++ b/apps/web/src/components/canvas/CanvasNodeVideo.vue
@@ -8,7 +8,7 @@ import { useNodeMediaUpload } from '@/composables/useNodeMediaUpload'
 const props = defineProps<{
   id: string
   selected?: boolean
-  data: { url?: string; status: string; duration?: number; label?: string; errorMessage?: string }
+  data: { url?: string; status: string; duration?: number; label?: string; errorMessage?: string; generationStartedAt?: string }
 }>()
 
 const displayUrl = computed(() => resolveMediaUrl(String(props.data.url ?? '')))

--- a/apps/web/src/components/canvas/CanvasNodeVideo.vue
+++ b/apps/web/src/components/canvas/CanvasNodeVideo.vue
@@ -94,6 +94,7 @@ const {
       >
       <NodeTaskCornerActions
         :status="data.status"
+        :started-at="typeof data.generationStartedAt === 'string' ? data.generationStartedAt : undefined"
         :error-message="data.errorMessage as string | undefined"
       />
     </div>

--- a/apps/web/src/components/canvas/NeoBaseNode.vue
+++ b/apps/web/src/components/canvas/NeoBaseNode.vue
@@ -7,7 +7,6 @@ import {
   resolveNeoNodeTitle,
   type NeoNodeStatus,
 } from '@/components/canvas/neoNodeMeta'
-import NodeTaskBadge from '@/components/canvas/NodeTaskBadge.vue'
 import { CANVAS_NODE_RENAME_KEY } from '@/composables/canvasNodeActions'
 
 const props = withDefaults(
@@ -128,10 +127,6 @@ function cancelRename() {
         @mousedown.stop
       >
       <span v-else class="neo-node-title">{{ displayTitle }}</span>
-      <NodeTaskBadge
-        :status="data?.status"
-        :started-at="typeof data?.generationStartedAt === 'string' ? data.generationStartedAt : undefined"
-      />
       <span class="neo-node-status" :class="nodeStatus" />
     </div>
 

--- a/apps/web/src/components/canvas/NodeTaskBadge.vue
+++ b/apps/web/src/components/canvas/NodeTaskBadge.vue
@@ -1,60 +1,8 @@
 <script setup lang="ts">
-import { computed, onUnmounted, ref, watch } from 'vue'
-import { resolveTaskBadge } from '@/components/canvas/nodeTaskChrome'
-import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
-
-const props = defineProps<{
-  status?: unknown
-  startedAt?: string
-}>()
-
-const nowMs = ref(Date.now())
-const completedFlash = ref(false)
-let tick: ReturnType<typeof setInterval> | undefined
-let flashTimer: ReturnType<typeof setTimeout> | undefined
-
-watch(
-  () => props.status,
-  (s, prev) => {
-    if (s === NODE_GENERATION_STATUS.completed && prev && prev !== NODE_GENERATION_STATUS.completed) {
-      completedFlash.value = true
-      clearTimeout(flashTimer)
-      flashTimer = setTimeout(() => {
-        completedFlash.value = false
-      }, 2000)
-    }
-  },
-)
-
-watch(
-  () => props.status,
-  (s) => {
-    clearInterval(tick)
-    if (s === NODE_GENERATION_STATUS.generating || s === NODE_GENERATION_STATUS.fallback_pending) {
-      nowMs.value = Date.now()
-      tick = setInterval(() => {
-        nowMs.value = Date.now()
-      }, 1000)
-    }
-  },
-  { immediate: true },
-)
-
-onUnmounted(() => {
-  clearInterval(tick)
-  clearTimeout(flashTimer)
-})
-
-const badge = computed(() =>
-  resolveTaskBadge({
-    status: props.status,
-    startedAt: props.startedAt,
-    nowMs: nowMs.value,
-    completedFlash: completedFlash.value,
-  }),
-)
+/** Elapsed-only label; primary chrome lives in NodeTaskCornerActions. */
+defineProps<{ elapsedText?: string | null }>()
 </script>
 
 <template>
-  <span v-if="badge" class="neo-task-badge" :class="`is-${badge.tone}`">{{ badge.text }}</span>
+  <span v-if="elapsedText" class="neo-task-elapsed">{{ elapsedText }}</span>
 </template>

--- a/apps/web/src/components/canvas/NodeTaskBadge.vue
+++ b/apps/web/src/components/canvas/NodeTaskBadge.vue
@@ -1,8 +1,0 @@
-<script setup lang="ts">
-/** Elapsed-only label; primary chrome lives in NodeTaskCornerActions. */
-defineProps<{ elapsedText?: string | null }>()
-</script>
-
-<template>
-  <span v-if="elapsedText" class="neo-task-elapsed">{{ elapsedText }}</span>
-</template>

--- a/apps/web/src/components/canvas/NodeTaskCornerActions.vue
+++ b/apps/web/src/components/canvas/NodeTaskCornerActions.vue
@@ -1,15 +1,66 @@
 <script setup lang="ts">
-import { computed, inject } from 'vue'
+import { computed, inject, onUnmounted, ref, watch } from 'vue'
 import { useNodeId } from '@vue-flow/core'
-import { resolveCornerAction, truncateError } from '@/components/canvas/nodeTaskChrome'
+import { resolveTaskChrome, truncateError } from '@/components/canvas/nodeTaskChrome'
 import { CANVAS_NODE_CANCEL_KEY, CANVAS_NODE_RETRY_KEY } from '@/composables/canvasNodeActions'
 import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
 
-const props = defineProps<{ status?: unknown; errorMessage?: string }>()
+const props = defineProps<{
+  status?: unknown
+  startedAt?: string
+  errorMessage?: string
+}>()
+
 const nodeId = useNodeId()
 const cancel = inject(CANVAS_NODE_CANCEL_KEY, null)
 const retry = inject(CANVAS_NODE_RETRY_KEY, null)
-const action = computed(() => resolveCornerAction(props.status))
+
+const nowMs = ref(Date.now())
+const completedFlash = ref(false)
+let tick: ReturnType<typeof setInterval> | undefined
+let flashTimer: ReturnType<typeof setTimeout> | undefined
+
+watch(
+  () => props.status,
+  (s, prev) => {
+    if (s === NODE_GENERATION_STATUS.completed && prev && prev !== NODE_GENERATION_STATUS.completed) {
+      completedFlash.value = true
+      clearTimeout(flashTimer)
+      flashTimer = setTimeout(() => {
+        completedFlash.value = false
+      }, 2000)
+    }
+  },
+)
+
+watch(
+  () => props.status,
+  (s) => {
+    clearInterval(tick)
+    if (s === NODE_GENERATION_STATUS.generating) {
+      nowMs.value = Date.now()
+      tick = setInterval(() => {
+        nowMs.value = Date.now()
+      }, 1000)
+    }
+  },
+  { immediate: true },
+)
+
+onUnmounted(() => {
+  clearInterval(tick)
+  clearTimeout(flashTimer)
+})
+
+const chrome = computed(() =>
+  resolveTaskChrome({
+    status: props.status,
+    startedAt: props.startedAt,
+    nowMs: nowMs.value,
+    completedFlash: completedFlash.value,
+  }),
+)
+
 const err = computed(() => truncateError(props.errorMessage))
 const showError = computed(
   () =>
@@ -18,26 +69,107 @@ const showError = computed(
       props.status === NODE_GENERATION_STATUS.failed),
 )
 
+const isClickable = computed(
+  () => chrome.value?.action === 'cancel' || chrome.value?.action === 'retry',
+)
+
 function onAction(e: Event) {
   e.stopPropagation()
   e.preventDefault()
-  if (!nodeId) return
-  if (action.value === 'cancel') cancel?.(nodeId)
-  if (action.value === 'retry') void retry?.(nodeId)
+  if (!nodeId || !chrome.value?.action) return
+  if (chrome.value.action === 'cancel') cancel?.(nodeId)
+  if (chrome.value.action === 'retry') void retry?.(nodeId)
 }
 </script>
 
 <template>
-  <div class="neo-task-corner nodrag nopan" @pointerdown.stop @mousedown.stop @click.stop>
+  <div
+    v-if="chrome"
+    class="neo-task-chrome nodrag nopan"
+    @pointerdown.stop
+    @mousedown.stop
+    @click.stop
+  >
     <p v-if="showError" class="neo-task-error">{{ err }}</p>
-    <button
-      v-if="action"
-      type="button"
-      class="neo-task-corner-btn"
-      :class="action === 'retry' ? 'is-retry' : 'is-cancel'"
-      @click="onAction"
-    >
-      {{ action === 'retry' ? '重试' : '取消' }}
-    </button>
+    <div class="neo-task-chrome-row">
+      <span v-if="chrome.elapsedText" class="neo-task-elapsed">{{ chrome.elapsedText }}</span>
+      <button
+        type="button"
+        class="neo-task-chrome-btn"
+        :class="[
+          `is-${chrome.tone}`,
+          {
+            'is-clickable': isClickable,
+            'is-flash': chrome.flashSuccess,
+          },
+        ]"
+        :title="
+          chrome.action === 'cancel'
+            ? '取消生成'
+            : chrome.action === 'retry'
+              ? '重试'
+              : chrome.tone === 'pending'
+                ? '待确认'
+                : undefined
+        "
+        :aria-label="
+          chrome.action === 'cancel'
+            ? '取消生成'
+            : chrome.action === 'retry'
+              ? '重试'
+              : chrome.tone === 'pending'
+                ? '待确认'
+                : '已完成'
+        "
+        :disabled="!isClickable"
+        @click="onAction"
+      >
+        <span v-if="chrome.showSpinner" class="neo-task-spinner" aria-hidden="true" />
+        <svg
+          v-else-if="chrome.action === 'retry'"
+          viewBox="0 0 24 24"
+          width="14"
+          height="14"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M21 12a9 9 0 1 1-2.64-6.36" />
+          <path d="M21 3v6h-6" />
+        </svg>
+        <svg
+          v-else-if="chrome.tone === 'pending'"
+          viewBox="0 0 24 24"
+          width="14"
+          height="14"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <path d="M12 6v6l4 2" />
+        </svg>
+        <svg
+          v-else-if="chrome.flashSuccess"
+          viewBox="0 0 24 24"
+          width="14"
+          height="14"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M20 6 9 17l-5-5" />
+        </svg>
+      </button>
+    </div>
   </div>
 </template>

--- a/apps/web/src/components/canvas/dock-studio/panels/AudioDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/AudioDockPanel.vue
@@ -101,16 +101,7 @@ watch(() => props.node, syncFromNode, { immediate: true, deep: true })
 
 watch(audioModel, () => syncVoiceToCatalog(true))
 
-watch(
-  () => props.upstream,
-  (ctx) => {
-    if (!prompt.value.trim() && ctx.textPrompt) {
-      prompt.value = ctx.textPrompt
-      emit('patch', { prompt: ctx.textPrompt })
-    }
-  },
-  { immediate: true },
-)
+const hasRefs = computed(() => (props.refs?.length ?? 0) > 0)
 
 function onPromptInput(value: string) {
   prompt.value = value
@@ -206,7 +197,7 @@ function onRefRemove(ref: NodeRef) {
         <DockCreditBadge :credits="credits" />
         <DockGenerateButton
           :generating="generating"
-          :disabled="!generating && !prompt.trim() && !upstream.textPrompt.trim()"
+          :disabled="!generating && !prompt.trim() && !hasRefs"
           @generate="onGenerate"
         />
       </div>

--- a/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
@@ -116,10 +116,6 @@ watch(() => props.node, syncFromNode, { immediate: true, deep: true })
 watch(
   () => props.upstream,
   (ctx) => {
-    if (!prompt.value.trim() && ctx.textPrompt) {
-      prompt.value = ctx.textPrompt
-      emit('patch', { prompt: ctx.textPrompt })
-    }
     if (!referenceImageUrl.value.trim() && ctx.referenceImageUrl) {
       referenceImageUrl.value = ctx.referenceImageUrl
       emit('patch', { referenceImageUrl: ctx.referenceImageUrl })

--- a/apps/web/src/components/canvas/dock-studio/panels/SceneComposerDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/SceneComposerDockPanel.vue
@@ -58,17 +58,6 @@ function syncFromNode() {
 
 watch(() => props.node, syncFromNode, { immediate: true, deep: true })
 
-watch(
-  () => props.upstream,
-  (ctx) => {
-    if (!payload.value.prompt?.trim() && ctx.textPrompt) {
-      payload.value.prompt = ctx.textPrompt
-      commitPatch()
-    }
-  },
-  { immediate: true },
-)
-
 function commitPatch() {
   emit('patch', sceneComposerToNodePatch(payload.value))
 }

--- a/apps/web/src/components/canvas/dock-studio/panels/ShotDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ShotDockPanel.vue
@@ -54,17 +54,6 @@ function syncFromNode() {
 
 watch(() => props.node, syncFromNode, { immediate: true, deep: true })
 
-watch(
-  () => props.upstream,
-  (ctx) => {
-    if (!prompt.value.trim() && ctx.textPrompt) {
-      prompt.value = ctx.textPrompt
-      emit('patch', { prompt: ctx.textPrompt })
-    }
-  },
-  { immediate: true },
-)
-
 function onPromptInput(value: string) {
   prompt.value = value
   emit('patch', { prompt: value })

--- a/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
@@ -75,17 +75,6 @@ watch(
   () => syncFromNode(),
 )
 
-watch(
-  () => props.upstream,
-  (ctx) => {
-    if (!prompt.value.trim() && ctx.textPrompt) {
-      prompt.value = ctx.textPrompt
-      emit('patch', { prompt: ctx.textPrompt })
-    }
-  },
-  { immediate: true },
-)
-
 function onPromptInput(value: string) {
   prompt.value = value
   emit('patch', { prompt: value })

--- a/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
@@ -77,10 +77,6 @@ watch(() => props.node, syncFromNode, { immediate: true, deep: true })
 watch(
   () => props.upstream,
   (ctx) => {
-    if (!prompt.value.trim() && ctx.textPrompt) {
-      prompt.value = ctx.textPrompt
-      emit('patch', { prompt: ctx.textPrompt })
-    }
     if (!referenceImageUrl.value.trim() && ctx.referenceImageUrl) {
       referenceImageUrl.value = ctx.referenceImageUrl
       emit('patch', { referenceImageUrl: ctx.referenceImageUrl })

--- a/apps/web/src/components/canvas/dock-studio/shared/DockGenerateButton.vue
+++ b/apps/web/src/components/canvas/dock-studio/shared/DockGenerateButton.vue
@@ -84,6 +84,7 @@ const emit = defineEmits<{
   opacity: 1 !important;
   pointer-events: auto !important;
   cursor: pointer;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.35);
 }
 
 .dock-generate-btn.is-generating:hover:not(:disabled) {

--- a/apps/web/src/components/canvas/nodeTaskChrome.test.ts
+++ b/apps/web/src/components/canvas/nodeTaskChrome.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   formatElapsed,
-  resolveTaskBadge,
-  resolveCornerAction,
+  resolveTaskChrome,
   truncateError,
 } from './nodeTaskChrome'
 import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
@@ -12,23 +11,67 @@ describe('nodeTaskChrome', () => {
     const start = new Date('2026-07-20T00:00:00.000Z').toISOString()
     expect(formatElapsed(start, Date.parse('2026-07-20T00:00:42.000Z'))).toBe('0:42')
     expect(formatElapsed(start, Date.parse('2026-07-20T00:03:05.000Z'))).toBe('3:05')
+    expect(formatElapsed(undefined, Date.now())).toBe('0:00')
   })
 
-  it('badge for generating includes elapsed', () => {
+  it('generating shows spinner, cancel action, and elapsed', () => {
     const start = new Date('2026-07-20T00:00:00.000Z').toISOString()
-    const b = resolveTaskBadge({
-      status: NODE_GENERATION_STATUS.generating,
-      startedAt: start,
-      nowMs: Date.parse('2026-07-20T00:00:12.000Z'),
+    expect(
+      resolveTaskChrome({
+        status: NODE_GENERATION_STATUS.generating,
+        startedAt: start,
+        nowMs: Date.parse('2026-07-20T00:00:12.000Z'),
+      }),
+    ).toEqual({
+      action: 'cancel',
+      showSpinner: true,
+      elapsedText: '0:12',
+      tone: 'running',
     })
-    expect(b).toEqual({ text: '生成中 · 0:12', tone: 'running' })
   })
 
-  it('corner cancel/retry mapping', () => {
-    expect(resolveCornerAction(NODE_GENERATION_STATUS.generating)).toBe('cancel')
-    expect(resolveCornerAction(NODE_GENERATION_STATUS.error)).toBe('retry')
-    expect(resolveCornerAction(NODE_GENERATION_STATUS.fallback_pending)).toBeNull()
-    expect(resolveCornerAction(NODE_GENERATION_STATUS.completed)).toBeNull()
+  it('error and failed show retry action', () => {
+    const expected = { action: 'retry' as const, showSpinner: false, elapsedText: null, tone: 'error' as const }
+    expect(
+      resolveTaskChrome({ status: NODE_GENERATION_STATUS.error, nowMs: Date.now() }),
+    ).toEqual(expected)
+    expect(
+      resolveTaskChrome({ status: NODE_GENERATION_STATUS.failed, nowMs: Date.now() }),
+    ).toEqual(expected)
+  })
+
+  it('fallback_pending shows pending tone without action', () => {
+    expect(
+      resolveTaskChrome({ status: NODE_GENERATION_STATUS.fallback_pending, nowMs: Date.now() }),
+    ).toEqual({
+      action: null,
+      showSpinner: false,
+      elapsedText: null,
+      tone: 'pending',
+    })
+  })
+
+  it('completed flashes success then hides', () => {
+    expect(
+      resolveTaskChrome({
+        status: NODE_GENERATION_STATUS.completed,
+        nowMs: Date.now(),
+        completedFlash: true,
+      }),
+    ).toEqual({
+      action: null,
+      showSpinner: false,
+      elapsedText: null,
+      tone: 'success',
+      flashSuccess: true,
+    })
+    expect(
+      resolveTaskChrome({
+        status: NODE_GENERATION_STATUS.completed,
+        nowMs: Date.now(),
+        completedFlash: false,
+      }),
+    ).toBeNull()
   })
 
   it('truncates error', () => {

--- a/apps/web/src/components/canvas/nodeTaskChrome.ts
+++ b/apps/web/src/components/canvas/nodeTaskChrome.ts
@@ -4,9 +4,12 @@ export type TaskCornerAction = 'cancel' | 'retry' | null
 
 export type TaskBadgeTone = 'running' | 'error' | 'success' | 'pending'
 
-export type TaskBadge = {
-  text: string
+export type TaskChromeView = {
+  action: TaskCornerAction
+  showSpinner: boolean
+  elapsedText: string | null
   tone: TaskBadgeTone
+  flashSuccess?: boolean
 }
 
 /** Elapsed time as m:ss. Missing/invalid startedAt → "0:00". */
@@ -20,47 +23,55 @@ export function formatElapsed(startedAt: string | undefined, nowMs: number): str
   return `${minutes}:${String(seconds).padStart(2, '0')}`
 }
 
-/**
- * Title badge for Layout C. Status-driven (works for text/image/video/audio/shot).
- * completed only shows while completedFlash is true.
- */
-export function resolveTaskBadge(input: {
+/** Unified chrome view for circular corner controls + elapsed. */
+export function resolveTaskChrome(input: {
   status: unknown
   startedAt?: string
   nowMs: number
   completedFlash?: boolean
-}): TaskBadge | null {
+}): TaskChromeView | null {
   const { status, startedAt, nowMs, completedFlash } = input
 
   if (status === NODE_GENERATION_STATUS.generating) {
     return {
-      text: `生成中 · ${formatElapsed(startedAt, nowMs)}`,
+      action: 'cancel',
+      showSpinner: true,
+      elapsedText: formatElapsed(startedAt, nowMs),
       tone: 'running',
     }
   }
 
   if (status === NODE_GENERATION_STATUS.error || status === NODE_GENERATION_STATUS.failed) {
-    return { text: '失败', tone: 'error' }
+    return {
+      action: 'retry',
+      showSpinner: false,
+      elapsedText: null,
+      tone: 'error',
+    }
   }
 
   if (status === NODE_GENERATION_STATUS.fallback_pending) {
-    return { text: '待确认', tone: 'pending' }
+    return {
+      action: null,
+      showSpinner: false,
+      elapsedText: null,
+      tone: 'pending',
+    }
   }
 
   if (status === NODE_GENERATION_STATUS.completed) {
-    if (completedFlash) return { text: '已完成', tone: 'success' }
+    if (completedFlash) {
+      return {
+        action: null,
+        showSpinner: false,
+        elapsedText: null,
+        tone: 'success',
+        flashSuccess: true,
+      }
+    }
     return null
   }
 
-  return null
-}
-
-/** Corner action: cancel while generating, retry on error/failed. */
-export function resolveCornerAction(status: unknown): TaskCornerAction {
-  if (status === NODE_GENERATION_STATUS.generating) return 'cancel'
-  if (status === NODE_GENERATION_STATUS.error || status === NODE_GENERATION_STATUS.failed) {
-    return 'retry'
-  }
   return null
 }
 

--- a/apps/web/src/components/membership/MembershipModal.vue
+++ b/apps/web/src/components/membership/MembershipModal.vue
@@ -43,6 +43,7 @@ async function claimDaily() {
   try {
     const { data } = await membershipApi.claimDaily()
     points.value = data.data.points
+    auth.setPoints(data.data.points)
     message.value = `已领取 ${data.data.added} 积分`
   } catch {
     message.value = '领取失败'

--- a/apps/web/src/composables/useNodeGeneration.test.ts
+++ b/apps/web/src/composables/useNodeGeneration.test.ts
@@ -27,6 +27,7 @@ vi.mock('@/services/studio-api', () => ({
     generatePrompt: vi.fn(),
     confirmPlatformFallback: vi.fn(),
     cancelPlatformFallback: vi.fn(),
+    cancelGeneration: vi.fn(),
   },
 }))
 
@@ -41,6 +42,7 @@ vi.mock('@/services/canvas-api', () => ({
     exportVideoComposition: vi.fn(),
     confirmMaterialPlatformFallback: vi.fn(),
     cancelMaterialPlatformFallback: vi.fn(),
+    cancelMaterial: vi.fn(),
   },
 }))
 function mockAxiosResponse<T>(data: T): AxiosResponse<T> {
@@ -730,16 +732,21 @@ describe('useNodeGeneration', () => {
     await pending
   })
 
-  it('cancelGeneration stops generation and shot polling', () => {
+  it('cancelGeneration stops generation and shot polling', async () => {
     const stopGenerationPolling = vi.fn()
     const stopShotPolling = vi.fn()
     const node = createNode('image', {
       prompt: 'x',
       status: NODE_GENERATION_STATUS.generating,
+      generationRecordId: 'rec-cancel-1',
     }, 'img-1')
     const { api } = createDeps([node], { stopGenerationPolling, stopShotPolling })
+    vi.mocked(studioApi.cancelGeneration).mockResolvedValue(
+      mockAxiosResponse({ data: { id: 'rec-cancel-1', status: 'failed' } }),
+    )
 
     api.cancelGeneration('img-1')
+    await vi.waitFor(() => expect(studioApi.cancelGeneration).toHaveBeenCalledWith('rec-cancel-1'))
 
     expect(stopGenerationPolling).toHaveBeenCalledWith('img-1')
     expect(stopShotPolling).toHaveBeenCalledWith('img-1')

--- a/apps/web/src/composables/useNodeGeneration.test.ts
+++ b/apps/web/src/composables/useNodeGeneration.test.ts
@@ -10,6 +10,14 @@ import { defaultModelKey } from '@/constants/studioModels'
 import { canvasApi } from '@/services/canvas-api'
 import { studioApi } from '@/services/studio-api'
 
+const mockRefreshPoints = vi.fn(async () => 100)
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    refreshPoints: mockRefreshPoints,
+  }),
+}))
+
 vi.mock('@/services/studio-api', () => ({
   studioApi: {
     generateImage: vi.fn(),
@@ -103,12 +111,56 @@ function createDeps(nodes: EditableFlowNode[], overrides: Record<string, unknown
 describe('useNodeGeneration', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockRefreshPoints.mockResolvedValue(100)
     vi.mocked(studioApi.generateAudio).mockResolvedValue(
       mockAxiosResponse({ data: { ...completedRecord, type: 'audio', url: 'https://example.com/out.mp3' } }),
     )
     vi.mocked(studioApi.generateImage).mockResolvedValue(
       mockAxiosResponse({ data: completedRecord }),
     )
+  })
+
+  it('maps 积分不足 to recharge message and calls onInsufficientPoints', async () => {
+    const node = createNode('image', { prompt: 'a cat' })
+    const onInsufficientPoints = vi.fn()
+    vi.mocked(studioApi.generateImage).mockRejectedValue({
+      response: { data: { message: '积分不足' } },
+    })
+    const { api, deps } = createDeps([node], { onInsufficientPoints })
+
+    await api.generateForNode(node)
+
+    expect(deps.patchNodeData).toHaveBeenCalledWith('image-1', {
+      status: NODE_GENERATION_STATUS.error,
+      errorMessage: '积分不足，请充值后再试',
+    })
+    expect(onInsufficientPoints).toHaveBeenCalled()
+    expect(mockRefreshPoints).toHaveBeenCalled()
+  })
+
+  it('maps generation failure with refundedPoints in response', async () => {
+    const node = createNode('image', { prompt: 'a cat' })
+    vi.mocked(studioApi.generateImage).mockRejectedValue({
+      response: { data: { message: 'upstream failed', refundedPoints: 10 } },
+    })
+    const { api, deps } = createDeps([node])
+
+    await api.generateForNode(node)
+
+    expect(deps.patchNodeData).toHaveBeenCalledWith('image-1', {
+      status: NODE_GENERATION_STATUS.error,
+      errorMessage: '生成失败，10 积分已返回',
+    })
+    expect(mockRefreshPoints).toHaveBeenCalled()
+  })
+
+  it('refreshes points after successful generation', async () => {
+    const node = createNode('image', { prompt: 'a cat' })
+    const { api } = createDeps([node])
+
+    await api.generateForNode(node)
+
+    expect(mockRefreshPoints).toHaveBeenCalled()
   })
 
   it('passes audio options to studioApi.generateAudio', async () => {
@@ -680,7 +732,7 @@ describe('useNodeGeneration', () => {
       'shot-1',
       expect.objectContaining({
         status: NODE_GENERATION_STATUS.draft,
-        errorMessage: null,
+        errorMessage: '已取消',
       }),
     )
     expect(shot.data?.status).toBe(NODE_GENERATION_STATUS.draft)
@@ -888,9 +940,34 @@ describe('useNodeGeneration', () => {
       'img-1',
       expect.objectContaining({
         status: NODE_GENERATION_STATUS.draft,
-        errorMessage: null,
+        errorMessage: '已取消',
       }),
     )
+  })
+
+  it('overwrites cancel message when abort response includes refundedPoints', async () => {
+    let rejectHang!: (e: unknown) => void
+    const hang = new Promise((_r, j) => { rejectHang = j })
+    vi.mocked(studioApi.generateImage).mockImplementation((_a, _b, _c, _d, _e, _f, _g, signal?: AbortSignal) => {
+      signal?.addEventListener('abort', () => {
+        rejectHang({
+          response: { data: { message: '已取消', refundedPoints: 10 } },
+        })
+      })
+      return hang as never
+    })
+
+    const node = createNode('image', { prompt: 'cancel-refund' }, 'img-refund')
+    const { api, deps } = createDeps([node])
+    const pending = api.generateForNode(node)
+    await Promise.resolve()
+    await api.generateForNode(node)
+    await pending
+
+    expect(deps.patchNodeData).toHaveBeenCalledWith('img-refund', {
+      errorMessage: '已取消，10 积分已返回',
+    })
+    expect(mockRefreshPoints).toHaveBeenCalled()
   })
 
   it('uses catalog defaults for generateShot when media child is missing', async () => {

--- a/apps/web/src/composables/useNodeGeneration.test.ts
+++ b/apps/web/src/composables/useNodeGeneration.test.ts
@@ -351,6 +351,40 @@ describe('useNodeGeneration', () => {
     )
   })
 
+  it('applyStudioRecord failed with metadata.refundedPoints shows refund message', async () => {
+    const node = createNode('image', {
+      prompt: 'failed image',
+      imageAspect: '16:9',
+      imageResolution: '1K',
+      imageCount: 1,
+    })
+    vi.mocked(studioApi.generateImage).mockResolvedValue(
+      mockAxiosResponse({
+        data: {
+          id: 'rec-failed-refund',
+          type: 'image',
+          prompt: 'failed image',
+          status: NODE_GENERATION_STATUS.failed,
+          url: null,
+          metadata: JSON.stringify({ refundedPoints: 10 }),
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      }),
+    )
+    const { api, deps } = createDeps([node])
+
+    await api.generateForNode(node)
+
+    expect(deps.patchNodeData).toHaveBeenCalledWith(
+      'image-1',
+      expect.objectContaining({
+        status: NODE_GENERATION_STATUS.error,
+        errorMessage: '生成失败，10 积分已返回',
+        generationRecordId: 'rec-failed-refund',
+      }),
+    )
+  })
+
   it('sets node error when onFallbackPending confirm API fails', async () => {
     const requestFallbackConfirm = vi.fn(async () => 'confirm' as const)
     vi.mocked(studioApi.confirmPlatformFallback).mockRejectedValue(new Error('confirm failed'))

--- a/apps/web/src/composables/useNodeGeneration.test.ts
+++ b/apps/web/src/composables/useNodeGeneration.test.ts
@@ -742,7 +742,15 @@ describe('useNodeGeneration', () => {
     }, 'img-1')
     const { api } = createDeps([node], { stopGenerationPolling, stopShotPolling })
     vi.mocked(studioApi.cancelGeneration).mockResolvedValue(
-      mockAxiosResponse({ data: { id: 'rec-cancel-1', status: 'failed' } }),
+      mockAxiosResponse({
+        data: {
+          id: 'rec-cancel-1',
+          type: 'image',
+          prompt: 'x',
+          status: 'failed',
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      }),
     )
 
     api.cancelGeneration('img-1')

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -33,6 +33,12 @@ import {
   resolveCanvasVideoParams,
   sceneComposerToNodePatch,
 } from '@/utils/sceneComposer'
+import {
+  extractRefundedPointsFromError,
+  formatCancelledMessage,
+  formatGenerationFailureMessage,
+} from '@/utils/generationPointsMessage'
+import { useAuthStore } from '@/stores/auth'
 
 export type FallbackConfirmDecision = 'confirm' | 'cancel'
 
@@ -59,6 +65,7 @@ export interface NodeGenerationDeps {
   resolveProviderModels: () => { image: string; video: string; text: string }
   requestFallbackConfirm?: (req: FallbackPendingRequest) => Promise<FallbackConfirmDecision>
   isModelSelectable?: (modality: StudioModality, model: string) => boolean
+  onInsufficientPoints?: () => void
 }
 
 /** Node still accepts poll / resolve writes (not cancelled to draft). */
@@ -186,8 +193,31 @@ function isAbortError(err: unknown): boolean {
 }
 
 export function useNodeGeneration(deps: NodeGenerationDeps) {
+  const auth = useAuthStore()
   const busyNodeIds = ref(new Set<string>())
   const abortByNodeId = new Map<string, AbortController>()
+
+  function refreshPointsAfterGeneration() {
+    void auth.refreshPoints()
+  }
+
+  function patchGenerationError(nodeId: string, err: unknown, signal?: AbortSignal) {
+    const refundedPoints = extractRefundedPointsFromError(err)
+    if (signal?.aborted) {
+      if (refundedPoints) {
+        deps.patchNodeData(nodeId, { errorMessage: formatCancelledMessage(refundedPoints) })
+      }
+      return
+    }
+    if (isAbortError(err)) return
+    const errorMessage = formatGenerationFailureMessage(err, refundedPoints)
+    if (errorMessage.includes('积分不足')) deps.onInsufficientPoints?.()
+    if (!nodeAcceptsWrite(nodeId)) return
+    deps.patchNodeData(nodeId, {
+      status: NODE_GENERATION_STATUS.error,
+      errorMessage,
+    })
+  }
 
   function isNodeBusy(nodeId: string): boolean {
     return busyNodeIds.value.has(nodeId)
@@ -234,7 +264,7 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
         deps.stopShotPolling?.(shotId)
         deps.patchNodeData(shotId, {
           status: NODE_GENERATION_STATUS.draft,
-          errorMessage: null,
+          errorMessage: formatCancelledMessage(),
         })
         markIdle(shotId)
       }
@@ -254,7 +284,7 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
         markIdle(child.id)
         deps.patchNodeData(child.id, {
           status: NODE_GENERATION_STATUS.draft,
-          errorMessage: null,
+          errorMessage: formatCancelledMessage(),
         })
       }
     }
@@ -262,8 +292,9 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     syncGeneratingFlag()
     deps.patchNodeData(nodeId, {
       status: NODE_GENERATION_STATUS.draft,
-      errorMessage: null,
+      errorMessage: formatCancelledMessage(),
     })
+    refreshPointsAfterGeneration()
   }
 
   function beginNodeWork(nodeId: string): AbortSignal {
@@ -490,14 +521,16 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
         await generateShot(node, local, data, signal)
       }
     } catch (err) {
-      if (isAbortError(err) || signal.aborted) return
+      if (signal.aborted) {
+        patchGenerationError(node.id, err, signal)
+        return
+      }
+      if (isAbortError(err)) return
       console.error('[NodeGeneration]', nodeType, err)
-      deps.patchNodeData(node.id, {
-        status: NODE_GENERATION_STATUS.error,
-        errorMessage: err instanceof Error ? err.message : '生成失败',
-      })
+      patchGenerationError(node.id, err, signal)
     } finally {
       endNodeWork(node.id, signal)
+      refreshPointsAfterGeneration()
     }
   }
 
@@ -768,10 +801,15 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       })
       await deps.saveCanvas()
     } catch (err) {
-      if (isAbortError(err) || signal.aborted) return
-      deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.error })
+      if (signal.aborted) {
+        patchGenerationError(node.id, err, signal)
+        return
+      }
+      if (isAbortError(err)) return
+      patchGenerationError(node.id, err, signal)
     } finally {
       endNodeWork(node.id, signal)
+      refreshPointsAfterGeneration()
     }
   }
 
@@ -827,10 +865,15 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.generating })
       await deps.saveCanvas()
     } catch (err) {
-      if (isAbortError(err) || signal.aborted) return
-      deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.error })
+      if (signal.aborted) {
+        patchGenerationError(node.id, err, signal)
+        return
+      }
+      if (isAbortError(err)) return
+      patchGenerationError(node.id, err, signal)
     } finally {
       endNodeWork(node.id, signal)
+      refreshPointsAfterGeneration()
     }
   }
 
@@ -870,10 +913,15 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       })
       await deps.saveCanvas()
     } catch (err) {
-      if (isAbortError(err) || signal.aborted) return
-      deps.patchNodeData(node.id, { status: NODE_GENERATION_STATUS.error })
+      if (signal.aborted) {
+        patchGenerationError(node.id, err, signal)
+        return
+      }
+      if (isAbortError(err)) return
+      patchGenerationError(node.id, err, signal)
     } finally {
       endNodeWork(node.id, signal)
+      refreshPointsAfterGeneration()
     }
   }
 

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -37,6 +37,7 @@ import {
   extractRefundedPointsFromError,
   formatCancelledMessage,
   formatGenerationFailureMessage,
+  parseRefundedPointsFromMetadata,
 } from '@/utils/generationPointsMessage'
 import { useAuthStore } from '@/stores/auth'
 
@@ -385,7 +386,12 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     }
     deps.patchNodeData(nodeId, {
       status: NODE_GENERATION_STATUS.error,
-      errorMessage: '生成失败',
+      errorMessage: (() => {
+        const refundedPoints = parseRefundedPointsFromMetadata(record.metadata)
+        return refundedPoints
+          ? formatGenerationFailureMessage(new Error('生成失败'), refundedPoints)
+          : '生成失败'
+      })(),
       generationRecordId: record.id,
     })
     return true

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -248,6 +248,63 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     return acceptsGenerationWrite(current?.data?.status)
   }
 
+function resolveMaterialId(node: EditableFlowNode | undefined): string | undefined {
+  if (!node) return undefined
+  const data = node.data ?? {}
+  if (typeof data.materialId === 'string' && data.materialId.trim()) {
+    return data.materialId.trim()
+  }
+  return undefined
+}
+
+function collectCancelTargets(nodeId: string): {
+  recordIds: string[]
+  materialIds: string[]
+} {
+  const recordIds = new Set<string>()
+  const materialIds = new Set<string>()
+  const node = findNodeById(deps.nodes.value, nodeId)
+  if (!node) return { recordIds: [], materialIds: [] }
+
+  const recordId = node.data?.generationRecordId
+  if (typeof recordId === 'string' && recordId.trim()) recordIds.add(recordId.trim())
+
+  const materialId = resolveMaterialId(node)
+  if (materialId) materialIds.add(materialId)
+
+  if (node.type === 'shot') {
+    for (const edge of deps.edges.value) {
+      if (edge.source !== nodeId) continue
+      const child = findNodeById(deps.nodes.value, edge.target)
+      if (!child || (child.type !== 'image' && child.type !== 'video')) continue
+      const childMaterialId = resolveMaterialId(child)
+      if (childMaterialId) materialIds.add(childMaterialId)
+    }
+  }
+
+  if (node.type === 'image' || node.type === 'video') {
+    const linkedShotEdge = findIncomingEdge(deps.edges.value, nodeId)
+    const shotId = linkedShotEdge?.source
+    const shotNode = shotId ? findNodeById(deps.nodes.value, shotId) : null
+    if (shotNode?.type === 'shot' && shotId) {
+      const shotMaterialId = resolveMaterialId(shotNode)
+      if (shotMaterialId) materialIds.add(shotMaterialId)
+    }
+  }
+
+  return { recordIds: [...recordIds], materialIds: [...materialIds] }
+}
+
+async function cancelRemoteGeneration(nodeId: string) {
+  const { recordIds, materialIds } = collectCancelTargets(nodeId)
+  if (!recordIds.length && !materialIds.length) return
+  await Promise.all([
+    ...recordIds.map((id) => studioApi.cancelGeneration(id).catch(() => undefined)),
+    ...materialIds.map((id) => canvasApi.cancelMaterial(id).catch(() => undefined)),
+  ])
+  await refreshPointsAfterGeneration()
+}
+
   function cancelGeneration(nodeId: string) {
     const ac = abortByNodeId.get(nodeId)
     if (ac) {
@@ -296,6 +353,7 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       errorMessage: formatCancelledMessage(),
     })
     refreshPointsAfterGeneration()
+    void cancelRemoteGeneration(nodeId)
   }
 
   function beginNodeWork(nodeId: string): AbortSignal {
@@ -567,10 +625,16 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       })
       if (nodeType === 'video') {
         const params = resolveCanvasVideoParams(data)
-        await canvasApi.generateVideo(shotId, prompt, { ...params, refs, mentionedKeys })
+        const { data: matRes } = await canvasApi.generateVideo(shotId, prompt, { ...params, refs, mentionedKeys })
+        const materialId = (matRes.data as { id: string }).id
+        deps.patchNodeData(node.id, { materialId })
+        deps.patchNodeData(shotId, { materialId })
       } else {
         const params = resolveCanvasImageParams(data)
-        await canvasApi.generateImage(shotId, prompt, { ...params, refs, mentionedKeys })
+        const { data: matRes } = await canvasApi.generateImage(shotId, prompt, { ...params, refs, mentionedKeys })
+        const materialId = (matRes.data as { id: string }).id
+        deps.patchNodeData(node.id, { materialId })
+        deps.patchNodeData(shotId, { materialId })
       }
       if (signal?.aborted || !nodeAcceptsWrite(node.id) || !nodeAcceptsWrite(shotId)) return
       deps.startShotPolling([shotId])
@@ -733,21 +797,29 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
     if (shouldGenerateVideo) {
       const childNode = findShotMediaChild(deps.nodes.value, deps.edges.value, node.id, 'video')
       const params = resolveCanvasVideoParams(childNode?.data ?? {})
-      await canvasApi.generateVideo(node.id, prompt, { ...params, refs, mentionedKeys })
+      const { data: matRes } = await canvasApi.generateVideo(node.id, prompt, { ...params, refs, mentionedKeys })
+      const materialId = (matRes.data as { id: string }).id
+      deps.patchNodeData(node.id, { materialId })
+      if (childNode) deps.patchNodeData(childNode.id, { materialId })
     } else if (shouldGenerateImage) {
       const childNode = findShotMediaChild(deps.nodes.value, deps.edges.value, node.id, 'image')
       const params = resolveCanvasImageParams(childNode?.data ?? {})
-      await canvasApi.generateImage(node.id, prompt, { ...params, refs, mentionedKeys })
+      const { data: matRes } = await canvasApi.generateImage(node.id, prompt, { ...params, refs, mentionedKeys })
+      const materialId = (matRes.data as { id: string }).id
+      deps.patchNodeData(node.id, { materialId })
+      if (childNode) deps.patchNodeData(childNode.id, { materialId })
     } else {
       const params = resolveCanvasImageParams({})
       const matRes = await canvasApi.generateImage(node.id, prompt, { ...params, refs, mentionedKeys })
       if (signal?.aborted || !nodeAcceptsWrite(node.id)) return
       const material = matRes.data.data as { id: string }
+      deps.patchNodeData(node.id, { materialId: material.id })
       deps.addNode('image', {
         url: '',
         ...startedAtPatch(),
         status: NODE_GENERATION_STATUS.generating,
         prompt,
+        materialId: material.id,
       }, {
         id: material.id,
         position: { x: node.position.x + 280, y: node.position.y },

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -48,6 +48,7 @@ import CanvasNodeWorldModel from '@/components/canvas/CanvasNodeWorldModel.vue'
 import NodePanelDock from '@/components/canvas/NodePanelDock.vue'
 import DockStudioToolbar from '@/components/canvas/DockStudioToolbar.vue'
 import CanvasFloatingChrome from '@/components/canvas/CanvasFloatingChrome.vue'
+import CanvasAccountChrome from '@/components/canvas/CanvasAccountChrome.vue'
 import CanvasBottomLeftControls from '@/components/canvas/CanvasBottomLeftControls.vue'
 import ProviderConfigDialog from '@/components/canvas/ProviderConfigDialog.vue'
 import ByokFallbackConfirmDialog from '@/components/canvas/ByokFallbackConfirmDialog.vue'
@@ -95,6 +96,10 @@ import PublishNeoTVDialog from '@/components/works/PublishNeoTVDialog.vue'
 import AgentSideRail from '@/components/agent/AgentSideRail.vue'
 import CanvasAgentFab from '@/components/agent/CanvasAgentFab.vue'
 import { useSelectedNodeEditor, type EditableFlowNode, EDITABLE_NODE_TYPES } from '@/composables/useSelectedNodeEditor'
+import {
+  formatGenerationFailureMessage,
+  parseRefundedPointsFromMetadata,
+} from '@/utils/generationPointsMessage'
 
 const PlayCanvasView = defineAsyncComponent(
   () => import('@/canvas/playcanvas/PlayCanvasView.vue'),
@@ -132,6 +137,7 @@ const showModelSettings = ref(false)
 const contextMenu = ref<{ x: number; y: number; nodeId?: string; nodeType?: string } | null>(null)
 const { settings: viewportSettings, cycleMinimap } = useCanvasViewportSettings()
 const { theme: canvasTheme, toggleTheme: toggleCanvasTheme } = useCanvasTheme()
+const showMembership = ref(false)
 
 const DEFAULT_DARK_GRID_COLOR = 'rgba(255,255,255,0.08)'
 const effectiveGridColor = computed(() => {
@@ -380,7 +386,13 @@ const generationPolling = useGenerationPolling((results) => {
       }
       patchNodeData(task.nodeId, patch)
     } else if (record.status === NODE_GENERATION_STATUS.failed || record.status === NODE_GENERATION_STATUS.error) {
-      patchNodeData(task.nodeId, { status: NODE_GENERATION_STATUS.error })
+      const refundedPoints = parseRefundedPointsFromMetadata(record.metadata)
+      patchNodeData(task.nodeId, {
+        status: NODE_GENERATION_STATUS.error,
+        errorMessage: refundedPoints
+          ? formatGenerationFailureMessage(new Error('生成失败'), refundedPoints)
+          : '生成失败',
+      })
     }
   }
   void saveCanvas()
@@ -1662,6 +1674,9 @@ const {
   }),
   requestFallbackConfirm,
   isModelSelectable,
+  onInsufficientPoints: () => {
+    showMembership.value = true
+  },
 })
 
 function retryNodeGeneration(nodeId: string) {
@@ -1971,22 +1986,25 @@ onMounted(() => {
           @asset-upload="triggerMediaUpload()"
         />
 
-        <button
-          type="button"
-          class="canvas-theme-toggle pointer-events-auto absolute right-3 top-3 z-[50] flex h-9 w-9 items-center justify-center rounded-xl border border-white/[0.08] bg-[rgba(22,22,22,0.88)] text-white/70 shadow-lg backdrop-blur-xl transition hover:text-white"
-          :title="canvasTheme === 'dark' ? '切换白天模式' : '切换黑夜模式'"
-          @click="toggleCanvasTheme"
-        >
-          <!-- 太阳 -->
-          <svg v-if="canvasTheme === 'dark'" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75">
-            <circle cx="12" cy="12" r="4" />
-            <path stroke-linecap="round" d="M12 3v2m0 14v2M5.64 5.64l1.41 1.41m9.9 9.9 1.41 1.41M3 12h2m14 0h2M5.64 18.36l1.41-1.41m9.9-9.9 1.41-1.41" />
-          </svg>
-          <!-- 月亮 -->
-          <svg v-else class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-          </svg>
-        </button>
+        <div class="pointer-events-none absolute right-3 top-3 z-[50] flex items-center gap-2">
+          <button
+            type="button"
+            class="canvas-theme-toggle pointer-events-auto flex h-9 w-9 items-center justify-center rounded-xl border border-white/[0.08] bg-[rgba(22,22,22,0.88)] text-white/70 shadow-lg backdrop-blur-xl transition hover:text-white"
+            :title="canvasTheme === 'dark' ? '切换白天模式' : '切换黑夜模式'"
+            @click="toggleCanvasTheme"
+          >
+            <!-- 太阳 -->
+            <svg v-if="canvasTheme === 'dark'" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75">
+              <circle cx="12" cy="12" r="4" />
+              <path stroke-linecap="round" d="M12 3v2m0 14v2M5.64 5.64l1.41 1.41m9.9 9.9 1.41 1.41M3 12h2m14 0h2M5.64 18.36l1.41-1.41m9.9-9.9 1.41-1.41" />
+            </svg>
+            <!-- 月亮 -->
+            <svg v-else class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+            </svg>
+          </button>
+          <CanvasAccountChrome v-model:show-membership="showMembership" />
+        </div>
 
         <input
           ref="mediaInputRef"

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -337,6 +337,30 @@ const shotPolling = useShotPolling((shots) => {
         void invokeFallbackPendingFromPoll('material', material.id, nodeId)
         continue
       }
+      if (material.status === 'failed') {
+        const nodeId = findLinkedMediaNodeId(shot.id, material.id)
+        const childNode = nodes.value.find((n) => n.id === nodeId)
+        const refundedPoints = parseRefundedPointsFromMetadata(
+          (material as { metadata?: string | null }).metadata,
+        )
+        const errorMessage = refundedPoints
+          ? formatGenerationFailureMessage(new Error('生成失败'), refundedPoints)
+          : '生成失败'
+        if (childNode && acceptsPollWrite(childNode.data?.status)) {
+          patchNodeData(nodeId, {
+            status: NODE_GENERATION_STATUS.error,
+            errorMessage,
+          })
+        }
+        if (acceptsPollWrite(shotNode?.data?.status)) {
+          patchNodeData(shot.id, {
+            status: NODE_GENERATION_STATUS.error,
+            errorMessage,
+          })
+        }
+        void auth.refreshPoints()
+        continue
+      }
     }
     const material = shot.materials.find((m) => m.status === 'completed' && m.url)
     if (!material) continue

--- a/apps/web/src/services/canvas-api.ts
+++ b/apps/web/src/services/canvas-api.ts
@@ -73,4 +73,5 @@ export const canvasApi = {
     api.post(`/agent/canvas/material/${id}/confirm-platform-fallback`, {}, { timeout: 120_000 }),
   cancelMaterialPlatformFallback: (id: string) =>
     api.post(`/agent/canvas/material/${id}/cancel-platform-fallback`),
+  cancelMaterial: (id: string) => api.post(`/agent/canvas/material/${id}/cancel`),
 }

--- a/apps/web/src/services/provider-api.ts
+++ b/apps/web/src/services/provider-api.ts
@@ -115,13 +115,4 @@ export const providerApi = {
   syncWebdav: () => unwrap(api.post<ApiEnvelope<ProviderWebdavPublic>>('/provider/webdav/sync')),
 }
 
-export function apiErrorMessage(err: unknown, fallback = '请求失败'): string {
-  const ax = err as {
-    response?: { data?: { message?: string | string[]; error?: string } }
-    message?: string
-  }
-  const msg = ax.response?.data?.message ?? ax.response?.data?.error ?? ax.message
-  if (Array.isArray(msg)) return msg.join('; ') || fallback
-  if (typeof msg === 'string' && msg.trim()) return msg
-  return fallback
-}
+export { apiErrorMessage } from '@/utils/apiError'

--- a/apps/web/src/services/studio-api.ts
+++ b/apps/web/src/services/studio-api.ts
@@ -82,4 +82,6 @@ export const studioApi = {
     }),
   cancelPlatformFallback: (id: string) =>
     api.post<{ data: GenerationRecord }>(`/studio/generations/${id}/cancel-platform-fallback`),
+  cancelGeneration: (id: string) =>
+    api.post<{ data: GenerationRecord }>(`/studio/generations/${id}/cancel`),
 }

--- a/apps/web/src/stores/auth.ts
+++ b/apps/web/src/stores/auth.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import type { User } from '@lnkpi/shared'
 import { api } from '@/services/api'
+import { membershipApi } from '@/services/users-api'
 
 const AUTH_TIMEOUT_MS = 45_000
 
@@ -82,6 +83,25 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
+  function setPoints(n: number) {
+    if (user.value) user.value.points = n
+  }
+
+  async function refreshPoints(): Promise<number> {
+    if (!token.value) return user.value?.points ?? 0
+    try {
+      const { data } = await membershipApi.getPoints()
+      const points = data.data.points
+      if (user.value) {
+        user.value.points = points
+        user.value.membership = data.data.membership
+      }
+      return points
+    } catch {
+      return user.value?.points ?? 0
+    }
+  }
+
   return {
     user,
     token,
@@ -93,5 +113,7 @@ export const useAuthStore = defineStore('auth', () => {
     logout,
     openLogin,
     restoreSession,
+    setPoints,
+    refreshPoints,
   }
 })

--- a/apps/web/src/styles/neo-node.css
+++ b/apps/web/src/styles/neo-node.css
@@ -698,13 +698,8 @@
   border-color: rgba(255, 255, 255, 0.2);
 }
 
-.bottom-toolbar-container.is-dock-readonly {
-  opacity: 0.88;
-}
-
 .dock-studio-toolbar.is-dock-locked .bottom-toolbar-actions button:not(.bottom-toolbar-close):not(.dock-generate-btn) {
   pointer-events: none;
-  opacity: 0.55;
 }
 
 .dock-studio-toolbar.is-dock-locked .dock-generate-btn,
@@ -715,7 +710,6 @@
 
 .bottom-toolbar-container.is-dock-readonly .bottom-toolbar-actions :not(.bottom-toolbar-close):not(.dock-generate-btn) {
   pointer-events: none;
-  opacity: 0.55;
 }
 
 .group-node-container {

--- a/apps/web/src/styles/neo-node.css
+++ b/apps/web/src/styles/neo-node.css
@@ -56,23 +56,7 @@
   white-space: nowrap;
 }
 
-.neo-task-badge {
-  margin-left: 6px;
-  max-width: 120px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  border-radius: 999px;
-  padding: 1px 7px;
-  font-size: 10px;
-  font-weight: 600;
-}
-.neo-task-badge.is-running { background: rgba(59,130,246,0.2); color: #93c5fd; }
-.neo-task-badge.is-error { background: rgba(239,68,68,0.2); color: #fca5a5; }
-.neo-task-badge.is-success { background: rgba(34,197,94,0.2); color: #86efac; }
-.neo-task-badge.is-pending { background: rgba(245,158,11,0.2); color: #fcd34d; }
-
-.neo-task-corner {
+.neo-task-chrome {
   position: absolute;
   top: 8px;
   right: 8px;
@@ -84,24 +68,112 @@
   max-width: 70%;
 }
 
-.neo-task-corner-btn {
+.neo-task-chrome-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.neo-task-elapsed {
+  padding: 2px 6px;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.55);
+  color: #93c5fd;
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+}
+
+.neo-task-chrome-btn {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
   border: none;
   border-radius: 999px;
-  padding: 4px 10px;
-  font-size: 10px;
-  font-weight: 600;
-  cursor: pointer;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+  cursor: default;
+  transition:
+    transform 0.15s ease,
+    background 0.15s ease,
+    opacity 0.15s ease;
 }
 
-.neo-task-corner-btn.is-cancel {
-  background: #fff;
-  color: #111;
+.neo-task-chrome-btn.is-clickable {
+  cursor: pointer;
 }
 
-.neo-task-corner-btn.is-retry {
+.neo-task-chrome-btn.is-clickable:hover {
+  transform: scale(1.05);
+}
+
+.neo-task-chrome-btn.is-running {
+  background: #111;
+  color: #fff;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.35);
+}
+
+.neo-task-chrome-btn.is-running.is-clickable:hover {
+  background: #333;
+}
+
+.neo-task-chrome-btn.is-error {
   background: #ef4444;
   color: #fff;
+}
+
+.neo-task-chrome-btn.is-error.is-clickable:hover {
+  background: #dc2626;
+}
+
+.neo-task-chrome-btn.is-pending {
+  background: rgba(245, 158, 11, 0.95);
+  color: #fff;
+}
+
+.neo-task-chrome-btn.is-success,
+.neo-task-chrome-btn.is-flash {
+  background: rgba(34, 197, 94, 0.95);
+  color: #fff;
+}
+
+.neo-task-chrome-btn.is-flash {
+  animation: neo-task-flash 2s ease-out forwards;
+}
+
+@keyframes neo-task-flash {
+  0% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  15% {
+    transform: scale(1.08);
+  }
+  70% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+}
+
+.neo-task-spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: neo-task-spin 0.8s linear infinite;
+}
+
+@keyframes neo-task-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .neo-task-error {

--- a/apps/web/src/utils/apiError.ts
+++ b/apps/web/src/utils/apiError.ts
@@ -1,0 +1,10 @@
+export function apiErrorMessage(err: unknown, fallback = '请求失败'): string {
+  const ax = err as {
+    response?: { data?: { message?: string | string[]; error?: string } }
+    message?: string
+  }
+  const msg = ax.response?.data?.message ?? ax.response?.data?.error ?? ax.message
+  if (Array.isArray(msg)) return msg.join('; ') || fallback
+  if (typeof msg === 'string' && msg.trim()) return msg
+  return fallback
+}

--- a/apps/web/src/utils/generationPointsMessage.test.ts
+++ b/apps/web/src/utils/generationPointsMessage.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import {
+  extractRefundedPointsFromError,
+  formatCancelledMessage,
+  formatGenerationFailureMessage,
+} from '@/utils/generationPointsMessage'
+
+function axiosLikeError(message: string, extra?: Record<string, unknown>) {
+  return {
+    response: {
+      data: {
+        message,
+        ...extra,
+      },
+    },
+  }
+}
+
+describe('formatGenerationFailureMessage', () => {
+  it('maps 积分不足 to recharge prompt', () => {
+    expect(formatGenerationFailureMessage(axiosLikeError('积分不足'))).toBe('积分不足，请充值后再试')
+  })
+
+  it('maps failure with refundedPoints', () => {
+    expect(formatGenerationFailureMessage(new Error('upstream failed'), 10)).toBe(
+      '生成失败，10 积分已返回',
+    )
+  })
+
+  it('maps 已取消 without refund amount', () => {
+    expect(formatGenerationFailureMessage(axiosLikeError('已取消'))).toBe('已取消')
+  })
+
+  it('maps 已取消 with refundedPoints', () => {
+    expect(formatGenerationFailureMessage(axiosLikeError('已取消'), 5)).toBe('已取消，5 积分已返回')
+  })
+
+  it('normalizes generic axios 400 message', () => {
+    expect(formatGenerationFailureMessage(new Error('Request failed with status code 400'))).toBe(
+      '生成失败',
+    )
+  })
+
+  it('passes through other server messages', () => {
+    expect(formatGenerationFailureMessage(axiosLikeError('模型不可用'))).toBe('模型不可用')
+  })
+})
+
+describe('formatCancelledMessage', () => {
+  it('returns plain cancel when no refund', () => {
+    expect(formatCancelledMessage()).toBe('已取消')
+    expect(formatCancelledMessage(0)).toBe('已取消')
+  })
+
+  it('includes refunded points when positive', () => {
+    expect(formatCancelledMessage(8)).toBe('已取消，8 积分已返回')
+  })
+})
+
+describe('extractRefundedPointsFromError', () => {
+  it('reads refundedPoints from response data', () => {
+    expect(extractRefundedPointsFromError(axiosLikeError('已取消', { refundedPoints: 12 }))).toBe(12)
+  })
+
+  it('reads nested refundedPoints', () => {
+    expect(
+      extractRefundedPointsFromError({
+        response: { data: { data: { refundedPoints: 6 } } },
+      }),
+    ).toBe(6)
+  })
+
+  it('returns undefined when missing or non-positive', () => {
+    expect(extractRefundedPointsFromError(new Error('canceled'))).toBeUndefined()
+    expect(extractRefundedPointsFromError(axiosLikeError('fail', { refundedPoints: 0 }))).toBeUndefined()
+  })
+})

--- a/apps/web/src/utils/generationPointsMessage.test.ts
+++ b/apps/web/src/utils/generationPointsMessage.test.ts
@@ -70,6 +70,14 @@ describe('extractRefundedPointsFromError', () => {
     ).toBe(6)
   })
 
+  it('reads refundedPoints from Nest object message', () => {
+    expect(
+      extractRefundedPointsFromError({
+        response: { data: { message: { message: '已取消', refundedPoints: 8 } } },
+      }),
+    ).toBe(8)
+  })
+
   it('returns undefined when missing or non-positive', () => {
     expect(extractRefundedPointsFromError(new Error('canceled'))).toBeUndefined()
     expect(extractRefundedPointsFromError(axiosLikeError('fail', { refundedPoints: 0 }))).toBeUndefined()

--- a/apps/web/src/utils/generationPointsMessage.ts
+++ b/apps/web/src/utils/generationPointsMessage.ts
@@ -1,0 +1,29 @@
+import { apiErrorMessage } from '@/utils/apiError'
+
+export function extractRefundedPointsFromError(err: unknown): number | undefined {
+  const ax = err as {
+    response?: { data?: { refundedPoints?: unknown; data?: { refundedPoints?: unknown } } }
+  }
+  const raw = ax.response?.data?.refundedPoints ?? ax.response?.data?.data?.refundedPoints
+  return typeof raw === 'number' && raw > 0 ? raw : undefined
+}
+
+export function formatCancelledMessage(refundedPoints?: number): string {
+  return refundedPoints && refundedPoints > 0
+    ? `已取消，${refundedPoints} 积分已返回`
+    : '已取消'
+}
+
+export function formatGenerationFailureMessage(err: unknown, refundedPoints?: number): string {
+  const raw = apiErrorMessage(err, '生成失败')
+  if (raw.includes('积分不足')) return '积分不足，请充值后再试'
+  if (raw.includes('已取消')) {
+    return refundedPoints && refundedPoints > 0
+      ? `已取消，${refundedPoints} 积分已返回`
+      : '已取消'
+  }
+  if (refundedPoints && refundedPoints > 0) {
+    return `生成失败，${refundedPoints} 积分已返回`
+  }
+  return raw === 'Request failed with status code 400' ? '生成失败' : raw
+}

--- a/apps/web/src/utils/generationPointsMessage.ts
+++ b/apps/web/src/utils/generationPointsMessage.ts
@@ -1,11 +1,42 @@
 import { apiErrorMessage } from '@/utils/apiError'
 
-export function extractRefundedPointsFromError(err: unknown): number | undefined {
-  const ax = err as {
-    response?: { data?: { refundedPoints?: unknown; data?: { refundedPoints?: unknown } } }
-  }
-  const raw = ax.response?.data?.refundedPoints ?? ax.response?.data?.data?.refundedPoints
+type ErrorResponseData = {
+  refundedPoints?: unknown
+  message?: unknown
+  data?: { refundedPoints?: unknown }
+}
+
+function readPositiveRefundedPoints(raw: unknown): number | undefined {
   return typeof raw === 'number' && raw > 0 ? raw : undefined
+}
+
+function readRefundedPointsFromData(data?: ErrorResponseData): number | undefined {
+  if (!data) return undefined
+  const message = data.message
+  const fromMessage =
+    message && typeof message === 'object' && message !== null
+      ? readPositiveRefundedPoints((message as { refundedPoints?: unknown }).refundedPoints)
+      : undefined
+  return (
+    readPositiveRefundedPoints(data.refundedPoints) ??
+    fromMessage ??
+    readPositiveRefundedPoints(data.data?.refundedPoints)
+  )
+}
+
+export function extractRefundedPointsFromError(err: unknown): number | undefined {
+  const ax = err as { response?: { data?: ErrorResponseData } }
+  return readRefundedPointsFromData(ax.response?.data)
+}
+
+export function parseRefundedPointsFromMetadata(metadata?: string | null): number | undefined {
+  if (!metadata) return undefined
+  try {
+    const meta = JSON.parse(metadata) as { refundedPoints?: unknown }
+    return readPositiveRefundedPoints(meta.refundedPoints)
+  } catch {
+    return undefined
+  }
 }
 
 export function formatCancelledMessage(refundedPoints?: number): string {

--- a/docs/superpowers/plans/2026-07-20-points-dock-node-ux.md
+++ b/docs/superpowers/plans/2026-07-20-points-dock-node-ux.md
@@ -1,0 +1,552 @@
+# 积分退款与画布/Dock/节点 UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 真正退款与明确积分文案、画布右上实时积分/用户、Dock 取消显性化、上游文本不灌 prompt、节点圆形运行/重试图标——单 PR 一次交付。
+
+**Architecture:** 服务端 `PointsService.refund` + 生成路径「先扣后做、失败/取消/BYOK-pending 必退、确认平台再扣」；请求 `close` 标记取消以保证 sync 接口也能退。前端统一 `apiErrorMessage`、`auth` 积分同步、`CanvasAccountChrome`；Dock 收窄 locked 样式；去掉 `textPrompt` seed；`nodeTaskChrome` 改为圆形图标模型。
+
+**Tech Stack:** NestJS、Prisma、Vue 3、Pinia、Vitest、现有 Studio/Material/Dock 组件
+
+**Spec:** `docs/superpowers/specs/2026-07-20-points-dock-node-ux-design.md`
+
+## Global Constraints
+
+- 真正退款；取消只要已扣费一律退；BYOK `fallback_pending` 立刻退，确认平台再扣
+- 文案：`积分不足，请充值后再试` / `生成失败，N 积分已返回` / `已取消，N 积分已返回`
+- 画布顶栏方案 A：主题 | 积分胶囊 | 头像昵称下拉
+- 单 PR；分支建议 `fix/points-dock-node-ux`
+- 不把 `.superpowers/` 加入 commit（可写入 `.gitignore`）
+- 相关单测绿；提交前 `pnpm --filter @lnkpi/server exec vitest run` 与 `pnpm --filter @lnkpi/web exec vitest run` 通过
+
+---
+
+## File Structure Map
+
+| 路径 | 职责 |
+|------|------|
+| `apps/server/src/points/points.service.ts` | `refund`；可选 `consume` 返回 balance |
+| `apps/server/src/points/points.service.test.ts` | refund / 幂等相关单测 |
+| `apps/server/src/points/charge-session.ts`（新建） | `chargedPoints` / `refundedPoints` metadata 助手 + 取消标志 |
+| `apps/server/src/studio/studio.service.ts` | 扣费后失败退；BYOK pending 先退；confirm 再扣；req close 取消 |
+| `apps/server/src/canvas/material.service.ts` | 同上（素材路径） |
+| `apps/server/src/studio/studio.fallback.test.ts` | 更新为 pending 已退 + confirm 再扣 |
+| `apps/server/src/canvas/material.fallback.test.ts` | 同上 |
+| `apps/web/src/utils/apiError.ts`（新建）或抽自 `provider-api` | 共享 `apiErrorMessage` |
+| `apps/web/src/stores/auth.ts` | `setPoints` / `refreshPoints` |
+| `apps/web/src/composables/useNodeGeneration.ts` | 错误文案、取消文案、刷新积分 |
+| `apps/web/src/components/canvas/CanvasAccountChrome.vue`（新建） | 画布右上积分+用户 |
+| `apps/web/src/pages/CanvasPage.vue` | 挂载账户条；会员弹窗 |
+| `apps/web/src/styles/neo-node.css` | Dock locked 收窄；圆形任务控件样式 |
+| `apps/web/src/components/canvas/dock-studio/shared/DockGenerateButton.vue` | 停止态更高对比 |
+| `apps/web/src/components/canvas/DockStudioToolbar.vue` | locked 语义保留但样式变弱 |
+| `apps/web/src/components/canvas/dock-studio/panels/*DockPanel.vue` | 删除 textPrompt seed |
+| `apps/web/src/components/canvas/nodeTaskChrome.ts` | 圆形控件状态模型 |
+| `apps/web/src/components/canvas/NodeTaskCornerActions.vue` | 圆形图标 UI |
+| `apps/web/src/components/canvas/NodeTaskBadge.vue` | 弱化/移除标题文字徽章或仅保留耗时旁注 |
+| `.gitignore` | 忽略 `.superpowers/` |
+
+---
+
+### Task 1: PointsService.refund + charge metadata helpers
+
+**Files:**
+- Modify: `apps/server/src/points/points.service.ts`
+- Modify: `apps/server/src/points/points.service.test.ts`
+- Create: `apps/server/src/points/charge-session.ts`
+- Create: `apps/server/src/points/charge-session.test.ts`
+- Modify: `.gitignore`（追加 `.superpowers/`）
+
+**Interfaces:**
+- Produces:
+  - `PointsService.refund(userId: string, amount: number, reason: string): Promise<void>`
+  - `applyChargeMeta(meta: Record<string, unknown>, chargedPoints: number): Record<string, unknown>`
+  - `applyRefundMeta(meta: Record<string, unknown>, refundedPoints: number, refundReason: string): Record<string, unknown>`
+  - `alreadyRefunded(meta: Record<string, unknown>): boolean`
+
+- [ ] **Step 1: Write failing refund test**
+
+在 `points.service.test.ts` 追加：
+
+```ts
+it('increments points and writes positive transaction on refund', async () => {
+  const updateMany = vi.fn(async () => ({ count: 1 }))
+  const create = vi.fn(async (args: { data: Record<string, unknown> }) => ({ id: 'pt2', ...args.data }))
+  const $transaction = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
+    fn({ user: { updateMany }, pointTransaction: { create } }),
+  )
+  const moduleRef = await Test.createTestingModule({
+    providers: [
+      PointsService,
+      { provide: PrismaService, useValue: { $transaction } },
+    ],
+  }).compile()
+
+  await moduleRef.get(PointsService).refund('u1', 5, '文本生成退款')
+
+  expect(updateMany).toHaveBeenCalledWith({
+    where: { id: 'u1' },
+    data: { points: { increment: 5 } },
+  })
+  expect(create).toHaveBeenCalledWith({
+    data: { userId: 'u1', amount: 5, reason: '文本生成退款' },
+  })
+})
+
+it('no-ops when refund amount <= 0', async () => {
+  const $transaction = vi.fn()
+  const moduleRef = await Test.createTestingModule({
+    providers: [
+      PointsService,
+      { provide: PrismaService, useValue: { $transaction } },
+    ],
+  }).compile()
+  await moduleRef.get(PointsService).refund('u1', 0, 'x')
+  expect($transaction).not.toHaveBeenCalled()
+})
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+Run: `pnpm --filter @lnkpi/server exec vitest run src/points/points.service.test.ts`
+Expected: FAIL（`refund` 不存在）
+
+- [ ] **Step 3: Implement refund**
+
+```ts
+async refund(userId: string, amount: number, reason: string): Promise<void> {
+  if (amount <= 0) return
+  await this.prisma.$transaction(async (tx) => {
+    await tx.user.updateMany({
+      where: { id: userId },
+      data: { points: { increment: amount } },
+    })
+    await tx.pointTransaction.create({
+      data: { userId, amount, reason },
+    })
+  })
+}
+```
+
+- [ ] **Step 4: Add charge-session helpers + tests**
+
+```ts
+export function applyChargeMeta(meta: Record<string, unknown>, chargedPoints: number) {
+  return { ...meta, chargedPoints }
+}
+
+export function alreadyRefunded(meta: Record<string, unknown>): boolean {
+  return typeof meta.refundedPoints === 'number' && meta.refundedPoints > 0
+}
+
+export function applyRefundMeta(
+  meta: Record<string, unknown>,
+  refundedPoints: number,
+  refundReason: string,
+) {
+  return { ...meta, refundedPoints, refundReason }
+}
+```
+
+单测覆盖 `alreadyRefunded` true/false。
+
+- [ ] **Step 5: Append `.superpowers/` to `.gitignore`**
+
+- [ ] **Step 6: Run tests — expect PASS**
+
+Run: `pnpm --filter @lnkpi/server exec vitest run src/points/`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/server/src/points .gitignore
+git commit -m "feat(server): add points refund and charge metadata helpers"
+```
+
+---
+
+### Task 2: Studio 生成失败退款 + BYOK pending 先退 + confirm 再扣
+
+**Files:**
+- Modify: `apps/server/src/studio/studio.service.ts`
+- Modify: `apps/server/src/studio/studio.fallback.test.ts`
+- Create or extend: `apps/server/src/studio/studio.refund.test.ts`（可选，或扩 fallback 测）
+
+**Interfaces:**
+- Consumes: `PointsService.refund`, `applyChargeMeta`, `applyRefundMeta`, `alreadyRefunded`
+- Produces: generation metadata 含 `chargedPoints` / `refundedPoints`；`fallback_pending` 时已退费；`confirmPlatformFallback` 内再次 `consume`
+
+**约定（`generateText` 为模板，image/video/audio/prompt 同构）：**
+
+```ts
+const cost = 5
+await this.points.consume(userId, cost, '文本生成')
+// … resolve + try generate …
+// success metadata: applyChargeMeta({...}, cost)
+// BYOK catch → await this.points.refund(userId, cost, '文本生成-BYOK失败退款')
+//   status fallback_pending, metadata: applyRefundMeta(applyChargeMeta({...}, cost), cost, 'byok_failed')
+// platform throw → await refund then rethrow
+```
+
+`confirmPlatformFallback` 在真正调平台前：
+
+```ts
+const platformCost = /* 与类型对应：text 5 / image 10*n / … */
+await this.points.consume(userId, platformCost, '平台回退生成')
+try {
+  // existing platform generate…
+  // metadata: chargedPoints: platformCost, priorByokRefunded: true
+} catch (err) {
+  await this.points.refund(userId, platformCost, '平台回退失败退款')
+  // update failed + refundedPoints
+  throw err
+}
+```
+
+- [ ] **Step 1: Update fallback tests to expect refund on pending + consume on confirm**
+
+在 `studio.fallback.test.ts`：mock `points.refund` 与 `points.consume`；断言 user 失败路径调用 `refund`；`confirmPlatformFallback` 调用 `consume`。
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `pnpm --filter @lnkpi/server exec vitest run src/studio/studio.fallback.test.ts`
+
+- [ ] **Step 3: Implement studio.service 退款/再扣逻辑**
+
+覆盖：`generateText`、`generatePrompt`、`generateImage`、`generateAudio`、视频更新失败路径、`confirmPlatformFallback`、`cancelPlatformFallback`（已退过则不再退）。
+
+平台路径失败（非 BYOK）：`consume` 后 catch → `refund` → throw。
+
+- [ ] **Step 4: Run fallback + 相关 studio 测 — PASS**
+
+Run: `pnpm --filter @lnkpi/server exec vitest run src/studio/studio.fallback.test.ts src/points/`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/studio
+git commit -m "feat(studio): refund on failure and re-charge on platform fallback confirm"
+```
+
+---
+
+### Task 3: Material 路径对齐 + 请求取消退款
+
+**Files:**
+- Modify: `apps/server/src/canvas/material.service.ts`
+- Modify: `apps/server/src/canvas/material.fallback.test.ts`
+- Modify: `apps/server/src/studio/studio.controller.ts`（传入 `req` 或 abort 标志）
+- Modify: `apps/server/src/studio/studio.service.ts`（`bindRequestCancel(req)`）
+- Modify: `apps/server/src/canvas/canvas.controller.ts`（素材生成同样绑定）
+
+**Interfaces:**
+- Produces: `createCancelFlag(req: { on(event: 'close', cb: () => void): void }): { isCancelled(): boolean }`
+- 生成结束后若 `isCancelled()`：`refund`（若未退）并返回/标记取消，不把成功结果当作有效完成（或写 `status: 'failed'` + refund 文案元数据）
+
+```ts
+export function createCancelFlag(req: { on(event: string, cb: () => void): void; aborted?: boolean }) {
+  let cancelled = Boolean(req.aborted)
+  req.on('close', () => {
+    cancelled = true
+  })
+  return { isCancelled: () => cancelled }
+}
+```
+
+Sync 文本示例：
+
+```ts
+const cancel = createCancelFlag(req)
+await this.points.consume(...)
+try {
+  const { text } = await createTextProvider(...).generate(...)
+  if (cancel.isCancelled()) {
+    await this.safeRefund(userId, cost, '文本生成-取消退款')
+    throw new BadRequestException('已取消')
+  }
+  return create completed with chargedPoints
+} catch (err) {
+  // BYOK / platform / cancel 分支按 Task 2；注意 alreadyRefunded
+}
+```
+
+客户端 abort → 连接 close → 即便上游已返回也退款并抛「已取消」。
+
+Material 异步：在现有 cancel/停轮询对应的服务端更新 failed 时调用 `safeRefund`；若仅有前端停轮询，增加 `POST .../material/:id/cancel`（若已有则挂退款）。**先查** `material.service` 是否已有 cancel；没有则最小新增：将 status 置 failed + refund。
+
+- [ ] **Step 1: Write/adjust material.fallback tests for refund-on-pending + consume-on-confirm**
+
+- [ ] **Step 2: Implement material + cancel flag wiring**
+
+- [ ] **Step 3: Run**
+
+Run: `pnpm --filter @lnkpi/server exec vitest run src/canvas/material.fallback.test.ts src/studio/studio.fallback.test.ts`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/server/src/canvas apps/server/src/studio apps/server/src/points
+git commit -m "feat(canvas): align material refunds and cancel-via-request-close"
+```
+
+---
+
+### Task 4: 前端错误文案 + 积分实时刷新
+
+**Files:**
+- Create: `apps/web/src/utils/apiError.ts`（从 `provider-api.ts` 挪出 `apiErrorMessage` 并 re-export）
+- Modify: `apps/web/src/services/provider-api.ts`（re-export 保持兼容）
+- Modify: `apps/web/src/stores/auth.ts` — `setPoints`、`refreshPoints`
+- Modify: `apps/web/src/composables/useNodeGeneration.ts`
+- Modify: `apps/web/src/composables/useNodeGeneration.test.ts`
+- Create: `apps/web/src/utils/generationPointsMessage.ts` + test
+
+**Interfaces:**
+- Produces:
+  - `formatGenerationFailureMessage(err: unknown, refundedPoints?: number): string`
+  - `formatCancelledMessage(refundedPoints: number): string`
+  - `auth.refreshPoints(): Promise<number>`
+  - `auth.setPoints(n: number): void`
+
+```ts
+export function formatGenerationFailureMessage(err: unknown, refundedPoints?: number): string {
+  const raw = apiErrorMessage(err, '生成失败')
+  if (raw.includes('积分不足')) return '积分不足，请充值后再试'
+  if (raw.includes('已取消')) {
+    return refundedPoints && refundedPoints > 0
+      ? `已取消，${refundedPoints} 积分已返回`
+      : '已取消'
+  }
+  if (refundedPoints && refundedPoints > 0) {
+    return `生成失败，${refundedPoints} 积分已返回`
+  }
+  return raw === 'Request failed with status code 400' ? '生成失败' : raw
+}
+```
+
+`useNodeGeneration` catch：
+- `formatGenerationFailureMessage(err)`
+- 若文案含「积分不足」，可选 `deps.onInsufficientPoints?.()`（Canvas 打开 MembershipModal）
+- 每次生成结束（成功/失败/取消）调用 `auth.refreshPoints()`（`membershipApi.getPoints`）
+
+取消路径 `cancelGeneration`：patch `errorMessage` 为取消文案；因 sync 退款在服务端 close 后发生，取消后仍 `refreshPoints()`（可短 delay 或依赖 abort 后的错误响应）。若 abort 导致 Axios cancel 而无 body，文案用 `已取消` 并 refresh；若后续拿到带 `refundedPoints` 的错误再覆盖。
+
+- [ ] **Step 1: Failing unit tests for message helpers + generation catch mapping**
+
+- [ ] **Step 2: Implement utils + auth + wire useNodeGeneration**
+
+- [ ] **Step 3: Run**
+
+Run: `pnpm --filter @lnkpi/web exec vitest run src/utils/generationPointsMessage.test.ts src/composables/useNodeGeneration.test.ts`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/utils apps/web/src/stores/auth.ts apps/web/src/services/provider-api.ts apps/web/src/composables
+git commit -m "feat(web): surface points shortage/refund messages and refresh balance"
+```
+
+---
+
+### Task 5: CanvasAccountChrome（方案 A）
+
+**Files:**
+- Create: `apps/web/src/components/canvas/CanvasAccountChrome.vue`
+- Modify: `apps/web/src/pages/CanvasPage.vue`
+- Optional smoke: 组件浅测或手工验收清单写入 PR
+
+**UI：**
+- 右上现有主题按钮旁：`{{ points }} 积分` 按钮 → `MembershipModal`
+- 头像字 + 昵称 → 下拉或两个入口：资料 `/profile`、退出 `auth.logout()`
+- 绑定 `auth.user?.points`；MembershipModal 内领取/升级后已有写回则复用
+
+```vue
+<!-- 示意结构 -->
+<div class="canvas-account-chrome">
+  <button type="button" class="canvas-points-pill" @click="showMembership = true">
+    {{ auth.user?.points ?? 0 }} 积分
+  </button>
+  <div class="canvas-user-menu">...</div>
+  <MembershipModal v-model="showMembership" />
+</div>
+```
+
+- [ ] **Step 1: Implement component + mount on CanvasPage beside theme toggle**
+
+- [ ] **Step 2: Manual check / minimal test that points render from auth store**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/canvas/CanvasAccountChrome.vue apps/web/src/pages/CanvasPage.vue
+git commit -m "feat(web): show points and user chrome on immersive canvas"
+```
+
+---
+
+### Task 6: Dock 生成中 — 停止显性、少置灰
+
+**Files:**
+- Modify: `apps/web/src/styles/neo-node.css`（`.is-dock-locked` 规则）
+- Modify: `apps/web/src/components/canvas/dock-studio/shared/DockGenerateButton.vue`
+- Modify: panels 仅保留控件级 `disabled`（已有则不动逻辑）
+
+**CSS 目标：**
+- 删除或改写对非 generate/close 按钮的 `opacity: 0.55` 全局灰；改为依赖各 input `:disabled` 默认样式（轻微即可）
+- `.dock-generate-btn.is-generating`：黑底白方块、`opacity: 1`、`box-shadow` 轻微强调，**禁止**被父级降透明
+
+```css
+.dock-generate-btn.is-generating {
+  background: #111;
+  color: #fff;
+  opacity: 1;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.35);
+}
+```
+
+- [ ] **Step 1: Adjust CSS + generate button styles**
+
+- [ ] **Step 2: Visual sanity（本地或浏览器）：生成中停止钮对比清晰，参数控件 disabled 但不整条发灰**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/styles/neo-node.css apps/web/src/components/canvas/dock-studio/shared/DockGenerateButton.vue
+git commit -m "fix(web): make dock stop control obvious while keeping params disabled"
+```
+
+---
+
+### Task 7: 去掉上游 textPrompt 灌入 prompt
+
+**Files:**
+- Modify: `TextDockPanel.vue`、`ImageDockPanel.vue`、`VideoDockPanel.vue`、`AudioDockPanel.vue`、`ShotDockPanel.vue`、`SceneComposerDockPanel.vue`
+- Modify/add tests if panels 有测；否则在 `useUpstreamNodeContext` 或 dock 相关测里断言「不再 patch prompt」
+
+**每个 panel 删除类似：**
+
+```ts
+if (!prompt.value.trim() && ctx.textPrompt) {
+  prompt.value = ctx.textPrompt
+  emit('patch', { prompt: ctx.textPrompt })
+}
+```
+
+保留 chips / `@` / generate 时 refs。`AudioDockPanel` 的 disabled 条件若依赖 `upstream.textPrompt`，改为「有 prompt 或有 refs/芯片」即可。
+
+- [ ] **Step 1: Remove seed blocks from all listed panels**
+
+- [ ] **Step 2: Run web tests touching dock/upstream if any**
+
+Run: `pnpm --filter @lnkpi/web exec vitest run src/composables/useUpstreamNodeContext.test.ts src/composables/useNodeGeneration.test.ts`（若文件不存在则跳过缺失路径）
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/canvas/dock-studio/panels
+git commit -m "fix(web): stop seeding upstream text into dock prompt editors"
+```
+
+---
+
+### Task 8: 节点圆形运行/取消/重试图标 + 耗时
+
+**Files:**
+- Modify: `apps/web/src/components/canvas/nodeTaskChrome.ts`
+- Modify: `apps/web/src/components/canvas/nodeTaskChrome.test.ts`
+- Modify: `apps/web/src/components/canvas/NodeTaskCornerActions.vue`
+- Modify: `apps/web/src/components/canvas/NodeTaskBadge.vue`（改为仅旁侧耗时或合并进 CornerActions）
+- Modify: `apps/web/src/styles/neo-node.css`
+- Modify: `NeoBaseNode.vue` 若徽章槽需调整
+
+**状态模型建议：**
+
+```ts
+export type TaskChromeView = {
+  action: 'cancel' | 'retry' | null
+  showSpinner: boolean
+  elapsedText: string | null // generating 时 m:ss
+  tone: TaskBadgeTone
+  flashSuccess?: boolean
+}
+
+export function resolveTaskChrome(input: {
+  status: unknown
+  startedAt?: string
+  nowMs: number
+  completedFlash?: boolean
+}): TaskChromeView | null
+```
+
+UI：圆形 28px 按钮；generating = spinner/pulse + 点击 cancel；error = retry 图标；旁侧 `elapsedText`；完成 flash 后 null。
+
+保留现有 provide `CANVAS_NODE_CANCEL_KEY` / `RETRY_KEY`。
+
+- [ ] **Step 1: Rewrite pure functions + failing tests for chrome view**
+
+- [ ] **Step 2: Implement circular CornerActions; slim/remove text badge**
+
+- [ ] **Step 3: Run**
+
+Run: `pnpm --filter @lnkpi/web exec vitest run src/components/canvas/nodeTaskChrome.test.ts src/composables/useNodeGeneration.test.ts`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/canvas apps/web/src/styles/neo-node.css
+git commit -m "feat(web): circular node run/cancel/retry controls with elapsed time"
+```
+
+---
+
+### Task 9: 全量回归与 PR
+
+**Files:** 无新功能；验证 + PR
+
+- [ ] **Step 1: Run server + web tests**
+
+```bash
+pnpm --filter @lnkpi/server exec vitest run
+pnpm --filter @lnkpi/web exec vitest run
+```
+
+Expected: PASS（或仅有与本变更无关的既有失败时需先确认）
+
+- [ ] **Step 2: Build web（若仓库惯例需要）**
+
+```bash
+pnpm --filter @lnkpi/web build
+```
+
+- [ ] **Step 3: 按 spec 验收清单手测**
+
+- [ ] **Step 4: Push + `gh pr create`（标题/正文覆盖 5 项与测试计划）**
+
+---
+
+## Self-Review (plan vs spec)
+
+| Spec 项 | Task |
+|---------|------|
+| §1 退款 / 不足文案 / BYOK 先退再扣 | T1–T4 |
+| §2 画布账户条 | T5 |
+| §3 Dock 取消显性 | T6 |
+| §4 不灌 prompt | T7 |
+| §5 圆形图标 + m:ss | T8 |
+| 单 PR | T9 |
+| `.superpowers` 不提交 | T1 gitignore |
+
+无 TBD 占位；`refund` / `chargedPoints` / `fallback` 语义前后一致。
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-07-20-points-dock-node-ux.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven（推荐）** — 每任务新开子代理，任务间复审  
+2. **Inline Execution** — 本会话按 `executing-plans` 连续做，设检查点  
+
+选哪种？

--- a/docs/superpowers/specs/2026-07-20-points-dock-node-ux-design.md
+++ b/docs/superpowers/specs/2026-07-20-points-dock-node-ux-design.md
@@ -1,0 +1,152 @@
+# 积分反馈、画布账户条与节点/Dock 交互改进
+
+**日期：** 2026-07-20  
+**状态：** 已确认设计，待实现  
+**范围：** 单 PR 一次交付（5 项）
+
+## 背景
+
+- 生成接口先扣积分；余额为 0 时返回 HTTP 400「积分不足」，画布侧常显示为笼统的 Axios `status code 400`。
+- 失败与取消当前**不退款**；用户期望失败/取消后「X 积分已返回」。
+- 沉浸画布隐藏 `AppHeader`，右上仅有主题切换，生成过程中看不到余额变化。
+- Dock 生成中整区 `opacity` + `pointer-events` 锁定，停止按钮观感像禁用。
+- 下游 Dock 在 prompt 为空时会把上游文本 seed 进编辑区，干扰编辑；数据流应靠芯片/`@` 引用。
+- 节点任务态为文字徽章 + 文案按钮，期望改为圆形图标动画（所见即所得）。
+
+## 目标
+
+1. 积分不足有明确摘要并引导充值；失败/取消真正退款并提示「N 积分已返回」。
+2. 画布右上展示积分与用户信息，余额随扣费/退款实时可见。
+3. Dock 生成中停止按钮显性可点；参数禁改但不整区灰死。
+4. 上游文本不自动灌入下游 prompt 编辑区；芯片 + `@` + 服务端 merge 打通数据流。
+5. 节点运行中/取消/重试改为圆形图标 + 旁侧耗时。
+
+## 非目标
+
+- 不改变平台/BYOK 模型单价表本身（仅退款与二次扣费时机）。
+- 不强制清空历史画布里已灌入的 prompt。
+- 不重做会员体系/支付渠道（复用 `MembershipModal`）。
+- 不在本 PR 修复平台上游 `model_not_found` 等 Agnes 网关运维问题。
+
+## 已确认决策
+
+| 项 | 决策 |
+|----|------|
+| 退款 | 真正退款（失败、取消一律退本次已扣） |
+| 取消 | 只要已扣费，取消一律退回 |
+| BYOK fallback | BYOK 失败立刻退 X；确认走平台再按平台单价另扣；平台失败再退 |
+| 画布顶栏 | 方案 A：积分胶囊 + 头像/昵称下拉（主题旁） |
+| 交付节奏 | 单 PR 一把梭 |
+| 节点 chrome | 圆形图标（转圈/脉冲/重试）+ 旁侧 `m:ss` |
+
+---
+
+## §1 积分扣费 / 退款 / 文案
+
+### 服务端
+
+- `PointsService` 新增 `refund(userId, amount, reason)`：`points` increment + 正向 `pointTransaction`。
+- 每次成功 `consume` 后，在生成记录 / material 的 `metadata` 写入 `chargedPoints`。
+- **失败**（上游错误、业务失败）：`refund(chargedPoints)`，metadata 写 `refundedPoints`、`refundReason`。
+- **用户取消**：若已扣费且未退过，同样 `refund`；取消路径需能定位到对应 record/material 与 `chargedPoints`。
+- **BYOK → `fallback_pending`**：进入 pending 前立刻退回本次 X，并清/标记 `refundedPoints`；用户**确认平台回退**时再 `consume` 平台单价，写入新的 `chargedPoints`；平台失败再退。
+- **积分不足**：`consume` 抛 `BadRequestException('积分不足')`，不落生成记录、不调用上游。
+
+### 前端
+
+- 生成链路统一用类似 `apiErrorMessage` 解析 Nest `message`。
+- 节点 `errorMessage` 文案约定：
+  - 不足：`积分不足，请充值后再试`（可触发打开会员弹窗）
+  - 失败已退：`生成失败，N 积分已返回`
+  - 取消已退：`已取消，N 积分已返回`
+- 扣费/退款后刷新 `auth.user.points`：开始时可乐观减少；以接口返回或随后 `GET` profile/points 为准；退款后加回。
+
+### 测试要点
+
+- `consume` 不足 → 400 + 文案；余额不变。
+- 扣费后上游失败 → 余额恢复 + `refundedPoints`。
+- 取消已扣费任务 → 余额恢复。
+- BYOK pending：先退；确认平台再扣；平台失败再退。
+
+---
+
+## §2 画布右上账户条
+
+- 沉浸画布仍隐藏全局 `AppHeader`。
+- 在 `CanvasPage` 右上（主题按钮旁）增加 `CanvasAccountChrome`：
+  - 顺序：`主题 | 积分胶囊 | 头像+昵称`
+  - 积分点击 → `MembershipModal`
+  - 用户 → 下拉：个人资料 / 退出（对齐现有 Header）
+- 余额与 §1 的乐观/回写同步，生成过程中可见扣除与退回。
+
+---
+
+## §3 Dock 生成中交互
+
+- **保持可点**：关闭 Dock、停止方块（高对比实心，非半透明灰）。
+- **禁改但不整区灰死**：模型/参数/参考图/标题等用控件级 `disabled`/`readonly`；移除（或收窄）`.is-dock-locked` 对整块的 `opacity: 0.55` + `pointer-events: none`。
+- Prompt：生成中不可编辑，对比度保持正常；停止按钮单独高亮。
+- 停止 = 现有 `cancelGeneration`；成功后按 §1 提示取消退款文案。
+
+---
+
+## §4 上游文本不灌进 prompt
+
+- 删除各 Dock panel「prompt 为空则 seed `upstream.textPrompt`」逻辑。
+- 上游经连线 → `DockRefStrip` 芯片 + `@Tn` mention；生成仍传 `refs` + `mentionedKeys`，服务端 `mergeRefsToPrompt` 不变。
+- 本地 prompt 仅用户手写内容 + mention 标记。
+- **兼容**：历史已灌入的 prompt 不强制清空；新连接/新打开不再自动灌入。
+
+---
+
+## §5 节点圆形任务控件
+
+- 替换标题旁文字徽章 + 角上文案按钮。
+- 右上角圆形按钮：
+  - 生成中：转圈/脉冲；旁侧 `m:ss`；点击取消
+  - 失败：重试图标可点；短错误可用 tooltip/旁侧摘要
+  - `fallback_pending`：区分图标；确认仍走现有弹窗
+  - 完成：短暂成功态后消失
+- 与 Dock 停止语义一致，均为一眼可点。
+
+---
+
+## 架构与数据流（摘要）
+
+```text
+generate 请求
+  → consume(X) → metadata.chargedPoints=X → 更新前端 points
+  → 上游成功 → completed
+  → 上游失败 / 取消 → refund(X) → metadata.refundedPoints=X → 前端文案 + points
+  → BYOK 失败 → refund(X) + fallback_pending
+       → 用户确认平台 → consume(Y) → …
+       → 用户拒绝 → 已退过，结束
+```
+
+## 主要改动面（实现时）
+
+| 区域 | 预期触及 |
+|------|----------|
+| Server | `points.service`、`studio.service`、`material.service`、取消/fallback 路径、相关单测 |
+| Web | `useNodeGeneration`、错误解析、`CanvasPage` 账户条、`auth` points 同步、Dock CSS/Generate 按钮、Dock seed 逻辑、`NodeTaskBadge`/`CornerActions`/`nodeTaskChrome` |
+| Shared（可选） | 文案常量、`chargedPoints`/`refundedPoints` 类型约定 |
+
+## 错误处理
+
+- 退款失败：打日志；前端仍展示失败原因，并提示「退款异常，请联系支持」（避免静默丢点）；实现时优先保证退款与失败状态同事务或补偿可重试。
+- 重复退款：以 metadata 是否已有 `refundedPoints` / 幂等 reason+recordId 防护。
+
+## 验收清单
+
+- [ ] 积分为 0 生成：节点明确「积分不足，请充值」并可打开充值
+- [ ] 扣费后失败：余额恢复，文案含「N 积分已返回」
+- [ ] 生成中取消：停止明显可点；余额恢复；文案「已取消，N 积分已返回」
+- [ ] 画布右上积分随扣/退实时变化；用户下拉可用
+- [ ] Dock 生成中非整区发灰；停止高对比
+- [ ] 新连下游：prompt 不自动出现上游全文；芯片可见；生成仍能引用上游
+- [ ] 节点圆形运行/重试 + `m:ss`；重试可点
+
+## 风险
+
+- 取消与异步上游竞态：需在现有 cancel 忽略晚到结果的基础上，保证退款只发生一次。
+- BYOK 二次扣费改变现有「一次扣费管到底」行为，需更新 fallback 相关测试与文案。


### PR DESCRIPTION
## Summary

单 PR 交付积分反馈、画布账户条与 Dock/节点交互改进（spec: `docs/superpowers/specs/2026-07-20-points-dock-node-ux-design.md`）。

### §1 积分扣费 / 退款 / 文案
- 服务端新增 `PointsService.refund`，扣费后写入 `metadata.chargedPoints`
- 失败、取消、BYOK→平台 fallback 路径均真正退款；BYOK pending 先退再扣平台价
- 前端统一解析「积分不足」「N 积分已返回」文案，并同步 `auth.user.points`

### §2 画布右上账户条
- 沉浸画布新增 `CanvasAccountChrome`：主题 | 积分胶囊 | 头像/昵称下拉
- 积分点击打开 `MembershipModal`；余额随扣费/退款乐观更新

### §3 Dock 生成中交互
- 移除整区 `opacity` 锁定；参数控件级 disabled
- 停止按钮高对比实心，生成中明显可点

### §4 上游文本不灌进 prompt
- 删除各 Dock panel 的 upstream seed 逻辑
- 数据流仍靠芯片 + `@` mention + 服务端 `mergeRefsToPrompt`

### §5 节点圆形任务控件
- 文字徽章/文案按钮改为 `NodeTaskCornerActions` 圆形图标 + 旁侧 `m:ss`
- 运行/取消/重试/fallback_pending 态与 Dock 停止语义一致

## Test plan

### 自动化
- [x] `pnpm --filter @lnkpi/server exec vitest run` — 89 passed
- [x] `pnpm --filter @lnkpi/web exec vitest run` — 64 passed
- [x] `pnpm --filter @lnkpi/web build`

### 手测验收（spec 清单）
- [ ] 积分为 0 生成：节点明确「积分不足，请充值」并可打开充值
- [ ] 扣费后失败：余额恢复，文案含「N 积分已返回」
- [ ] 生成中取消：停止明显可点；余额恢复；文案「已取消，N 积分已返回」
- [ ] 画布右上积分随扣/退实时变化；用户下拉可用
- [ ] Dock 生成中非整区发灰；停止高对比
- [ ] 新连下游：prompt 不自动出现上游全文；芯片可见；生成仍能引用上游
- [ ] 节点圆形运行/重试 + `m:ss`；重试可点


Made with [Cursor](https://cursor.com)