### PR TITLE
feat: 节点生成失败 C2 诊断（ⓘ + Dock 胶囊 + 按需完整诊断）

### DIFF
--- a/apps/server/src/canvas/canvas.controller.ts
+++ b/apps/server/src/canvas/canvas.controller.ts
@@ -470,6 +470,13 @@ export class CanvasController {
     return { code: 0, message: 'ok', data }
   }
 
+  @Get('material/:id/diagnostic')
+  @UseGuards(AuthGuard)
+  async materialDiagnostic(@Req() req: { user: { sub: string } }, @Param('id') id: string) {
+    const data = await this.materialService.getMaterialDiagnostic(req.user.sub, id)
+    return { data }
+  }
+
   @Get('shot/status/batch')
   @UseGuards(AuthGuard)
   async statusBatch(@Query('ids') ids: string) {

--- a/apps/server/src/canvas/material.diagnostic.test.ts
+++ b/apps/server/src/canvas/material.diagnostic.test.ts
@@ -1,0 +1,107 @@
+import 'reflect-metadata'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Test } from '@nestjs/testing'
+import { NotFoundException } from '@nestjs/common'
+import { PointsService } from '../points/points.service'
+import { PrismaService } from '../prisma/prisma.service'
+import { ProviderResolverService } from '../provider/provider-resolver.service'
+import { MaterialService } from './material.service'
+
+describe('MaterialService.getMaterialDiagnostic', () => {
+  let svc: MaterialService
+  let materialFindFirst: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    materialFindFirst = vi.fn()
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        MaterialService,
+        {
+          provide: PointsService,
+          useValue: { consume: vi.fn(), refund: vi.fn() },
+        },
+        {
+          provide: PrismaService,
+          useValue: {
+            shot: { findUnique: vi.fn() },
+            material: {
+              create: vi.fn(),
+              update: vi.fn(),
+              updateMany: vi.fn(),
+              findFirst: materialFindFirst,
+            },
+          },
+        },
+        {
+          provide: ProviderResolverService,
+          useValue: { resolveForGeneration: vi.fn() },
+        },
+      ],
+    }).compile()
+
+    svc = moduleRef.get(MaterialService)
+  })
+
+  it('getMaterialDiagnostic returns 404 when not failed', async () => {
+    materialFindFirst.mockResolvedValue({
+      id: 'm1',
+      type: 'image',
+      status: 'completed',
+      prompt: 'a cat',
+      createdAt: new Date('2026-07-21T00:00:00.000Z'),
+      metadata: JSON.stringify({}),
+      shot: { session: { userId: 'u1', id: 'sess-1' } },
+    })
+
+    await expect(svc.getMaterialDiagnostic('u1', 'm1')).rejects.toThrow(/不存在|找不到|诊断/)
+    await expect(svc.getMaterialDiagnostic('u1', 'm1')).rejects.toBeInstanceOf(NotFoundException)
+  })
+
+  it('getMaterialDiagnostic redacts provider snippet', async () => {
+    materialFindFirst.mockResolvedValue({
+      id: 'm1',
+      type: 'image',
+      status: 'failed',
+      prompt: 'a cat',
+      createdAt: new Date('2026-07-21T00:00:00.000Z'),
+      metadata: JSON.stringify({
+        errorCode: 'upstream_error',
+        errorRaw: 'Bearer sk-secret hello',
+        userMessage: '上游服务异常',
+        failedAt: '2026-07-21T01:00:00.000Z',
+        channelId: 'platform',
+        model: 'seedream-5.0-pro',
+      }),
+      shot: { session: { userId: 'u1', id: 'sess-1' } },
+    })
+
+    const d = await svc.getMaterialDiagnostic('u1', 'm1')
+    expect(d.code).toBe('upstream_error')
+    expect(d.taskKind).toBe('material')
+    expect(d.taskId).toBe('m1')
+    expect(d.providerSnippet).not.toContain('sk-secret')
+  })
+
+  it('getMaterialDiagnostic allows status error', async () => {
+    materialFindFirst.mockResolvedValue({
+      id: 'm2',
+      type: 'video',
+      status: 'error',
+      prompt: null,
+      createdAt: new Date('2026-07-21T00:00:00.000Z'),
+      metadata: JSON.stringify({
+        errorCode: 'upstream_timeout',
+        errorRaw: 'timeout of 90000ms exceeded',
+        failedAt: '2026-07-21T02:00:00.000Z',
+      }),
+      shot: { session: { userId: 'u1', id: 'sess-1' } },
+    })
+
+    const d = await svc.getMaterialDiagnostic('u1', 'm2')
+    expect(d.code).toBe('upstream_timeout')
+    expect(d.taskId).toBe('m2')
+    expect(d.taskKind).toBe('material')
+  })
+})

--- a/apps/server/src/canvas/material.service.ts
+++ b/apps/server/src/canvas/material.service.ts
@@ -15,8 +15,12 @@ import {
 } from '@lnkpi/agent'
 import {
   BYOK_FALLBACK_CONFIRM_MESSAGE,
+  mapMessageToErrorCode,
+  redactProviderSnippet,
   resolveImageSize,
   resolveModelKey,
+  type ErrorCode,
+  type GenerationDiagnostic,
   type GenerationRefPayload,
   type ImageResolutionTier,
 } from '@lnkpi/shared'
@@ -112,6 +116,98 @@ function parseMeta(raw: string | null | undefined): Record<string, unknown> {
   } catch {
     return {}
   }
+}
+
+function hintForCode(code: ErrorCode): string | undefined {
+  switch (code) {
+    case 'upstream_timeout':
+      return '请稍后重试'
+    case 'insufficient_points':
+      return '请充值后再试'
+    case 'cancelled':
+      return '可重新发起生成'
+    case 'upload_required':
+      return '请先上传参考图'
+    case 'model_unavailable':
+      return '请更换可用模型'
+    case 'upstream_error':
+      return '请稍后重试或更换模型'
+    case 'fallback_pending':
+      return '可确认使用平台通道或取消'
+    case 'invalid_input':
+      return '请检查输入后重试'
+    default:
+      return undefined
+  }
+}
+
+function userMessageForCode(code: ErrorCode, fallback: string): string {
+  switch (code) {
+    case 'insufficient_points':
+      return '积分不足'
+    case 'upstream_timeout':
+      return '上游超时，请稍后重试'
+    case 'cancelled':
+      return '已取消'
+    case 'upload_required':
+      return '参考图尚未上传'
+    case 'model_unavailable':
+      return '模型不可用'
+    case 'upstream_error':
+      return '上游服务异常'
+    case 'fallback_pending':
+      return '需要确认是否使用平台回退'
+    case 'invalid_input':
+      return '输入无效'
+    default:
+      return fallback.trim() || '生成失败'
+  }
+}
+
+function errMessage(err: unknown): string {
+  if (err instanceof BadRequestException) {
+    const response = err.getResponse()
+    if (typeof response === 'string') return response
+    if (response && typeof response === 'object') {
+      const message = (response as { message?: unknown }).message
+      if (typeof message === 'string') return message
+      if (Array.isArray(message)) return message.map(String).join('; ')
+    }
+  }
+  if (err instanceof Error) return err.message
+  return '生成失败'
+}
+
+function applyFailureDiagnosticMeta(
+  existingMeta: Record<string, unknown>,
+  err: unknown,
+  overrides: { userMessage?: string; errorCode?: ErrorCode } = {},
+): Record<string, unknown> {
+  const errMsg = errMessage(err)
+  const errorCode = overrides.errorCode ?? mapMessageToErrorCode(errMsg)
+  const userMessage = overrides.userMessage ?? userMessageForCode(errorCode, errMsg)
+  return {
+    ...existingMeta,
+    errorCode,
+    errorRaw: errMsg.slice(0, 8000),
+    userMessage,
+    failedAt: new Date().toISOString(),
+  }
+}
+
+function throwMaterialFailure(opts: {
+  userMessage: string
+  errorCode: ErrorCode
+  taskId: string
+  refundedPoints?: number
+}): never {
+  throw new BadRequestException({
+    message: opts.userMessage,
+    errorCode: opts.errorCode,
+    taskKind: 'material',
+    taskId: opts.taskId,
+    ...(opts.refundedPoints != null ? { refundedPoints: opts.refundedPoints } : {}),
+  })
 }
 
 type CancelFlag = { isCancelled(): boolean }
@@ -433,13 +529,16 @@ export class MaterialService {
       throw new BadRequestException('不支持的素材类型')
     } catch (err) {
       if (isCancelledException(err)) {
+        const cancelledMeta = applyFailureDiagnosticMeta(
+          applyRefundMeta(chargedMeta, platformCost, 'cancelled'),
+          err,
+          { errorCode: 'cancelled', userMessage: '已取消' },
+        )
         await this.prisma.material.update({
           where: { id: material.id },
           data: {
             status: 'failed',
-            metadata: JSON.stringify(
-              applyRefundMeta(chargedMeta, platformCost, 'cancelled'),
-            ),
+            metadata: JSON.stringify(cancelledMeta),
           },
         })
         throw err
@@ -449,16 +548,23 @@ export class MaterialService {
         rethrowWithRefundedPoints(err, platformCost)
       }
       await this.points.refund(userId, platformCost, '平台回退失败退款')
+      const failedMeta = applyFailureDiagnosticMeta(
+        applyRefundMeta(chargedMeta, platformCost, 'platform_fallback_failed'),
+        err,
+      )
       await this.prisma.material.update({
         where: { id: material.id },
         data: {
           status: 'failed',
-          metadata: JSON.stringify(
-            applyRefundMeta(chargedMeta, platformCost, 'platform_fallback_failed'),
-          ),
+          metadata: JSON.stringify(failedMeta),
         },
       })
-      rethrowWithRefundedPoints(err, platformCost)
+      throwMaterialFailure({
+        userMessage: String(failedMeta.userMessage ?? '生成失败'),
+        errorCode: failedMeta.errorCode as ErrorCode,
+        taskId: material.id,
+        refundedPoints: platformCost,
+      })
     }
   }
 
@@ -478,9 +584,17 @@ export class MaterialService {
           : this.platformFallbackCost(material.type, meta)
       await this.points.refund(userId, cost, '平台回退取消退款')
     }
+    const cancelledMeta = applyFailureDiagnosticMeta(
+      { ...meta, cancelled: true },
+      new Error('已取消'),
+      { errorCode: 'cancelled', userMessage: '已取消' },
+    )
     return this.prisma.material.update({
       where: { id: material.id },
-      data: { status: 'failed' },
+      data: {
+        status: 'failed',
+        metadata: JSON.stringify(cancelledMeta),
+      },
     })
   }
 
@@ -500,6 +614,10 @@ export class MaterialService {
       await this.points.refund(userId, cost, `${chargeReason}-取消退款`)
       updatedMeta = applyRefundMeta(updatedMeta, cost, 'cancelled')
     }
+    updatedMeta = applyFailureDiagnosticMeta(updatedMeta, new Error('已取消'), {
+      errorCode: 'cancelled',
+      userMessage: '已取消',
+    })
     return this.prisma.material.update({
       where: { id: material.id },
       data: {
@@ -507,6 +625,50 @@ export class MaterialService {
         metadata: JSON.stringify(updatedMeta),
       },
     })
+  }
+
+  async getMaterialDiagnostic(userId: string, id: string): Promise<GenerationDiagnostic> {
+    const material = await this.prisma.material.findFirst({
+      where: { id, shot: { session: { userId } } },
+      include: { shot: { include: { session: true } } },
+    })
+    if (!material) throw new NotFoundException('素材不存在')
+    if (material.status !== 'failed' && material.status !== 'error') {
+      throw new NotFoundException('诊断不可用')
+    }
+    const meta = parseMeta(material.metadata)
+    const errRaw = meta.errorRaw != null ? String(meta.errorRaw) : ''
+    const code =
+      (typeof meta.errorCode === 'string' ? (meta.errorCode as ErrorCode) : undefined) ??
+      mapMessageToErrorCode(errRaw)
+    const defaultMessage = '生成失败'
+    const userMessage =
+      (typeof meta.userMessage === 'string' && meta.userMessage.trim()
+        ? meta.userMessage
+        : undefined) ?? defaultMessage
+    const occurredAt =
+      typeof meta.failedAt === 'string' && meta.failedAt
+        ? meta.failedAt
+        : material.createdAt.toISOString()
+    const sessionId = material.shot?.session?.id
+
+    return {
+      userMessage,
+      code,
+      taskKind: 'material',
+      taskId: material.id,
+      sessionId: typeof sessionId === 'string' ? sessionId : undefined,
+      model:
+        (typeof meta.model === 'string' ? meta.model : undefined) ??
+        (typeof meta.modelKey === 'string' ? meta.modelKey : undefined) ??
+        null,
+      channelId: typeof meta.channelId === 'string' ? meta.channelId : null,
+      apiFormat: typeof meta.apiFormat === 'string' ? meta.apiFormat : null,
+      httpStatus: typeof meta.httpStatus === 'number' ? meta.httpStatus : null,
+      occurredAt,
+      providerSnippet: errRaw ? redactProviderSnippet(errRaw) : null,
+      hint: hintForCode(code),
+    }
   }
 
   private async resolveMergedPrompt(
@@ -661,13 +823,15 @@ export class MaterialService {
       if (!existingFailed || existingFailed.status !== 'generating') return
       const prevFailed = parseMeta(existingFailed.metadata)
       if (isCancelledMeta(prevFailed) || alreadyRefunded(prevFailed)) return
+      const failedMeta = applyFailureDiagnosticMeta(
+        applyRefundMeta(prevFailed, skipCharge ? 0 : cost, 'platform_failed'),
+        err,
+      )
       await this.prisma.material.update({
         where: { id: materialId },
         data: {
           status: 'failed',
-          metadata: JSON.stringify(
-            applyRefundMeta(prevFailed, skipCharge ? 0 : cost, 'platform_failed'),
-          ),
+          metadata: JSON.stringify(failedMeta),
         },
       })
     }
@@ -807,13 +971,15 @@ export class MaterialService {
       if (!existingFailed || existingFailed.status !== 'generating') return
       const prevFailed = parseMeta(existingFailed.metadata)
       if (isCancelledMeta(prevFailed) || alreadyRefunded(prevFailed)) return
+      const failedMeta = applyFailureDiagnosticMeta(
+        applyRefundMeta(prevFailed, skipCharge ? 0 : cost, 'platform_failed'),
+        err,
+      )
       await this.prisma.material.update({
         where: { id: materialId },
         data: {
           status: 'failed',
-          metadata: JSON.stringify(
-            applyRefundMeta(prevFailed, skipCharge ? 0 : cost, 'platform_failed'),
-          ),
+          metadata: JSON.stringify(failedMeta),
         },
       })
     }

--- a/apps/server/src/studio/studio.controller.ts
+++ b/apps/server/src/studio/studio.controller.ts
@@ -246,6 +246,13 @@ export class StudioController {
     return { code: 0, message: 'ok', data }
   }
 
+  @Get('generations/:id/diagnostic')
+  @UseGuards(AuthGuard)
+  async generationDiagnostic(@Req() req: { user: { sub: string } }, @Param('id') id: string) {
+    const data = await this.studioService.getGenerationDiagnostic(req.user.sub, id)
+    return { data }
+  }
+
   @Get('generations/:id')
   @UseGuards(AuthGuard)
   async getGeneration(@Req() req: { user: { sub: string } }, @Param('id') id: string) {

--- a/apps/server/src/studio/studio.diagnostic.test.ts
+++ b/apps/server/src/studio/studio.diagnostic.test.ts
@@ -1,0 +1,102 @@
+import 'reflect-metadata'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Test } from '@nestjs/testing'
+import { NotFoundException } from '@nestjs/common'
+import { PointsService } from '../points/points.service'
+import { PrismaService } from '../prisma/prisma.service'
+import { ProviderResolverService } from '../provider/provider-resolver.service'
+import { StudioService } from './studio.service'
+
+describe('StudioService.getGenerationDiagnostic', () => {
+  let svc: StudioService
+  let generationFindFirst: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    generationFindFirst = vi.fn()
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        StudioService,
+        {
+          provide: PointsService,
+          useValue: { consume: vi.fn(), refund: vi.fn() },
+        },
+        {
+          provide: PrismaService,
+          useValue: {
+            generationRecord: {
+              create: vi.fn(),
+              update: vi.fn(),
+              updateMany: vi.fn(),
+              findFirst: generationFindFirst,
+              findMany: vi.fn(async () => []),
+            },
+          },
+        },
+        {
+          provide: ProviderResolverService,
+          useValue: { resolveForGeneration: vi.fn() },
+        },
+      ],
+    }).compile()
+
+    svc = moduleRef.get(StudioService)
+  })
+
+  it('getGenerationDiagnostic returns 404 when not failed', async () => {
+    generationFindFirst.mockResolvedValue({
+      id: 'g1',
+      userId: 'u1',
+      status: 'completed',
+      model: 'seedream-5.0-pro',
+      createdAt: new Date('2026-07-21T00:00:00.000Z'),
+      metadata: JSON.stringify({}),
+    })
+
+    await expect(svc.getGenerationDiagnostic('u1', 'g1')).rejects.toThrow(/不存在|找不到|诊断/)
+    await expect(svc.getGenerationDiagnostic('u1', 'g1')).rejects.toBeInstanceOf(NotFoundException)
+  })
+
+  it('getGenerationDiagnostic redacts provider snippet', async () => {
+    generationFindFirst.mockResolvedValue({
+      id: 'g1',
+      userId: 'u1',
+      status: 'failed',
+      model: 'seedream-5.0-pro',
+      createdAt: new Date('2026-07-21T00:00:00.000Z'),
+      metadata: JSON.stringify({
+        errorCode: 'upstream_error',
+        errorRaw: 'Bearer sk-secret hello',
+        userMessage: '上游服务异常',
+        failedAt: '2026-07-21T01:00:00.000Z',
+        channelId: 'platform',
+      }),
+    })
+
+    const d = await svc.getGenerationDiagnostic('u1', 'g1')
+    expect(d.code).toBe('upstream_error')
+    expect(d.taskKind).toBe('generation')
+    expect(d.taskId).toBe('g1')
+    expect(d.providerSnippet).not.toContain('sk-secret')
+  })
+
+  it('getGenerationDiagnostic allows status error', async () => {
+    generationFindFirst.mockResolvedValue({
+      id: 'g2',
+      userId: 'u1',
+      status: 'error',
+      model: null,
+      createdAt: new Date('2026-07-21T00:00:00.000Z'),
+      metadata: JSON.stringify({
+        errorCode: 'upstream_timeout',
+        errorRaw: 'timeout of 90000ms exceeded',
+        failedAt: '2026-07-21T02:00:00.000Z',
+      }),
+    })
+
+    const d = await svc.getGenerationDiagnostic('u1', 'g2')
+    expect(d.code).toBe('upstream_timeout')
+    expect(d.taskId).toBe('g2')
+  })
+})

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common'
+import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common'
 import {
   buildAudioRequest,
   buildImageProviderOptions,
@@ -14,8 +14,12 @@ import {
 } from '@lnkpi/agent'
 import {
   BYOK_FALLBACK_CONFIRM_MESSAGE,
+  mapMessageToErrorCode,
+  redactProviderSnippet,
   resolveImageSize,
   resolveModelKey,
+  type ErrorCode,
+  type GenerationDiagnostic,
   type ImageResolutionTier,
   type StudioModality,
 } from '@lnkpi/shared'
@@ -85,6 +89,98 @@ function parseMeta(raw: string | null | undefined): Record<string, unknown> {
   } catch {
     return {}
   }
+}
+
+function hintForCode(code: ErrorCode): string | undefined {
+  switch (code) {
+    case 'upstream_timeout':
+      return '请稍后重试'
+    case 'insufficient_points':
+      return '请充值后再试'
+    case 'cancelled':
+      return '可重新发起生成'
+    case 'upload_required':
+      return '请先上传参考图'
+    case 'model_unavailable':
+      return '请更换可用模型'
+    case 'upstream_error':
+      return '请稍后重试或更换模型'
+    case 'fallback_pending':
+      return '可确认使用平台通道或取消'
+    case 'invalid_input':
+      return '请检查输入后重试'
+    default:
+      return undefined
+  }
+}
+
+function userMessageForCode(code: ErrorCode, fallback: string): string {
+  switch (code) {
+    case 'insufficient_points':
+      return '积分不足'
+    case 'upstream_timeout':
+      return '上游超时，请稍后重试'
+    case 'cancelled':
+      return '已取消'
+    case 'upload_required':
+      return '参考图尚未上传'
+    case 'model_unavailable':
+      return '模型不可用'
+    case 'upstream_error':
+      return '上游服务异常'
+    case 'fallback_pending':
+      return '需要确认是否使用平台回退'
+    case 'invalid_input':
+      return '输入无效'
+    default:
+      return fallback.trim() || '生成失败'
+  }
+}
+
+function errMessage(err: unknown): string {
+  if (err instanceof BadRequestException) {
+    const response = err.getResponse()
+    if (typeof response === 'string') return response
+    if (response && typeof response === 'object') {
+      const message = (response as { message?: unknown }).message
+      if (typeof message === 'string') return message
+      if (Array.isArray(message)) return message.map(String).join('; ')
+    }
+  }
+  if (err instanceof Error) return err.message
+  return '生成失败'
+}
+
+function applyFailureDiagnosticMeta(
+  existingMeta: Record<string, unknown>,
+  err: unknown,
+  overrides: { userMessage?: string; errorCode?: ErrorCode } = {},
+): Record<string, unknown> {
+  const errMsg = errMessage(err)
+  const errorCode = overrides.errorCode ?? mapMessageToErrorCode(errMsg)
+  const userMessage = overrides.userMessage ?? userMessageForCode(errorCode, errMsg)
+  return {
+    ...existingMeta,
+    errorCode,
+    errorRaw: errMsg.slice(0, 8000),
+    userMessage,
+    failedAt: new Date().toISOString(),
+  }
+}
+
+function throwGenerationFailure(opts: {
+  userMessage: string
+  errorCode: ErrorCode
+  taskId: string
+  refundedPoints?: number
+}): never {
+  throw new BadRequestException({
+    message: opts.userMessage,
+    errorCode: opts.errorCode,
+    taskKind: 'generation',
+    taskId: opts.taskId,
+    ...(opts.refundedPoints != null ? { refundedPoints: opts.refundedPoints } : {}),
+  })
 }
 
 type CancelFlag = { isCancelled(): boolean }
