### PR TITLE
feat: canvas rail redesign, task history panel, and inline edit persistence fix

### DIFF
--- a/apps/web/src/components/canvas/CanvasFloatingChrome.vue
+++ b/apps/web/src/components/canvas/CanvasFloatingChrome.vue
@@ -27,7 +27,8 @@ useClickOutside(menuRef, closeMenu)
 </script>
 
 <template>
-  <div class="canvas-floating-chrome pointer-events-none absolute left-[52px] top-3 z-[50] flex items-start gap-2">
+  <!-- left-3：工具竖排面板已下移到标题栏下方，返回按钮回到左上角原点不再被遮挡 -->
+  <div class="canvas-floating-chrome pointer-events-none absolute left-3 top-3 z-[50] flex items-start gap-2">
     <button
       type="button"
       class="pointer-events-auto flex h-9 w-9 items-center justify-center rounded-xl border border-white/[0.08] bg-[rgba(22,22,22,0.88)] text-white/70 shadow-lg backdrop-blur-xl transition hover:bg-white/[0.06] hover:text-white"

--- a/apps/web/src/components/canvas/CanvasNodePrompt.vue
+++ b/apps/web/src/components/canvas/CanvasNodePrompt.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, inject, ref } from 'vue'
 import { useNodeId, useVueFlow } from '@vue-flow/core'
 import NeoBaseNode from '@/components/canvas/NeoBaseNode.vue'
 import PromptMarkdownEditor from '@/components/canvas/PromptMarkdownEditor.vue'
