### PR TITLE
feat(studio): 生图改为异步模式并带 3 秒快速路径

### DIFF
--- a/apps/server/src/studio/studio.controller.ts
+++ b/apps/server/src/studio/studio.controller.ts
@@ -262,11 +262,9 @@ export class StudioController {
 
   @Post('image/generate')
   @UseGuards(AuthGuard)
-  async generateImage(
-    @Req() req: { user: { sub: string }; on(event: string, cb: () => void): void; aborted?: boolean },
-    @Body() dto: GenerateImageDto,
-  ) {
-    const cancel = createCancelFlag(req)
+  async generateImage(@Req() req: { user: { sub: string } }, @Body() dto: GenerateImageDto) {
+    // Async mode: returns a `generating` record; client polls. Disconnect must
+    // not cancel the background generation, so no cancel flag here.
     const data = await this.studioService.generateImage(
       req.user.sub,
       dto.prompt,
@@ -276,7 +274,6 @@ export class StudioController {
       dto.mentionedKeys,
       dto.resolution,
       dto.count,
-      cancel,
     )
     return { code: 0, message: 'ok', data }
   }

--- a/apps/server/src/studio/studio.fallback.test.ts
+++ b/apps/server/src/studio/studio.fallback.test.ts
@@ -353,31 +353,26 @@ describe('StudioService BYOK fallback_pending', () => {
     expect((opts as { modelId?: string }).modelId).toBeTruthy()
   })
 
-  it.each([
-    {
-      name: 'image',
-      cost: 10,
-      refundReason: '图像生成-失败退款',
-      run: () => svc.generateImage('u1', 'a cat', undefined),
-      failOnce: () => imageGenerate.mockRejectedValueOnce(new Error('platform upstream 502')),
-    },
-    {
-      name: 'text',
-      cost: 5,
-      refundReason: '文本生成-失败退款',
-      run: () => svc.generateText('u1', 'hello'),
-      failOnce: () => textGenerate.mockRejectedValueOnce(new Error('platform upstream 502')),
-    },
-  ] as const)(
-    '$name: platform source failure → refund after consume',
-    async ({ run, failOnce, cost, refundReason }) => {
-      resolveForGeneration.mockResolvedValue(platformResolved)
-      failOnce()
-      await expect(run()).rejects.toThrow('platform upstream 502')
-      expect(pointsConsume).toHaveBeenCalledWith('u1', cost, expect.any(String))
-      expect(pointsRefund).toHaveBeenCalledWith('u1', cost, refundReason)
-    },
-  )
+  it('text: platform source failure → refund after consume', async () => {
+    resolveForGeneration.mockResolvedValue(platformResolved)
+    textGenerate.mockRejectedValueOnce(new Error('platform upstream 502'))
+    await expect(svc.generateText('u1', 'hello')).rejects.toThrow('platform upstream 502')
+    expect(pointsConsume).toHaveBeenCalledWith('u1', 5, expect.any(String))
+    expect(pointsRefund).toHaveBeenCalledWith('u1', 5, '文本生成-失败退款')
+  })
+
+  it('image: platform source failure → failed record with refund metadata', async () => {
+    resolveForGeneration.mockResolvedValue(platformResolved)
+    imageGenerate.mockRejectedValueOnce(new Error('platform upstream 502'))
+    const record = await svc.generateImage('u1', 'a cat', undefined)
+    expect(record.status).toBe('failed')
+    const meta = JSON.parse(String(record.metadata))
+    expect(meta.refundedPoints).toBe(10)
+    expect(meta.refundReason).toBe('platform_failed')
+    expect(meta.errorCode).toBeTruthy()
+    expect(pointsConsume).toHaveBeenCalledWith('u1', 10, expect.any(String))
+    expect(pointsRefund).toHaveBeenCalledWith('u1', 10, '图像生成-失败退款')
+  })
 
   it('confirmPlatformFallback: platform generate failure → refund, failed, refundedPoints', async () => {
     imageGenerate.mockRejectedValueOnce(new Error('upstream 502'))
@@ -491,37 +486,76 @@ describe('StudioService BYOK fallback_pending', () => {
     expect(generationCreate).not.toHaveBeenCalled()
   })
 
-  it('image: BYOK client abort after generate → refund once, no fallback_pending', async () => {
+  it('image fast path: provider finishes within grace window → returns completed with urls', async () => {
     imageGenerate.mockResolvedValueOnce({
-      url: 'https://example.com/i.png',
-      urls: ['https://example.com/i.png'],
+      url: 'https://example.com/i1.png',
+      urls: ['https://example.com/i1.png', 'https://example.com/i2.png'],
     })
-    const listeners: Record<string, (() => void)[]> = {}
-    const cancel = createCancelFlag({
-      aborted: false,
-      on(event: string, cb: () => void) {
-        listeners[event] = listeners[event] ?? []
-        listeners[event].push(cb)
-      },
-    })
-    const promise = svc.generateImage(
-      'u1',
-      'a cat',
-      'ch_user::custom-model',
-      '16:9',
-      [],
-      [],
-      '1K',
-      1,
-      cancel,
+    const record = await svc.generateImage('u1', 'a cat', 'ch_user::custom-model', '16:9', [], [], '1K', 2)
+    expect(record.status).toBe('completed')
+    expect(record.url).toBe('https://example.com/i1.png')
+    const meta = JSON.parse(String(record.metadata))
+    expect(meta.urls).toEqual(['https://example.com/i1.png', 'https://example.com/i2.png'])
+    expect(meta.chargedPoints).toBe(20)
+    expect(pointsRefund).not.toHaveBeenCalled()
+  })
+
+  it('image slow path: provider still running after grace window → returns generating, completes later', async () => {
+    vi.useFakeTimers()
+    try {
+      let resolveImage!: (v: { url: string; urls: string[] }) => void
+      imageGenerate.mockImplementationOnce(
+        () =>
+          new Promise((r) => {
+            resolveImage = r
+          }),
+      )
+      const promise = svc.generateImage('u1', 'a cat', 'ch_user::custom-model')
+      await vi.advanceTimersByTimeAsync(3000)
+      const record = await promise
+      expect(record.status).toBe('generating')
+      expect(generationCreate).toHaveBeenCalledTimes(1)
+
+      resolveImage({ url: 'https://example.com/late.png', urls: ['https://example.com/late.png'] })
+      await vi.advanceTimersByTimeAsync(10)
+      expect(generationUpdateMany).toHaveBeenCalled()
+      const updateData = generationUpdateMany.mock.calls[0][0].data
+      expect(updateData.status).toBe('completed')
+      expect(updateData.url).toBe('https://example.com/late.png')
+      expect(JSON.parse(String(updateData.metadata)).urls).toEqual(['https://example.com/late.png'])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('image: cancel before completeImage success → ignore late completed write', async () => {
+    let resolveImage!: (v: { url: string; urls: string[] }) => void
+    imageGenerate.mockImplementationOnce(
+      () =>
+        new Promise((r) => {
+          resolveImage = r
+        }),
     )
-    listeners.close?.forEach((cb) => cb())
-    await expect(promise).rejects.toMatchObject({
-      response: { message: '已取消', refundedPoints: 10 },
-    })
-    expect(pointsRefund).toHaveBeenCalledTimes(1)
-    expect(pointsRefund).toHaveBeenCalledWith('u1', 10, '图像生成-取消退款')
-    expect(generationCreate).not.toHaveBeenCalled()
+    vi.useFakeTimers()
+    let promise!: Promise<unknown>
+    try {
+      promise = svc.generateImage('u1', 'a cat', 'ch_user::custom-model')
+      await vi.advanceTimersByTimeAsync(3000)
+    } finally {
+      vi.useRealTimers()
+    }
+    const record = (await promise) as { status: string }
+    expect(record.status).toBe('generating')
+    stored = {
+      ...stored,
+      status: 'failed',
+      metadata: JSON.stringify({ chargedPoints: 10, cancelled: true, refundedPoints: 10 }),
+    }
+    resolveImage({ url: 'https://example.com/i.png', urls: ['https://example.com/i.png'] })
+    await new Promise((r) => setTimeout(r, 30))
+    expect(generationUpdateMany).not.toHaveBeenCalled()
+    expect(stored.status).toBe('failed')
+    expect(pointsRefund).not.toHaveBeenCalled()
   })
 
   it('confirmPlatformFallback: client abort after generate → refund once, failed', async () => {

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -43,6 +43,10 @@ import {
 
 const AUDIO_PLACEHOLDER = 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3'
 
+// Grace window before returning the async `generating` record: fast image
+// providers usually finish within this, sparing the client a polling round.
+const IMAGE_FAST_PATH_MS = 3000
+
 export interface StudioRefInput {
   refKey: string
   mediaType: string
@@ -539,7 +543,6 @@ export class StudioService {
     mentionedKeys?: string[],
     resolution = '1K',
     count = 1,
-    cancel?: CancelFlag,
   ) {
     const n = Math.max(1, Math.min(4, Number(count) || 1))
     const cost = 10 * n
@@ -567,116 +570,120 @@ export class StudioService {
     const primaryRef = built.referenceImages[0]
     const basePrompt = primaryRef ? buildPromptWithRefImage(mergedText, primaryRef) : mergedText
     const effectivePrompt = [basePrompt, built.effectivePromptSuffix].filter(Boolean).join('\n')
-
-    try {
-      if (resolved.source === 'user' && !resolved.credentials.apiKey) {
-        throw new Error('missing api key')
-      }
-      const { url, urls } = await createImageProvider(userProviderOpts(resolved)).generate(
-        effectivePrompt,
-        {
-          size: built.size,
-          n: built.n,
-          modelId,
-        },
-      )
-      const imageUrls = urls?.length ? urls : [url]
-      if (cancel?.isCancelled()) {
-        await this.points.refund(userId, cost, `${chargeReason}-取消退款`)
-        throwCancelledException(cost)
-      }
-      return this.prisma.generationRecord.create({
-        data: {
-          userId,
-          type: 'image',
-          prompt: effectivePrompt,
-          model: storeModel,
-          url: imageUrls[0],
-          status: 'completed',
-          metadata: JSON.stringify(
-            applyChargeMeta(
-              {
-                ...built.meta,
-                modelId,
-                aspectRatio,
-                resolution,
-                count: n,
-                size: built.size,
-                urls: imageUrls,
-                referenceImages,
-                skippedMerge,
-                channelId: resolved.channelId,
-              },
-              cost,
-            ),
-          ),
-        },
-      })
-    } catch (err) {
-      if (isCancelledException(err)) throw err
-      if (resolved.source !== 'user') {
-        await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
-        const failedMeta = applyFailureDiagnosticMeta(
-          applyRefundMeta(
-            applyChargeMeta(
-              {
-                ...built.meta,
-                modelId,
-                aspectRatio,
-                resolution,
-                count: n,
-                size: built.size,
-                referenceImages,
-                skippedMerge,
-                channelId: resolved.channelId,
-              },
-              cost,
-            ),
-            cost,
-            'platform_failed',
-          ),
-          err,
-        )
-        const failed = await this.prisma.generationRecord.create({
-          data: {
-            userId,
-            type: 'image',
-            prompt: effectivePrompt,
-            model: storeModel,
-            url: null,
-            status: 'failed',
-            metadata: JSON.stringify(failedMeta),
-          },
-        })
-        throwGenerationFailure({
-          userMessage: String(failedMeta.userMessage ?? '生成失败'),
-          errorCode: failedMeta.errorCode as ErrorCode,
-          taskId: failed.id,
-          refundedPoints: cost,
-        })
-      }
-      await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
-      return this.prisma.generationRecord.create({
-        data: {
-          userId,
-          type: 'image',
-          prompt: effectivePrompt,
-          model: storeModel,
-          url: null,
-          status: 'fallback_pending',
-          metadata: JSON.stringify(
-            this.byokPendingMeta(resolved, err, cost, {
+    const record = await this.prisma.generationRecord.create({
+      data: {
+        userId,
+        type: 'image',
+        prompt: effectivePrompt,
+        model: storeModel,
+        status: 'generating',
+        metadata: JSON.stringify(
+          applyChargeMeta(
+            {
               ...built.meta,
               modelId,
-              originalModel: model,
               aspectRatio,
               resolution,
               count: n,
               size: built.size,
               referenceImages,
               skippedMerge,
-            }),
+              channelId: resolved.channelId,
+              originalModel: model,
+              providerSource: resolved.source,
+            },
+            cost,
           ),
+        ),
+      },
+    })
+    const completion = this.completeImage(
+      record.id,
+      userId,
+      cost,
+      chargeReason,
+      effectivePrompt,
+      { modelId, size: built.size, n: built.n },
+      resolved,
+    ).catch((err) => {
+      console.error('Image generation failed:', err)
+      return null
+    })
+    // Fast path: quick providers finish within the grace window, so the client
+    // gets the terminal record directly instead of one extra polling round-trip.
+    let graceTimer: ReturnType<typeof setTimeout> | undefined
+    const fast = await Promise.race([
+      completion,
+      new Promise<null>((resolve) => {
+        graceTimer = setTimeout(() => resolve(null), IMAGE_FAST_PATH_MS)
+      }),
+    ])
+    if (graceTimer) clearTimeout(graceTimer)
+    return fast ?? record
+  }
+
+  private async completeImage(
+    id: string,
+    userId: string,
+    cost: number,
+    chargeReason: string,
+    prompt: string,
+    options: { modelId?: string; size?: string; n?: number },
+    resolved: ResolvedGenerationProvider,
+  ) {
+    try {
+      if (resolved.source === 'user' && !resolved.credentials.apiKey) {
+        throw new Error('missing api key')
+      }
+      const { url, urls } = await createImageProvider(userProviderOpts(resolved)).generate(
+        prompt,
+        {
+          size: options.size,
+          n: options.n,
+          modelId: options.modelId,
+        },
+      )
+      const imageUrls = urls?.length ? urls : [url]
+      const existing = await this.prisma.generationRecord.findFirst({ where: { id } })
+      if (!existing || existing.status !== 'generating') return null
+      const meta = parseMeta(existing.metadata)
+      if (isCancelledMeta(meta) || alreadyRefunded(meta)) return null
+      const updated = await this.prisma.generationRecord.updateMany({
+        where: { id, status: 'generating' },
+        data: {
+          url: imageUrls[0],
+          status: 'completed',
+          metadata: JSON.stringify({ ...meta, urls: imageUrls }),
+        },
+      })
+      if (updated.count === 0) return null
+      return this.prisma.generationRecord.findFirst({ where: { id } })
+    } catch (err) {
+      console.error('Image generation failed:', err)
+      const existing = await this.prisma.generationRecord.findFirst({ where: { id } })
+      if (!existing || existing.status !== 'generating') return null
+      const meta = parseMeta(existing.metadata)
+      if (isCancelledMeta(meta) || alreadyRefunded(meta)) return null
+      if (resolved.source === 'user') {
+        await this.points.refund(userId, cost, `${chargeReason}-BYOK失败退款`)
+        return this.prisma.generationRecord.update({
+          where: { id },
+          data: {
+            status: 'fallback_pending',
+            metadata: JSON.stringify(this.byokPendingMeta(resolved, err, cost, meta)),
+          },
+        })
+      }
+      await this.points.refund(userId, cost, `${chargeReason}-失败退款`)
+      const failedMeta = applyFailureDiagnosticMeta(
+        applyRefundMeta(meta, cost, 'platform_failed'),
+        err,
+      )
+      return this.prisma.generationRecord.update({
+        where: { id },
+        data: {
+          status: 'failed',
+          metadata: JSON.stringify(failedMeta),
         },
       })
     }

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -27,7 +27,7 @@ import { useAuthStore } from '@/stores/auth'
 import { useCanvasEditorStore } from '@/stores/canvasEditor'
 import { applyActionsToFlow, flowToCanvasData } from '@/composables/useCanvasActions'
 import { useShotPolling } from '@/composables/useShotPolling'
-import { useGenerationPolling, parseRecordText, parseRecordUrl, type GenerationPollTask } from '@/composables/useGenerationPolling'
+import { useGenerationPolling, parseRecordText, parseRecordUrl, parseRecordUrls, type GenerationPollTask } from '@/composables/useGenerationPolling'
 import { useNodeGeneration } from '@/composables/useNodeGeneration'
 import { createInitialSceneComposerNodeData } from '@/utils/sceneComposer'
 import { resolveCompositionTracks, mergeCompositionTracks, compositionTracksToNodePatch } from '@/utils/compositionUpstream'
@@ -390,12 +390,15 @@ const generationPolling = useGenerationPolling((results) => {
       continue
     }
     if (record.status === NODE_GENERATION_STATUS.completed) {
+      const urls = parseRecordUrls(record)
       const patch: Record<string, unknown> = {
-        url: parseRecordUrl(record),
+        url: urls[0] ?? parseRecordUrl(record),
         status: NODE_GENERATION_STATUS.completed,
       }
       if (record.type === 'text') {
         patch.content = parseRecordText(record)
+      } else if (urls.length) {
+        patch.images = urls
       }
       patchNodeData(task.nodeId, patch)
     } else if (record.status === NODE_GENERATION_STATUS.failed || record.status === NODE_GENERATION_STATUS.error) {
@@ -421,10 +424,10 @@ function startPollingForGeneratingShots() {
   if (generatingIds.length) shotPolling.start(generatingIds)
 }
 
-function startPollingForGeneratingVideos() {
+function startPollingForGeneratingRecords() {
   const tasks: GenerationPollTask[] = []
   for (const n of nodes.value) {
-    if (n.type !== 'video') continue
+    if (n.type !== 'video' && n.type !== 'image') continue
     const data = n.data as Record<string, unknown>
     if (data.status === NODE_GENERATION_STATUS.generating && data.generationRecordId) {
       tasks.push({ recordId: String(data.generationRecordId), nodeId: n.id })
@@ -1803,7 +1806,7 @@ async function loadSession() {
     nodeCounter = 1
   }
   startPollingForGeneratingShots()
-  startPollingForGeneratingVideos()
+  startPollingForGeneratingRecords()
 }
 
 async function loadSessions() {


### PR DESCRIPTION
## Summary
- Studio 独立生图 (`POST /studio/image/generate`) 从同步阻塞改为异步:先创建 `generating` 记录,后台 `completeImage` 完成后写回 `completed`(url + metadata.urls)/`fallback_pending`/`failed`,与视频链路一致。解决慢模型/带参考图场景撞 Vercel 代理 120s 超时导致客户端 504 的问题。
- 3 秒快速路径:上游在宽限窗口内完成则直接返回终态记录,快模型体验不受轮询间隔影响。
- 控制器不再给生图传 cancel flag——异步模式下客户端断开不应终止后台生成,取消统一走 `generations/:id/cancel`(已支持 image)。
- 前端:轮询完成时解析 `metadata.urls` 多图;画布重新加载时恢复 image 节点(原来只有 video)的 generating 轮询。画布分镜路径 (material.service) 本来就是异步,不需改动。
- 测试:平台失败由"抛异常"改为"返回 failed 记录(含退款元数据)";新增快速路径、慢路径后台完成、取消后忽略迟到写回三个用例。

## Test plan
- [x] pnpm build 全绿
- [x] server 106 tests / web 82 tests 全部通过
- [ ] 合并部署后生产复测:快路径(纯文本快模型)与慢路径(BYOK + 参考图)

Made with [Cursor](https://cursor.com)