@@ -257,7 +353,27 @@ export class StudioService {
       if (isCancelledException(err)) throw err
       if (resolved.source !== 'user') {
         await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
-        rethrowWithRefundedPoints(err, cost)
+        const failedMeta = applyFailureDiagnosticMeta(
+          applyRefundMeta(applyChargeMeta({ ...baseMeta }, cost), cost, 'platform_failed'),
+          err,
+        )
+        const failed = await this.prisma.generationRecord.create({
+          data: {
+            userId,
+            type: 'text',
+            prompt: mergedText,
+            model: storeModel,
+            url: null,
+            status: 'failed',
+            metadata: JSON.stringify(failedMeta),
+          },
+        })
+        throwGenerationFailure({
+          userMessage: String(failedMeta.userMessage ?? '生成失败'),
+          errorCode: failedMeta.errorCode as ErrorCode,
+          taskId: failed.id,
+          refundedPoints: cost,
+        })
       }
       await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
       return this.prisma.generationRecord.create({
@@ -326,7 +442,27 @@ export class StudioService {
       if (isCancelledException(err)) throw err
       if (resolved.source !== 'user') {
         await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
-        rethrowWithRefundedPoints(err, cost)
+        const failedMeta = applyFailureDiagnosticMeta(
+          applyRefundMeta(applyChargeMeta({ ...baseMeta }, cost), cost, 'platform_failed'),
+          err,
+        )
+        const failed = await this.prisma.generationRecord.create({
+          data: {
+            userId,
+            type: 'prompt',
+            prompt: trimmed,
+            model: storeModel,
+            url: null,
+            status: 'failed',
+            metadata: JSON.stringify(failedMeta),
+          },
+        })
+        throwGenerationFailure({
+          userMessage: String(failedMeta.userMessage ?? '生成失败'),
+          errorCode: failedMeta.errorCode as ErrorCode,
+          taskId: failed.id,
+          refundedPoints: cost,
+        })
       }
       await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
       return this.prisma.generationRecord.create({
@@ -356,6 +492,41 @@ export class StudioService {
       throw new BadRequestException('生成记录不存在')
     }
     return record
+  }
+
+  async getGenerationDiagnostic(userId: string, id: string): Promise<GenerationDiagnostic> {
+    const record = await this.getGeneration(userId, id)
+    if (record.status !== 'failed' && record.status !== 'error') {
+      throw new NotFoundException('诊断不可用')
+    }
+    const meta = parseMeta(record.metadata)
+    const errRaw = meta.errorRaw != null ? String(meta.errorRaw) : ''
+    const code =
+      (typeof meta.errorCode === 'string' ? (meta.errorCode as ErrorCode) : undefined) ??
+      mapMessageToErrorCode(errRaw)
+    const defaultMessage = '生成失败'
+    const userMessage =
+      (typeof meta.userMessage === 'string' && meta.userMessage.trim()
+        ? meta.userMessage
+        : undefined) ?? defaultMessage
+    const occurredAt =
+      typeof meta.failedAt === 'string' && meta.failedAt
+        ? meta.failedAt
+        : record.createdAt.toISOString()
+
+    return {
+      userMessage,
+      code,
+      taskKind: 'generation',
+      taskId: record.id,
+      model: record.model ?? (typeof meta.model === 'string' ? meta.model : null) ?? null,
+      channelId: typeof meta.channelId === 'string' ? meta.channelId : null,
+      apiFormat: typeof meta.apiFormat === 'string' ? meta.apiFormat : null,
+      httpStatus: typeof meta.httpStatus === 'number' ? meta.httpStatus : null,
+      occurredAt,
+      providerSnippet: errRaw ? redactProviderSnippet(errRaw) : null,
+      hint: hintForCode(code),
+    }
   }
 
   async generateImage(
@@ -444,7 +615,44 @@ export class StudioService {
       if (isCancelledException(err)) throw err
       if (resolved.source !== 'user') {
         await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
-        rethrowWithRefundedPoints(err, cost)
+        const failedMeta = applyFailureDiagnosticMeta(
+          applyRefundMeta(
+            applyChargeMeta(
+              {
+                ...built.meta,
+                modelId,
+                aspectRatio,
+                resolution,
+                count: n,
+                size: built.size,
+                referenceImages,
+                skippedMerge,
+                channelId: resolved.channelId,
+              },
+              cost,
+            ),
+            cost,
+            'platform_failed',
+          ),
+          err,
+        )
+        const failed = await this.prisma.generationRecord.create({
+          data: {
+            userId,
+            type: 'image',
+            prompt: effectivePrompt,
+            model: storeModel,
+            url: null,
+            status: 'failed',
+            metadata: JSON.stringify(failedMeta),
+          },
+        })
+        throwGenerationFailure({
+          userMessage: String(failedMeta.userMessage ?? '生成失败'),
+          errorCode: failedMeta.errorCode as ErrorCode,
+          taskId: failed.id,
+          refundedPoints: cost,
+        })
       }
       await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
       return this.prisma.generationRecord.create({
@@ -520,7 +728,38 @@ export class StudioService {
       if (isCancelledException(err)) throw err
       if (resolved.source !== 'user') {
         await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
-        rethrowWithRefundedPoints(err, cost)
+        const failedMeta = applyFailureDiagnosticMeta(
+          applyRefundMeta(
+            applyChargeMeta(
+              {
+                variation: true,
+                basePrompt,
+                channelId: resolved.channelId,
+              },
+              cost,
+            ),
+            cost,
+            'platform_failed',
+          ),
+          err,
+        )
+        const failed = await this.prisma.generationRecord.create({
+          data: {
+            userId,
+            type: 'image',
+            prompt: combined,
+            model: model ?? resolved.modelName,
+            url: null,
+            status: 'failed',
+            metadata: JSON.stringify(failedMeta),
+          },
+        })
+        throwGenerationFailure({
+          userMessage: String(failedMeta.userMessage ?? '生成失败'),
+          errorCode: failedMeta.errorCode as ErrorCode,
+          taskId: failed.id,
+          refundedPoints: cost,
+        })
       }
       await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
       return this.prisma.generationRecord.create({
@@ -715,7 +954,44 @@ export class StudioService {
       if (isCancelledException(err)) throw err
       if (resolved.source !== 'user') {
         await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
-        rethrowWithRefundedPoints(err, cost)
+        const failedMeta = applyFailureDiagnosticMeta(
+          applyRefundMeta(
+            applyChargeMeta(
+              {
+                ...built.meta,
+                skippedMerge,
+                voice: built.options.voice ?? options.voice ?? 'default',
+                emotion: options.emotion ?? 'neutral',
+                language: options.language ?? 'zh',
+                speed: options.speed ?? 1,
+                volume: options.volume,
+                pitch: options.pitch,
+                channelId: resolved.channelId,
+              },
+              cost,
+            ),
+            cost,
+            'platform_failed',
+          ),
+          err,
+        )
+        const failed = await this.prisma.generationRecord.create({
+          data: {
+            userId,
+            type: 'audio',
+            prompt: mergedText,
+            model: storeModel,
+            url: null,
+            status: 'failed',
+            metadata: JSON.stringify(failedMeta),
+          },
+        })
+        throwGenerationFailure({
+          userMessage: String(failedMeta.userMessage ?? '生成失败'),
+          errorCode: failedMeta.errorCode as ErrorCode,
+          taskId: failed.id,
+          refundedPoints: cost,
+        })
       }
       await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
       const record = await this.prisma.generationRecord.create({
@@ -904,13 +1180,16 @@ export class StudioService {
       throw new BadRequestException('不支持的生成类型')
     } catch (err) {
       if (isCancelledException(err)) {
+        const cancelledMeta = applyFailureDiagnosticMeta(
+          applyRefundMeta(chargedMeta, platformCost, 'cancelled'),
+          err,
+          { errorCode: 'cancelled', userMessage: '已取消' },
+        )
         await this.prisma.generationRecord.update({
           where: { id: record.id },
           data: {
             status: 'failed',
-            metadata: JSON.stringify(
-              applyRefundMeta(chargedMeta, platformCost, 'cancelled'),
-            ),
+            metadata: JSON.stringify(cancelledMeta),
           },
         })
         throw err
@@ -920,16 +1199,23 @@ export class StudioService {
         rethrowWithRefundedPoints(err, platformCost)
       }
       await this.points.refund(userId, platformCost, '平台回退失败退款')
+      const failedMeta = applyFailureDiagnosticMeta(
+        applyRefundMeta(chargedMeta, platformCost, 'platform_fallback_failed'),
+        err,
+      )
       await this.prisma.generationRecord.update({
         where: { id: record.id },
         data: {
           status: 'failed',
-          metadata: JSON.stringify(
-            applyRefundMeta(chargedMeta, platformCost, 'platform_fallback_failed'),
-          ),
+          metadata: JSON.stringify(failedMeta),
         },
       })
-      rethrowWithRefundedPoints(err, platformCost)
+      throwGenerationFailure({
+        userMessage: String(failedMeta.userMessage ?? '生成失败'),
+        errorCode: failedMeta.errorCode as ErrorCode,
+        taskId: record.id,
+        refundedPoints: platformCost,
+      })
     }
   }
 
@@ -946,9 +1232,17 @@ export class StudioService {
           : this.platformFallbackCost(record.type, meta)
       await this.points.refund(userId, cost, '平台回退取消退款')
     }
+    const cancelledMeta = applyFailureDiagnosticMeta(
+      { ...meta, cancelled: true },
+      new Error('已取消'),
+      { errorCode: 'cancelled', userMessage: '已取消' },
+    )
     return this.prisma.generationRecord.update({
       where: { id: record.id },
-      data: { status: 'failed' },
+      data: {
+        status: 'failed',
+        metadata: JSON.stringify(cancelledMeta),
+      },
     })
   }
 
@@ -966,6 +1260,10 @@ export class StudioService {
       await this.points.refund(userId, cost, `${chargeReason}-取消退款`)
       updatedMeta = applyRefundMeta(updatedMeta, cost, 'cancelled')
     }
+    updatedMeta = applyFailureDiagnosticMeta(updatedMeta, new Error('已取消'), {
+      errorCode: 'cancelled',
+      userMessage: '已取消',
+    })
     return this.prisma.generationRecord.update({
       where: { id: record.id },
       data: {
@@ -1026,11 +1324,15 @@ export class StudioService {
         return
       }
       await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
+      const failedMeta = applyFailureDiagnosticMeta(
+        applyRefundMeta(meta, cost, 'platform_failed'),
+        err,
+      )
       await this.prisma.generationRecord.update({
         where: { id },
         data: {
           status: 'failed',
-          metadata: JSON.stringify(applyRefundMeta(meta, cost, 'platform_failed')),
+          metadata: JSON.stringify(failedMeta),
         },
       })
     }

--- a/apps/web/src/components/canvas/CanvasNodeAudio.vue
+++ b/apps/web/src/components/canvas/CanvasNodeAudio.vue
@@ -2,15 +2,41 @@
 import NeoBaseNode from '@/components/canvas/NeoBaseNode.vue'
 import NodeTaskCornerActions from '@/components/canvas/NodeTaskCornerActions.vue'
 import { computed } from 'vue'
+import { useRoute } from 'vue-router'
 import { resolveMediaUrl } from '@/services/api-base'
 import { useNodeMediaUpload } from '@/composables/useNodeMediaUpload'
 
 const props = defineProps<{
   id: string
   selected?: boolean
-  data: { url?: string; status: string; prompt?: string; label?: string; errorMessage?: string; generationStartedAt?: string }
+  data: {
+    url?: string
+    status: string
+    prompt?: string
+    label?: string
+    errorMessage?: string
+    errorCode?: string
+    generationStartedAt?: string
+    generationRecordId?: string
+    materialId?: string
+  }
 }>()
 
+const route = useRoute()
+const sessionId = computed(() => route.params.sessionId as string | undefined)
+const taskId = computed(
+  () =>
+    (typeof props.data.generationRecordId === 'string' && props.data.generationRecordId) ||
+    (typeof props.data.materialId === 'string' && props.data.materialId) ||
+    undefined,
+)
+const taskKind = computed(() =>
+  typeof props.data.generationRecordId === 'string' && props.data.generationRecordId
+    ? ('generation' as const)
+    : typeof props.data.materialId === 'string' && props.data.materialId
+      ? ('material' as const)
+      : undefined,
+)
 const displayUrl = computed(() => resolveMediaUrl(String(props.data.url ?? '')))
 const {
   accept,
@@ -96,6 +122,11 @@ const {
         :status="data.status"
         :started-at="typeof data.generationStartedAt === 'string' ? data.generationStartedAt : undefined"
         :error-message="data.errorMessage as string | undefined"
+        :error-code="data.errorCode as string | undefined"
+        :task-kind="taskKind"
+        :task-id="taskId"
+        :node-label="typeof data.label === 'string' ? data.label : undefined"
+        :session-id="sessionId"
       />
     </div>
   </NeoBaseNode>

--- a/apps/web/src/components/canvas/CanvasNodeImage.vue
+++ b/apps/web/src/components/canvas/CanvasNodeImage.vue
@@ -4,15 +4,41 @@ import NodeTaskCornerActions from '@/components/canvas/NodeTaskCornerActions.vue
 import { useCanvasEditorStore } from '@/stores/canvasEditor'
 import { resolveMediaUrl } from '@/services/api-base'
 import { computed } from 'vue'
+import { useRoute } from 'vue-router'
 import { useNodeMediaUpload } from '@/composables/useNodeMediaUpload'
 
 const props = defineProps<{
   id: string
   selected?: boolean
-  data: { url?: string; status: string; prompt?: string; label?: string; errorMessage?: string; generationStartedAt?: string }
+  data: {
+    url?: string
+    status: string
+    prompt?: string
+    label?: string
+    errorMessage?: string
+    errorCode?: string
+    generationStartedAt?: string
+    generationRecordId?: string
+    materialId?: string
+  }
 }>()
 
 const editor = useCanvasEditorStore()
+const route = useRoute()
+const sessionId = computed(() => route.params.sessionId as string | undefined)
+const taskId = computed(
+  () =>
+    (typeof props.data.generationRecordId === 'string' && props.data.generationRecordId) ||
+    (typeof props.data.materialId === 'string' && props.data.materialId) ||
+    undefined,
+)
+const taskKind = computed(() =>
+  typeof props.data.generationRecordId === 'string' && props.data.generationRecordId
+    ? ('generation' as const)
+    : typeof props.data.materialId === 'string' && props.data.materialId
+      ? ('material' as const)
+      : undefined,
+)
 const displayUrl = computed(() => resolveMediaUrl(String(props.data.url ?? '')))
 const {
   accept,
@@ -113,6 +139,11 @@ function openEdit() {
         :status="data.status"
         :started-at="typeof data.generationStartedAt === 'string' ? data.generationStartedAt : undefined"
         :error-message="data.errorMessage as string | undefined"
+        :error-code="data.errorCode as string | undefined"
+        :task-kind="taskKind"
+        :task-id="taskId"
+        :node-label="typeof data.label === 'string' ? data.label : undefined"
+        :session-id="sessionId"
       />
     </div>
   </NeoBaseNode>

--- a/apps/web/src/components/canvas/CanvasNodeShot.vue
+++ b/apps/web/src/components/canvas/CanvasNodeShot.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
 import NeoBaseNode from '@/components/canvas/NeoBaseNode.vue'
 import NodeTaskCornerActions from '@/components/canvas/NodeTaskCornerActions.vue'
 
-defineProps<{
+const props = defineProps<{
   selected?: boolean
   data: {
     title?: string
@@ -11,9 +13,28 @@ defineProps<{
     coverUrl?: string
     label?: string
     errorMessage?: string
+    errorCode?: string
     generationStartedAt?: string
+    generationRecordId?: string
+    materialId?: string
   }
 }>()
+
+const route = useRoute()
+const sessionId = computed(() => route.params.sessionId as string | undefined)
+const taskId = computed(
+  () =>
+    (typeof props.data.generationRecordId === 'string' && props.data.generationRecordId) ||
+    (typeof props.data.materialId === 'string' && props.data.materialId) ||
+    undefined,
+)
+const taskKind = computed(() =>
+  typeof props.data.generationRecordId === 'string' && props.data.generationRecordId
+    ? ('generation' as const)
+    : typeof props.data.materialId === 'string' && props.data.materialId
+      ? ('material' as const)
+      : undefined,
+)
 </script>
 
 <template>
@@ -40,6 +61,11 @@ defineProps<{
         :status="data.status"
         :started-at="typeof data.generationStartedAt === 'string' ? data.generationStartedAt : undefined"
         :error-message="data.errorMessage as string | undefined"
+        :error-code="data.errorCode as string | undefined"
+        :task-kind="taskKind"
+        :task-id="taskId"
+        :node-label="typeof data.label === 'string' ? data.label : undefined"
+        :session-id="sessionId"
       />
     </div>
   </NeoBaseNode>

--- a/apps/web/src/components/canvas/CanvasNodeText.vue
+++ b/apps/web/src/components/canvas/CanvasNodeText.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
+import { useRoute } from 'vue-router'
 import { useNodeId, useVueFlow } from '@vue-flow/core'
 import NeoBaseNode from '@/components/canvas/NeoBaseNode.vue'
 import NodeTaskCornerActions from '@/components/canvas/NodeTaskCornerActions.vue'
@@ -7,11 +8,35 @@ import PromptMarkdownEditor from '@/components/canvas/PromptMarkdownEditor.vue'
 
 const props = defineProps<{
   selected?: boolean
-  data: { content: string; label?: string; status?: string; errorMessage?: string; generationStartedAt?: string }
+  data: {
+    content: string
+    label?: string
+    status?: string
+    errorMessage?: string
+    errorCode?: string
+    generationStartedAt?: string
+    generationRecordId?: string
+    materialId?: string
+  }
 }>()
 
 const nodeId = useNodeId()
 const { updateNodeData } = useVueFlow()
+const route = useRoute()
+const sessionId = computed(() => route.params.sessionId as string | undefined)
+const taskId = computed(
+  () =>
+    (typeof props.data.generationRecordId === 'string' && props.data.generationRecordId) ||
+    (typeof props.data.materialId === 'string' && props.data.materialId) ||
+    undefined,
+)
+const taskKind = computed(() =>
+  typeof props.data.generationRecordId === 'string' && props.data.generationRecordId
+    ? ('generation' as const)
+    : typeof props.data.materialId === 'string' && props.data.materialId
+      ? ('material' as const)
+      : undefined,
+)
 
 const editorOpen = ref(false)
 const draft = ref('')
@@ -34,6 +59,11 @@ function onSave(md: string) {
         :status="data.status"
         :started-at="typeof data.generationStartedAt === 'string' ? data.generationStartedAt : undefined"
         :error-message="data.errorMessage as string | undefined"
+        :error-code="data.errorCode as string | undefined"
+        :task-kind="taskKind"
+        :task-id="taskId"
+        :node-label="typeof data.label === 'string' ? data.label : undefined"
+        :session-id="sessionId"
       />
     </div>
     <PromptMarkdownEditor

--- a/apps/web/src/components/canvas/CanvasNodeVideo.vue
+++ b/apps/web/src/components/canvas/CanvasNodeVideo.vue
@@ -2,15 +2,41 @@
 import NeoBaseNode from '@/components/canvas/NeoBaseNode.vue'
 import NodeTaskCornerActions from '@/components/canvas/NodeTaskCornerActions.vue'
 import { computed } from 'vue'
+import { useRoute } from 'vue-router'
 import { resolveMediaUrl } from '@/services/api-base'
 import { useNodeMediaUpload } from '@/composables/useNodeMediaUpload'
 
 const props = defineProps<{
   id: string
   selected?: boolean
-  data: { url?: string; status: string; duration?: number; label?: string; errorMessage?: string; generationStartedAt?: string }
+  data: {
+    url?: string
+    status: string
+    duration?: number
+    label?: string
+    errorMessage?: string
+    errorCode?: string
+    generationStartedAt?: string
+    generationRecordId?: string
+    materialId?: string
+  }
 }>()
 
+const route = useRoute()
+const sessionId = computed(() => route.params.sessionId as string | undefined)
+const taskId = computed(
+  () =>
+    (typeof props.data.generationRecordId === 'string' && props.data.generationRecordId) ||
+    (typeof props.data.materialId === 'string' && props.data.materialId) ||
+    undefined,
+)
+const taskKind = computed(() =>
+  typeof props.data.generationRecordId === 'string' && props.data.generationRecordId
+    ? ('generation' as const)
+    : typeof props.data.materialId === 'string' && props.data.materialId
+      ? ('material' as const)
+      : undefined,
+)
 const displayUrl = computed(() => resolveMediaUrl(String(props.data.url ?? '')))
 const {
   accept,
@@ -96,6 +122,11 @@ const {
         :status="data.status"
         :started-at="typeof data.generationStartedAt === 'string' ? data.generationStartedAt : undefined"
         :error-message="data.errorMessage as string | undefined"
+        :error-code="data.errorCode as string | undefined"
+        :task-kind="taskKind"
+        :task-id="taskId"
+        :node-label="typeof data.label === 'string' ? data.label : undefined"
+        :session-id="sessionId"
       />
     </div>
   </NeoBaseNode>

--- a/apps/web/src/components/canvas/NodeDiagnosticPopover.vue
+++ b/apps/web/src/components/canvas/NodeDiagnosticPopover.vue
@@ -18,7 +18,10 @@ const root = ref<HTMLElement | null>(null)
 function onDocPointerDown(e: PointerEvent) {
   const el = root.value
   if (!el) return
-  if (e.target instanceof Node && el.contains(e.target)) return
+  const target = e.target
+  if (!(target instanceof Node)) return
+  if (el.contains(target)) return
+  if (target instanceof Element && target.closest('.neo-task-diag-btn')) return
   emit('close')
 }
 

--- a/apps/web/src/components/canvas/NodeDiagnosticPopover.vue
+++ b/apps/web/src/components/canvas/NodeDiagnosticPopover.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from 'vue'
+
+defineProps<{
+  userMessage: string
+  hint?: string
+  loading?: boolean
+  copyLabel?: string
+}>()
+
+const emit = defineEmits<{
+  copy: []
+  close: []
+}>()
+
+const root = ref<HTMLElement | null>(null)
+
+function onDocPointerDown(e: PointerEvent) {
+  const el = root.value
+  if (!el) return
+  if (e.target instanceof Node && el.contains(e.target)) return
+  emit('close')
+}
+
+onMounted(() => {
+  document.addEventListener('pointerdown', onDocPointerDown, true)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('pointerdown', onDocPointerDown, true)
+})
+</script>
+
+<template>
+  <div
+    ref="root"
+    class="neo-task-diag-pop nodrag nopan"
+    role="dialog"
+    aria-label="诊断信息"
+    @pointerdown.stop
+    @mousedown.stop
+    @click.stop
+  >
+    <p class="neo-task-diag-msg">{{ loading ? '加载中…' : userMessage }}</p>
+    <p v-if="!loading && hint" class="neo-task-diag-hint">{{ hint }}</p>
+    <button
+      type="button"
+      class="neo-task-diag-copy"
+      :disabled="loading"
+      @click.stop="emit('copy')"
+    >
+      {{ copyLabel || '复制诊断' }}
+    </button>
+  </div>
+</template>

--- a/apps/web/src/components/canvas/NodeTaskCornerActions.vue
+++ b/apps/web/src/components/canvas/NodeTaskCornerActions.vue
@@ -1,14 +1,29 @@
 <script setup lang="ts">
 import { computed, inject, onUnmounted, ref, watch } from 'vue'
 import { useNodeId } from '@vue-flow/core'
+import type { ErrorCode, GenerationDiagnostic, TaskKind } from '@lnkpi/shared'
+import NodeDiagnosticPopover from '@/components/canvas/NodeDiagnosticPopover.vue'
 import { resolveTaskChrome, truncateError } from '@/components/canvas/nodeTaskChrome'
 import { CANVAS_NODE_CANCEL_KEY, CANVAS_NODE_RETRY_KEY } from '@/composables/canvasNodeActions'
 import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
+import { canvasApi } from '@/services/canvas-api'
+import { studioApi } from '@/services/studio-api'
+import {
+  buildCopyForNode,
+  createDiagnosticCache,
+} from '@/utils/generationDiagnostic'
+
+const diagnosticCache = createDiagnosticCache()
 
 const props = defineProps<{
   status?: unknown
   startedAt?: string
   errorMessage?: string
+  errorCode?: string
+  taskKind?: TaskKind
+  taskId?: string
+  nodeLabel?: string
+  sessionId?: string
 }>()
 
 const nodeId = useNodeId()
@@ -19,6 +34,11 @@ const nowMs = ref(Date.now())
 const completedFlash = ref(false)
 let tick: ReturnType<typeof setInterval> | undefined
 let flashTimer: ReturnType<typeof setTimeout> | undefined
+
+const diagOpen = ref(false)
+const diagLoading = ref(false)
+const diag = ref<GenerationDiagnostic | null>(null)
+const copyLabel = ref('复制诊断')
 
 watch(
   () => props.status,
@@ -62,16 +82,35 @@ const chrome = computed(() =>
 )
 
 const err = computed(() => truncateError(props.errorMessage))
+const isFallbackPending = computed(
+  () => props.status === NODE_GENERATION_STATUS.fallback_pending,
+)
 const showError = computed(
   () =>
-    Boolean(err.value) &&
-    (props.status === NODE_GENERATION_STATUS.error ||
-      props.status === NODE_GENERATION_STATUS.failed),
+    (Boolean(err.value) &&
+      (props.status === NODE_GENERATION_STATUS.error ||
+        props.status === NODE_GENERATION_STATUS.failed ||
+        isFallbackPending.value)) ||
+    isFallbackPending.value,
 )
+const displayErr = computed(() => {
+  if (err.value) return err.value
+  if (isFallbackPending.value) return '平台回退待确认'
+  return ''
+})
 
 const isClickable = computed(
   () => chrome.value?.action === 'cancel' || chrome.value?.action === 'retry',
 )
+
+const popoverMessage = computed(
+  () => diag.value?.userMessage || props.errorMessage || displayErr.value || '生成失败',
+)
+const popoverHint = computed(() => {
+  if (diag.value?.hint) return diag.value.hint
+  if (isFallbackPending.value) return '请确认是否使用平台回退继续，或取消本次生成。'
+  return undefined
+})
 
 function onAction(e: Event) {
   e.stopPropagation()
@@ -79,6 +118,75 @@ function onAction(e: Event) {
   if (!nodeId || !chrome.value?.action) return
   if (chrome.value.action === 'cancel') cancel?.(nodeId)
   if (chrome.value.action === 'retry') void retry?.(nodeId)
+}
+
+function buildFallbackDiagnostic(): GenerationDiagnostic {
+  const code = (props.errorCode as ErrorCode | undefined) || 'unknown'
+  const taskKind: TaskKind = props.taskKind || 'generation'
+  return {
+    userMessage: props.errorMessage || displayErr.value || '生成失败',
+    code: isFallbackPending.value ? 'fallback_pending' : code,
+    taskKind,
+    taskId: props.taskId || 'unknown',
+    occurredAt: new Date().toISOString(),
+    providerSnippet: null,
+    hint: isFallbackPending.value
+      ? '请确认是否使用平台回退继续，或取消本次生成。'
+      : undefined,
+  }
+}
+
+async function fetchDiagnostic(): Promise<GenerationDiagnostic> {
+  const taskId = props.taskId
+  const taskKind = props.taskKind
+  if (!taskId || !taskKind) return buildFallbackDiagnostic()
+
+  return diagnosticCache.get(taskKind, taskId, () =>
+    taskKind === 'material'
+      ? canvasApi.getMaterialDiagnostic(taskId)
+      : studioApi.getGenerationDiagnostic(taskId),
+  )
+}
+
+async function openDiag(e: Event) {
+  e.stopPropagation()
+  e.preventDefault()
+  if (diagOpen.value) {
+    diagOpen.value = false
+    return
+  }
+  diagOpen.value = true
+  diagLoading.value = true
+  copyLabel.value = '复制诊断'
+  try {
+    diag.value = await fetchDiagnostic()
+  } catch {
+    diag.value = buildFallbackDiagnostic()
+  } finally {
+    diagLoading.value = false
+  }
+}
+
+async function copyDiag() {
+  const payload = diag.value || buildFallbackDiagnostic()
+  const text = buildCopyForNode(payload, {
+    nodeId: nodeId || undefined,
+    nodeLabel: props.nodeLabel,
+    sessionId: props.sessionId,
+  })
+  try {
+    await navigator.clipboard.writeText(text)
+    copyLabel.value = '已复制'
+    setTimeout(() => {
+      copyLabel.value = '复制诊断'
+    }, 1500)
+  } catch {
+    copyLabel.value = '复制失败'
+  }
+}
+
+function closeDiag() {
+  diagOpen.value = false
 }
 </script>
 
@@ -90,7 +198,29 @@ function onAction(e: Event) {
     @mousedown.stop
     @click.stop
   >
-    <p v-if="showError" class="neo-task-error">{{ err }}</p>
+    <div v-if="showError" class="neo-task-error-wrap">
+      <p class="neo-task-error-row">
+        <span class="neo-task-error">{{ displayErr }}</span>
+        <button
+          type="button"
+          class="neo-task-diag-btn"
+          aria-label="诊断信息"
+          title="诊断信息"
+          @click="openDiag"
+        >
+          ⓘ
+        </button>
+      </p>
+      <NodeDiagnosticPopover
+        v-if="diagOpen"
+        :user-message="popoverMessage"
+        :hint="popoverHint"
+        :loading="diagLoading"
+        :copy-label="copyLabel"
+        @copy="copyDiag"
+        @close="closeDiag"
+      />
+    </div>
     <div class="neo-task-chrome-row">
       <span v-if="chrome.elapsedText" class="neo-task-elapsed">{{ chrome.elapsedText }}</span>
       <button

--- a/apps/web/src/components/canvas/NodeTaskCornerActions.vue
+++ b/apps/web/src/components/canvas/NodeTaskCornerActions.vue
@@ -10,10 +10,8 @@ import { canvasApi } from '@/services/canvas-api'
 import { studioApi } from '@/services/studio-api'
 import {
   buildCopyForNode,
-  createDiagnosticCache,
+  sharedDiagnosticCache,
 } from '@/utils/generationDiagnostic'
-
-const diagnosticCache = createDiagnosticCache()
 
 const props = defineProps<{
   status?: unknown
@@ -141,7 +139,7 @@ async function fetchDiagnostic(): Promise<GenerationDiagnostic> {
   const taskKind = props.taskKind
   if (!taskId || !taskKind) return buildFallbackDiagnostic()
 
-  return diagnosticCache.get(taskKind, taskId, () =>
+  return sharedDiagnosticCache.get(taskKind, taskId, () =>
     taskKind === 'material'
       ? canvasApi.getMaterialDiagnostic(taskId)
       : studioApi.getGenerationDiagnostic(taskId),

--- a/apps/web/src/components/canvas/dock-studio/panels/AudioDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/AudioDockPanel.vue
@@ -7,6 +7,7 @@ import UniversalModelSelector from '@/components/canvas/UniversalModelSelector.v
 import VoiceModelSelector from '@/components/canvas/VoiceModelSelector.vue'
 import AudioVoiceSettingsSelector from '@/components/canvas/AudioVoiceSettingsSelector.vue'
 import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
+import { dockFailureBindFromNode } from '@/components/canvas/dock-studio/shared/dockFailureChip'
 import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
@@ -64,6 +65,7 @@ const modelVoices = computed(() => getModelEntry(catalogModelKeyFromValue(audioM
 
 const speech = useSpeechRecognition()
 const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
+const failureBind = computed(() => dockFailureBindFromNode(props.node))
 const credits = computed(() => estimateAudioCredits())
 
 function syncVoiceToCatalog(emitPatch: boolean) {
@@ -156,7 +158,7 @@ function onRefRemove(ref: NodeRef) {
 </script>
 
 <template>
-  <DockToolbarShell type="audio" @close="emit('close')">
+  <DockToolbarShell type="audio" v-bind="failureBind" @close="emit('close')">
     <DockRefStrip
       :refs="refs ?? []"
       @reorder="onRefReorder"

--- a/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
@@ -10,6 +10,7 @@ import ImageParamsSelector, {
   type ImageResolution,
 } from '@/components/canvas/ImageParamsSelector.vue'
 import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
+import { dockFailureBindFromNode } from '@/components/canvas/dock-studio/shared/dockFailureChip'
 import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
@@ -53,6 +54,7 @@ const refUploadError = ref('')
 
 const speech = useSpeechRecognition()
 const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
+const failureBind = computed(() => dockFailureBindFromNode(props.node))
 const credits = computed(() => estimateImageCredits(imageCount.value))
 
 const effectiveRefUrl = computed(() => {
@@ -217,7 +219,7 @@ function clearReferenceImage() {
 </script>
 
 <template>
-  <DockToolbarShell type="image" @close="emit('close')">
+  <DockToolbarShell type="image" v-bind="failureBind" @close="emit('close')">
     <DockRefStrip
       :refs="stripRefs"
       @reorder="onRefReorder"

--- a/apps/web/src/components/canvas/dock-studio/panels/MediaInputDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/MediaInputDockPanel.vue
@@ -4,6 +4,7 @@ import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
 import type { MentionOption } from '@/components/canvas/MentionInput.vue'
 import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
+import { dockFailureBindFromNode } from '@/components/canvas/dock-studio/shared/dockFailureChip'
 import { inferMediaInputKind, type MediaInputKind } from '@/composables/useMediaUpload'
 import { isNodeGenerating } from '@/constants/dockStudio'
 
@@ -32,6 +33,7 @@ const fileInput = ref<HTMLInputElement | null>(null)
 const locked = computed(
   () => !!props.readonly || isNodeGenerating(props.node.data?.status) || props.node.data?.status === 'uploading',
 )
+const failureBind = computed(() => dockFailureBindFromNode(props.node))
 
 const canConvertVideo = computed(() => mediaKind.value === 'image' || mediaKind.value === 'video')
 const canConvertImage = computed(() => mediaKind.value === 'image')
@@ -69,6 +71,7 @@ function onFileChange(event: Event) {
 <template>
   <DockToolbarShell
     type="mediaInput"
+    v-bind="failureBind"
     show-title
     :title="title"
     title-placeholder="素材名称"

--- a/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
@@ -5,6 +5,7 @@ import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
 import type { MentionOption } from '@/components/canvas/MentionInput.vue'
 import UniversalModelSelector from '@/components/canvas/UniversalModelSelector.vue'
 import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
+import { dockFailureBindFromNode } from '@/components/canvas/dock-studio/shared/dockFailureChip'
 import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
@@ -48,6 +49,7 @@ const textModel = ref(getConfig('text').model)
 
 const speech = useSpeechRecognition()
 const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
+const failureBind = computed(() => dockFailureBindFromNode(props.node))
 const promptMode = computed(() => {
   const mode = props.node.data?.promptMode
   return mode ? String(mode) : ''
@@ -131,7 +133,7 @@ function onRefRemove(ref: NodeRef) {
 </script>
 
 <template>
-  <DockToolbarShell type="prompt" @close="emit('close')">
+  <DockToolbarShell type="prompt" v-bind="failureBind" @close="emit('close')">
     <DockRefStrip
       :refs="textRefs"
       @reorder="onRefReorder"

--- a/apps/web/src/components/canvas/dock-studio/panels/SceneComposerDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/SceneComposerDockPanel.vue
@@ -4,6 +4,7 @@ import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
 import type { MentionOption } from '@/components/canvas/MentionInput.vue'
 import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
+import { dockFailureBindFromNode } from '@/components/canvas/dock-studio/shared/dockFailureChip'
 import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockOptimizePrompt from '@/components/canvas/dock-studio/shared/DockOptimizePrompt.vue'
 import { isNodeGenerating } from '@/constants/dockStudio'
@@ -40,6 +41,7 @@ const activeSceneId = ref(payload.value.scenes[0]?.id ?? '')
 const locked = computed(
   () => !!props.readonly || isNodeGenerating(props.node.data?.status) || !!props.generating,
 )
+const failureBind = computed(() => dockFailureBindFromNode(props.node))
 
 const activeScene = computed(() =>
   payload.value.scenes.find((scene) => scene.id === activeSceneId.value) ?? payload.value.scenes[0],
@@ -150,6 +152,7 @@ const canBatchGenerate = computed(() =>
     :title="payload.title ?? '场景编排'"
     title-placeholder="编排标题"
     :readonly="locked"
+    v-bind="failureBind"
     @update:title="onTitleInput"
     @close="emit('close')"
   >

--- a/apps/web/src/components/canvas/dock-studio/panels/ShotDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ShotDockPanel.vue
@@ -5,6 +5,7 @@ import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
 import type { MentionOption } from '@/components/canvas/MentionInput.vue'
 import VideoSettingsSelector from '@/components/canvas/VideoSettingsSelector.vue'
 import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
+import { dockFailureBindFromNode } from '@/components/canvas/dock-studio/shared/dockFailureChip'
 import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
@@ -37,6 +38,7 @@ const videoSettings = ref<VideoSettings>({ ...DEFAULT_VIDEO_SETTINGS })
 
 const speech = useSpeechRecognition()
 const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
+const failureBind = computed(() => dockFailureBindFromNode(props.node))
 
 const modeLabel = computed(
   () => SHOT_GENERATE_MODE_OPTIONS.find((m) => m.value === shotGenerateMode.value)?.label ?? '自动',
@@ -104,6 +106,7 @@ function toggleVoice() {
     show-title
     :title="title"
     title-placeholder="分镜标题"
+    v-bind="failureBind"
     @update:title="onTitleInput"
     @close="emit('close')"
   >

--- a/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
@@ -5,6 +5,7 @@ import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
 import type { MentionOption } from '@/components/canvas/MentionInput.vue'
 import UniversalModelSelector from '@/components/canvas/UniversalModelSelector.vue'
 import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
+import { dockFailureBindFromNode } from '@/components/canvas/dock-studio/shared/dockFailureChip'
 import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
@@ -45,6 +46,7 @@ const legacySeededForId = ref<string | null>(null)
 
 const speech = useSpeechRecognition()
 const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
+const failureBind = computed(() => dockFailureBindFromNode(props.node))
 const wordCount = computed(() => prompt.value.replace(/\s/g, '').length)
 const credits = computed(() => estimateTextCredits())
 const showThinkingControls = computed(() => isDeepSeekV4Model(textModel.value))
@@ -143,7 +145,7 @@ function onRefRemove(ref: NodeRef) {
 </script>
 
 <template>
-  <DockToolbarShell type="text" @close="emit('close')">
+  <DockToolbarShell type="text" v-bind="failureBind" @close="emit('close')">
     <DockRefStrip
       :refs="refs ?? []"
       @reorder="onRefReorder"

--- a/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
@@ -10,6 +10,7 @@ import type { MentionOption } from '@/components/canvas/MentionInput.vue'
 import UniversalModelSelector from '@/components/canvas/UniversalModelSelector.vue'
 import VideoSettingsSelector from '@/components/canvas/VideoSettingsSelector.vue'
 import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
+import { dockFailureBindFromNode } from '@/components/canvas/dock-studio/shared/dockFailureChip'
 import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
@@ -53,6 +54,7 @@ const refUploadError = ref('')
 
 const speech = useSpeechRecognition()
 const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
+const failureBind = computed(() => dockFailureBindFromNode(props.node))
 const credits = computed(() => estimateVideoCredits(videoSettings.value.duration))
 
 const effectiveRefUrl = computed(() => {
@@ -196,7 +198,7 @@ function onRefRemove(ref: NodeRef) {
 </script>
 
 <template>
-  <DockToolbarShell type="video" @close="emit('close')">
+  <DockToolbarShell type="video" v-bind="failureBind" @close="emit('close')">
     <DockRefStrip
       :refs="refs ?? []"
       @reorder="onRefReorder"

--- a/apps/web/src/components/canvas/dock-studio/shared/DockFailureChip.vue
+++ b/apps/web/src/components/canvas/dock-studio/shared/DockFailureChip.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import type { ErrorCode, GenerationDiagnostic, TaskKind } from '@lnkpi/shared'
+import { resolveDockFailureChip } from '@/components/canvas/dock-studio/shared/dockFailureChip'
+import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
+import { canvasApi } from '@/services/canvas-api'
+import { studioApi } from '@/services/studio-api'
+import {
+  buildCopyForNode,
+  sharedDiagnosticCache,
+} from '@/utils/generationDiagnostic'
+
+const props = defineProps<{
+  nodeId: string
+  status?: unknown
+  errorMessage?: string
+  errorCode?: string
+  taskKind?: TaskKind
+  taskId?: string
+  nodeLabel?: string
+}>()
+
+const route = useRoute()
+const sessionId = computed(() => route.params.sessionId as string | undefined)
+const copyLabel = ref('复制')
+
+const view = computed(() =>
+  resolveDockFailureChip({
+    status: props.status,
+    errorMessage: props.errorMessage,
+  }),
+)
+
+const isFallbackPending = computed(
+  () => props.status === NODE_GENERATION_STATUS.fallback_pending,
+)
+
+function buildFallbackDiagnostic(): GenerationDiagnostic {
+  const code = (props.errorCode as ErrorCode | undefined) || 'unknown'
+  const taskKind: TaskKind = props.taskKind || 'generation'
+  return {
+    userMessage: props.errorMessage || view.value.message || '生成失败',
+    code: isFallbackPending.value ? 'fallback_pending' : code,
+    taskKind,
+    taskId: props.taskId || 'unknown',
+    occurredAt: new Date().toISOString(),
+    providerSnippet: null,
+    hint: isFallbackPending.value
+      ? '请确认是否使用平台回退继续，或取消本次生成。'
+      : undefined,
+  }
+}
+
+async function fetchDiagnostic(): Promise<GenerationDiagnostic> {
+  const taskId = props.taskId
+  const taskKind = props.taskKind
+  if (!taskId || !taskKind) return buildFallbackDiagnostic()
+
+  return sharedDiagnosticCache.get(taskKind, taskId, () =>
+    taskKind === 'material'
+      ? canvasApi.getMaterialDiagnostic(taskId)
+      : studioApi.getGenerationDiagnostic(taskId),
+  )
+}
+
+async function onCopy() {
+  copyLabel.value = '复制中…'
+  let payload: GenerationDiagnostic
+  try {
+    payload = await fetchDiagnostic()
+  } catch {
+    payload = buildFallbackDiagnostic()
+  }
+  const text = buildCopyForNode(payload, {
+    nodeId: props.nodeId,
+    nodeLabel: props.nodeLabel,
+    sessionId: sessionId.value,
+  })
+  try {
+    await navigator.clipboard.writeText(text)
+    copyLabel.value = '已复制'
+    setTimeout(() => {
+      copyLabel.value = '复制'
+    }, 1500)
+  } catch {
+    copyLabel.value = '复制失败'
+    setTimeout(() => {
+      copyLabel.value = '复制'
+    }, 1500)
+  }
+}
+</script>
+
+<template>
+  <div
+    v-if="view.visible"
+    class="dock-failure-chip"
+    role="status"
+  >
+    <span class="dock-failure-chip__msg" :title="errorMessage || view.message">{{
+      view.message
+    }}</span>
+    <button
+      v-if="view.showCopy"
+      type="button"
+      class="dock-failure-chip__copy"
+      @click.stop="onCopy"
+    >
+      {{ copyLabel }}
+    </button>
+  </div>
+</template>

--- a/apps/web/src/components/canvas/dock-studio/shared/DockToolbarShell.vue
+++ b/apps/web/src/components/canvas/dock-studio/shared/DockToolbarShell.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import type { TaskKind } from '@lnkpi/shared'
+import DockFailureChip from './DockFailureChip.vue'
 import DockTypeIcon from './DockTypeIcon.vue'
 import { DOCK_TYPE_LABELS, dockTypeToIcon } from './dockIcons'
 
@@ -12,6 +14,14 @@ const props = defineProps<{
   title?: string
   titlePlaceholder?: string
   readonly?: boolean
+  /** Selected node id — enables quiet failure chip under header */
+  failureNodeId?: string
+  failureStatus?: unknown
+  failureMessage?: string
+  failureErrorCode?: string
+  failureTaskKind?: TaskKind
+  failureTaskId?: string
+  failureNodeLabel?: string
 }>()
 
 const emit = defineEmits<{
@@ -24,6 +34,8 @@ const tooltip = computed(() => {
   if (props.type && DOCK_TYPE_LABELS[props.type]) return DOCK_TYPE_LABELS[props.type]
   return props.typeLabel ?? '节点'
 })
+
+const showDefaultFailureChip = computed(() => Boolean(props.failureNodeId))
 </script>
 
 <template>
@@ -52,6 +64,18 @@ const tooltip = computed(() => {
         </svg>
       </button>
     </div>
+    <slot name="failure">
+      <DockFailureChip
+        v-if="showDefaultFailureChip && failureNodeId"
+        :node-id="failureNodeId"
+        :status="failureStatus"
+        :error-message="failureMessage"
+        :error-code="failureErrorCode"
+        :task-kind="failureTaskKind"
+        :task-id="failureTaskId"
+        :node-label="failureNodeLabel"
+      />
+    </slot>
     <slot />
   </div>
 </template>

--- a/apps/web/src/components/canvas/dock-studio/shared/dockFailureChip.test.ts
+++ b/apps/web/src/components/canvas/dock-studio/shared/dockFailureChip.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { resolveDockFailureChip } from './dockFailureChip'
+
+describe('resolveDockFailureChip', () => {
+  it('does not render without errorMessage on non-fallback statuses', () => {
+    expect(
+      resolveDockFailureChip({ status: 'error', errorMessage: undefined }),
+    ).toEqual({ visible: false, message: '', showCopy: false })
+    expect(
+      resolveDockFailureChip({ status: 'failed', errorMessage: '' }),
+    ).toEqual({ visible: false, message: '', showCopy: false })
+    expect(
+      resolveDockFailureChip({ status: 'completed', errorMessage: '旧错误' }),
+    ).toEqual({ visible: false, message: '', showCopy: false })
+  })
+
+  it('shows truncated message and copy affordance when failed with errorMessage', () => {
+    const long = '上游超时，请稍后重试。这是一段很长的失败说明用于截断验证'
+    const view = resolveDockFailureChip({ status: 'error', errorMessage: long })
+    expect(view.visible).toBe(true)
+    expect(view.showCopy).toBe(true)
+    expect(view.message.length).toBeLessThanOrEqual(48)
+    expect(view.message.length).toBeGreaterThan(0)
+  })
+
+  it('shows chip for fallback_pending even without errorMessage', () => {
+    const view = resolveDockFailureChip({
+      status: 'fallback_pending',
+      errorMessage: undefined,
+    })
+    expect(view.visible).toBe(true)
+    expect(view.showCopy).toBe(true)
+    expect(view.message).toBeTruthy()
+  })
+})

--- a/apps/web/src/components/canvas/dock-studio/shared/dockFailureChip.ts
+++ b/apps/web/src/components/canvas/dock-studio/shared/dockFailureChip.ts
@@ -1,0 +1,73 @@
+import type { TaskKind } from '@lnkpi/shared'
+import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
+import { truncateError } from '@/components/canvas/nodeTaskChrome'
+
+export type DockFailureChipView = {
+  visible: boolean
+  message: string
+  showCopy: boolean
+}
+
+export type DockFailureShellBind = {
+  failureNodeId: string
+  failureStatus?: unknown
+  failureMessage?: string
+  failureErrorCode?: string
+  failureTaskKind?: TaskKind
+  failureTaskId?: string
+  failureNodeLabel?: string
+}
+
+const DOCK_MSG_MAX = 48
+
+/** Visibility + truncated message for the quiet Dock failure capsule. */
+export function resolveDockFailureChip(input: {
+  status?: unknown
+  errorMessage?: string
+}): DockFailureChipView {
+  const { status, errorMessage } = input
+  const isFallback = status === NODE_GENERATION_STATUS.fallback_pending
+  const isFail =
+    status === NODE_GENERATION_STATUS.error ||
+    status === NODE_GENERATION_STATUS.failed ||
+    isFallback
+
+  if (!isFail) {
+    return { visible: false, message: '', showCopy: false }
+  }
+
+  const truncated = truncateError(errorMessage, DOCK_MSG_MAX)
+  const message = truncated || (isFallback ? '平台回退待确认' : '')
+  if (!message) {
+    return { visible: false, message: '', showCopy: false }
+  }
+
+  return { visible: true, message, showCopy: true }
+}
+
+/** Map selected node → DockToolbarShell failure chip props. */
+export function dockFailureBindFromNode(node: {
+  id: string
+  data?: Record<string, unknown> | null
+}): DockFailureShellBind {
+  const data = node.data ?? {}
+  const generationRecordId =
+    typeof data.generationRecordId === 'string' ? data.generationRecordId : undefined
+  const materialId = typeof data.materialId === 'string' ? data.materialId : undefined
+  const taskId = generationRecordId || materialId
+  const taskKind: TaskKind | undefined = generationRecordId
+    ? 'generation'
+    : materialId
+      ? 'material'
+      : undefined
+
+  return {
+    failureNodeId: node.id,
+    failureStatus: data.status,
+    failureMessage: typeof data.errorMessage === 'string' ? data.errorMessage : undefined,
+    failureErrorCode: typeof data.errorCode === 'string' ? data.errorCode : undefined,
+    failureTaskKind: taskKind,
+    failureTaskId: taskId,
+    failureNodeLabel: typeof data.label === 'string' ? data.label : undefined,
+  }
+}

--- a/apps/web/src/composables/useNodeGeneration.test.ts
+++ b/apps/web/src/composables/useNodeGeneration.test.ts
@@ -156,6 +156,68 @@ describe('useNodeGeneration', () => {
     expect(mockRefreshPoints).toHaveBeenCalled()
   })
 
+  it('persists short failure errorCode and generationRecordId from structured axios error', async () => {
+    const node = createNode('image', {
+      prompt: 'a cat',
+      generationRecordId: 'rec-existing',
+    })
+    vi.mocked(studioApi.generateImage).mockRejectedValue({
+      response: {
+        data: {
+          message: '上游超时',
+          errorCode: 'upstream_timeout',
+          taskKind: 'generation',
+          taskId: 'rec-timeout-1',
+        },
+      },
+    })
+    const { api, deps } = createDeps([node])
+
+    await api.generateForNode(node)
+
+    expect(deps.patchNodeData).toHaveBeenCalledWith(
+      'image-1',
+      expect.objectContaining({
+        status: NODE_GENERATION_STATUS.error,
+        errorMessage: '上游超时',
+        errorCode: 'upstream_timeout',
+        generationRecordId: 'rec-timeout-1',
+      }),
+    )
+  })
+
+  it('keeps existing generationRecordId when structured error omits taskId', async () => {
+    const node = createNode('image', {
+      prompt: 'a cat',
+      generationRecordId: 'rec-keep-me',
+    })
+    vi.mocked(studioApi.generateImage).mockRejectedValue({
+      response: {
+        data: {
+          message: '上游错误',
+          errorCode: 'upstream_error',
+        },
+      },
+    })
+    const { api, deps } = createDeps([node])
+
+    await api.generateForNode(node)
+
+    expect(deps.patchNodeData).toHaveBeenCalledWith(
+      'image-1',
+      expect.objectContaining({
+        status: NODE_GENERATION_STATUS.error,
+        errorMessage: '上游错误',
+        errorCode: 'upstream_error',
+      }),
+    )
+    const errorPatch = deps.patchNodeData.mock.calls.find(
+      (call) => call[1]?.status === NODE_GENERATION_STATUS.error,
+    )?.[1] as Record<string, unknown>
+    expect(errorPatch).not.toHaveProperty('generationRecordId')
+    expect(node.data?.generationRecordId).toBe('rec-keep-me')
+  })
+
   it('refreshes points after successful generation', async () => {
     const node = createNode('image', { prompt: 'a cat' })
     const { api } = createDeps([node])
@@ -383,6 +445,41 @@ describe('useNodeGeneration', () => {
         status: NODE_GENERATION_STATUS.error,
         errorMessage: '生成失败，10 积分已返回',
         generationRecordId: 'rec-failed-refund',
+      }),
+    )
+  })
+
+  it('applyStudioRecord failed persists errorCode from metadata', async () => {
+    const node = createNode('image', {
+      prompt: 'failed image',
+      imageAspect: '16:9',
+      imageResolution: '1K',
+      imageCount: 1,
+    })
+    vi.mocked(studioApi.generateImage).mockResolvedValue(
+      mockAxiosResponse({
+        data: {
+          id: 'rec-failed-code',
+          type: 'image',
+          prompt: 'failed image',
+          status: NODE_GENERATION_STATUS.failed,
+          url: null,
+          metadata: JSON.stringify({ errorCode: 'upstream_timeout', refundedPoints: 5 }),
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      }),
+    )
+    const { api, deps } = createDeps([node])
+
+    await api.generateForNode(node)
+
+    expect(deps.patchNodeData).toHaveBeenCalledWith(
+      'image-1',
+      expect.objectContaining({
+        status: NODE_GENERATION_STATUS.error,
+        errorMessage: '生成失败，5 积分已返回',
+        errorCode: 'upstream_timeout',
+        generationRecordId: 'rec-failed-code',
       }),
     )
   })

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -1,5 +1,5 @@
 import { ref, type Ref } from 'vue'
-import type { ErrorCode, VideoSettings } from '@lnkpi/shared'
+import type { VideoSettings } from '@lnkpi/shared'
 import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import { NODE_GENERATION_STATUS, isNodeGenerating } from '@/constants/dockStudio'
 import { DEFAULT_AUDIO_VOICE } from '@/constants/dockAudio'
@@ -36,10 +36,11 @@ import {
 import {
   extractRefundedPointsFromError,
   formatCancelledMessage,
-  formatGenerationFailureMessage,
-  parseRefundedPointsFromMetadata,
 } from '@/utils/generationPointsMessage'
-import { parseShortGenerationError } from '@/utils/generationDiagnostic'
+import {
+  buildPollingFailurePatch,
+  parseShortGenerationError,
+} from '@/utils/generationDiagnostic'
 import { useAuthStore } from '@/stores/auth'
 
 export type FallbackConfirmDecision = 'confirm' | 'cancel'
@@ -168,18 +169,6 @@ function parseConfirmMessage(metadata?: string | null): string | undefined {
   try {
     const meta = JSON.parse(metadata) as { confirmMessage?: string }
     return typeof meta.confirmMessage === 'string' ? meta.confirmMessage : undefined
-  } catch {
-    return undefined
-  }
-}
-
-function parseErrorCodeFromMetadata(metadata?: string | null): ErrorCode | undefined {
-  if (!metadata) return undefined
-  try {
-    const meta = JSON.parse(metadata) as { errorCode?: unknown }
-    return parseShortGenerationError({
-      response: { data: { errorCode: meta.errorCode } },
-    }).errorCode
   } catch {
     return undefined
   }
@@ -459,17 +448,13 @@ async function cancelRemoteGeneration(nodeId: string) {
       deps.startGenerationPolling([{ recordId: record.id, nodeId }])
       return true
     }
-    const refundedPoints = parseRefundedPointsFromMetadata(record.metadata)
-    const errorCode = parseErrorCodeFromMetadata(record.metadata)
-    const patch: Record<string, unknown> = {
-      status: NODE_GENERATION_STATUS.error,
-      errorMessage: refundedPoints
-        ? formatGenerationFailureMessage(new Error('生成失败'), refundedPoints)
-        : '生成失败',
-      generationRecordId: record.id,
-    }
-    if (errorCode) patch.errorCode = errorCode
-    deps.patchNodeData(nodeId, patch)
+    deps.patchNodeData(
+      nodeId,
+      buildPollingFailurePatch({
+        metadata: record.metadata,
+        generationRecordId: record.id,
+      }),
+    )
     return true
   }
 

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -1,5 +1,5 @@
 import { ref, type Ref } from 'vue'
-import type { VideoSettings } from '@lnkpi/shared'
+import type { ErrorCode, VideoSettings } from '@lnkpi/shared'
 import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import { NODE_GENERATION_STATUS, isNodeGenerating } from '@/constants/dockStudio'
 import { DEFAULT_AUDIO_VOICE } from '@/constants/dockAudio'
@@ -39,6 +39,7 @@ import {
   formatGenerationFailureMessage,
   parseRefundedPointsFromMetadata,
 } from '@/utils/generationPointsMessage'
+import { parseShortGenerationError } from '@/utils/generationDiagnostic'
 import { useAuthStore } from '@/stores/auth'
 
 export type FallbackConfirmDecision = 'confirm' | 'cancel'
@@ -172,6 +173,18 @@ function parseConfirmMessage(metadata?: string | null): string | undefined {
   }
 }
 
+function parseErrorCodeFromMetadata(metadata?: string | null): ErrorCode | undefined {
+  if (!metadata) return undefined
+  try {
+    const meta = JSON.parse(metadata) as { errorCode?: unknown }
+    return parseShortGenerationError({
+      response: { data: { errorCode: meta.errorCode } },
+    }).errorCode
+  } catch {
+    return undefined
+  }
+}
+
 function modalityForNodeType(nodeType: string): StudioModality | null {
   if (nodeType === 'image') return 'image'
   if (nodeType === 'video') return 'video'
@@ -211,13 +224,17 @@ export function useNodeGeneration(deps: NodeGenerationDeps) {
       return
     }
     if (isAbortError(err)) return
-    const errorMessage = formatGenerationFailureMessage(err, refundedPoints)
-    if (errorMessage.includes('积分不足')) deps.onInsufficientPoints?.()
+    const short = parseShortGenerationError(err)
+    if (short.userMessage.includes('积分不足')) deps.onInsufficientPoints?.()
     if (!nodeAcceptsWrite(nodeId)) return
-    deps.patchNodeData(nodeId, {
+    const patch: Record<string, unknown> = {
       status: NODE_GENERATION_STATUS.error,
-      errorMessage,
-    })
+      errorMessage: short.userMessage,
+    }
+    if (short.errorCode) patch.errorCode = short.errorCode
+    if (short.taskKind === 'generation' && short.taskId) patch.generationRecordId = short.taskId
+    if (short.taskKind === 'material' && short.taskId) patch.materialId = short.taskId
+    deps.patchNodeData(nodeId, patch)
   }
 
   function isNodeBusy(nodeId: string): boolean {
@@ -442,16 +459,17 @@ async function cancelRemoteGeneration(nodeId: string) {
       deps.startGenerationPolling([{ recordId: record.id, nodeId }])
       return true
     }
-    deps.patchNodeData(nodeId, {
+    const refundedPoints = parseRefundedPointsFromMetadata(record.metadata)
+    const errorCode = parseErrorCodeFromMetadata(record.metadata)
+    const patch: Record<string, unknown> = {
       status: NODE_GENERATION_STATUS.error,
-      errorMessage: (() => {
-        const refundedPoints = parseRefundedPointsFromMetadata(record.metadata)
-        return refundedPoints
-          ? formatGenerationFailureMessage(new Error('生成失败'), refundedPoints)
-          : '生成失败'
-      })(),
+      errorMessage: refundedPoints
+        ? formatGenerationFailureMessage(new Error('生成失败'), refundedPoints)
+        : '生成失败',
       generationRecordId: record.id,
-    })
+    }
+    if (errorCode) patch.errorCode = errorCode
+    deps.patchNodeData(nodeId, patch)
     return true
   }
 

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -96,10 +96,7 @@ import PublishNeoTVDialog from '@/components/works/PublishNeoTVDialog.vue'
 import AgentSideRail from '@/components/agent/AgentSideRail.vue'
 import CanvasAgentFab from '@/components/agent/CanvasAgentFab.vue'
 import { useSelectedNodeEditor, type EditableFlowNode, EDITABLE_NODE_TYPES } from '@/composables/useSelectedNodeEditor'
-import {
-  formatGenerationFailureMessage,
-  parseRefundedPointsFromMetadata,
-} from '@/utils/generationPointsMessage'
+import { buildPollingFailurePatch } from '@/utils/generationDiagnostic'
 
 const PlayCanvasView = defineAsyncComponent(
   () => import('@/canvas/playcanvas/PlayCanvasView.vue'),
@@ -340,23 +337,15 @@ const shotPolling = useShotPolling((shots) => {
       if (material.status === 'failed') {
         const nodeId = findLinkedMediaNodeId(shot.id, material.id)
         const childNode = nodes.value.find((n) => n.id === nodeId)
-        const refundedPoints = parseRefundedPointsFromMetadata(
-          (material as { metadata?: string | null }).metadata,
-        )
-        const errorMessage = refundedPoints
-          ? formatGenerationFailureMessage(new Error('生成失败'), refundedPoints)
-          : '生成失败'
+        const failurePatch = buildPollingFailurePatch({
+          metadata: (material as { metadata?: string | null }).metadata,
+          materialId: material.id,
+        })
         if (childNode && acceptsPollWrite(childNode.data?.status)) {
-          patchNodeData(nodeId, {
-            status: NODE_GENERATION_STATUS.error,
-            errorMessage,
-          })
+          patchNodeData(nodeId, failurePatch)
         }
         if (acceptsPollWrite(shotNode?.data?.status)) {
-          patchNodeData(shot.id, {
-            status: NODE_GENERATION_STATUS.error,
-            errorMessage,
-          })
+          patchNodeData(shot.id, failurePatch)
         }
         void auth.refreshPoints()
         continue
@@ -410,13 +399,13 @@ const generationPolling = useGenerationPolling((results) => {
       }
       patchNodeData(task.nodeId, patch)
     } else if (record.status === NODE_GENERATION_STATUS.failed || record.status === NODE_GENERATION_STATUS.error) {
-      const refundedPoints = parseRefundedPointsFromMetadata(record.metadata)
-      patchNodeData(task.nodeId, {
-        status: NODE_GENERATION_STATUS.error,
-        errorMessage: refundedPoints
-          ? formatGenerationFailureMessage(new Error('生成失败'), refundedPoints)
-          : '生成失败',
-      })
+      patchNodeData(
+        task.nodeId,
+        buildPollingFailurePatch({
+          metadata: record.metadata,
+          generationRecordId: record.id,
+        }),
+      )
     }
   }
   void saveCanvas()

--- a/apps/web/src/services/canvas-api.ts
+++ b/apps/web/src/services/canvas-api.ts
@@ -1,5 +1,5 @@
 import { api } from './api'
-import type { GenerationRefPayload, VideoSettings } from '@lnkpi/shared'
+import type { GenerationDiagnostic, GenerationRefPayload, VideoSettings } from '@lnkpi/shared'
 import type {
   SceneComposerBatchGenerateRequest,
   SceneComposerSaveRequest,
@@ -78,4 +78,8 @@ export const canvasApi = {
   cancelMaterialPlatformFallback: (id: string) =>
     api.post(`/agent/canvas/material/${id}/cancel-platform-fallback`),
   cancelMaterial: (id: string) => api.post(`/agent/canvas/material/${id}/cancel`),
+  getMaterialDiagnostic: (id: string) =>
+    api
+      .get<{ data: GenerationDiagnostic }>(`/agent/canvas/material/${id}/diagnostic`)
+      .then((r) => r.data.data),
 }

--- a/apps/web/src/services/studio-api.ts
+++ b/apps/web/src/services/studio-api.ts
@@ -1,5 +1,5 @@
 import { api } from './api'
-import type { GenerationRefPayload } from '@lnkpi/shared'
+import type { GenerationDiagnostic, GenerationRefPayload } from '@lnkpi/shared'
 
 export type StudioRefPayload = GenerationRefPayload
 
@@ -92,4 +92,8 @@ export const studioApi = {
     api.post<{ data: GenerationRecord }>(`/studio/generations/${id}/cancel-platform-fallback`),
   cancelGeneration: (id: string) =>
     api.post<{ data: GenerationRecord }>(`/studio/generations/${id}/cancel`),
+  getGenerationDiagnostic: (id: string) =>
+    api
+      .get<{ data: GenerationDiagnostic }>(`/studio/generations/${id}/diagnostic`)
+      .then((r) => r.data.data),
 }

--- a/apps/web/src/styles/neo-node.css
+++ b/apps/web/src/styles/neo-node.css
@@ -176,15 +176,106 @@
   }
 }
 
-.neo-task-error {
+.neo-task-error-wrap {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  max-width: 100%;
+}
+
+.neo-task-error-row {
   margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 100%;
   padding: 4px 6px;
   border-radius: 6px;
   background: rgba(0, 0, 0, 0.65);
+}
+
+.neo-task-error {
+  margin: 0;
+  min-width: 0;
   color: #fca5a5;
   font-size: 10px;
   line-height: 1.3;
   text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.neo-task-diag-btn {
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.35);
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+
+.neo-task-diag-btn:hover {
+  color: #c4b5fd;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.neo-task-diag-pop {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 6;
+  width: 228px;
+  padding: 10px 11px;
+  border-radius: 12px;
+  background: rgba(22, 22, 24, 0.97);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.55);
+  text-align: left;
+}
+
+.neo-task-diag-msg {
+  margin: 0 0 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #fff;
+  line-height: 1.35;
+}
+
+.neo-task-diag-hint {
+  margin: 0 0 8px;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.62);
+  line-height: 1.45;
+}
+
+.neo-task-diag-copy {
+  width: 100%;
+  border: none;
+  border-radius: 8px;
+  padding: 7px;
+  background: #6366f1;
+  color: #fff;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.neo-task-diag-copy:hover:not(:disabled) {
+  background: rgba(99, 102, 241, 0.85);
+}
+
+.neo-task-diag-copy:disabled {
+  opacity: 0.55;
+  cursor: default;
 }
 
 .neo-node-rename-input {

--- a/apps/web/src/styles/neo-node.css
+++ b/apps/web/src/styles/neo-node.css
@@ -766,6 +766,49 @@
   min-height: 24px;
 }
 
+/* Quiet ~28px failure capsule under dock header (C2) */
+.dock-failure-chip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 28px;
+  margin-bottom: 8px;
+  padding: 0 10px 0 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(248, 113, 113, 0.28);
+  background: rgba(248, 113, 113, 0.1);
+  color: rgba(254, 226, 226, 0.92);
+  font-size: 12px;
+  line-height: 1;
+  min-width: 0;
+}
+
+.dock-failure-chip__msg {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dock-failure-chip__copy {
+  flex-shrink: 0;
+  height: 22px;
+  padding: 0 8px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 11px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.dock-failure-chip__copy:hover {
+  background: rgba(255, 255, 255, 0.14);
+  color: rgba(255, 255, 255, 0.92);
+}
+
 .bottom-toolbar-type-icon {
   display: inline-flex;
   width: 24px;

--- a/apps/web/src/utils/generationDiagnostic.test.ts
+++ b/apps/web/src/utils/generationDiagnostic.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
-import { createDiagnosticCache, parseShortGenerationError } from './generationDiagnostic'
+import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
+import {
+  buildPollingFailurePatch,
+  createDiagnosticCache,
+  parseErrorCodeFromMetadata,
+  parseShortGenerationError,
+} from './generationDiagnostic'
 
 describe('parseShortGenerationError', () => {
   it('reads structured body', () => {
@@ -41,6 +47,62 @@ describe('parseShortGenerationError', () => {
       userMessage: '已取消，8 积分已返回',
       refundedPoints: 8,
     })
+  })
+})
+
+describe('parseErrorCodeFromMetadata', () => {
+  it('reads valid errorCode from metadata JSON', () => {
+    expect(
+      parseErrorCodeFromMetadata(JSON.stringify({ errorCode: 'upstream_timeout' })),
+    ).toBe('upstream_timeout')
+  })
+
+  it('returns undefined for missing or invalid metadata', () => {
+    expect(parseErrorCodeFromMetadata(null)).toBeUndefined()
+    expect(parseErrorCodeFromMetadata('{')).toBeUndefined()
+    expect(parseErrorCodeFromMetadata(JSON.stringify({ errorCode: 'nope' }))).toBeUndefined()
+  })
+})
+
+describe('buildPollingFailurePatch', () => {
+  it('persists generationRecordId and errorCode from studio metadata', () => {
+    expect(
+      buildPollingFailurePatch({
+        metadata: JSON.stringify({ errorCode: 'upstream_timeout', refundedPoints: 5 }),
+        generationRecordId: 'rec-1',
+      }),
+    ).toEqual({
+      status: NODE_GENERATION_STATUS.error,
+      errorMessage: '生成失败，5 积分已返回',
+      generationRecordId: 'rec-1',
+      errorCode: 'upstream_timeout',
+    })
+  })
+
+  it('persists materialId on shot/material failures', () => {
+    expect(
+      buildPollingFailurePatch({
+        metadata: JSON.stringify({ errorCode: 'upstream_error' }),
+        materialId: 'mat-1',
+      }),
+    ).toEqual({
+      status: NODE_GENERATION_STATUS.error,
+      errorMessage: '生成失败',
+      materialId: 'mat-1',
+      errorCode: 'upstream_error',
+    })
+  })
+
+  it('omits errorCode when metadata has none', () => {
+    const patch = buildPollingFailurePatch({
+      generationRecordId: 'rec-2',
+    })
+    expect(patch).toEqual({
+      status: NODE_GENERATION_STATUS.error,
+      errorMessage: '生成失败',
+      generationRecordId: 'rec-2',
+    })
+    expect(patch).not.toHaveProperty('errorCode')
   })
 })
 

--- a/apps/web/src/utils/generationDiagnostic.test.ts
+++ b/apps/web/src/utils/generationDiagnostic.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createDiagnosticCache, parseShortGenerationError } from './generationDiagnostic'
+
+describe('parseShortGenerationError', () => {
+  it('reads structured body', () => {
+    const parsed = parseShortGenerationError({
+      response: {
+        data: {
+          message: '上游超时',
+          errorCode: 'upstream_timeout',
+          taskKind: 'generation',
+          taskId: 'g1',
+        },
+      },
+    })
+    expect(parsed).toMatchObject({
+      userMessage: '上游超时',
+      errorCode: 'upstream_timeout',
+      taskId: 'g1',
+    })
+  })
+
+  it('falls back to formatGenerationFailureMessage for legacy errors', () => {
+    const parsed = parseShortGenerationError({
+      response: { data: { message: '积分不足' } },
+    })
+    expect(parsed.userMessage).toBe('积分不足，请充值后再试')
+    expect(parsed.errorCode).toBeUndefined()
+  })
+
+  it('reads refundedPoints from structured body', () => {
+    const parsed = parseShortGenerationError({
+      response: {
+        data: {
+          message: '已取消',
+          refundedPoints: 8,
+        },
+      },
+    })
+    expect(parsed).toMatchObject({
+      userMessage: '已取消，8 积分已返回',
+      refundedPoints: 8,
+    })
+  })
+})
+
+describe('createDiagnosticCache', () => {
+  it('dedupes in-flight fetches', async () => {
+    const cache = createDiagnosticCache()
+    const fetcher = vi.fn().mockResolvedValue({ taskId: 'g1', code: 'unknown' })
+    const a = cache.get('generation', 'g1', fetcher)
+    const b = cache.get('generation', 'g1', fetcher)
+    await Promise.all([a, b])
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears by taskId', async () => {
+    const cache = createDiagnosticCache()
+    const fetcher = vi.fn().mockResolvedValue({ taskId: 'g1', code: 'unknown' })
+    await cache.get('generation', 'g1', fetcher)
+    cache.clear('g1')
+    await cache.get('generation', 'g1', fetcher)
+    expect(fetcher).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/web/src/utils/generationDiagnostic.test.ts
+++ b/apps/web/src/utils/generationDiagnostic.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
 import {
+  buildCopyForNode,
   buildPollingFailurePatch,
   createDiagnosticCache,
   parseErrorCodeFromMetadata,
@@ -103,6 +104,24 @@ describe('buildPollingFailurePatch', () => {
       generationRecordId: 'rec-2',
     })
     expect(patch).not.toHaveProperty('errorCode')
+  })
+})
+
+describe('buildCopyForNode', () => {
+  it('buildCopyForNode merges node context', () => {
+    const text = buildCopyForNode(
+      {
+        userMessage: 'x',
+        code: 'unknown',
+        taskKind: 'generation',
+        taskId: 'g1',
+        occurredAt: 't',
+        providerSnippet: null,
+      },
+      { nodeId: 'n1', nodeLabel: '文本', sessionId: 's1' },
+    )
+    expect(text).toContain('nodeId: n1')
+    expect(text).toContain('sessionId: s1')
   })
 })
 

--- a/apps/web/src/utils/generationDiagnostic.test.ts
+++ b/apps/web/src/utils/generationDiagnostic.test.ts
@@ -54,6 +54,19 @@ describe('createDiagnosticCache', () => {
     expect(fetcher).toHaveBeenCalledTimes(1)
   })
 
+  it('retries after fetch rejection', async () => {
+    const cache = createDiagnosticCache()
+    const fetcher = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce({ taskId: 'g1', code: 'unknown' })
+
+    await expect(cache.get('generation', 'g1', fetcher)).rejects.toThrow('network')
+    const result = await cache.get('generation', 'g1', fetcher)
+    expect(result).toEqual({ taskId: 'g1', code: 'unknown' })
+    expect(fetcher).toHaveBeenCalledTimes(2)
+  })
+
   it('clears by taskId', async () => {
     const cache = createDiagnosticCache()
     const fetcher = vi.fn().mockResolvedValue({ taskId: 'g1', code: 'unknown' })

--- a/apps/web/src/utils/generationDiagnostic.ts
+++ b/apps/web/src/utils/generationDiagnostic.ts
@@ -1,0 +1,72 @@
+import type { ErrorCode, GenerationDiagnostic, TaskKind } from '@lnkpi/shared'
+import { formatDiagnosticCopy } from '@lnkpi/shared'
+import {
+  extractRefundedPointsFromError,
+  extractStructuredGenerationFields,
+  formatGenerationFailureMessage,
+} from '@/utils/generationPointsMessage'
+
+export type { ErrorCode, GenerationDiagnostic, TaskKind }
+export { formatDiagnosticCopy }
+
+export interface ShortGenerationError {
+  userMessage: string
+  errorCode?: ErrorCode
+  taskKind?: TaskKind
+  taskId?: string
+  refundedPoints?: number
+}
+
+export function parseShortGenerationError(err: unknown): ShortGenerationError {
+  const structured = extractStructuredGenerationFields(err)
+  const refundedPoints =
+    structured.refundedPoints ?? extractRefundedPointsFromError(err)
+  const errForFormat = structured.userMessage
+    ? { response: { data: { message: structured.userMessage } } }
+    : err
+  const userMessage = formatGenerationFailureMessage(errForFormat, refundedPoints)
+
+  return {
+    userMessage,
+    errorCode: structured.errorCode,
+    taskKind: structured.taskKind,
+    taskId: structured.taskId,
+    refundedPoints,
+  }
+}
+
+export interface DiagnosticCache {
+  get(
+    taskKind: TaskKind,
+    taskId: string,
+    fetcher: () => Promise<GenerationDiagnostic>,
+  ): Promise<GenerationDiagnostic>
+  clear(taskId?: string): void
+}
+
+export function createDiagnosticCache(): DiagnosticCache {
+  const inflight = new Map<string, Promise<GenerationDiagnostic>>()
+
+  return {
+    get(taskKind, taskId, fetcher) {
+      const key = `${taskKind}:${taskId}`
+      const existing = inflight.get(key)
+      if (existing) return existing
+
+      const promise = fetcher()
+      inflight.set(key, promise)
+      return promise
+    },
+    clear(taskId) {
+      if (taskId === undefined) {
+        inflight.clear()
+        return
+      }
+      for (const key of inflight.keys()) {
+        if (key.endsWith(`:${taskId}`)) {
+          inflight.delete(key)
+        }
+      }
+    },
+  }
+}

--- a/apps/web/src/utils/generationDiagnostic.ts
+++ b/apps/web/src/utils/generationDiagnostic.ts
@@ -1,9 +1,11 @@
 import type { ErrorCode, GenerationDiagnostic, TaskKind } from '@lnkpi/shared'
 import { formatDiagnosticCopy } from '@lnkpi/shared'
+import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
 import {
   extractRefundedPointsFromError,
   extractStructuredGenerationFields,
   formatGenerationFailureMessage,
+  parseRefundedPointsFromMetadata,
 } from '@/utils/generationPointsMessage'
 
 export type { ErrorCode, GenerationDiagnostic, TaskKind }
@@ -33,6 +35,37 @@ export function parseShortGenerationError(err: unknown): ShortGenerationError {
     taskId: structured.taskId,
     refundedPoints,
   }
+}
+
+export function parseErrorCodeFromMetadata(metadata?: string | null): ErrorCode | undefined {
+  if (!metadata) return undefined
+  try {
+    const meta = JSON.parse(metadata) as { errorCode?: unknown }
+    return parseShortGenerationError({
+      response: { data: { errorCode: meta.errorCode } },
+    }).errorCode
+  } catch {
+    return undefined
+  }
+}
+
+export function buildPollingFailurePatch(opts: {
+  metadata?: string | null
+  generationRecordId?: string
+  materialId?: string
+}): Record<string, unknown> {
+  const refundedPoints = parseRefundedPointsFromMetadata(opts.metadata)
+  const errorCode = parseErrorCodeFromMetadata(opts.metadata)
+  const patch: Record<string, unknown> = {
+    status: NODE_GENERATION_STATUS.error,
+    errorMessage: refundedPoints
+      ? formatGenerationFailureMessage(new Error('生成失败'), refundedPoints)
+      : '生成失败',
+  }
+  if (opts.generationRecordId) patch.generationRecordId = opts.generationRecordId
+  if (opts.materialId) patch.materialId = opts.materialId
+  if (errorCode) patch.errorCode = errorCode
+  return patch
 }
 
 export interface DiagnosticCache {

--- a/apps/web/src/utils/generationDiagnostic.ts
+++ b/apps/web/src/utils/generationDiagnostic.ts
@@ -53,7 +53,10 @@ export function createDiagnosticCache(): DiagnosticCache {
       const existing = inflight.get(key)
       if (existing) return existing
 
-      const promise = fetcher()
+      const promise = fetcher().catch((error) => {
+        inflight.delete(key)
+        throw error
+      })
       inflight.set(key, promise)
       return promise
     },

--- a/apps/web/src/utils/generationDiagnostic.ts
+++ b/apps/web/src/utils/generationDiagnostic.ts
@@ -11,6 +11,24 @@ import {
 export type { ErrorCode, GenerationDiagnostic, TaskKind }
 export { formatDiagnosticCopy }
 
+export interface DiagnosticNodeContext {
+  nodeId?: string
+  nodeLabel?: string
+  sessionId?: string
+}
+
+export function buildCopyForNode(
+  diag: GenerationDiagnostic,
+  ctx: DiagnosticNodeContext,
+): string {
+  return formatDiagnosticCopy({
+    ...diag,
+    nodeId: ctx.nodeId ?? diag.nodeId,
+    nodeLabel: ctx.nodeLabel ?? diag.nodeLabel,
+    sessionId: ctx.sessionId ?? diag.sessionId,
+  })
+}
+
 export interface ShortGenerationError {
   userMessage: string
   errorCode?: ErrorCode

--- a/apps/web/src/utils/generationDiagnostic.ts
+++ b/apps/web/src/utils/generationDiagnostic.ts
@@ -124,3 +124,6 @@ export function createDiagnosticCache(): DiagnosticCache {
     },
   }
 }
+
+/** Session-scoped cache shared by node ⓘ popover and Dock failure chip. */
+export const sharedDiagnosticCache = createDiagnosticCache()

--- a/apps/web/src/utils/generationPointsMessage.ts
+++ b/apps/web/src/utils/generationPointsMessage.ts
@@ -1,9 +1,66 @@
+import type { ErrorCode, TaskKind } from '@lnkpi/shared'
 import { apiErrorMessage } from '@/utils/apiError'
 
 type ErrorResponseData = {
   refundedPoints?: unknown
   message?: unknown
+  errorCode?: unknown
+  taskKind?: unknown
+  taskId?: unknown
   data?: { refundedPoints?: unknown }
+}
+
+const ERROR_CODES = new Set<string>([
+  'insufficient_points',
+  'upstream_timeout',
+  'upstream_error',
+  'cancelled',
+  'invalid_input',
+  'model_unavailable',
+  'upload_required',
+  'fallback_pending',
+  'unknown',
+])
+
+const TASK_KINDS = new Set<string>(['generation', 'material'])
+
+function readStringField(raw: unknown): string | undefined {
+  return typeof raw === 'string' && raw.trim() ? raw.trim() : undefined
+}
+
+function readErrorCode(raw: unknown): ErrorCode | undefined {
+  return typeof raw === 'string' && ERROR_CODES.has(raw) ? (raw as ErrorCode) : undefined
+}
+
+function readTaskKind(raw: unknown): TaskKind | undefined {
+  return typeof raw === 'string' && TASK_KINDS.has(raw) ? (raw as TaskKind) : undefined
+}
+
+export function extractStructuredGenerationFields(err: unknown): {
+  userMessage?: string
+  errorCode?: ErrorCode
+  taskKind?: TaskKind
+  taskId?: string
+  refundedPoints?: number
+} {
+  const data = (err as { response?: { data?: ErrorResponseData } }).response?.data
+  if (!data) return {}
+
+  const message = data.message
+  const userMessage =
+    typeof message === 'string'
+      ? message
+      : message && typeof message === 'object' && message !== null
+        ? readStringField((message as { message?: unknown }).message)
+        : undefined
+
+  return {
+    userMessage,
+    errorCode: readErrorCode(data.errorCode),
+    taskKind: readTaskKind(data.taskKind),
+    taskId: readStringField(data.taskId),
+    refundedPoints: readRefundedPointsFromData(data),
+  }
 }
 
 function readPositiveRefundedPoints(raw: unknown): number | undefined {

--- a/docs/superpowers/plans/2026-07-21-node-generation-failure-diagnostics.md
+++ b/docs/superpowers/plans/2026-07-21-node-generation-failure-diagnostics.md
@@ -1,0 +1,583 @@
+# 节点生成失败诊断（C2）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 实现简约 C2 失败 UX（ⓘ 浮层 + Dock 28px 胶囊）与按需完整诊断 API（含脱敏 `providerSnippet`），复制文本含 `nodeId` + `taskId`。
+
+**Architecture:** 共享包提供 `ErrorCode`、脱敏与复制格式化；服务端失败时写 metadata + 短结构化错误体，并暴露 `GET …/diagnostic`；前端短字段落节点，点 ⓘ/复制时按 `taskId` 拉取并缓存诊断。
+
+**Tech Stack:** NestJS、Prisma `GenerationRecord`/`Material` metadata JSON、Vue 3、Vitest、现有 `NodeTaskCornerActions` / `DockToolbarShell` / `useNodeGeneration`
+
+**Spec:** `docs/superpowers/specs/2026-07-21-node-generation-failure-diagnostics-design.md`
+
+## Global Constraints
+
+- UI 锁定 **C2**：卡片短错 + 18px ⓘ + 重试；选中失败节点才显示 Dock **28px 胶囊**
+- 数据锁定 **方案 2**：短失败不含 `providerSnippet`；诊断按需 GET
+- 标识锁定 **A**：复制带 `nodeId` + `taskId`；不引入 `nodeCode`
+- 非失败记录 diagnostic → **404**
+- 脱敏后 snippet ≤ 2048 字符；禁止在 UI 常驻展示未脱敏原文
+- TDD：每个任务先写失败测试再实现；提交信息用中文或 `feat:`/`fix:`/`test:` 前缀
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `packages/shared/src/generationDiagnostics.ts` | `ErrorCode`、脱敏、复制文本、短/完整 DTO 类型 |
+| `packages/shared/src/generationDiagnostics.test.ts` | 共享单测 |
+| `packages/shared/src/index.ts` | 导出 |
+| `apps/server/src/common/generation-diagnostics.ts` | 服务端组装 diagnostic / 映射 ErrorCode（可 thin-wrap shared） |
+| `apps/server/src/studio/studio.service.ts` | 失败 metadata + `getGenerationDiagnostic` |
+| `apps/server/src/studio/studio.controller.ts` | `GET generations/:id/diagnostic` |
+| `apps/server/src/canvas/material.service.ts` | 同上 material 路径 |
+| `apps/server/src/canvas/canvas.controller.ts` | `GET materials/:id/diagnostic` |
+| `apps/web/src/services/studio-api.ts` / `canvas-api.ts` | diagnostic 客户端 |
+| `apps/web/src/utils/generationDiagnostic.ts` | 缓存 + `formatCopy` 包装 + 解析短错误 |
+| `apps/web/src/composables/useNodeGeneration.ts` | 写入 `errorCode` 等短字段 |
+| `apps/web/src/components/canvas/NodeTaskCornerActions.vue` | ⓘ + 浮层 |
+| `apps/web/src/components/canvas/dock-studio/shared/DockFailureChip.vue` | Dock 胶囊 |
+| `apps/web/src/components/canvas/dock-studio/shared/DockToolbarShell.vue` | 插入 chip slot |
+| `apps/web/src/styles/neo-node.css` | ⓘ / 浮层 / 胶囊样式 |
+
+---
+
+### Task 1: Shared ErrorCode、脱敏与复制格式化
+
+**Files:**
+- Create: `packages/shared/src/generationDiagnostics.ts`
+- Create: `packages/shared/src/generationDiagnostics.test.ts`
+- Modify: `packages/shared/src/index.ts`
+
+**Interfaces:**
+- Produces:
+  - `export type ErrorCode = 'insufficient_points' | 'upstream_timeout' | 'upstream_error' | 'cancelled' | 'invalid_input' | 'model_unavailable' | 'upload_required' | 'fallback_pending' | 'unknown'`
+  - `export type TaskKind = 'generation' | 'material'`
+  - `export interface GenerationDiagnostic { userMessage: string; code: ErrorCode; taskKind: TaskKind; taskId: string; nodeId?: string; nodeLabel?: string; sessionId?: string; model?: string | null; channelId?: string | null; apiFormat?: string | null; httpStatus?: number | null; occurredAt: string; providerSnippet: string | null; hint?: string }`
+  - `export function redactProviderSnippet(raw: string, maxLen = 2048): string`
+  - `export function formatDiagnosticCopy(d: GenerationDiagnostic): string`
+  - `export function mapMessageToErrorCode(message: string): ErrorCode`（启发式映射，供服务端兜底）
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest'
+import {
+  formatDiagnosticCopy,
+  redactProviderSnippet,
+  mapMessageToErrorCode,
+} from './generationDiagnostics'
+
+describe('redactProviderSnippet', () => {
+  it('redacts bearer tokens and truncates', () => {
+    const raw = `Authorization: Bearer sk-live-abc123secret\nemail user@example.com\n${'x'.repeat(3000)}`
+    const out = redactProviderSnippet(raw, 200)
+    expect(out).not.toContain('sk-live-abc123secret')
+    expect(out).not.toMatch(/user@example\.com/)
+    expect(out.length).toBeLessThanOrEqual(220)
+    expect(out).toContain('truncated')
+  })
+})
+
+describe('formatDiagnosticCopy', () => {
+  it('formats stable key lines including nodeId and taskId', () => {
+    const text = formatDiagnosticCopy({
+      userMessage: '上游超时',
+      code: 'upstream_timeout',
+      taskKind: 'generation',
+      taskId: 'gen_1',
+      nodeId: 'node_1',
+      occurredAt: '2026-07-21T00:00:00.000Z',
+      providerSnippet: 'timeout of 90000ms exceeded',
+    })
+    expect(text).toContain('lnkpi diagnostic')
+    expect(text).toContain('code: upstream_timeout')
+    expect(text).toContain('taskId: gen_1')
+    expect(text).toContain('nodeId: node_1')
+    expect(text).toContain('providerSnippet:')
+  })
+})
+
+describe('mapMessageToErrorCode', () => {
+  it('maps known phrases', () => {
+    expect(mapMessageToErrorCode('积分不足')).toBe('insufficient_points')
+    expect(mapMessageToErrorCode('timeout of 90000ms exceeded')).toBe('upstream_timeout')
+    expect(mapMessageToErrorCode('weird')).toBe('unknown')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @lnkpi/shared exec vitest run src/generationDiagnostics.test.ts`  
+（若 shared 尚无 vitest 脚本，用 `pnpm --filter @lnkpi/shared exec vitest run` 并确保 `package.json` 有 vitest；或先把测试放在 `packages/shared` 现有测试方式下——当前 shared 用节点旁 `*.test.ts`，agent 包用 vitest；**本仓库 shared 已有 `*.test.ts` 且被 agent/server 引用时，优先：`cd packages/shared && npx vitest run src/generationDiagnostics.test.ts`**）  
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Write minimal implementation**
+
+在 `packages/shared/src/generationDiagnostics.ts` 实现类型与上述三函数：
+
+- `redactProviderSnippet`：替换 `/Bearer\s+\S+/gi`、`/sk-[A-Za-z0-9_-]{8,}/g`、邮箱、手机号；URL 中 `key|token|signature=` 打码；超长截断 + `\n…(truncated)`
+- `formatDiagnosticCopy`：按 spec 行式输出；空字段省略；`providerSnippet` 用 `providerSnippet: |\n  ` 缩进多行
+- `mapMessageToErrorCode`：包含 `积分不足`→`insufficient_points`，`timeout`/`ETIMEDOUT`→`upstream_timeout`，`已取消`→`cancelled`，`参考图尚未上传`→`upload_required`，`模型`+`停用`→`model_unavailable`，默认 `unknown`
+
+`index.ts` 增加：`export * from './generationDiagnostics'`
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @lnkpi/shared exec vitest run src/generationDiagnostics.test.ts`  
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/generationDiagnostics.ts packages/shared/src/generationDiagnostics.test.ts packages/shared/src/index.ts
+git commit -m "feat(shared): generation diagnostic types, redact, and copy format"
+```
+
+---
+
+### Task 2: Studio diagnostic API + 失败 metadata
+
+**Files:**
+- Create: `apps/server/src/studio/studio.diagnostic.test.ts`（或扩展现有 `studio.fallback.test.ts` 旁新文件）
+- Modify: `apps/server/src/studio/studio.service.ts`
+- Modify: `apps/server/src/studio/studio.controller.ts`
+
+**Interfaces:**
+- Consumes: `GenerationDiagnostic`, `redactProviderSnippet`, `mapMessageToErrorCode`, `ErrorCode` from `@lnkpi/shared`
+- Produces:
+  - `StudioService.getGenerationDiagnostic(userId: string, id: string): Promise<GenerationDiagnostic>`
+  - 失败更新 metadata 时写入 `errorCode`、`errorRaw`（未脱敏原文，仅服务端存）、`failedAt`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+// 按仓库现有 studio 测试风格 mock Prisma；断言：
+// 1) status !== failed → NotFoundException
+// 2) 成功时 providerSnippet 不含 raw key，且 code 来自 metadata.errorCode
+
+it('getGenerationDiagnostic returns 404 when not failed', async () => {
+  // arrange record status completed
+  await expect(svc.getGenerationDiagnostic('u1', 'g1')).rejects.toThrow(/不存在|找不到|诊断/)
+})
+
+it('getGenerationDiagnostic redacts provider snippet', async () => {
+  // arrange failed + metadata.errorRaw = 'Bearer sk-secret hello'
+  const d = await svc.getGenerationDiagnostic('u1', 'g1')
+  expect(d.code).toBe('upstream_error')
+  expect(d.taskKind).toBe('generation')
+  expect(d.taskId).toBe('g1')
+  expect(d.providerSnippet).not.toContain('sk-secret')
+})
+```
+
+（具体 mock 语法对齐 `studio.fallback.test.ts`。）
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @lnkpi/server exec vitest run src/studio/studio.diagnostic.test.ts`  
+Expected: FAIL — `getGenerationDiagnostic` undefined
+
+- [ ] **Step 3: Write minimal implementation**
+
+1. `getGeneration(userId, id)` 已有则复用；若 `status` 不是 `failed`/`error` → `NotFoundException('诊断不可用')`
+2. `parseMeta` 读取 `errorCode`、`errorRaw`、`model`、`channelId`、`apiFormat`、`httpStatus`、`failedAt`
+3. 返回：
+
+```ts
+{
+  userMessage: meta.userMessage ?? record 失败默认文案 ?? '生成失败',
+  code: (meta.errorCode as ErrorCode) ?? mapMessageToErrorCode(String(meta.errorRaw ?? '')),
+  taskKind: 'generation',
+  taskId: record.id,
+  model: record.model ?? meta.model ?? null,
+  channelId: meta.channelId ?? null,
+  apiFormat: meta.apiFormat ?? null,
+  httpStatus: typeof meta.httpStatus === 'number' ? meta.httpStatus : null,
+  occurredAt: meta.failedAt ?? record.createdAt.toISOString(),
+  providerSnippet: meta.errorRaw ? redactProviderSnippet(String(meta.errorRaw)) : null,
+  hint: hintForCode(code), // 本地小函数：timeout→稍后重试；points→充值 等
+}
+```
+
+4. Controller：
+
+```ts
+@Get('generations/:id/diagnostic')
+async generationDiagnostic(@Req() req: { user: { sub: string } }, @Param('id') id: string) {
+  const data = await this.studioService.getGenerationDiagnostic(req.user.sub, id)
+  return { data }
+}
+```
+
+5. 在**至少一处**代表性 catch（如文本/图片生成失败更新 `status: 'failed'` 处）写入：
+
+```ts
+metadata: JSON.stringify({
+  ...existingMeta,
+  errorCode: mapMessageToErrorCode(errMsg),
+  errorRaw: errMsg.slice(0, 8000),
+  userMessage: /* 友好文案 */,
+  failedAt: new Date().toISOString(),
+})
+```
+
+并在 `BadRequestException` 抛出时使用对象 body：
+
+```ts
+throw new BadRequestException({
+  message: userMessage,
+  errorCode,
+  taskKind: 'generation',
+  taskId: record.id,
+  refundedPoints, // 若有
+})
+```
+
+（其余失败路径可在本任务末尾批量补齐同一 helper，避免漏网。）
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @lnkpi/server exec vitest run src/studio/studio.diagnostic.test.ts`  
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/studio/studio.service.ts apps/server/src/studio/studio.controller.ts apps/server/src/studio/studio.diagnostic.test.ts
+git commit -m "feat(server): studio generation diagnostic endpoint"
+```
+
+---
+
+### Task 3: Material diagnostic API + 失败 metadata
+
+**Files:**
+- Create: `apps/server/src/canvas/material.diagnostic.test.ts`
+- Modify: `apps/server/src/canvas/material.service.ts`
+- Modify: `apps/server/src/canvas/canvas.controller.ts`
+
+**Interfaces:**
+- Produces: `MaterialService.getMaterialDiagnostic(userId, id): Promise<GenerationDiagnostic>`（`taskKind: 'material'`）
+- 与 Task 2 相同 metadata 字段约定
+
+- [ ] **Step 1: Write the failing test**
+
+镜像 Task 2：非 failed → 抛错；failed + `errorRaw` 含 secret → snippet 已脱敏；`taskKind === 'material'`。
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @lnkpi/server exec vitest run src/canvas/material.diagnostic.test.ts`  
+Expected: FAIL
+
+- [ ] **Step 3: Write minimal implementation**
+
+- `GET` 路由挂在 canvas controller（与现有 `cancelMaterial` 同级鉴权）
+- 通过 material → shot → session 校验 `userId`
+- 失败 catch 写 `errorCode` / `errorRaw` / `userMessage` / `failedAt`
+- 短错误 `BadRequestException` body 含 `taskKind: 'material'`, `taskId: material.id`
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm --filter @lnkpi/server exec vitest run src/canvas/material.diagnostic.test.ts`  
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/canvas/material.service.ts apps/server/src/canvas/canvas.controller.ts apps/server/src/canvas/material.diagnostic.test.ts
+git commit -m "feat(server): material diagnostic endpoint"
+```
+
+---
+
+### Task 4: Web API + diagnostic 缓存 / 复制工具
+
+**Files:**
+- Create: `apps/web/src/utils/generationDiagnostic.ts`
+- Create: `apps/web/src/utils/generationDiagnostic.test.ts`
+- Modify: `apps/web/src/services/studio-api.ts`
+- Modify: `apps/web/src/services/canvas-api.ts`
+- Modify: `apps/web/src/utils/generationPointsMessage.ts`（解析 `errorCode` / `taskId` 从 axios body，保持旧行为兼容）
+
+**Interfaces:**
+- Produces:
+  - `studioApi.getGenerationDiagnostic(id: string): Promise<GenerationDiagnostic>`
+  - `canvasApi.getMaterialDiagnostic(id: string): Promise<GenerationDiagnostic>`
+  - `parseShortGenerationError(err: unknown): { userMessage: string; errorCode?: ErrorCode; taskKind?: TaskKind; taskId?: string; refundedPoints?: number }`
+  - `createDiagnosticCache()` → `{ get(taskKind, taskId, fetcher), clear(taskId?) }`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it, vi } from 'vitest'
+import { createDiagnosticCache, parseShortGenerationError } from './generationDiagnostic'
+
+it('parseShortGenerationError reads structured body', () => {
+  const parsed = parseShortGenerationError({
+    response: {
+      data: {
+        message: '上游超时',
+        errorCode: 'upstream_timeout',
+        taskKind: 'generation',
+        taskId: 'g1',
+      },
+    },
+  })
+  expect(parsed).toMatchObject({
+    userMessage: '上游超时',
+    errorCode: 'upstream_timeout',
+    taskId: 'g1',
+  })
+})
+
+it('createDiagnosticCache dedupes in-flight fetches', async () => {
+  const cache = createDiagnosticCache()
+  const fetcher = vi.fn().mockResolvedValue({ taskId: 'g1', code: 'unknown' })
+  const a = cache.get('generation', 'g1', fetcher)
+  const b = cache.get('generation', 'g1', fetcher)
+  await Promise.all([a, b])
+  expect(fetcher).toHaveBeenCalledTimes(1)
+})
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `pnpm --filter @lnkpi/web exec vitest run src/utils/generationDiagnostic.test.ts`  
+Expected: FAIL
+
+- [ ] **Step 3: Implement**
+
+```ts
+// studio-api
+getGenerationDiagnostic: (id: string) =>
+  api.get<{ data: GenerationDiagnostic }>(`/studio/generations/${id}/diagnostic`).then((r) => r.data.data),
+
+// canvas-api
+getMaterialDiagnostic: (id: string) =>
+  api.get<{ data: GenerationDiagnostic }>(`/canvas/materials/${id}/diagnostic`).then((r) => r.data.data),
+```
+
+`parseShortGenerationError`：优先结构化字段；否则 fallback `formatGenerationFailureMessage` 逻辑（可内部调用现有函数）。
+
+`createDiagnosticCache`：`Map<string, Promise<GenerationDiagnostic>>`，key = `${taskKind}:${taskId}`。
+
+- [ ] **Step 4: Run tests — PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/utils/generationDiagnostic.ts apps/web/src/utils/generationDiagnostic.test.ts apps/web/src/services/studio-api.ts apps/web/src/services/canvas-api.ts apps/web/src/utils/generationPointsMessage.ts
+git commit -m "feat(web): diagnostic API client and cache"
+```
+
+---
+
+### Task 5: useNodeGeneration 写入短失败字段
+
+**Files:**
+- Modify: `apps/web/src/composables/useNodeGeneration.ts`
+- Modify: `apps/web/src/composables/useNodeGeneration.test.ts`
+
+**Interfaces:**
+- Consumes: `parseShortGenerationError`
+- Produces: 节点 data 增加 `errorCode?: ErrorCode`；确保已有 `generationRecordId` / `materialId` 在失败时仍在；导出或 provide `fetchNodeDiagnostic(nodeId)`（可选，若 UI 直接调 cache+api 也可只在 Task 6/7 组装）
+
+- [ ] **Step 1: Write failing test**
+
+在现有 `useNodeGeneration.test.ts` 增加：mock 生成抛出 structured axios error → `patchNodeData` 收到 `errorMessage` + `errorCode` + 保留 `generationRecordId`。
+
+- [ ] **Step 2: Run — expect FAIL**（尚未写 errorCode）
+
+- [ ] **Step 3: Update `patchGenerationError`**
+
+```ts
+function patchGenerationError(nodeId: string, err: unknown, signal?: AbortSignal) {
+  // … abort / refund 分支保持
+  const short = parseShortGenerationError(err)
+  if (short.userMessage.includes('积分不足')) deps.onInsufficientPoints?.()
+  if (!nodeAcceptsWrite(nodeId)) return
+  const node = findNodeById(deps.nodes.value, nodeId)
+  const patch: Record<string, unknown> = {
+    status: NODE_GENERATION_STATUS.error,
+    errorMessage: short.userMessage,
+  }
+  if (short.errorCode) patch.errorCode = short.errorCode
+  if (short.taskKind === 'generation' && short.taskId) patch.generationRecordId = short.taskId
+  if (short.taskKind === 'material' && short.taskId) patch.materialId = short.taskId
+  // 若 node 已有 id，不要清空
+  deps.patchNodeData(nodeId, patch)
+}
+```
+
+轮询失败路径（`applyStudioRecord` 等 status error）同样写入 `errorCode`（从 record.metadata 解析若可得）。
+
+- [ ] **Step 4: Run tests — PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/composables/useNodeGeneration.ts apps/web/src/composables/useNodeGeneration.test.ts
+git commit -m "feat(web): persist short failure code and task id on nodes"
+```
+
+---
+
+### Task 6: C2 卡片 ⓘ + 诊断浮层
+
+**Files:**
+- Create: `apps/web/src/components/canvas/NodeDiagnosticPopover.vue`
+- Modify: `apps/web/src/components/canvas/NodeTaskCornerActions.vue`
+- Modify: `apps/web/src/components/canvas/nodeTaskChrome.test.ts`（若有组件测则加；否则新增 `NodeTaskCornerActions` 相关测或轻量测 popover helper）
+- Modify: `apps/web/src/styles/neo-node.css`
+- Modify: 各节点传入 props（`CanvasNodeText.vue` 等）：增加 `errorCode`、`generationRecordId`/`materialId` 透传若需要
+
+**Interfaces:**
+- `NodeTaskCornerActions` props 增加：`errorCode?: string`；`taskKind?: 'generation' | 'material'`；`taskId?: string`；`nodeLabel?: string`；`sessionId?: string`
+- 点击 ⓘ：`stopPropagation`；拉取 diagnostic；展示 `userMessage` + `hint` + 复制按钮
+- 复制：`formatDiagnosticCopy({ ...diag, nodeId, nodeLabel, sessionId })` + `navigator.clipboard.writeText`
+
+- [ ] **Step 1: Write failing test**
+
+优先测纯函数/小组件：若用 VTU 成本高，则测「组装 copy 时合并 nodeId」的 helper（放在 `generationDiagnostic.ts` 的 `buildCopyForNode(diag, ctx)`）。
+
+```ts
+it('buildCopyForNode merges node context', () => {
+  const text = buildCopyForNode(
+    { userMessage: 'x', code: 'unknown', taskKind: 'generation', taskId: 'g1', occurredAt: 't', providerSnippet: null },
+    { nodeId: 'n1', nodeLabel: '文本', sessionId: 's1' },
+  )
+  expect(text).toContain('nodeId: n1')
+  expect(text).toContain('sessionId: s1')
+})
+```
+
+- [ ] **Step 2: Run — FAIL**
+
+- [ ] **Step 3: Implement UI**
+
+`NodeTaskCornerActions` 错误行：
+
+```vue
+<p v-if="showError" class="neo-task-error-row">
+  <span class="neo-task-error">{{ err }}</span>
+  <button type="button" class="neo-task-diag-btn" aria-label="诊断信息" title="诊断信息" @click="openDiag">ⓘ</button>
+</p>
+```
+
+浮层：绝对定位、暗色、`userMessage`、`hint`、主按钮「复制诊断」；点击外部关闭。
+
+样式：`.neo-task-diag-btn` 18×18，默认 `color: rgba(255,255,255,.35)`，hover 淡紫；不增加「详情」文案。
+
+`fallback_pending`：同样显示 ⓘ（spec），文案 hint 引导确认/取消回退。
+
+- [ ] **Step 4: 相关 vitest PASS；手动不要求本任务**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/canvas/NodeTaskCornerActions.vue apps/web/src/components/canvas/NodeDiagnosticPopover.vue apps/web/src/styles/neo-node.css apps/web/src/utils/generationDiagnostic.ts apps/web/src/utils/generationDiagnostic.test.ts apps/web/src/components/canvas/CanvasNode*.vue
+git commit -m "feat(web): C2 node diagnostic info button and popover"
+```
+
+---
+
+### Task 7: Dock 28px 失败胶囊
+
+**Files:**
+- Create: `apps/web/src/components/canvas/dock-studio/shared/DockFailureChip.vue`
+- Modify: `apps/web/src/components/canvas/dock-studio/shared/DockToolbarShell.vue`
+- Modify: 各 `*DockPanel.vue` 或仅 Shell：通过 props/`slot` 在 header 下插入 chip
+- Modify: `DockStudioToolbar.vue` / `DockStudioRouter` 传入失败态
+
+**Interfaces:**
+- 当 `status` 为 `error`/`failed`（及可选 `fallback_pending`）且节点选中（Dock 已可见）时渲染：
+  - 文案：截断 `errorMessage`
+  - 按钮：复制（同 Task 6 的 `buildCopyForNode` + cache）
+- 高度约 28px；圆角胶囊；不挤压 prompt（margin-bottom 8px）
+
+- [ ] **Step 1: Write failing test**
+
+`DockFailureChip` 可见性：无 `errorMessage` 不渲染；有则显示复制按钮（可用 VTU 或纯 props→computed）。
+
+- [ ] **Step 2: Run — FAIL**
+
+- [ ] **Step 3: Implement**
+
+在 `DockToolbarShell` 增加可选 slot `failure` 或 props：
+
+```vue
+<div v-if="failureMessage" class="dock-failure-chip">
+  <span class="dock-failure-chip__msg">{{ failureMessage }}</span>
+  <button type="button" @click="emit('copy-diagnostic')">复制</button>
+</div>
+```
+
+各面板从 `node.data` 传入；`DockStudioToolbar` 已仅在选中可编辑节点时显示 → 满足「选中才出现」。
+
+- [ ] **Step 4: PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/canvas/dock-studio/
+git commit -m "feat(web): dock failure chip with copy diagnostic"
+```
+
+---
+
+### Task 8: 端到端校验与收尾
+
+**Files:**
+- 必要时补 `studio.integration.test.ts` 对 diagnostic 路由的冒烟
+- 更新 spec status（可选）
+
+- [ ] **Step 1: Run full verification**
+
+```bash
+pnpm --filter @lnkpi/shared exec vitest run src/generationDiagnostics.test.ts
+pnpm --filter @lnkpi/server exec vitest run src/studio/studio.diagnostic.test.ts src/canvas/material.diagnostic.test.ts
+pnpm --filter @lnkpi/web exec vitest run src/utils/generationDiagnostic.test.ts src/composables/useNodeGeneration.test.ts
+pnpm build
+```
+
+Expected: all PASS / build OK
+
+- [ ] **Step 2: Manual checklist（本地或预发）**
+
+- [ ] 失败节点仅短错 + ⓘ + 重试  
+- [ ] ⓘ 打开浮层可复制，含 `nodeId`/`taskId`，snippet 无 key  
+- [ ] 选中失败节点 Dock 有胶囊；取消选中胶囊随 Dock 消失  
+- [ ] 短失败网络面板无 `providerSnippet`  
+- [ ] 非失败 id 请求 diagnostic → 404  
+
+- [ ] **Step 3: Commit（若有收尾改动）**
+
+```bash
+git add -u
+git commit -m "test: verify generation failure diagnostics end-to-end"
+```
+
+---
+
+## Spec coverage self-check
+
+| Spec item | Task |
+|-----------|------|
+| C2 ⓘ + 浮层 | 6 |
+| Dock 28px 胶囊 | 7 |
+| 短失败无 snippet | 2, 3, 5 |
+| 按需 diagnostic GET | 2, 3, 4 |
+| 完整字段 + 脱敏 | 1, 2, 3 |
+| nodeId + taskId，无 nodeCode | 1, 6 |
+| ErrorCode 枚举 | 1, 2, 5 |
+| 非失败 404 | 2, 3 |
+| fallback_pending 可 ⓘ | 6 |
+| 测试：复制一致 / 脱敏 | 1, 4, 6, 8 |
+
+## Placeholder / type consistency
+
+- `GenerationDiagnostic`、`ErrorCode`、`TaskKind` 以 Task 1 为准，后续任务不得改名
+- `taskId` 始终对应 `generationRecordId` 或 `materialId`
+- 复制统一 `formatDiagnosticCopy` / `buildCopyForNode`，禁止手写第二套模板

--- a/docs/superpowers/specs/2026-07-21-node-generation-failure-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-07-21-node-generation-failure-diagnostics-design.md
@@ -1,0 +1,219 @@
+# 节点生成失败诊断（C2 + 按需完整诊断）Design
+
+**Date:** 2026-07-21  
+**Status:** Approved for planning (pending user review of this file)  
+**Related:** 画布节点生成失败 UX；不影响 Dock/节点默认操作体验
+
+## Goal
+
+让创作者快速理解失败并重试，同时让支持/开发能通过**一键复制**拿到完整排障信息（含脱敏后的 provider 片段），且默认 UI 保持简约。
+
+## Decisions (locked)
+
+| Topic | Choice |
+|-------|--------|
+| Audience | 两者：短结论给人 + 可复制诊断给支持 |
+| Visual / interaction | **C2**：卡片短错 + 18px ⓘ + 重试；选中失败节点时 Dock **28px 胶囊** + 复制 |
+| Data loading | **方案 2**：短失败响应 + 按需 `GET …/diagnostic` |
+| Diagnostic depth | **完整档**：标准字段 + 脱敏 `providerSnippet` |
+| Node identity | **A**：`nodeId` + 可选 `nodeLabel`；**不**引入稳定 `nodeCode`（T1 类引用键不作主键） |
+| Task identity | `taskKind` + `taskId`（`GenerationRecord.id` 或 `Material.id`） |
+
+## Non-goals (this iteration)
+
+- 稳定人读 `nodeCode`（创建即 T/I/V/A 序号）
+- 生成记录页大改版
+- 视频异步链路重构
+- 管理员全局日志后台
+- 在 UI 常驻展示未脱敏或完整 provider 原文
+
+## Current baseline
+
+- 失败时节点写入 `errorMessage`；角标约 40 字截断 + 重试
+- `formatGenerationFailureMessage` / `apiErrorMessage` 多为扁平字符串
+- Studio：`GenerationRecord`（cuid）→ 节点 `generationRecordId`
+- Canvas material：`Material`（cuid）→ 节点 `materialId`
+- `@T1` / `@I1` 仅为上游 refs 临时编号，**不能**作排障主键
+
+## UX (C2)
+
+### Default (quiet)
+
+失败节点卡片仅：
+
+1. 一行短结论（`userMessage`，可截断）
+2. **18px ⓘ**（无「详情」文案按钮）
+3. 重试
+
+### On demand
+
+- 点击 ⓘ → 轻量浮层：可读结论、一句建议（`hint`）、「复制诊断」
+- **仅当该失败节点被选中**时，Dock 顶部出现 **28px 胶囊**（短结论 + 复制）；未选中不出现
+- 浮层与胶囊共用同一诊断数据源；provider 原文**不**在浮层默认展开，只进入复制文本
+- 不引入第二套大红失败条，避免挤占提示词编辑区
+
+### Copy
+
+复制内容为纯文本块，字段稳定、便于粘贴给支持（见 Diagnostic payload）。
+
+## Data model
+
+### Short failure payload (immediate, stored on node)
+
+写入节点（与现有字段对齐处复用）：
+
+```ts
+{
+  userMessage: string       // → errorMessage
+  code: ErrorCode           // → errorCode
+  taskKind: 'generation' | 'material'
+  taskId: string            // → generationRecordId | materialId（已有则复用）
+  model?: string
+  occurredAt?: string       // ISO
+}
+```
+
+**禁止**在短响应中下发 `providerSnippet`。
+
+### ErrorCode (v1)
+
+```ts
+type ErrorCode =
+  | 'insufficient_points'
+  | 'upstream_timeout'
+  | 'upstream_error'
+  | 'cancelled'
+  | 'invalid_input'
+  | 'model_unavailable'
+  | 'upload_required'
+  | 'fallback_pending'
+  | 'unknown'
+```
+
+未映射错误一律 `unknown`，`userMessage` 仍给可读兜底。
+
+### Diagnostic payload (on-demand)
+
+```ts
+{
+  userMessage: string
+  code: ErrorCode
+  taskKind: 'generation' | 'material'
+  taskId: string
+  nodeId?: string           // 通常由前端拼进复制文本
+  nodeLabel?: string
+  sessionId?: string
+  model?: string | null
+  channelId?: string | null
+  apiFormat?: string | null
+  httpStatus?: number | null
+  occurredAt: string
+  providerSnippet: string | null  // 已脱敏，截断
+  hint?: string
+}
+```
+
+### Persistence
+
+失败时在 `GenerationRecord.metadata` / `Material.metadata`（JSON）写入至少：
+
+- `errorCode`
+- 可供 diagnostic 组装的错误摘要（服务端侧，返回前脱敏）
+- `model` 等已有上下文
+
+不新增独立表（本期）。
+
+## API
+
+### Endpoints
+
+- `GET /studio/generations/:id/diagnostic`
+- `GET /canvas/materials/:id/diagnostic`
+
+### Auth / errors
+
+- 仅记录所属用户可读
+- 记录不存在或不属于当前用户 → 404/403
+- 非失败状态：**404**（仅 `failed` / `error` 返回完整 diagnostic）
+
+### Frontend fetch policy
+
+1. 用户点 ⓘ 或「复制」
+2. 若该 `taskId` 无内存缓存 → GET diagnostic
+3. 缓存于节点/任务级 Map（会话内有效）
+4. 拉取失败：浮层仍显示短结论；复制降级为短字段（`userMessage` + `code` + `taskId` + `nodeId`）
+
+## Redaction rules (`providerSnippet`)
+
+1. 剥离 API Key / Bearer / cookie / 私钥形态串  
+2. 邮箱、手机号打码  
+3. URL query 中 `key` / `token` / `signature` 等敏感参数打码  
+4. 长度上限（建议 1–2KB）+ `…(truncated)`  
+5. 复制文本中的 snippet 必须已是脱敏结果；客户端不再二次依赖明文
+
+## Component / code touchpoints
+
+**Web**
+
+- `NodeTaskCornerActions`：ⓘ + 浮层
+- Dock：选中失败节点时的 28px 胶囊（`DockToolbarShell` 或共享子组件）
+- `useNodeGeneration`：短失败写入；`getDiagnostic` / 复制格式化
+- `studio-api.ts` / `canvas-api.ts`：diagnostic GET
+- 既有 `errorMessage` 展示路径保持兼容
+
+**Server**
+
+- `studio.service` / `material.service`：失败映射 `ErrorCode` + metadata
+- 新 diagnostic handlers + 脱敏工具（可放 `packages/shared` 或 server util，便于单测）
+
+## Data flow
+
+```
+生成失败
+  → 短响应 → 节点 errorMessage / errorCode / taskId
+用户点 ⓘ 或复制
+  → GET diagnostic(taskId) → 缓存
+  → 浮层展示 / 剪贴板
+选中失败节点
+  → Dock 胶囊（短文案；复制走同一 getDiagnostic）
+```
+
+## Copy text format (normative)
+
+纯文本，行式 key: value，例如：
+
+```
+lnkpi diagnostic
+code: upstream_timeout
+userMessage: …
+taskKind: generation
+taskId: …
+nodeId: …
+nodeLabel: …
+sessionId: …
+model: …
+channelId: …
+apiFormat: …
+httpStatus: …
+occurredAt: …
+hint: …
+providerSnippet: |
+  …
+```
+
+缺省字段可省略行。
+
+## Testing
+
+- 短失败响应不含 `providerSnippet`
+- diagnostic 含脱敏片段；样例含 key/token 时输出已打码
+- ⓘ 与 Dock 胶囊复制字段一致（同源）
+- 未选中失败节点时不出现 Dock 胶囊
+- 无权 / 非失败 task 不可读完整 diagnostic
+- 积分不足等已有友好文案仍映射到对应 `ErrorCode`
+
+## Open implementation notes (non-blocking)
+
+- `nodeId` / `sessionId` 可由前端在复制时附加；服务端 diagnostic 可不强制存 node 关联
+- 异步轮询最终失败与同步抛错两条路径都需写入短字段 + metadata
+- `fallback_pending` 是否显示 ⓘ：显示，文案引导确认/取消回退（与现有回退 UX 一致）

--- a/packages/shared/src/generationDiagnostics.test.ts
+++ b/packages/shared/src/generationDiagnostics.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatDiagnosticCopy,
+  redactProviderSnippet,
+  mapMessageToErrorCode,
+} from './generationDiagnostics'
+
+describe('redactProviderSnippet', () => {
+  it('redacts bearer tokens and truncates', () => {
+    const raw = `Authorization: Bearer sk-live-abc123secret\nemail user@example.com\n${'x'.repeat(3000)}`
+    const out = redactProviderSnippet(raw, 200)
+    expect(out).not.toContain('sk-live-abc123secret')
+    expect(out).not.toMatch(/user@example\.com/)
+    expect(out.length).toBeLessThanOrEqual(220)
+    expect(out).toContain('truncated')
+  })
+})
+
+describe('formatDiagnosticCopy', () => {
+  it('formats stable key lines including nodeId and taskId', () => {
+    const text = formatDiagnosticCopy({
+      userMessage: '上游超时',
+      code: 'upstream_timeout',
+      taskKind: 'generation',
+      taskId: 'gen_1',
+      nodeId: 'node_1',
+      occurredAt: '2026-07-21T00:00:00.000Z',
+      providerSnippet: 'timeout of 90000ms exceeded',
+    })
+    expect(text).toContain('lnkpi diagnostic')
+    expect(text).toContain('code: upstream_timeout')
+    expect(text).toContain('taskId: gen_1')
+    expect(text).toContain('nodeId: node_1')
+    expect(text).toContain('providerSnippet:')
+  })
+})
+
+describe('mapMessageToErrorCode', () => {
+  it('maps known phrases', () => {
+    expect(mapMessageToErrorCode('积分不足')).toBe('insufficient_points')
+    expect(mapMessageToErrorCode('timeout of 90000ms exceeded')).toBe('upstream_timeout')
+    expect(mapMessageToErrorCode('weird')).toBe('unknown')
+  })
+})

--- a/packages/shared/src/generationDiagnostics.ts
+++ b/packages/shared/src/generationDiagnostics.ts
@@ -1,0 +1,100 @@
+export type ErrorCode =
+  | 'insufficient_points'
+  | 'upstream_timeout'
+  | 'upstream_error'
+  | 'cancelled'
+  | 'invalid_input'
+  | 'model_unavailable'
+  | 'upload_required'
+  | 'fallback_pending'
+  | 'unknown'
+
+export type TaskKind = 'generation' | 'material'
+
+export interface GenerationDiagnostic {
+  userMessage: string
+  code: ErrorCode
+  taskKind: TaskKind
+  taskId: string
+  nodeId?: string
+  nodeLabel?: string
+  sessionId?: string
+  model?: string | null
+  channelId?: string | null
+  apiFormat?: string | null
+  httpStatus?: number | null
+  occurredAt: string
+  providerSnippet: string | null
+  hint?: string
+}
+
+const BEARER_PATTERN = /Bearer\s+\S+/gi
+const SK_KEY_PATTERN = /sk-[A-Za-z0-9_-]{8,}/g
+const EMAIL_PATTERN = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g
+const PHONE_PATTERN = /\b1[3-9]\d{9}\b/g
+const SENSITIVE_QUERY_PARAM_PATTERN =
+  /([?&](?:key|token|signature)=)([^&\s]+)/gi
+
+function redactSensitiveValues(text: string): string {
+  return text
+    .replace(BEARER_PATTERN, 'Bearer [REDACTED]')
+    .replace(SK_KEY_PATTERN, 'sk-[REDACTED]')
+    .replace(EMAIL_PATTERN, '[REDACTED_EMAIL]')
+    .replace(PHONE_PATTERN, '[REDACTED_PHONE]')
+    .replace(SENSITIVE_QUERY_PARAM_PATTERN, '$1[REDACTED]')
+}
+
+export function redactProviderSnippet(raw: string, maxLen = 2048): string {
+  let text = redactSensitiveValues(raw)
+
+  if (text.length <= maxLen) {
+    return text
+  }
+
+  return `${text.slice(0, maxLen)}\n…(truncated)`
+}
+
+function isPresent(value: unknown): value is string | number {
+  return value !== undefined && value !== null && value !== ''
+}
+
+function formatProviderSnippetBlock(snippet: string): string {
+  const lines = snippet.split('\n')
+  if (lines.length === 1) {
+    return `providerSnippet: |\n  ${lines[0]}`
+  }
+  return `providerSnippet: |\n${lines.map((line) => `  ${line}`).join('\n')}`
+}
+
+export function formatDiagnosticCopy(d: GenerationDiagnostic): string {
+  const lines = ['lnkpi diagnostic', `code: ${d.code}`, `userMessage: ${d.userMessage}`, `taskKind: ${d.taskKind}`, `taskId: ${d.taskId}`]
+
+  if (isPresent(d.nodeId)) lines.push(`nodeId: ${d.nodeId}`)
+  if (isPresent(d.nodeLabel)) lines.push(`nodeLabel: ${d.nodeLabel}`)
+  if (isPresent(d.sessionId)) lines.push(`sessionId: ${d.sessionId}`)
+  if (isPresent(d.model)) lines.push(`model: ${d.model}`)
+  if (isPresent(d.channelId)) lines.push(`channelId: ${d.channelId}`)
+  if (isPresent(d.apiFormat)) lines.push(`apiFormat: ${d.apiFormat}`)
+  if (isPresent(d.httpStatus)) lines.push(`httpStatus: ${d.httpStatus}`)
+  if (isPresent(d.occurredAt)) lines.push(`occurredAt: ${d.occurredAt}`)
+  if (isPresent(d.hint)) lines.push(`hint: ${d.hint}`)
+
+  if (d.providerSnippet != null && d.providerSnippet !== '') {
+    lines.push(formatProviderSnippetBlock(d.providerSnippet))
+  }
+
+  return lines.join('\n')
+}
+
+export function mapMessageToErrorCode(message: string): ErrorCode {
+  const text = message.trim()
+  if (!text) return 'unknown'
+
+  if (text.includes('积分不足')) return 'insufficient_points'
+  if (/timeout/i.test(text) || text.includes('ETIMEDOUT')) return 'upstream_timeout'
+  if (text.includes('已取消')) return 'cancelled'
+  if (text.includes('参考图尚未上传')) return 'upload_required'
+  if (text.includes('模型') && text.includes('停用')) return 'model_unavailable'
+
+  return 'unknown'
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,6 +8,7 @@ export * from './nodeRefs'
 export * from './imageParams'
 export * from './studioModelCatalog'
 export * from './providerChannels'
+export * from './generationDiagnostics'
 
 export type GenerationType = 'text' | 'image' | 'video'
 


### PR DESCRIPTION
## Summary
- C2 UX：失败节点短结论 + 18px ⓘ 浮层 + 重试；选中时 Dock 28px 失败胶囊，均可一键复制诊断
- 方案 2：短失败响应只带 `errorCode`/`taskId`；`GET …/diagnostic` 按需返回脱敏 `providerSnippet`
- 标识用 `nodeId` + `taskId`（generation/material），不做稳定 nodeCode

## Test plan
- [x] `pnpm build` / shared+agent+diagnostic 相关单测
- [ ] 失败节点仅短错 + ⓘ；点 ⓘ 可复制含 nodeId/taskId 的诊断，snippet 无 key
- [ ] 选中失败节点 Dock 出现胶囊；取消选中随 Dock 消失
- [ ] 短失败响应体不含 providerSnippet；非失败 id 诊断 404
- [ ] 异步轮询失败节点仍写入 errorCode + task id


Made with [Cursor](https://cursor.com)