+import { CANVAS_NODE_PATCH_KEY } from '@/composables/canvasNodeActions'
 import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
 
 const props = defineProps<{
@@ -12,6 +13,8 @@ const props = defineProps<{
 
 const nodeId = useNodeId()
 const { updateNodeData } = useVueFlow()
+// 同 CanvasNodeText:受控模式下必须走页面级 patch 才能持久化并让下游引用可见。
+const patchCanvasNode = inject(CANVAS_NODE_PATCH_KEY, null)
 
 const editorOpen = ref(false)
 const draft = ref('')
@@ -32,7 +35,11 @@ function openEditor() {
 }
 
 function onSave(md: string) {
-  updateNodeData(nodeId, { content: md })
+  if (patchCanvasNode && nodeId) {
+    patchCanvasNode(nodeId, { content: md })
+  } else {
+    updateNodeData(nodeId, { content: md })
+  }
 }
 </script>
 

--- a/apps/web/src/components/canvas/CanvasNodeText.vue
+++ b/apps/web/src/components/canvas/CanvasNodeText.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, inject, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { useNodeId, useVueFlow } from '@vue-flow/core'
 import NeoBaseNode from '@/components/canvas/NeoBaseNode.vue'
 import NodeTaskCornerActions from '@/components/canvas/NodeTaskCornerActions.vue'
 import PromptMarkdownEditor from '@/components/canvas/PromptMarkdownEditor.vue'
+import { CANVAS_NODE_PATCH_KEY } from '@/composables/canvasNodeActions'
 
 const props = defineProps<{
   selected?: boolean
@@ -22,6 +23,9 @@ const props = defineProps<{
 
 const nodeId = useNodeId()
 const { updateNodeData } = useVueFlow()
+// 画布是受控模式(nodes.value 为真源),必须走页面级 patch 才能持久化并让下游引用可见;
+// updateNodeData 只写 Vue Flow 内部 store,会在下一次页面 patch 时被旧数据覆盖。
+const patchCanvasNode = inject(CANVAS_NODE_PATCH_KEY, null)
 const route = useRoute()
 const sessionId = computed(() => route.params.sessionId as string | undefined)
 const taskId = computed(
@@ -47,14 +51,18 @@ function openEditor() {
 }
 
 function onSave(md: string) {
-  updateNodeData(nodeId, { content: md })
+  if (patchCanvasNode && nodeId) {
+    patchCanvasNode(nodeId, { content: md })
+  } else {
+    updateNodeData(nodeId, { content: md })
+  }
 }
 </script>
 
 <template>
   <NeoBaseNode node-type="text" :selected="selected" :data="data" :status="data.status">
     <div class="neo-text-card" @dblclick.stop="openEditor">
-      <p>{{ data.content || '点击下方 Dock Studio 编辑...' }}</p>
+      <p>{{ data.content || '双击编辑文本,或在下方 Dock 生成' }}</p>
       <NodeTaskCornerActions
         :status="data.status"
         :started-at="typeof data.generationStartedAt === 'string' ? data.generationStartedAt : undefined"

--- a/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
+++ b/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
@@ -1,0 +1,154 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { studioApi, type GenerationRecord } from '@/services/studio-api'
+import DockTypeIcon from '@/components/canvas/dock-studio/shared/DockTypeIcon.vue'
+
+const loading = ref(false)
+const error = ref('')
+const records = ref<GenerationRecord[]>([])
+const filter = ref<'all' | 'text' | 'image' | 'video' | 'audio'>('all')
+
+const FILTERS = [
+  { key: 'all', label: '全部' },
+  { key: 'text', label: '文本' },
+  { key: 'image', label: '生图' },
+  { key: 'video', label: '视频' },
+  { key: 'audio', label: '音频' },
+] as const
+
+const TYPE_LABELS: Record<string, string> = {
+  text: '文本',
+  prompt: '提示词',
+  image: '生图',
+  video: '视频',
+  audio: '音频',
+}
+
+const STATUS_META: Record<string, { label: string; cls: string }> = {
+  completed: { label: '成功', cls: 'bg-emerald-500/15 text-emerald-300' },
+  generating: { label: '生成中', cls: 'bg-indigo-500/15 text-indigo-300 animate-pulse' },
+  pending: { label: '排队中', cls: 'bg-indigo-500/15 text-indigo-300 animate-pulse' },
+  fallback_pending: { label: '待确认', cls: 'bg-amber-500/15 text-amber-300' },
+  failed: { label: '失败', cls: 'bg-red-500/15 text-red-300' },
+  error: { label: '失败', cls: 'bg-red-500/15 text-red-300' },
+}
+
+function statusMeta(status: string) {
+  return STATUS_META[status] ?? { label: status, cls: 'bg-white/10 text-white/50' }
+}
+
+function recordModel(record: GenerationRecord): string {
+  if (record.model) return record.model
+  try {
+    const meta = JSON.parse(record.metadata ?? '{}') as {
+      modelId?: string
+      modelKey?: string
+      originalModel?: string
+    }
+    return meta.originalModel ?? meta.modelId ?? meta.modelKey ?? '—'
+  } catch {
+    return '—'
+  }
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+const filtered = computed(() => {
+  if (filter.value === 'all') return records.value
+  if (filter.value === 'text') {
+    return records.value.filter((r) => r.type === 'text' || r.type === 'prompt')
+  }
+  return records.value.filter((r) => r.type === filter.value)
+})
+
+async function load() {
+  loading.value = true
+  error.value = ''
+  try {
+    const { data } = await studioApi.listGenerations()
+    records.value = data.data
+  } catch {
+    error.value = '加载失败，请确认已登录'
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div class="canvas-task-history flex max-h-[min(520px,72vh)] w-[404px] flex-col">
+    <div class="flex items-center gap-2 border-b border-white/[0.06] px-3 py-2.5">
+      <span class="text-[13px] font-medium text-white/90">任务历史</span>
+      <span class="text-[10px] text-white/30">最近 {{ records.length }} 条</span>
+      <button
+        type="button"
+        class="ml-auto flex h-6 w-6 items-center justify-center rounded-lg text-white/45 transition hover:bg-white/[0.08] hover:text-white"
+        title="刷新"
+        :disabled="loading"
+        @click="load"
+      >
+        <svg class="h-3.5 w-3.5" :class="loading ? 'animate-spin' : ''" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h5M20 20v-5h-5M5.5 9A7.5 7.5 0 0 1 19 8.5M18.5 15A7.5 7.5 0 0 1 5 15.5" />
+        </svg>
+      </button>
+    </div>
+
+    <div class="flex gap-1 px-3 py-2">
+      <button
+        v-for="f in FILTERS"
+        :key="f.key"
+        type="button"
+        class="rounded-full px-2.5 py-1 text-[10px] transition"
+        :class="filter === f.key ? 'bg-[#6366f1]/25 text-[#a5b4fc]' : 'bg-white/[0.04] text-white/45 hover:bg-white/[0.08] hover:text-white/70'"
+        @click="filter = f.key"
+      >
+        {{ f.label }}
+      </button>
+    </div>
+
+    <div class="min-h-0 flex-1 overflow-y-auto px-3 pb-3">
+      <p v-if="error" class="py-8 text-center text-[11px] text-white/35">{{ error }}</p>
+      <p v-else-if="loading && !records.length" class="py-8 text-center text-[11px] text-white/35">加载中...</p>
+      <p v-else-if="!filtered.length" class="py-8 text-center text-[11px] text-white/35">暂无任务记录</p>
+      <div v-else class="grid grid-cols-2 gap-2">
+        <div
+          v-for="record in filtered"
+          :key="record.id"
+          class="rounded-xl border border-white/[0.06] bg-white/[0.03] p-2.5"
+        >
+          <div class="flex items-center gap-1.5">
+            <span class="text-white/55"><DockTypeIcon :type="record.type" :size="13" /></span>
+            <span class="text-[11px] text-white/80">{{ TYPE_LABELS[record.type] ?? record.type }}</span>
+            <span
+              class="ml-auto shrink-0 rounded-md px-1.5 py-0.5 text-[9px]"
+              :class="statusMeta(record.status).cls"
+            >
+              {{ statusMeta(record.status).label }}
+            </span>
+          </div>
+          <img
+            v-if="record.type === 'image' && record.url"
+            :src="record.url"
+            class="mt-1.5 h-16 w-full rounded-lg object-cover"
+            alt=""
+            loading="lazy"
+          />
+          <p class="mt-1.5 line-clamp-2 min-h-[26px] text-[10px] leading-relaxed text-white/50">
+            {{ record.prompt || '—' }}
+          </p>
+          <div class="mt-1.5 flex items-center justify-between gap-2 text-[9px] text-white/35">
+            <span class="truncate" :title="recordModel(record)">{{ recordModel(record) }}</span>
+            <span class="shrink-0 tabular-nums">{{ formatTime(record.createdAt) }}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/web/src/components/canvas/NodePanelDock.vue
+++ b/apps/web/src/components/canvas/NodePanelDock.vue
@@ -2,6 +2,8 @@
 import { ref } from 'vue'
 import { CANVAS_DOCK_MENU_ITEMS } from '@/components/canvas/canvasDockMenu'
 import CanvasAssetPanel, { type CanvasAssetItem } from '@/components/canvas/CanvasAssetPanel.vue'
+import CanvasTaskHistoryPanel from '@/components/canvas/CanvasTaskHistoryPanel.vue'
+import DockTypeIcon from '@/components/canvas/dock-studio/shared/DockTypeIcon.vue'
 import { useClickOutside } from '@/composables/useClickOutside'
 
 export type DockNodeType =
@@ -33,6 +35,7 @@ const emit = defineEmits<{
 
 const showMenu = ref(false)
 const showAssets = ref(false)
+const showHistory = ref(false)
 const rootRef = ref<HTMLElement | null>(null)
 
 const menuItems = CANVAS_DOCK_MENU_ITEMS
@@ -42,87 +45,126 @@ function add(type: DockNodeType) {
   showMenu.value = false
 }
 
+function closePopovers() {
+  showMenu.value = false
+  showAssets.value = false
+  showHistory.value = false
+}
+
 function toggleMenu() {
-  showMenu.value = !showMenu.value
-  if (showMenu.value) showAssets.value = false
+  const next = !showMenu.value
+  closePopovers()
+  showMenu.value = next
 }
 
 function toggleAssets() {
-  showAssets.value = !showAssets.value
-  if (showAssets.value) showMenu.value = false
+  const next = !showAssets.value
+  closePopovers()
+  showAssets.value = next
 }
 
-useClickOutside(rootRef, () => {
-  showMenu.value = false
-  showAssets.value = false
-})
+function toggleHistory() {
+  const next = !showHistory.value
+  closePopovers()
+  showHistory.value = next
+}
+
+useClickOutside(rootRef, closePopovers)
 </script>
 
 <template>
+  <!-- top-[60px]：让出上方返回首页/标题栏，避免遮挡 -->
   <div
     ref="rootRef"
-    class="node-panel-dock pointer-events-none absolute left-3 top-3 z-[50]"
+    class="node-panel-dock pointer-events-none absolute left-3 top-[60px] z-[50]"
   >
     <div class="pointer-events-auto relative">
-      <!-- 竖向面板：添加节点 + 资产库 + 模型设置（文字+图标组合） -->
+      <!-- 竖向面板：添加节点 + 资产库 + 任务历史 + 模型设置 -->
       <div
         class="vertical-capsule flex flex-col items-stretch gap-0.5 rounded-2xl border border-white/[0.08] bg-[rgba(22,22,22,0.94)] p-1 shadow-[0_8px_28px_rgba(0,0,0,0.42)] backdrop-blur-xl"
       >
         <button
           type="button"
-          class="rail-btn text-[#818cf8]"
+          class="rail-btn"
           :class="showMenu ? 'is-active' : ''"
           title="添加节点"
           @click.stop="toggleMenu"
         >
-          <svg
-            class="h-[17px] w-[17px] transition-transform duration-200"
-            :class="showMenu ? 'rotate-45' : ''"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-          </svg>
-          <span class="rail-btn-label">添加</span>
+          <span class="rail-circle rail-circle-primary">
+            <svg
+              class="h-[18px] w-[18px] transition-transform duration-200"
+              :class="showMenu ? 'rotate-45' : ''"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.25" d="M12 4v16m8-8H4" />
+            </svg>
+          </span>
+          <span class="rail-btn-label text-white/85">添加</span>
         </button>
 
         <button
           type="button"
-          class="rail-btn text-white/55"
+          class="rail-btn"
           :class="showAssets ? 'is-active' : ''"
           title="资产库"
           @click.stop="toggleAssets"
         >
-          <svg class="h-[16px] w-[16px]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
-          </svg>
+          <span class="rail-circle">
+            <svg class="h-[16px] w-[16px]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.75"
+                d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"
+              />
+            </svg>
+          </span>
           <span class="rail-btn-label">资产库</span>
           <span
             v-if="assets.length"
-            class="absolute -right-1 -top-1 flex h-3.5 min-w-[14px] items-center justify-center rounded-full bg-[#6366f1] px-0.5 text-[8px] font-semibold text-white"
+            class="absolute right-1 top-0 flex h-3.5 min-w-[14px] items-center justify-center rounded-full bg-[#6366f1] px-0.5 text-[8px] font-semibold text-white"
           >
             {{ assets.length > 99 ? '99+' : assets.length }}
           </span>
+        </button>
+
+        <button
+          type="button"
+          class="rail-btn"
+          :class="showHistory ? 'is-active' : ''"
+          title="任务历史"
+          @click.stop="toggleHistory"
+        >
+          <span class="rail-circle">
+            <svg class="h-[16px] w-[16px]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <circle cx="12" cy="12" r="9" stroke-width="1.75" />
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" d="M12 7v5l3 2" />
+            </svg>
+          </span>
+          <span class="rail-btn-label">历史</span>
         </button>
 
         <span class="mx-auto my-0.5 h-px w-8 bg-white/[0.08]" />
 
         <button
           type="button"
-          class="rail-btn text-white/55"
+          class="rail-btn"
           title="模型服务配置"
           @click.stop="emit('open-settings')"
         >
-          <svg class="h-[16px] w-[16px]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1.75"
-              d="M12 6V4m0 16v-2M6 12H4m16 0h-2M7.05 7.05l-1.4-1.4m12.7 12.7-1.4-1.4M7.05 16.95l-1.4 1.4m12.7-12.7-1.4 1.4"
-            />
-            <circle cx="12" cy="12" r="3" stroke-width="1.75" />
-          </svg>
+          <span class="rail-circle">
+            <svg class="h-[16px] w-[16px]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <circle cx="12" cy="12" r="3" stroke-width="1.75" />
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.75"
+                d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"
+              />
+            </svg>
+          </span>
           <span class="rail-btn-label">设置</span>
         </button>
       </div>
@@ -142,10 +184,10 @@ useClickOutside(rootRef, () => {
             @click="add(item.type)"
           >
             <span
-              class="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-[11px] font-medium"
+              class="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg"
               :class="item.tone"
             >
-              {{ item.label.slice(0, 1) }}
+              <DockTypeIcon :type="item.type" :size="14" />
             </span>
             <div class="min-w-0 flex-1">
               <div class="flex items-center gap-2">
@@ -173,13 +215,23 @@ useClickOutside(rootRef, () => {
           />
         </div>
       </Transition>
+
+      <Transition name="menu-pop">
+        <div
+          v-if="showHistory"
+          class="history-popover absolute left-[calc(100%+10px)] top-0 overflow-hidden rounded-2xl border border-white/10 bg-[#242424] shadow-2xl"
+          @click.stop
+        >
+          <CanvasTaskHistoryPanel />
+        </div>
+      </Transition>
     </div>
   </div>
 </template>
 
 <style scoped>
 .rail-btn {
-  @apply relative flex w-[52px] flex-col items-center justify-center gap-0.5 rounded-xl px-1 py-1.5 transition;
+  @apply relative flex w-[52px] flex-col items-center justify-center gap-1 rounded-xl px-1 py-1.5 text-white/55 transition;
 }
 .rail-btn:hover {
   @apply bg-white/[0.06] text-[#a5b4fc];
@@ -187,6 +239,29 @@ useClickOutside(rootRef, () => {
 .rail-btn.is-active {
   @apply bg-[#6366f1]/15 text-[#a5b4fc];
 }
+
+/* 统一大小的圆形图标底座 */
+.rail-circle {
+  @apply flex h-9 w-9 items-center justify-center rounded-full border border-white/[0.08] bg-white/[0.05] transition;
+}
+.rail-btn:hover .rail-circle {
+  @apply border-white/[0.14] bg-white/[0.1];
+}
+.rail-btn.is-active .rail-circle {
+  @apply border-[#6366f1]/40 bg-[#6366f1]/20;
+}
+
+/* 添加节点：白色高亮凸显 */
+.rail-circle-primary {
+  @apply border-transparent bg-white text-[#161616] shadow-[0_0_14px_rgba(255,255,255,0.35)];
+}
+.rail-btn:hover .rail-circle-primary {
+  @apply border-transparent bg-white text-[#161616] shadow-[0_0_20px_rgba(255,255,255,0.5)];
+}
+.rail-btn.is-active .rail-circle-primary {
+  @apply border-transparent bg-white text-[#161616];
+}
+
 .rail-btn-label {
   @apply text-[10px] leading-none;
 }

--- a/apps/web/src/components/canvas/dock-studio/shared/DockTypeIcon.vue
+++ b/apps/web/src/components/canvas/dock-studio/shared/DockTypeIcon.vue
@@ -50,6 +50,32 @@ const px = computed(() => props.size ?? 16)
       <polyline points="17 8 12 3 7 8" />
       <line x1="12" y1="3" x2="12" y2="15" />
     </template>
+    <template v-else-if="kind === 'shot'">
+      <rect x="2.5" y="5" width="19" height="14" rx="2" stroke-width="1.5" />
+      <line x1="7" y1="5" x2="7" y2="19" stroke-width="1.5" />
+      <line x1="17" y1="5" x2="17" y2="19" stroke-width="1.5" />
+    </template>
+    <template v-else-if="kind === 'director'">
+      <path d="M4 11l16-4v4L4 15v-4z" stroke-width="1.5" />
+      <path d="M6 15l-2 6M12 13.5L10 21M18 12l2 6" stroke-width="1.5" />
+    </template>
+    <template v-else-if="kind === 'composition'">
+      <rect x="2.5" y="4" width="19" height="16" rx="2" stroke-width="1.5" />
+      <line x1="2.5" y1="12" x2="21.5" y2="12" stroke-width="1.5" />
+      <line x1="8" y1="4" x2="8" y2="12" stroke-width="1.5" />
+      <line x1="14" y1="12" x2="14" y2="20" stroke-width="1.5" />
+    </template>
+    <template v-else-if="kind === 'world'">
+      <circle cx="12" cy="12" r="9" stroke-width="1.5" />
+      <ellipse cx="12" cy="12" rx="4" ry="9" stroke-width="1.5" />
+      <line x1="3" y1="12" x2="21" y2="12" stroke-width="1.5" />
+    </template>
+    <template v-else-if="kind === 'group'">
+      <rect x="3" y="3" width="8" height="8" rx="2" stroke-width="1.5" />
+      <rect x="13" y="3" width="8" height="8" rx="2" stroke-width="1.5" />
+      <rect x="3" y="13" width="8" height="8" rx="2" stroke-width="1.5" />
+      <rect x="13" y="13" width="8" height="8" rx="2" stroke-width="1.5" />
+    </template>
     <template v-else>
       <rect x="3" y="3" width="18" height="18" rx="4" />
     </template>


### PR DESCRIPTION
## Summary
- 修复文本/提示词节点双击编辑不持久化的 bug：`onSave` 改为走注入的 `patchCanvasNode`（更新 `nodes` 源数据并触发 `saveCanvas`），不再直接调用 Vue Flow 内部的 `updateNodeData`
- 左上角工具卡下移避开返回按钮；按钮统一圆形，「添加」白色高亮，资产库/设置换成文件夹/齿轮图标
- 新增节点弹窗条目图标化（`DockTypeIcon` 新增 shot/director/composition/world/group 图形）
- 新增「历史」时钟按钮 + `CanvasTaskHistoryPanel`：网格展示生成任务（类型筛选、模型、状态、时间），数据来自 `/studio/generations`

## Test plan
- [x] pnpm build 全绿
- [x] agent 测试 50 passed / server 测试 106 passed
- [x] 本地浏览器验证：双击编辑文本 → 刷新后内容仍在（持久化修复生效）
- [x] Dock 生成会覆盖节点原有内容（符合产品预期）
- [x] 历史面板展示任务记录（文本/成功/模型/时间），类型筛选正常
- [x] 工具卡不再遮挡返回按钮，添加弹窗图标化渲染正常

Made with [Cursor](https://cursor.com)