### PR TITLE
fix: DeepSeek 文本 thinking 开关与文本/图片超时加长

### DIFF
--- a/apps/server/src/canvas/material.service.ts
+++ b/apps/server/src/canvas/material.service.ts
@@ -515,6 +515,7 @@ export class MaterialService {
     downstreamType: 'image' | 'video',
     mentionedKeys?: string[],
     credentials?: { apiKey?: string; baseUrl?: string },
+    model?: string,
   ) {
     const { mergedText, skippedMerge } = await mergeRefsToPrompt({
       sources: extractTextSources(refs),
@@ -523,6 +524,7 @@ export class MaterialService {
       mentionedKeys: mentionedKeys?.length ? mentionedKeys : undefined,
       apiKey: credentials?.apiKey ?? process.env.OPENAI_API_KEY,
       baseUrl: credentials?.baseUrl ?? process.env.OPENAI_BASE_URL,
+      model,
     })
     return {
       mergedText,
@@ -551,6 +553,7 @@ export class MaterialService {
       'image',
       mentionedKeys,
       resolved.source === 'user' ? resolved.credentials : undefined,
+      resolved.modelName,
     )
     this.logger.log(
       JSON.stringify({
@@ -692,6 +695,7 @@ export class MaterialService {
       'video',
       mentionedKeys,
       resolved.source === 'user' ? resolved.credentials : undefined,
+      resolved.modelName,
     )
     this.logger.log(
       JSON.stringify({

--- a/apps/server/src/studio/studio.controller.ts
+++ b/apps/server/src/studio/studio.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Get, Inject, Param, Post, Query, Req, UseGuards } from '@nestjs/common'
 import { Type } from 'class-transformer'
-import { IsArray, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator'
+import { IsArray, IsBoolean, IsIn, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator'
 import { AuthGuard } from '../auth/auth.guard'
 import { createCancelFlag } from '../points/charge-session'
 import { StudioService } from './studio.service'
@@ -155,6 +155,14 @@ class GenerateTextDto {
   @IsArray()
   @IsString({ each: true })
   mentionedKeys?: string[]
+
+  @IsOptional()
+  @IsBoolean()
+  thinking?: boolean
+
+  @IsOptional()
+  @IsIn(['high', 'max'])
+  thinkingEffort?: 'high' | 'max'
 }
 
 class GeneratePromptDto {
@@ -204,6 +212,8 @@ export class StudioController {
       dto.refs,
       dto.mentionedKeys,
       cancel,
+      dto.thinking,
+      dto.thinkingEffort,
     )
     return { code: 0, message: 'ok', data }
   }

--- a/apps/server/src/studio/studio.integration.test.ts
+++ b/apps/server/src/studio/studio.integration.test.ts
@@ -113,7 +113,10 @@ describe('StudioService integration (provider params)', () => {
     await svc.generateText('u1', 'hello world', 'gemini-3.1-flash')
 
     expect(createTextProvider).toHaveBeenCalled()
-    expect(textGenerate).toHaveBeenCalledWith('hello world', 'gemini-3.1-flash')
+    expect(textGenerate).toHaveBeenCalledWith('hello world', 'gemini-3.1-flash', {
+      thinking: false,
+      thinkingEffort: 'high',
+    })
     expect(generateTextWithImages).not.toHaveBeenCalled()
   })
 

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -111,6 +111,7 @@ export class StudioService {
     downstreamType: 'text' | 'image' | 'video' | 'audio',
     mentionedKeys?: string[],
     credentials?: { apiKey?: string; baseUrl?: string },
+    model?: string,
   ) {
     const { mergedText, skippedMerge } = await mergeRefsToPrompt({
       sources: extractTextSources(refs),
@@ -119,6 +120,7 @@ export class StudioService {
       mentionedKeys: mentionedKeys?.length ? mentionedKeys : undefined,
       apiKey: credentials?.apiKey ?? process.env.OPENAI_API_KEY,
       baseUrl: credentials?.baseUrl ?? process.env.OPENAI_BASE_URL,
+      model,
     })
     return {
       mergedText,
@@ -187,22 +189,29 @@ export class StudioService {
     refs?: StudioRefInput[],
     mentionedKeys?: string[],
     cancel?: CancelFlag,
+    thinking?: boolean,
+    thinkingEffort?: 'high' | 'max',
   ) {
     const cost = 5
     const chargeReason = '文本生成'
     await this.points.consume(userId, cost, chargeReason)
     const resolved = await this.resolver.resolveForGeneration(userId, model, 'text')
+    const { modelKey: resolvedKey, entry, fallback } = resolveModelKey('text', resolved.modelName)
+    const gatewayModelId =
+      resolved.source === 'user' ? resolved.modelName : entry.gatewayModelId
     const { mergedText, skippedMerge, referenceImages } = await this.resolveMergedPrompt(
       prompt,
       refs,
       'text',
       mentionedKeys,
       resolved.source === 'user' ? resolved.credentials : undefined,
+      gatewayModelId,
     )
-    const { modelKey: resolvedKey, entry, fallback } = resolveModelKey('text', resolved.modelName)
-    const gatewayModelId =
-      resolved.source === 'user' ? resolved.modelName : entry.gatewayModelId
     const storeModel = resolved.source === 'user' ? model ?? resolvedKey : resolvedKey
+    const textOpts = {
+      thinking: !!thinking,
+      thinkingEffort: thinkingEffort === 'max' ? ('max' as const) : ('high' as const),
+    }
     const baseMeta = {
       modelKey: resolvedKey,
       gatewayModelId,
@@ -211,6 +220,8 @@ export class StudioService {
       refsCount: refs?.length ?? 0,
       visionUsed: referenceImages.length > 0,
       referenceImages,
+      thinking: textOpts.thinking,
+      thinkingEffort: textOpts.thinking ? textOpts.thinkingEffort : undefined,
       ...(fallback && resolved.source === 'platform' ? { modelFallback: true } : {}),
     }
 
@@ -226,7 +237,7 @@ export class StudioService {
               apiKey: opts?.apiKey ?? process.env.OPENAI_API_KEY,
               baseUrl: opts?.baseUrl ?? process.env.OPENAI_BASE_URL,
             })
-          : await createTextProvider(opts).generate(mergedText, gatewayModelId)
+          : await createTextProvider(opts).generate(mergedText, gatewayModelId, textOpts)
       if (cancel?.isCancelled()) {
         await this.points.refund(userId, cost, `${chargeReason}-取消退款`)
         throwCancelledException(cost)
@@ -369,6 +380,7 @@ export class StudioService {
       'image',
       mentionedKeys,
       resolved.source === 'user' ? resolved.credentials : undefined,
+      resolved.modelName,
     )
     const size = resolveImageSize(aspectRatio, resolution as ImageResolutionTier)
     const built = buildImageProviderOptions({
@@ -552,6 +564,7 @@ export class StudioService {
       'video',
       mentionedKeys,
       resolved.source === 'user' ? resolved.credentials : undefined,
+      resolved.modelName,
     )
     const built = buildVideoProviderOptions({
       modelKey: resolved.modelName,
@@ -638,6 +651,7 @@ export class StudioService {
       'audio',
       mentionedKeys,
       resolved.source === 'user' ? resolved.credentials : undefined,
+      resolved.modelName,
     )
     const built = buildAudioRequest({
       mergedText,

--- a/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
@@ -14,7 +14,7 @@ import DockRefStrip from '@/components/canvas/dock-studio/shared/DockRefStrip.vu
 import type { NodeRef } from '@/composables/useNodeRefs'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
 import { useModelProviderSettings } from '@/composables/useModelProviderSettings'
-import { resolveGenerationModel } from '@/constants/studioModels'
+import { resolveGenerationModel, isDeepSeekV4Model } from '@/constants/studioModels'
 import { isNodeGenerating } from '@/constants/dockStudio'
 import { estimateTextCredits } from '@/constants/credits'
 
@@ -38,6 +38,8 @@ const emit = defineEmits<{
 /** Dock input only — never sync from generated `content` after prompt exists. */
 const prompt = ref('')
 const textModel = ref(getConfig('text').model)
+const textThinking = ref(false)
+const textThinkingEffort = ref<'high' | 'max'>('high')
 /** One-shot legacy content→prompt seed for the current node visit. */
 const legacySeededForId = ref<string | null>(null)
 
@@ -45,6 +47,7 @@ const speech = useSpeechRecognition()
 const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
 const wordCount = computed(() => prompt.value.replace(/\s/g, '').length)
 const credits = computed(() => estimateTextCredits())
+const showThinkingControls = computed(() => isDeepSeekV4Model(textModel.value))
 
 function syncFromNode() {
   const data = props.node.data ?? {}
@@ -60,6 +63,8 @@ function syncFromNode() {
   }
 
   textModel.value = resolveGenerationModel('text', data.textModel as string | undefined)
+  textThinking.value = data.textThinking === true
+  textThinkingEffort.value = data.textThinkingEffort === 'max' ? 'max' : 'high'
 }
 
 watch(
@@ -71,7 +76,13 @@ watch(
   { immediate: true },
 )
 watch(
-  () => [props.node.data?.prompt, props.node.data?.textModel] as const,
+  () =>
+    [
+      props.node.data?.prompt,
+      props.node.data?.textModel,
+      props.node.data?.textThinking,
+      props.node.data?.textThinkingEffort,
+    ] as const,
   () => syncFromNode(),
 )
 
@@ -85,8 +96,27 @@ function onOptimized(value: string) {
   emit('patch', { prompt: value })
 }
 
+function setThinking(enabled: boolean) {
+  textThinking.value = enabled
+  emit('patch', {
+    textThinking: enabled,
+    textThinkingEffort: enabled ? textThinkingEffort.value : undefined,
+  })
+}
+
+function setThinkingEffort(effort: 'high' | 'max') {
+  textThinkingEffort.value = effort
+  emit('patch', { textThinking: true, textThinkingEffort: effort })
+}
+
 function onGenerate() {
-  emit('patch', { prompt: prompt.value, textModel: textModel.value })
+  emit('patch', {
+    prompt: prompt.value,
+    textModel: textModel.value,
+    textThinking: showThinkingControls.value ? textThinking.value : false,
+    textThinkingEffort:
+      showThinkingControls.value && textThinking.value ? textThinkingEffort.value : undefined,
+  })
   emit('generate')
 }
 
@@ -134,6 +164,41 @@ function onRefRemove(ref: NodeRef) {
         type="text"
         @update:model-value="emit('patch', { textModel: $event })"
       />
+      <div
+        v-if="showThinkingControls"
+        class="flex items-center gap-1.5 rounded-lg border border-white/10 bg-white/5 px-2 py-1"
+      >
+        <button
+          type="button"
+          class="text-[10px] transition"
+          :class="textThinking ? 'text-[#818cf8]' : 'text-white/50 hover:text-white/70'"
+          :disabled="readonly"
+          title="深度思考（DeepSeek V4）"
+          @click="setThinking(!textThinking)"
+        >
+          深度思考 {{ textThinking ? '开' : '关' }}
+        </button>
+        <template v-if="textThinking">
+          <button
+            type="button"
+            class="rounded px-1.5 py-0.5 text-[10px] transition"
+            :class="textThinkingEffort === 'high' ? 'bg-[#6366f1]/30 text-[#818cf8]' : 'text-white/45 hover:bg-white/10'"
+            :disabled="readonly"
+            @click="setThinkingEffort('high')"
+          >
+            high
+          </button>
+          <button
+            type="button"
+            class="rounded px-1.5 py-0.5 text-[10px] transition"
+            :class="textThinkingEffort === 'max' ? 'bg-[#6366f1]/30 text-[#818cf8]' : 'text-white/45 hover:bg-white/10'"
+            :disabled="readonly"
+            @click="setThinkingEffort('max')"
+          >
+            max
+          </button>
+        </template>
+      </div>
       <DockOptimizePrompt
         :prompt="prompt"
         optimize-style="copywriting"

--- a/apps/web/src/composables/useNodeGeneration.test.ts
+++ b/apps/web/src/composables/useNodeGeneration.test.ts
@@ -648,6 +648,8 @@ describe('useNodeGeneration', () => {
       [],
       [],
       expect.any(AbortSignal),
+      false,
+      undefined,
     )
     expect(deps.patchNodeData).toHaveBeenCalledWith(
       'text-1',

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -539,12 +539,16 @@ async function cancelRemoteGeneration(nodeId: string) {
           status: NODE_GENERATION_STATUS.generating,
           prompt: local,
         })
+        const thinking = data.textThinking === true
+        const thinkingEffort = data.textThinkingEffort === 'max' ? 'max' : 'high'
         const { data: res } = await studioApi.generateText(
           local,
           resolveGenerationModel('text', data.textModel as string | undefined),
           refs,
           mentionedKeys,
           signal,
+          thinking,
+          thinking ? thinkingEffort : undefined,
         )
         if (signal.aborted) return
         await resolveStudioRecord(node.id, res.data)

--- a/apps/web/src/constants/studioModels.ts
+++ b/apps/web/src/constants/studioModels.ts
@@ -48,3 +48,9 @@ export function resolveGenerationModel(
 export function catalogModelKeyFromValue(value: string): string {
   return decodeChannelModel(value)?.modelName ?? value
 }
+
+/** DeepSeek V4 family (pro/flash) — used for Dock thinking UI visibility. */
+export function isDeepSeekV4Model(model?: string | null): boolean {
+  if (!model) return false
+  return /deepseek-v4/i.test(model)
+}

--- a/apps/web/src/services/canvas-api.ts
+++ b/apps/web/src/services/canvas-api.ts
@@ -29,16 +29,20 @@ export const canvasApi = {
       mentionedKeys?: string[]
     },
   ) =>
-    api.post('/agent/canvas/material/generate-image', {
-      shotId,
-      prompt,
-      model: opts?.model,
-      aspectRatio: opts?.aspectRatio,
-      resolution: opts?.resolution,
-      count: 1,
-      refs: opts?.refs,
-      mentionedKeys: opts?.mentionedKeys,
-    }),
+    api.post(
+      '/agent/canvas/material/generate-image',
+      {
+        shotId,
+        prompt,
+        model: opts?.model,
+        aspectRatio: opts?.aspectRatio,
+        resolution: opts?.resolution,
+        count: 1,
+        refs: opts?.refs,
+        mentionedKeys: opts?.mentionedKeys,
+      },
+      { timeout: 300_000 },
+    ),
   generateVideo: (
     shotId: string,
     prompt: string,

--- a/apps/web/src/services/studio-api.ts
+++ b/apps/web/src/services/studio-api.ts
@@ -42,18 +42,26 @@ export const studioApi = {
     api.post<{ data: GenerationRecord }>(
       '/studio/image/generate',
       { prompt, model, aspectRatio, refs, mentionedKeys, resolution, count },
-      { timeout: 120_000, signal },
+      { timeout: 300_000, signal },
     ),
   generateImageVariation: (prompt: string, basePrompt?: string, model?: string, signal?: AbortSignal) =>
-    api.post<{ data: GenerationRecord }>('/studio/image/variation', { prompt, basePrompt, model }, { timeout: 120_000, signal }),
-  generateText: (prompt: string, model?: string, refs?: StudioRefPayload[], mentionedKeys?: string[], signal?: AbortSignal) =>
+    api.post<{ data: GenerationRecord }>('/studio/image/variation', { prompt, basePrompt, model }, { timeout: 300_000, signal }),
+  generateText: (
+    prompt: string,
+    model?: string,
+    refs?: StudioRefPayload[],
+    mentionedKeys?: string[],
+    signal?: AbortSignal,
+    thinking?: boolean,
+    thinkingEffort?: 'high' | 'max',
+  ) =>
     api.post<{ data: GenerationRecord }>(
       '/studio/text/generate',
-      { prompt, model, refs, mentionedKeys },
-      { timeout: 90_000, signal },
+      { prompt, model, refs, mentionedKeys, thinking, thinkingEffort },
+      { timeout: thinking ? 300_000 : 180_000, signal },
     ),
   generatePrompt: (prompt: string, model?: string, signal?: AbortSignal) =>
-    api.post<{ data: GenerationRecord }>('/studio/prompt/generate', { prompt, model }, { timeout: 90_000, signal }),
+    api.post<{ data: GenerationRecord }>('/studio/prompt/generate', { prompt, model }, { timeout: 180_000, signal }),
   generateVideo: (
     prompt: string,
     model?: string,

--- a/docs/superpowers/plans/2026-07-20-text-image-timeout-thinking.md
+++ b/docs/superpowers/plans/2026-07-20-text-image-timeout-thinking.md
@@ -1,0 +1,32 @@
+# 文本 Thinking + 文本/图片超时 — 实现计划
+
+> **For agentic workers:** 按任务顺序执行；每任务先写失败测试再改实现。
+
+**Goal:** DeepSeek V4 Dock 深度思考开关（关/开+high/max）+ 文本/图片 axios 超时加长；merge 用渠道模型并关 thinking。
+
+**Architecture:** UI → node.data → studio API body → OpenAITextProvider 按模型映射 thinking；超时按 thinking 开关分支。
+
+**Tech Stack:** Vue Dock、Nest StudioService、packages/agent text-provider、vitest
+
+---
+
+### Task 1: agent text-provider thinking 映射
+
+**Files:** `packages/agent/src/tools/text-provider.ts`, `text-provider.test.ts`
+
+- 增加 `isDeepSeekV4Model`、`buildDeepSeekThinkingBody`
+- `generate(prompt, model?, opts?: { thinking?, thinkingEffort? })`
+
+### Task 2: mergeRefsToPrompt 传 model + 关 thinking
+
+**Files:** `packages/agent/src/refs/merge-refs.ts`, tests；`studio.service.ts` resolveMergedPrompt 传入 modelName
+
+### Task 3: Studio API DTO + generateText/Prompt
+
+**Files:** studio.controller / studio.service
+
+### Task 4: 前端超时 + TextDock UI + 传参
+
+**Files:** studio-api.ts, canvas-api.ts, TextDockPanel.vue, useNodeGeneration.ts
+
+### Task 5: 跑相关单测

--- a/docs/superpowers/specs/2026-07-20-text-image-timeout-thinking-design.md
+++ b/docs/superpowers/specs/2026-07-20-text-image-timeout-thinking-design.md
@@ -1,0 +1,62 @@
+# 文本 Thinking 开关与文本/图片超时
+
+**日期：** 2026-07-20  
+**状态：** 已批准  
+**范围：** 文本 + 图片超时治理；不含视频异步
+
+## 目标
+
+1. DeepSeek V4 系文本默认关闭 thinking，避免非流式长 TTFB 触发前端超时。
+2. Dock 提供「深度思考」开关；开启后可选 effort：`high` | `max`。
+3. 按是否开启 thinking 使用不同前端超时；图片统一加长超时。
+4. BYOK merge 使用当前渠道模型，且 merge 请求强制关 thinking。
+
+## 非目标
+
+- 视频异步化 / merge 挪入 `completeVideo` 后台（另案）。
+- 全局流式 SSE。
+- 非 DeepSeek 模型的 thinking UI。
+
+## UI（TextDockPanel）
+
+- 开关「深度思考」，默认关。
+- 打开后显示 effort：`high`（默认）| `max`。
+- 仅当当前 `textModel` 判定为 DeepSeek V4（`/(^|::|\/)deepseek-v4/i`）时显示。
+
+## 数据与 API
+
+- `node.data.textThinking?: boolean`（默认 false）
+- `node.data.textThinkingEffort?: 'high' | 'max'`（开启时默认 high）
+- `POST /studio/text/generate`、`POST /studio/prompt/generate` 可选：
+  - `thinking?: boolean`
+  - `thinkingEffort?: 'high' | 'max'`
+
+## 上游映射（DeepSeek V4）
+
+| UI | Body |
+|----|------|
+| 关 | `thinking: { type: "disabled" }` |
+| 开 + high | `thinking: { type: "enabled" }`, `reasoning_effort: "high"` |
+| 开 + max | `thinking: { type: "enabled" }`, `reasoning_effort: "max"` |
+
+非 DeepSeek：不传上述字段。
+
+## 超时（前端 axios）
+
+| 请求 | 超时 |
+|------|------|
+| text / prompt，thinking 关 | 180s |
+| text / prompt，thinking 开 | 300s |
+| studio image / variation | 300s |
+| canvas material generate-image | 300s |
+
+## Merge
+
+- `mergeRefsToPrompt` 传入当前生成用的渠道 `modelName`。
+- merge 调用强制 thinking disabled（若走 DeepSeek）。
+
+## 验收
+
+- 默认关：DeepSeek 短文本不再轻易 90s 超时。
+- 开 + high/max：参数正确，超时 300s。
+- 非 DeepSeek：无开关、请求无 thinking 字段。

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2,11 +2,18 @@ export { CanvasAgent, RuleBasedAgent, OpenAIAgent } from './agent'
 export { CANVAS_TOOLS } from './tools/canvas-tools'
 export { CanvasToolExecutor, applyCanvasActions } from './tools/executor'
 export { createImageProvider, PlaceholderImageProvider, OpenAIImageProvider } from './tools/image-provider'
-export { createTextProvider, PlaceholderTextProvider, OpenAITextProvider } from './tools/text-provider'
+export {
+  createTextProvider,
+  PlaceholderTextProvider,
+  OpenAITextProvider,
+  isDeepSeekV4Model,
+  buildDeepSeekThinkingFields,
+} from './tools/text-provider'
+
 export { createVideoProvider, PlaceholderVideoProvider, AgnesVideoProvider, resolveVideoParams } from './tools/video-provider'
 export { createAudioProvider, PlaceholderAudioProvider, OpenAITTSProvider, FallbackAudioProvider } from './tools/audio-provider'
 export type { ImageProvider, ProviderCredentialOpts } from './tools/image-provider'
-export type { TextProvider } from './tools/text-provider'
+export type { TextProvider, TextGenerateOptions, TextThinkingEffort } from './tools/text-provider'
 export type { VideoProvider } from './tools/video-provider'
 export type { AudioProvider, AudioGenerateOptions } from './tools/audio-provider'
 export type { AgentStreamEvent, AgentMessage, AgentToolCall, AgentContext, AgentToolDefinition } from './types'

--- a/packages/agent/src/refs/merge-refs.test.ts
+++ b/packages/agent/src/refs/merge-refs.test.ts
@@ -123,4 +123,25 @@ describe('mergeRefsToPrompt LLM merge', () => {
     expect(user).toContain('【优先参考】')
     expect(user).toContain('T1、I2')
   })
+
+  it('passes model and disables deepseek thinking on merge', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'merged' } }] }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await mergeRefsToPrompt({
+      sources: [{ refKey: 'T1', label: 'L1', text: 'A' }],
+      localPrompt: 'B',
+      downstreamType: 'text',
+      apiKey: 'test-key',
+      model: 'deepseek-v4-pro',
+    })
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string) as Record<string, unknown>
+    expect(body.model).toBe('deepseek-v4-pro')
+    expect(body.thinking).toEqual({ type: 'disabled' })
+  })
 })

--- a/packages/agent/src/refs/merge-refs.ts
+++ b/packages/agent/src/refs/merge-refs.ts
@@ -1,3 +1,5 @@
+import { buildDeepSeekThinkingFields, isDeepSeekV4Model } from '../tools/text-provider'
+
 export interface MergeTextSource {
   refKey: string
   label: string
@@ -72,18 +74,25 @@ export async function mergeRefsToPrompt(input: {
     return { mergedText: fallbackConcat(entries), skippedMerge: false }
   }
 
+  const model = input.model ?? process.env.OPENAI_CHAT_MODEL ?? 'gpt-4o'
+  const body: Record<string, unknown> = {
+    model,
+    temperature: 0.3,
+    messages: [
+      { role: 'system', content: buildSystemPrompt(input.downstreamType, input.mentionedKeys) },
+      { role: 'user', content: buildMergeUserMessage(entries, input.downstreamType, input.mentionedKeys) },
+    ],
+  }
+  // Merge is latency-sensitive: always disable DeepSeek V4 thinking when applicable.
+  if (isDeepSeekV4Model(model)) {
+    Object.assign(body, buildDeepSeekThinkingFields({ thinking: false }))
+  }
+
   const baseUrl = (input.baseUrl ?? process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1').replace(/\/$/, '')
   const res = await fetch(`${baseUrl}/chat/completions`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
-    body: JSON.stringify({
-      model: input.model ?? process.env.OPENAI_CHAT_MODEL ?? 'gpt-4o',
-      temperature: 0.3,
-      messages: [
-        { role: 'system', content: buildSystemPrompt(input.downstreamType, input.mentionedKeys) },
-        { role: 'user', content: buildMergeUserMessage(entries, input.downstreamType, input.mentionedKeys) },
-      ],
-    }),
+    body: JSON.stringify(body),
   })
   if (!res.ok) {
     throw new Error(`LLM 请求失败: ${res.status} ${res.statusText}`)

--- a/packages/agent/src/tools/text-provider.test.ts
+++ b/packages/agent/src/tools/text-provider.test.ts
@@ -1,5 +1,40 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createTextProvider, OpenAITextProvider } from './text-provider'
+import {
+  buildDeepSeekThinkingFields,
+  createTextProvider,
+  isDeepSeekV4Model,
+  OpenAITextProvider,
+} from './text-provider'
+
+describe('isDeepSeekV4Model', () => {
+  it('matches common deepseek-v4 id shapes', () => {
+    expect(isDeepSeekV4Model('deepseek-v4')).toBe(true)
+    expect(isDeepSeekV4Model('deepseek-v4-pro')).toBe(true)
+    expect(isDeepSeekV4Model('ch_x::deepseek-v4-flash')).toBe(true)
+    expect(isDeepSeekV4Model('deepseek/deepseek-v4-pro')).toBe(true)
+    expect(isDeepSeekV4Model('gpt-4o')).toBe(false)
+  })
+})
+
+describe('buildDeepSeekThinkingFields', () => {
+  it('disables thinking by default', () => {
+    expect(buildDeepSeekThinkingFields()).toEqual({ thinking: { type: 'disabled' } })
+    expect(buildDeepSeekThinkingFields({ thinking: false })).toEqual({
+      thinking: { type: 'disabled' },
+    })
+  })
+
+  it('enables thinking with effort', () => {
+    expect(buildDeepSeekThinkingFields({ thinking: true, thinkingEffort: 'high' })).toEqual({
+      thinking: { type: 'enabled' },
+      reasoning_effort: 'high',
+    })
+    expect(buildDeepSeekThinkingFields({ thinking: true, thinkingEffort: 'max' })).toEqual({
+      thinking: { type: 'enabled' },
+      reasoning_effort: 'max',
+    })
+  })
+})
 
 describe('createTextProvider', () => {
   const env = { ...process.env }
@@ -46,5 +81,39 @@ describe('createTextProvider', () => {
     expect(url).toBe('https://env.example.com/v1/chat/completions')
     expect(init.headers).toMatchObject({ Authorization: 'Bearer env-key' })
     expect(JSON.parse(String(init.body))).toMatchObject({ model: 'env-model' })
+  })
+
+  it('adds disabled thinking for deepseek-v4 by default', async () => {
+    const provider = createTextProvider({
+      apiKey: 'k',
+      baseUrl: 'https://api.deepseek.com',
+      model: 'deepseek-v4-pro',
+    })
+    await provider.generate('hello', 'deepseek-v4-pro')
+    const body = JSON.parse(String((fetchMock.mock.calls[0] as [string, RequestInit])[1].body))
+    expect(body.thinking).toEqual({ type: 'disabled' })
+    expect(body.reasoning_effort).toBeUndefined()
+  })
+
+  it('adds enabled thinking + effort when requested', async () => {
+    const provider = createTextProvider({
+      apiKey: 'k',
+      baseUrl: 'https://api.deepseek.com',
+    })
+    await provider.generate('hello', 'deepseek-v4-flash', {
+      thinking: true,
+      thinkingEffort: 'max',
+    })
+    const body = JSON.parse(String((fetchMock.mock.calls[0] as [string, RequestInit])[1].body))
+    expect(body.thinking).toEqual({ type: 'enabled' })
+    expect(body.reasoning_effort).toBe('max')
+  })
+
+  it('does not add thinking fields for non-deepseek models', async () => {
+    const provider = createTextProvider({ apiKey: 'k', baseUrl: 'https://api.openai.com/v1' })
+    await provider.generate('hello', 'gpt-4o', { thinking: true, thinkingEffort: 'max' })
+    const body = JSON.parse(String((fetchMock.mock.calls[0] as [string, RequestInit])[1].body))
+    expect(body.thinking).toBeUndefined()
+    expect(body.reasoning_effort).toBeUndefined()
   })
 })

--- a/packages/agent/src/tools/text-provider.ts
+++ b/packages/agent/src/tools/text-provider.ts
@@ -1,5 +1,32 @@
+export type TextThinkingEffort = 'high' | 'max'
+
+export type TextGenerateOptions = {
+  thinking?: boolean
+  thinkingEffort?: TextThinkingEffort
+}
+
 export interface TextProvider {
-  generate(prompt: string, model?: string): Promise<{ text: string }>
+  generate(prompt: string, model?: string, options?: TextGenerateOptions): Promise<{ text: string }>
+}
+
+/** Match deepseek-v4 / deepseek-v4-pro / channel::deepseek-v4-flash / provider/deepseek-v4-pro */
+export function isDeepSeekV4Model(model?: string | null): boolean {
+  if (!model) return false
+  return /deepseek-v4/i.test(model)
+}
+
+/** Extra chat.completions fields for DeepSeek V4 thinking control. */
+export function buildDeepSeekThinkingFields(
+  options?: TextGenerateOptions,
+): Record<string, unknown> {
+  if (!options?.thinking) {
+    return { thinking: { type: 'disabled' } }
+  }
+  const effort = options.thinkingEffort === 'max' ? 'max' : 'high'
+  return {
+    thinking: { type: 'enabled' },
+    reasoning_effort: effort,
+  }
 }
 
 export class PlaceholderTextProvider implements TextProvider {
@@ -17,21 +44,27 @@ export class OpenAITextProvider implements TextProvider {
     private model = 'gpt-4o',
   ) {}
 
-  async generate(prompt: string, model?: string): Promise<{ text: string }> {
+  async generate(prompt: string, model?: string, options?: TextGenerateOptions): Promise<{ text: string }> {
+    const resolvedModel = model ?? this.model
+    const body: Record<string, unknown> = {
+      model: resolvedModel,
+      messages: [
+        { role: 'system', content: '你是专业 AI 创作助手，擅长脚本、旁白与分镜描述。用中文回复，结构清晰。' },
+        { role: 'user', content: prompt },
+      ],
+      temperature: 0.8,
+    }
+    if (isDeepSeekV4Model(resolvedModel)) {
+      Object.assign(body, buildDeepSeekThinkingFields(options))
+    }
+
     const res = await fetch(`${this.baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${this.apiKey}`,
       },
-      body: JSON.stringify({
-        model: model ?? this.model,
-        messages: [
-          { role: 'system', content: '你是专业 AI 创作助手，擅长脚本、旁白与分镜描述。用中文回复，结构清晰。' },
-          { role: 'user', content: prompt },
-        ],
-        temperature: 0.8,
-      }),
+      body: JSON.stringify(body),
     })
     if (!res.ok) throw new Error(`Text API ${res.status}: ${await res.text()}`)
     const json = await res.json() as { choices: Array<{ message: { content: string } }> }


### PR DESCRIPTION
## Summary
- Text Dock 为 DeepSeek V4 增加「深度思考」开关（默认关），开启后可选 effort `high`/`max`，并映射到 DeepSeek `thinking` + `reasoning_effort`
- 文本前端超时：关闭思考 180s、开启 300s；Studio/Canvas 图片生成超时加长至 300s，避免 axios 过早超时
- `mergeRefsToPrompt` 传入渠道 model，并对 DeepSeek 强制关闭 thinking，避免合并阶段拖慢

## Test plan
- [ ] `pnpm build` / agent 单测通过
- [ ] DeepSeek V4 默认关思考：文本生成可在 ~180s 内返回，不再出现 90s timeout
- [ ] 开启「深度思考」+ high/max：请求体带 thinking/effort，超时放宽到 300s
- [ ] 非 DeepSeek 模型：不显示思考开关，行为不变
- [ ] Agnes/自定义渠道图片生成：慢请求可撑到 300s 而不被前端掐断
- [ ] 文本 refs merge 路径仍正常，且不因 thinking 拖慢


Made with [Cursor](https://cursor.com)