### PR TITLE
fix(studio): refs 合并改用文本模型并在 LLM 失败时降级拼接

### DIFF
--- a/apps/server/src/canvas/material.service.ts
+++ b/apps/server/src/canvas/material.service.ts
@@ -37,6 +37,7 @@ import { PrismaService } from '../prisma/prisma.service'
 import { PointsService } from '../points/points.service'
 import { videoCredits } from '../points/video-credits'
 import { classifyByokFailure } from '../provider/byok-fallback'
+import { mergeChatModel } from '../provider/merge-chat-model'
 import {
   ProviderResolverService,
   type ResolvedGenerationProvider,
@@ -686,7 +687,7 @@ export class MaterialService {
       mentionedKeys: mentionedKeys?.length ? mentionedKeys : undefined,
       apiKey: credentials?.apiKey ?? process.env.OPENAI_API_KEY,
       baseUrl: credentials?.baseUrl ?? process.env.OPENAI_BASE_URL,
-      model,
+      model: mergeChatModel(downstreamType, model),
     })
     return {
       mergedText,

--- a/apps/server/src/provider/merge-chat-model.test.ts
+++ b/apps/server/src/provider/merge-chat-model.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { resolveModelKey } from '@lnkpi/shared'
+import { mergeChatModel } from './merge-chat-model'
+
+const DEFAULT_TEXT_MODEL = resolveModelKey('text', undefined).entry.gatewayModelId
+
+describe('mergeChatModel', () => {
+  afterEach(() => {
+    delete process.env.OPENAI_CHAT_MODEL
+  })
+
+  it('keeps resolved model for text downstream', () => {
+    expect(mergeChatModel('text', 'deepseek-v4')).toBe('deepseek-v4')
+  })
+
+  it('never passes video/image/audio models to chat merge', () => {
+    expect(mergeChatModel('video', 'seedance-2.0-min')).toBe(DEFAULT_TEXT_MODEL)
+    expect(mergeChatModel('image', 'seedream-5.0-pro')).toBe(DEFAULT_TEXT_MODEL)
+    expect(mergeChatModel('audio', 'speech-2.8-hd')).toBe(DEFAULT_TEXT_MODEL)
+  })
+
+  it('prefers OPENAI_CHAT_MODEL env for non-text downstream', () => {
+    process.env.OPENAI_CHAT_MODEL = 'my-chat-model'
+    expect(mergeChatModel('video', 'seedance-2.0-min')).toBe('my-chat-model')
+  })
+
+  it('falls back to default text model when text downstream has no model', () => {
+    expect(mergeChatModel('text', undefined)).toBe(DEFAULT_TEXT_MODEL)
+  })
+})

--- a/apps/server/src/provider/merge-chat-model.ts
+++ b/apps/server/src/provider/merge-chat-model.ts
@@ -1,0 +1,20 @@
+import { resolveModelKey } from '@lnkpi/shared'
+
+/**
+ * Chat model used by the refs-merge (chat/completions) call.
+ *
+ * Non-text generations resolve their own modality model (e.g. a video model),
+ * which must never be sent to chat/completions — the gateway rejects it
+ * (403 Forbidden) and the whole generation fails. Always merge with a
+ * text-capable model instead.
+ */
+export function mergeChatModel(
+  downstreamType: 'text' | 'image' | 'video' | 'audio',
+  resolvedModel?: string,
+): string | undefined {
+  if (downstreamType === 'text' && resolvedModel) return resolvedModel
+  return (
+    process.env.OPENAI_CHAT_MODEL ||
+    resolveModelKey('text', undefined).entry.gatewayModelId
+  )
+}

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -35,6 +35,7 @@ import {
 import { PointsService } from '../points/points.service'
 import { PrismaService } from '../prisma/prisma.service'
 import { classifyByokFailure } from '../provider/byok-fallback'
+import { mergeChatModel } from '../provider/merge-chat-model'
 import {
   ProviderResolverService,
   type ResolvedGenerationProvider,
@@ -216,7 +217,7 @@ export class StudioService {
       mentionedKeys: mentionedKeys?.length ? mentionedKeys : undefined,
       apiKey: credentials?.apiKey ?? process.env.OPENAI_API_KEY,
       baseUrl: credentials?.baseUrl ?? process.env.OPENAI_BASE_URL,
-      model,
+      model: mergeChatModel(downstreamType, model),
     })
     return {
       mergedText,

--- a/packages/agent/src/refs/merge-refs.test.ts
+++ b/packages/agent/src/refs/merge-refs.test.ts
@@ -80,22 +80,52 @@ describe('mergeRefsToPrompt LLM merge', () => {
     expect(body.messages.length).toBeGreaterThanOrEqual(2)
   })
 
-  it('throws when API returns !ok', async () => {
+  it('falls back to concat when API returns !ok', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: false,
-      status: 500,
-      statusText: 'Internal Server Error',
+      status: 403,
+      statusText: 'Forbidden',
     }))
-    await expect(
-      mergeRefsToPrompt({
-        sources: [
-          { refKey: 'T1', label: 'A', text: 'one' },
-          { refKey: 'T2', label: 'B', text: 'two' },
-        ],
-        downstreamType: 'text',
-        apiKey: 'test-key',
-      }),
-    ).rejects.toThrow(/LLM 请求失败/)
+    const result = await mergeRefsToPrompt({
+      sources: [
+        { refKey: 'T1', label: 'A', text: 'one' },
+        { refKey: 'T2', label: 'B', text: 'two' },
+      ],
+      downstreamType: 'text',
+      apiKey: 'test-key',
+    })
+    expect(result.skippedMerge).toBe(false)
+    expect(result.mergedText).toContain('【T1·A】')
+    expect(result.mergedText).toContain('one')
+    expect(result.mergedText).toContain('【T2·B】')
+    expect(result.mergedText).toContain('two')
+  })
+
+  it('falls back to concat when fetch rejects or content is empty', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')))
+    const rejected = await mergeRefsToPrompt({
+      sources: [
+        { refKey: 'T1', label: 'A', text: 'one' },
+        { refKey: 'T2', label: 'B', text: 'two' },
+      ],
+      downstreamType: 'video',
+      apiKey: 'test-key',
+    })
+    expect(rejected.mergedText).toContain('【T1·A】')
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: '   ' } }] }),
+    }))
+    const empty = await mergeRefsToPrompt({
+      sources: [
+        { refKey: 'T1', label: 'A', text: 'one' },
+        { refKey: 'T2', label: 'B', text: 'two' },
+      ],
+      downstreamType: 'video',
+      apiKey: 'test-key',
+    })
+    expect(empty.mergedText).toContain('【T2·B】')
   })
 
   it('includes mentionedKeys in LLM system and user messages', async () => {

--- a/packages/agent/src/refs/merge-refs.ts
+++ b/packages/agent/src/refs/merge-refs.ts
@@ -89,18 +89,28 @@ export async function mergeRefsToPrompt(input: {
   }
 
   const baseUrl = (input.baseUrl ?? process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1').replace(/\/$/, '')
-  const res = await fetch(`${baseUrl}/chat/completions`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
-    body: JSON.stringify(body),
-  })
-  if (!res.ok) {
-    throw new Error(`LLM 请求失败: ${res.status} ${res.statusText}`)
+  // Merge is best-effort: any LLM failure degrades to concat instead of failing the whole generation
+  // (points are already consumed by the caller at this stage).
+  try {
+    const res = await fetch(`${baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
+      body: JSON.stringify(body),
+    })
+    if (!res.ok) {
+      throw new Error(`LLM 请求失败: ${res.status} ${res.statusText}`)
+    }
+    const json = (await res.json()) as { choices: Array<{ message: { content: string } }> }
+    const mergedText = json.choices[0]?.message?.content?.trim()
+    if (!mergedText) {
+      throw new Error('LLM 返回空内容')
+    }
+    return { mergedText, skippedMerge: false }
+  } catch (err) {
+    console.warn(
+      '[merge-refs] LLM merge failed, falling back to concat:',
+      err instanceof Error ? err.message : err,
+    )
+    return { mergedText: fallbackConcat(entries), skippedMerge: false }
   }
-  const json = (await res.json()) as { choices: Array<{ message: { content: string } }> }
-  const mergedText = json.choices[0]?.message?.content?.trim()
-  if (!mergedText) {
-    throw new Error('LLM 返回空内容')
-  }
-  return { mergedText, skippedMerge: false }
 }


### PR DESCRIPTION
## Summary
- 修复视频节点生成 500（`Internal server error`）：`generateVideo`/`generateImage`/`generateAudio` 之前把各自**模态模型名**（如 `seedance-2.0-min`）传给 refs 合并的 `chat/completions` 调用，网关返回 `403 Forbidden`，未捕获异常导致整次生成失败且积分已扣、记录未落库（生产日志 `mergeRefsToPrompt → resolveMergedPrompt → generateVideo` 堆栈可证）。
- 新增 `mergeChatModel()`：非 text 下游合并固定使用文本聊天模型（`OPENAI_CHAT_MODEL` 或模型目录默认文本模型），studio 与 canvas material 两条链路统一接入。
- `mergeRefsToPrompt` 对 LLM 调用失败（非 2xx / 网络异常 / 空内容）降级为 refKey 拼接（复用无 Key 时的 `fallbackConcat` 路径），合并是 best-effort，不再让提示词合并失败中断整次生成。

## Test plan
- [x] `pnpm --filter @lnkpi/agent test`（50 passed，含新增 !ok/网络异常/空内容降级用例）
- [x] `pnpm --filter @lnkpi/server test`（104 passed，含新增 merge-chat-model 用例）
- [x] `pnpm build`
- [ ] 合并部署后在生产复测：视频节点挂多条文本参考生成不再 500

Made with [Cursor](https://cursor.com)