### PR TITLE
feat: 全局资产库、媒体预览下载、历史定位与上下游连线高亮

### DIFF
--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -24,6 +24,22 @@ model User {
   providerChannels ProviderChannel[]
   aiPreferences    UserAiPreferences?
   webdavConfig     UserWebdavConfig?
+  assets           UserAsset[]
+}
+
+// 用户全局资产库：跨画布可用，用户在节点上主动保存或面板上传入库
+model UserAsset {
+  id           String   @id @default(cuid())
+  userId       String
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  kind         String   @default("image") // image | video | audio
+  url          String
+  label        String   @default("")
+  sourceNodeId String?
+  createdAt    DateTime @default(now())
+
+  @@unique([userId, url])
+  @@index([userId, createdAt])
 }
 
 model ProviderChannel {

--- a/apps/server/src/assets/assets.controller.ts
+++ b/apps/server/src/assets/assets.controller.ts
@@ -1,6 +1,23 @@
-import { Controller, Get, Query } from '@nestjs/common'
-import { IsIn, IsOptional, IsString } from 'class-validator'
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Inject,
+  NotFoundException,
+  Param,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common'
+import { IsIn, IsOptional, IsString, MaxLength } from 'class-validator'
+import { Request } from 'express'
+import { AuthGuard } from '../auth/auth.guard'
+import { PrismaService } from '../prisma/prisma.service'
 import { PUBLIC_ASSETS } from './public-assets.data'
+
+type AuthedRequest = Request & { user: { sub: string; phone: string } }
 
 class PublicAssetsQueryDto {
   @IsOptional()
@@ -12,8 +29,29 @@ class PublicAssetsQueryDto {
   search?: string
 }
 
+class SaveUserAssetDto {
+  @IsIn(['image', 'video', 'audio'])
+  kind!: 'image' | 'video' | 'audio'
+
+  @IsString()
+  @MaxLength(2048)
+  url!: string
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(128)
+  label?: string
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  sourceNodeId?: string
+}
+
 @Controller('assets')
 export class AssetsController {
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
+
   @Get('public')
   findPublic(@Query() query: PublicAssetsQueryDto) {
     let items = PUBLIC_ASSETS
@@ -25,5 +63,45 @@ export class AssetsController {
       items = items.filter((item) => item.label.toLowerCase().includes(q))
     }
     return { code: 0, message: 'ok', data: { items } }
+  }
+
+  @Get('mine')
+  @UseGuards(AuthGuard)
+  async findMine(@Req() req: AuthedRequest) {
+    const items = await this.prisma.userAsset.findMany({
+      where: { userId: req.user.sub },
+      orderBy: { createdAt: 'desc' },
+      take: 500,
+    })
+    return { code: 0, message: 'ok', data: { items } }
+  }
+
+  @Post('mine')
+  @UseGuards(AuthGuard)
+  async saveMine(@Req() req: AuthedRequest, @Body() dto: SaveUserAssetDto) {
+    // 同一 URL 重复保存时更新标签，保持幂等
+    const item = await this.prisma.userAsset.upsert({
+      where: { userId_url: { userId: req.user.sub, url: dto.url } },
+      create: {
+        userId: req.user.sub,
+        kind: dto.kind,
+        url: dto.url,
+        label: dto.label ?? '',
+        sourceNodeId: dto.sourceNodeId,
+      },
+      update: { label: dto.label ?? '', kind: dto.kind },
+    })
+    return { code: 0, message: 'ok', data: item }
+  }
+
+  @Delete('mine/:id')
+  @UseGuards(AuthGuard)
+  async removeMine(@Req() req: AuthedRequest, @Param('id') id: string) {
+    const existing = await this.prisma.userAsset.findFirst({
+      where: { id, userId: req.user.sub },
+    })
+    if (!existing) throw new NotFoundException('资产不存在')
+    await this.prisma.userAsset.delete({ where: { id } })
+    return { code: 0, message: 'ok', data: { id } }
   }
 }

--- a/apps/web/src/components/canvas/CanvasAssetPanel.vue
+++ b/apps/web/src/components/canvas/CanvasAssetPanel.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
 import { assetsApi } from '@/services/assets-api'
+import { assetLibraryVersion, bumpAssetLibrary, saveAssetToLibrary } from '@/composables/useAssetLibrary'
+import { fileToPersistedPayload } from '@/composables/useMediaUpload'
+import { resolveMediaUrl } from '@/services/api-base'
+import { useCanvasEditorStore } from '@/stores/canvasEditor'
 
 export interface CanvasAssetItem {
   id: string
@@ -10,18 +15,15 @@ export interface CanvasAssetItem {
   kind: 'image' | 'video' | 'audio' | 'other'
   /** 资产产生时间（毫秒时间戳），用于时间线分组 */
   createdAt?: number
-  /** user = 画布同步的用户资产；public = 平台发布的公共资产 */
+  /** user = 用户全局资产库；public = 平台发布的公共资产 */
   source?: 'user' | 'public'
 }
 
-const props = defineProps<{
-  assets: CanvasAssetItem[]
-}>()
-
 const emit = defineEmits<{
   apply: [asset: CanvasAssetItem]
-  upload: []
 }>()
+
+const editor = useCanvasEditorStore()
 
 type AssetTab = 'user' | 'public'
 type AssetKindFilter = 'all' | 'image' | 'video' | 'audio'
@@ -30,9 +32,15 @@ const tab = ref<AssetTab>('user')
 const kindFilter = ref<AssetKindFilter>('all')
 const search = ref('')
 
+const userAssets = ref<CanvasAssetItem[]>([])
+const userLoading = ref(false)
 const publicAssets = ref<CanvasAssetItem[]>([])
 const publicLoading = ref(false)
 const publicLoaded = ref(false)
+const uploading = ref(false)
+const fileInput = ref<HTMLInputElement | null>(null)
+
+const loggedIn = computed(() => Boolean(localStorage.getItem('token')))
 
 const kindOptions: Array<{ value: AssetKindFilter; label: string }> = [
   { value: 'all', label: '全部' },
@@ -40,6 +48,30 @@ const kindOptions: Array<{ value: AssetKindFilter; label: string }> = [
   { value: 'video', label: '视频' },
   { value: 'audio', label: '音频' },
 ]
+
+async function loadUserAssets() {
+  if (!loggedIn.value) {
+    userAssets.value = []
+    return
+  }
+  userLoading.value = true
+  try {
+    const res = await assetsApi.listMine()
+    userAssets.value = (res.data?.data?.items ?? []).map((item) => ({
+      id: item.id,
+      nodeId: item.sourceNodeId ?? '',
+      url: item.url,
+      label: item.label,
+      kind: item.kind,
+      createdAt: Date.parse(item.createdAt) || undefined,
+      source: 'user' as const,
+    }))
+  } catch {
+    // 加载失败留空，切换 tab 或保存资产后会重试
+  } finally {
+    userLoading.value = false
+  }
+}
 
 async function loadPublicAssets() {
   if (publicLoaded.value || publicLoading.value) return
@@ -64,16 +96,23 @@ async function loadPublicAssets() {
 }
 
 onMounted(() => {
+  void loadUserAssets()
   void loadPublicAssets()
+})
+
+// 节点侧「存入资产库」成功后自动刷新
+watch(assetLibraryVersion, () => {
+  void loadUserAssets()
 })
 
 function switchTab(next: AssetTab) {
   tab.value = next
   if (next === 'public') void loadPublicAssets()
+  if (next === 'user') void loadUserAssets()
 }
 
 const activeAssets = computed<CanvasAssetItem[]>(() =>
-  tab.value === 'user' ? props.assets : publicAssets.value,
+  tab.value === 'user' ? userAssets.value : publicAssets.value,
 )
 
 const filtered = computed(() => {
@@ -128,6 +167,89 @@ const timeline = computed<TimelineGroup[]>(() => {
   return groups
 })
 
+function displayUrl(asset: CanvasAssetItem) {
+  return resolveMediaUrl(asset.url)
+}
+
+/** 点击 = 预览 */
+function preview(asset: CanvasAssetItem) {
+  if (asset.kind === 'other') return
+  editor.openMediaPreview({
+    url: displayUrl(asset),
+    kind: asset.kind,
+    label: asset.label,
+  })
+}
+
+/** hover 操作：加载到当前画布（选中节点则作为引用，否则新建节点） */
+function apply(asset: CanvasAssetItem) {
+  emit('apply', asset)
+}
+
+async function removeAsset(asset: CanvasAssetItem) {
+  try {
+    await assetsApi.removeMine(asset.id)
+    bumpAssetLibrary()
+  } catch {
+    ElMessage.error('删除失败，请稍后重试')
+  }
+}
+
+async function renameAsset(asset: CanvasAssetItem) {
+  if (asset.kind === 'other') return
+  let value: string
+  try {
+    const result = await ElMessageBox.prompt('输入新的资产名称', '重命名', {
+      inputValue: asset.label,
+      inputPattern: /\S/,
+      inputErrorMessage: '名称不能为空',
+      confirmButtonText: '保存',
+      cancelButtonText: '取消',
+    })
+    value = result.value.trim()
+  } catch {
+    return
+  }
+  if (!value || value === asset.label) return
+  try {
+    // POST /assets/mine 对同一 url 幂等 upsert，直接用于更新标签
+    await assetsApi.saveMine({ kind: asset.kind, url: asset.url, label: value })
+    bumpAssetLibrary()
+  } catch {
+    ElMessage.error('重命名失败，请稍后重试')
+  }
+}
+
+function openUploadPicker() {
+  if (!loggedIn.value) {
+    ElMessage.warning('登录后才能上传到资产库')
+    return
+  }
+  fileInput.value?.click()
+}
+
+async function onUploadChange(event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  input.value = ''
+  if (!file) return
+  uploading.value = true
+  try {
+    const payload = await fileToPersistedPayload(file)
+    if (payload.kind !== 'image' && payload.kind !== 'video' && payload.kind !== 'audio') {
+      ElMessage.warning('仅支持图片、视频、音频文件')
+      return
+    }
+    if (payload.url.startsWith('blob:')) {
+      ElMessage.error('文件上传失败，请重试')
+      return
+    }
+    await saveAssetToLibrary({ kind: payload.kind, url: payload.url, label: payload.fileName })
+  } finally {
+    uploading.value = false
+  }
+}
+
 function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
   event.dataTransfer?.setData('application/lnkpi-asset', JSON.stringify(asset))
   event.dataTransfer?.setData('text/plain', asset.url)
@@ -137,7 +259,7 @@ function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
 
 <template>
   <div class="flex max-h-[min(480px,60vh)] w-[312px] flex-col">
-    <!-- 用户资产 / 公共资产 tab -->
+    <!-- 我的资产（全局） / 公共资产 tab -->
     <div class="flex items-center gap-1 border-b border-[var(--neo-border)] px-3 pt-2.5 pb-2">
       <button
         type="button"
@@ -146,7 +268,7 @@ function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
         @click="switchTab('user')"
       >
         我的资产
-        <span class="ml-0.5 text-[9px] font-normal opacity-60">{{ assets.length }}</span>
+        <span class="ml-0.5 text-[9px] font-normal opacity-60">{{ userAssets.length }}</span>
       </button>
       <button
         type="button"
@@ -161,14 +283,22 @@ function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
         v-if="tab === 'user'"
         type="button"
         class="flex items-center gap-1 rounded-lg px-2 py-1 text-[10px] text-[var(--neo-accent-text)] hover:bg-[var(--neo-hover-bg)]"
-        title="上传素材"
-        @click="emit('upload')"
+        :disabled="uploading"
+        title="上传素材到资产库"
+        @click="openUploadPicker"
       >
         <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M12 4v12m0-12l-4 4m4-4l4 4" />
         </svg>
-        上传
+        {{ uploading ? '上传中...' : '上传' }}
       </button>
+      <input
+        ref="fileInput"
+        type="file"
+        accept="image/*,video/*,audio/*"
+        class="hidden"
+        @change="onUploadChange"
+      >
     </div>
 
     <!-- 分类检索：类型 chips + 关键词搜索 -->
@@ -196,11 +326,14 @@ function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
 
     <!-- 历史时间线 + 网格 -->
     <div class="min-h-0 flex-1 overflow-y-auto px-3 py-2">
-      <p v-if="tab === 'public' && publicLoading" class="py-6 text-center text-[11px] text-[var(--neo-text-muted)]">
-        加载公共资产中...
+      <p v-if="tab === 'user' && !loggedIn" class="py-6 text-center text-[11px] text-[var(--neo-text-muted)]">
+        登录后可使用全局资产库
+      </p>
+      <p v-else-if="(tab === 'user' && userLoading) || (tab === 'public' && publicLoading)" class="py-6 text-center text-[11px] text-[var(--neo-text-muted)]">
+        加载中...
       </p>
       <p v-else-if="!timeline.length" class="py-6 text-center text-[11px] text-[var(--neo-text-muted)]">
-        {{ tab === 'user' ? '画布中生成或上传的素材会同步到这里' : '暂无公共资产' }}
+        {{ tab === 'user' ? '在节点上点「存入资产库」或在此上传素材' : '暂无公共资产' }}
       </p>
 
       <div v-for="group in timeline" :key="group.label" class="mb-3 last:mb-1">
@@ -209,26 +342,28 @@ function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
           {{ group.label }}
         </p>
         <div class="grid grid-cols-3 gap-1.5">
-          <button
+          <div
             v-for="asset in group.items"
             :key="asset.id"
-            type="button"
+            role="button"
+            tabindex="0"
             draggable="true"
-            class="group relative aspect-square overflow-hidden rounded-lg border border-[var(--neo-border)] bg-[var(--neo-hover-bg)] transition hover:border-[var(--neo-accent-border)]"
-            :title="asset.label"
+            class="group relative aspect-square cursor-zoom-in overflow-hidden rounded-lg border border-[var(--neo-border)] bg-[var(--neo-hover-bg)] transition hover:border-[var(--neo-accent-border)]"
+            :title="`${asset.label}（点击预览 · 可拖到画布新建节点 / 拖到底部工具条作引用）`"
             @dragstart="onDragStart($event, asset)"
-            @click="emit('apply', asset)"
+            @click="preview(asset)"
+            @keydown.enter="preview(asset)"
           >
             <img
               v-if="asset.kind === 'image'"
-              :src="asset.url"
+              :src="displayUrl(asset)"
               alt=""
               loading="lazy"
               class="h-full w-full object-cover"
             >
             <video
               v-else-if="asset.kind === 'video'"
-              :src="asset.url"
+              :src="displayUrl(asset)"
               muted
               preload="metadata"
               class="h-full w-full object-cover"
@@ -242,7 +377,7 @@ function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
             <!-- 类型角标 -->
             <span
               v-if="asset.kind !== 'image'"
-              class="absolute left-1 top-1 rounded bg-black/60 px-1 py-px text-[8px] text-[var(--neo-text-secondary)]"
+              class="absolute left-1 top-1 rounded bg-black/60 px-1 py-px text-[8px] text-white/85"
             >
               {{ asset.kind === 'video' ? '视频' : '音频' }}
             </span>
@@ -253,13 +388,42 @@ function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
               公共
             </span>
 
-            <!-- hover 显示名称 -->
-            <span
-              class="absolute inset-x-0 bottom-0 truncate bg-gradient-to-t from-black/80 to-transparent px-1 pb-0.5 pt-3 text-left text-[9px] text-[var(--neo-text-primary)] opacity-0 transition group-hover:opacity-100"
+            <!-- hover 操作层：加载到画布 / 删除 -->
+            <div
+              class="absolute inset-x-0 bottom-0 flex items-center justify-center gap-1 bg-gradient-to-t from-black/85 to-transparent px-1 pb-1 pt-4 opacity-0 transition group-hover:opacity-100"
             >
-              {{ asset.label }}
-            </span>
-          </button>
+              <button
+                type="button"
+                class="rounded-md bg-white/90 px-1.5 py-0.5 text-[9px] font-medium text-black transition hover:bg-white"
+                title="加载到当前画布"
+                @click.stop="apply(asset)"
+              >
+                加载到画布
+              </button>
+              <button
+                v-if="asset.source === 'user'"
+                type="button"
+                class="flex h-4 w-4 items-center justify-center rounded-md bg-black/60 text-white/80 transition hover:bg-black/85 hover:text-white"
+                title="重命名"
+                @click.stop="renameAsset(asset)"
+              >
+                <svg viewBox="0 0 24 24" width="9" height="9" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5z" />
+                </svg>
+              </button>
+              <button
+                v-if="asset.source === 'user'"
+                type="button"
+                class="flex h-4 w-4 items-center justify-center rounded-md bg-black/60 text-white/80 transition hover:bg-red-500/90 hover:text-white"
+                title="从资产库删除"
+                @click.stop="removeAsset(asset)"
+              >
+                <svg viewBox="0 0 24 24" width="9" height="9" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M3 6h18M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2m3 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/canvas/CanvasBottomLeftControls.vue
+++ b/apps/web/src/components/canvas/CanvasBottomLeftControls.vue
@@ -245,7 +245,7 @@ watch(
     </div>
 
     <!-- 单行底栏 -->
-    <div class="toolbar-row neo-chrome pointer-events-auto flex flex-nowrap items-center gap-1 rounded-xl px-1.5 py-1">
+    <div class="toolbar-row neo-glass-lite pointer-events-auto flex flex-nowrap items-center gap-1 rounded-xl px-1.5 py-1">
       <!-- 小地图切换 -->
       <button
         type="button"
@@ -340,7 +340,7 @@ watch(
                 min="8"
                 max="48"
                 step="2"
-                class="mt-1 w-full accent-[var(--neo-accent)]"
+                class="mt-1 w-full accent-[var(--neo-slider-accent)]"
                 :value="settings.gridGap"
                 @input="patch({ gridGap: Number(($event.target as HTMLInputElement).value) })"
               >
@@ -352,7 +352,7 @@ watch(
                 min="0.5"
                 max="4"
                 step="0.1"
-                class="mt-1 w-full accent-[var(--neo-accent)]"
+                class="mt-1 w-full accent-[var(--neo-slider-accent)]"
                 :value="settings.gridDotSize"
                 @input="patch({ gridDotSize: Number(($event.target as HTMLInputElement).value) })"
               >
@@ -364,7 +364,7 @@ watch(
                 min="0.8"
                 max="2"
                 step="0.1"
-                class="mt-1 w-full accent-[var(--neo-accent)]"
+                class="mt-1 w-full accent-[var(--neo-slider-accent)]"
                 :value="settings.bottomToolbarScale"
                 @input="patch({ bottomToolbarScale: Number(($event.target as HTMLInputElement).value) })"
               >
@@ -434,8 +434,9 @@ watch(
 }
 
 .bar-btn.is-accent {
-  background: var(--neo-accent-soft);
-  color: var(--neo-accent-text);
+  background: var(--neo-hi-bg);
+  color: var(--neo-hi-text);
+  box-shadow: var(--neo-hi-shadow);
 }
 
 .list-search {
@@ -483,7 +484,7 @@ watch(
 .zoom-slider {
   width: 64px;
   flex-shrink: 0;
-  accent-color: var(--neo-accent);
+  accent-color: var(--neo-slider-accent);
   height: 4px;
   margin: 0;
 }

--- a/apps/web/src/components/canvas/CanvasNodeAudio.vue
+++ b/apps/web/src/components/canvas/CanvasNodeAudio.vue
@@ -5,6 +5,8 @@ import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { resolveMediaUrl } from '@/services/api-base'
 import { useNodeMediaUpload } from '@/composables/useNodeMediaUpload'
+import { downloadMediaFile, mediaDownloadName } from '@/composables/useCanvasMedia'
+import { saveAssetToLibrary } from '@/composables/useAssetLibrary'
 
 const props = defineProps<{
   id: string
@@ -49,6 +51,25 @@ const {
   onDragLeave,
   onDrop,
 } = useNodeMediaUpload(props.id, 'audio')
+
+function download() {
+  if (!displayUrl.value) return
+  void downloadMediaFile(
+    displayUrl.value,
+    mediaDownloadName(displayUrl.value, 'audio', props.data.label ?? props.data.prompt),
+  )
+}
+
+function saveToLibrary() {
+  const url = String(props.data.url ?? '').trim()
+  if (!url) return
+  void saveAssetToLibrary({
+    kind: 'audio',
+    url,
+    label: props.data.label ?? props.data.prompt ?? '',
+    sourceNodeId: props.id,
+  })
+}
 </script>
 
 <template>
@@ -77,6 +98,32 @@ const {
             <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
             <polyline points="17 8 12 3 7 8" />
             <line x1="12" y1="3" x2="12" y2="15" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          class="neo-node-download-btn nodrag"
+          title="下载音频"
+          @pointerdown.stop
+          @mousedown.stop
+          @click.stop="download"
+        >
+          <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="7 10 12 15 17 10" />
+            <line x1="12" y1="15" x2="12" y2="3" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          class="neo-node-save-btn nodrag"
+          title="存入资产库"
+          @pointerdown.stop
+          @mousedown.stop
+          @click.stop="saveToLibrary"
+        >
+          <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M19 21l-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
           </svg>
         </button>
       </div>

--- a/apps/web/src/components/canvas/CanvasNodeImage.vue
+++ b/apps/web/src/components/canvas/CanvasNodeImage.vue
@@ -6,6 +6,8 @@ import { resolveMediaUrl } from '@/services/api-base'
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useNodeMediaUpload } from '@/composables/useNodeMediaUpload'
+import { downloadMediaFile, mediaDownloadName } from '@/composables/useCanvasMedia'
+import { saveAssetToLibrary } from '@/composables/useAssetLibrary'
 
 const props = defineProps<{
   id: string
@@ -60,6 +62,34 @@ function openEdit() {
     prompt: props.data.prompt,
   })
 }
+
+function openPreview() {
+  if (!displayUrl.value) return
+  editor.openMediaPreview({
+    url: displayUrl.value,
+    kind: 'image',
+    label: props.data.label ?? props.data.prompt,
+  })
+}
+
+function download() {
+  if (!displayUrl.value) return
+  void downloadMediaFile(
+    displayUrl.value,
+    mediaDownloadName(displayUrl.value, 'image', props.data.label ?? props.data.prompt),
+  )
+}
+
+function saveToLibrary() {
+  const url = String(props.data.url ?? '').trim()
+  if (!url) return
+  void saveAssetToLibrary({
+    kind: 'image',
+    url,
+    label: props.data.label ?? props.data.prompt ?? '',
+    sourceNodeId: props.id,
+  })
+}
 </script>
 
 <template>
@@ -74,7 +104,7 @@ function openEdit() {
       @dragleave="onDragLeave"
       @drop="onDrop"
     >
-      <div v-if="data.url" class="neo-gen-preview">
+      <div v-if="data.url" class="neo-gen-preview" title="双击预览大图" @dblclick.stop="openPreview">
         <img :src="displayUrl" alt="">
         <button
           type="button"
@@ -88,6 +118,32 @@ function openEdit() {
             <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
             <polyline points="17 8 12 3 7 8" />
             <line x1="12" y1="3" x2="12" y2="15" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          class="neo-node-download-btn nodrag"
+          title="下载图片"
+          @pointerdown.stop
+          @mousedown.stop
+          @click.stop="download"
+        >
+          <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="7 10 12 15 17 10" />
+            <line x1="12" y1="15" x2="12" y2="3" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          class="neo-node-save-btn nodrag"
+          title="存入资产库"
+          @pointerdown.stop
+          @mousedown.stop
+          @click.stop="saveToLibrary"
+        >
+          <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M19 21l-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
           </svg>
         </button>
         <button

--- a/apps/web/src/components/canvas/CanvasNodeVideo.vue
+++ b/apps/web/src/components/canvas/CanvasNodeVideo.vue
@@ -5,6 +5,8 @@ import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { resolveMediaUrl } from '@/services/api-base'
 import { useNodeMediaUpload } from '@/composables/useNodeMediaUpload'
+import { downloadMediaFile, mediaDownloadName } from '@/composables/useCanvasMedia'
+import { saveAssetToLibrary } from '@/composables/useAssetLibrary'
 
 const props = defineProps<{
   id: string
@@ -49,6 +51,20 @@ const {
   onDragLeave,
   onDrop,
 } = useNodeMediaUpload(props.id, 'video')
+
+function download() {
+  if (!displayUrl.value) return
+  void downloadMediaFile(
+    displayUrl.value,
+    mediaDownloadName(displayUrl.value, 'video', props.data.label),
+  )
+}
+
+function saveToLibrary() {
+  const url = String(props.data.url ?? '').trim()
+  if (!url) return
+  void saveAssetToLibrary({ kind: 'video', url, label: props.data.label ?? '', sourceNodeId: props.id })
+}
 </script>
 
 <template>
@@ -77,6 +93,32 @@ const {
             <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
             <polyline points="17 8 12 3 7 8" />
             <line x1="12" y1="3" x2="12" y2="15" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          class="neo-node-download-btn nodrag"
+          title="下载视频"
+          @pointerdown.stop
+          @mousedown.stop
+          @click.stop="download"
+        >
+          <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="7 10 12 15 17 10" />
+            <line x1="12" y1="15" x2="12" y2="3" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          class="neo-node-save-btn nodrag"
+          title="存入资产库"
+          @pointerdown.stop
+          @mousedown.stop
+          @click.stop="saveToLibrary"
+        >
+          <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M19 21l-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
           </svg>
         </button>
       </div>

--- a/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
+++ b/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
@@ -2,11 +2,20 @@
 import { computed, onMounted, ref } from 'vue'
 import { studioApi, type GenerationRecord } from '@/services/studio-api'
 import DockTypeIcon from '@/components/canvas/dock-studio/shared/DockTypeIcon.vue'
+import { useCanvasEditorStore } from '@/stores/canvasEditor'
+
+const emit = defineEmits<{
+  /** 请求定位到产生该记录的画布节点 */
+  locate: [recordId: string]
+}>()
+
+const editor = useCanvasEditorStore()
 
 const loading = ref(false)
 const error = ref('')
 const records = ref<GenerationRecord[]>([])
 const filter = ref<'all' | 'text' | 'image' | 'video' | 'audio'>('all')
+const detailRecord = ref<GenerationRecord | null>(null)
 
 const FILTERS = [
   { key: 'all', label: '全部' },
@@ -58,6 +67,13 @@ function formatTime(iso: string): string {
   return `${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
+function formatFullTime(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+}
+
 const filtered = computed(() => {
   if (filter.value === 'all') return records.value
   if (filter.value === 'text') {
@@ -79,76 +95,188 @@ async function load() {
   }
 }
 
+function openDetail(record: GenerationRecord) {
+  detailRecord.value = record
+}
+
+function previewDetailMedia(record: GenerationRecord) {
+  if (!record.url) return
+  const kind = record.type === 'video' ? 'video' : record.type === 'audio' ? 'audio' : 'image'
+  editor.openMediaPreview({ url: record.url, kind, label: record.prompt })
+}
+
 onMounted(load)
 </script>
 
 <template>
   <div class="canvas-task-history flex max-h-[min(520px,72vh)] w-[404px] flex-col">
-    <div class="flex items-center gap-2 border-b border-[var(--neo-border)] px-3 py-2.5">
-      <span class="text-[13px] font-medium text-[var(--neo-text-primary)]">任务历史</span>
-      <span class="text-[10px] text-[var(--neo-text-muted)]">最近 {{ records.length }} 条</span>
-      <button
-        type="button"
-        class="ml-auto flex h-6 w-6 items-center justify-center rounded-lg text-[var(--neo-text-muted)] transition hover:bg-[var(--neo-active-bg)] hover:text-[var(--neo-text-primary)]"
-        title="刷新"
-        :disabled="loading"
-        @click="load"
-      >
-        <svg class="h-3.5 w-3.5" :class="loading ? 'animate-spin' : ''" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h5M20 20v-5h-5M5.5 9A7.5 7.5 0 0 1 19 8.5M18.5 15A7.5 7.5 0 0 1 5 15.5" />
-        </svg>
-      </button>
-    </div>
-
-    <div class="flex gap-1 px-3 py-2">
-      <button
-        v-for="f in FILTERS"
-        :key="f.key"
-        type="button"
-        class="rounded-full px-2.5 py-1 text-[10px] transition"
-        :class="filter === f.key ? 'bg-[var(--neo-accent-soft)] text-[var(--neo-accent-text)]' : 'bg-[var(--neo-hover-bg)] text-[var(--neo-text-muted)] hover:bg-[var(--neo-active-bg)] hover:text-[var(--neo-text-secondary)]'"
-        @click="filter = f.key"
-      >
-        {{ f.label }}
-      </button>
-    </div>
-
-    <div class="min-h-0 flex-1 overflow-y-auto px-3 pb-3">
-      <p v-if="error" class="py-8 text-center text-[11px] text-[var(--neo-text-muted)]">{{ error }}</p>
-      <p v-else-if="loading && !records.length" class="py-8 text-center text-[11px] text-[var(--neo-text-muted)]">加载中...</p>
-      <p v-else-if="!filtered.length" class="py-8 text-center text-[11px] text-[var(--neo-text-muted)]">暂无任务记录</p>
-      <div v-else class="grid grid-cols-2 gap-2">
-        <div
-          v-for="record in filtered"
-          :key="record.id"
-          class="rounded-xl border border-[var(--neo-border)] bg-[var(--neo-hover-bg)] p-2.5"
+    <!-- 详情视图 -->
+    <template v-if="detailRecord">
+      <div class="flex items-center gap-2 border-b border-[var(--neo-border)] px-3 py-2.5">
+        <button
+          type="button"
+          class="flex h-6 w-6 items-center justify-center rounded-lg text-[var(--neo-text-muted)] transition hover:bg-[var(--neo-active-bg)] hover:text-[var(--neo-text-primary)]"
+          title="返回列表"
+          @click="detailRecord = null"
         >
-          <div class="flex items-center gap-1.5">
-            <span class="text-[var(--neo-text-muted)]"><DockTypeIcon :type="record.type" :size="13" /></span>
-            <span class="text-[11px] text-[var(--neo-text-secondary)]">{{ TYPE_LABELS[record.type] ?? record.type }}</span>
-            <span
-              class="ml-auto shrink-0 rounded-md px-1.5 py-0.5 text-[9px]"
-              :class="statusMeta(record.status).cls"
-            >
-              {{ statusMeta(record.status).label }}
-            </span>
+          <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+        <span class="text-[13px] font-medium text-[var(--neo-text-primary)]">任务详情</span>
+        <span
+          class="ml-auto shrink-0 rounded-md px-1.5 py-0.5 text-[9px]"
+          :class="statusMeta(detailRecord.status).cls"
+        >
+          {{ statusMeta(detailRecord.status).label }}
+        </span>
+      </div>
+
+      <div class="min-h-0 flex-1 overflow-y-auto px-3 py-3">
+        <div
+          v-if="detailRecord.url && detailRecord.type === 'image'"
+          class="mb-3 cursor-zoom-in overflow-hidden rounded-xl border border-[var(--neo-border)]"
+          title="点击预览大图"
+          @click="previewDetailMedia(detailRecord)"
+        >
+          <img :src="detailRecord.url" class="w-full object-cover" alt="" >
+        </div>
+        <video
+          v-else-if="detailRecord.url && detailRecord.type === 'video'"
+          :src="detailRecord.url"
+          controls
+          class="mb-3 w-full rounded-xl border border-[var(--neo-border)]"
+        />
+        <audio
+          v-else-if="detailRecord.url && detailRecord.type === 'audio'"
+          :src="detailRecord.url"
+          controls
+          class="mb-3 w-full"
+        />
+
+        <div class="space-y-2.5 text-[11px]">
+          <div>
+            <p class="mb-1 text-[10px] uppercase tracking-wider text-[var(--neo-text-muted)]">提示词</p>
+            <p class="whitespace-pre-wrap break-words rounded-lg bg-[var(--neo-hover-bg)] p-2 leading-relaxed text-[var(--neo-text-secondary)]">
+              {{ detailRecord.prompt || '—' }}
+            </p>
           </div>
-          <img
-            v-if="record.type === 'image' && record.url"
-            :src="record.url"
-            class="mt-1.5 h-16 w-full rounded-lg object-cover"
-            alt=""
-            loading="lazy"
-          />
-          <p class="mt-1.5 line-clamp-2 min-h-[26px] text-[10px] leading-relaxed text-[var(--neo-text-muted)]">
-            {{ record.prompt || '—' }}
-          </p>
-          <div class="mt-1.5 flex items-center justify-between gap-2 text-[9px] text-[var(--neo-text-muted)]">
-            <span class="truncate" :title="recordModel(record)">{{ recordModel(record) }}</span>
-            <span class="shrink-0 tabular-nums">{{ formatTime(record.createdAt) }}</span>
+          <div class="grid grid-cols-2 gap-2">
+            <div>
+              <p class="mb-0.5 text-[10px] text-[var(--neo-text-muted)]">类型</p>
+              <p class="text-[var(--neo-text-secondary)]">{{ TYPE_LABELS[detailRecord.type] ?? detailRecord.type }}</p>
+            </div>
+            <div>
+              <p class="mb-0.5 text-[10px] text-[var(--neo-text-muted)]">模型</p>
+              <p class="truncate text-[var(--neo-text-secondary)]" :title="recordModel(detailRecord)">{{ recordModel(detailRecord) }}</p>
+            </div>
+            <div class="col-span-2">
+              <p class="mb-0.5 text-[10px] text-[var(--neo-text-muted)]">创建时间</p>
+              <p class="tabular-nums text-[var(--neo-text-secondary)]">{{ formatFullTime(detailRecord.createdAt) }}</p>
+            </div>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          class="mt-3 flex w-full items-center justify-center gap-1.5 rounded-xl bg-[var(--neo-hi-bg)] py-2 text-[11px] font-medium text-[var(--neo-hi-text)] transition hover:brightness-105"
+          @click="emit('locate', detailRecord.id)"
+        >
+          <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <circle cx="12" cy="12" r="3" />
+            <path stroke-linecap="round" d="M12 2v4m0 12v4M2 12h4m12 0h4" />
+          </svg>
+          定位到画布节点
+        </button>
+      </div>
+    </template>
+
+    <!-- 列表视图 -->
+    <template v-else>
+      <div class="flex items-center gap-2 border-b border-[var(--neo-border)] px-3 py-2.5">
+        <span class="text-[13px] font-medium text-[var(--neo-text-primary)]">任务历史</span>
+        <span class="text-[10px] text-[var(--neo-text-muted)]">最近 {{ records.length }} 条</span>
+        <button
+          type="button"
+          class="ml-auto flex h-6 w-6 items-center justify-center rounded-lg text-[var(--neo-text-muted)] transition hover:bg-[var(--neo-active-bg)] hover:text-[var(--neo-text-primary)]"
+          title="刷新"
+          :disabled="loading"
+          @click="load"
+        >
+          <svg class="h-3.5 w-3.5" :class="loading ? 'animate-spin' : ''" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h5M20 20v-5h-5M5.5 9A7.5 7.5 0 0 1 19 8.5M18.5 15A7.5 7.5 0 0 1 5 15.5" />
+          </svg>
+        </button>
+      </div>
+
+      <div class="flex gap-1 px-3 py-2">
+        <button
+          v-for="f in FILTERS"
+          :key="f.key"
+          type="button"
+          class="rounded-full px-2.5 py-1 text-[10px] transition"
+          :class="filter === f.key ? 'bg-[var(--neo-accent-soft)] text-[var(--neo-accent-text)]' : 'bg-[var(--neo-hover-bg)] text-[var(--neo-text-muted)] hover:bg-[var(--neo-active-bg)] hover:text-[var(--neo-text-secondary)]'"
+          @click="filter = f.key"
+        >
+          {{ f.label }}
+        </button>
+      </div>
+
+      <div class="min-h-0 flex-1 overflow-y-auto px-3 pb-3">
+        <p v-if="error" class="py-8 text-center text-[11px] text-[var(--neo-text-muted)]">{{ error }}</p>
+        <p v-else-if="loading && !records.length" class="py-8 text-center text-[11px] text-[var(--neo-text-muted)]">加载中...</p>
+        <p v-else-if="!filtered.length" class="py-8 text-center text-[11px] text-[var(--neo-text-muted)]">暂无任务记录</p>
+        <div v-else class="grid grid-cols-2 gap-2">
+          <div
+            v-for="record in filtered"
+            :key="record.id"
+            role="button"
+            tabindex="0"
+            class="history-card group relative cursor-pointer rounded-xl border border-[var(--neo-border)] bg-[var(--neo-hover-bg)] p-2.5 transition hover:border-[var(--neo-accent-border)]"
+            title="点击查看详情"
+            @click="openDetail(record)"
+            @keydown.enter="openDetail(record)"
+          >
+            <div class="flex items-center gap-1.5">
+              <span class="text-[var(--neo-text-muted)]"><DockTypeIcon :type="record.type" :size="13" /></span>
+              <span class="text-[11px] text-[var(--neo-text-secondary)]">{{ TYPE_LABELS[record.type] ?? record.type }}</span>
+              <span
+                class="ml-auto shrink-0 rounded-md px-1.5 py-0.5 text-[9px]"
+                :class="statusMeta(record.status).cls"
+              >
+                {{ statusMeta(record.status).label }}
+              </span>
+            </div>
+            <img
+              v-if="record.type === 'image' && record.url"
+              :src="record.url"
+              class="mt-1.5 h-16 w-full rounded-lg object-cover"
+              alt=""
+              loading="lazy"
+            />
+            <p class="mt-1.5 line-clamp-2 min-h-[26px] text-[10px] leading-relaxed text-[var(--neo-text-muted)]">
+              {{ record.prompt || '—' }}
+            </p>
+            <div class="mt-1.5 flex items-center justify-between gap-2 text-[9px] text-[var(--neo-text-muted)]">
+              <span class="truncate" :title="recordModel(record)">{{ recordModel(record) }}</span>
+              <span class="shrink-0 tabular-nums">{{ formatTime(record.createdAt) }}</span>
+            </div>
+
+            <!-- hover 定位按钮 -->
+            <button
+              type="button"
+              class="absolute right-1.5 top-8 hidden h-6 w-6 items-center justify-center rounded-lg bg-black/60 text-white/85 transition hover:bg-black/85 hover:text-white group-hover:flex"
+              title="定位到画布节点"
+              @click.stop="emit('locate', record.id)"
+            >
+              <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <circle cx="12" cy="12" r="3" />
+                <path stroke-linecap="round" d="M12 2v4m0 12v4M2 12h4m12 0h4" />
+              </svg>
+            </button>
           </div>
         </div>
       </div>
-    </div>
+    </template>
   </div>
 </template>

--- a/apps/web/src/components/canvas/MediaPreviewOverlay.vue
+++ b/apps/web/src/components/canvas/MediaPreviewOverlay.vue
@@ -1,0 +1,151 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted } from 'vue'
+import { useCanvasEditorStore } from '@/stores/canvasEditor'
+import { downloadMediaFile, mediaDownloadName } from '@/composables/useCanvasMedia'
+
+const editor = useCanvasEditorStore()
+const target = computed(() => editor.previewTarget)
+
+function close() {
+  editor.closeMediaPreview()
+}
+
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape' && target.value) {
+    event.stopPropagation()
+    close()
+  }
+}
+
+async function download() {
+  if (!target.value) return
+  await downloadMediaFile(
+    target.value.url,
+    mediaDownloadName(target.value.url, target.value.kind, target.value.label),
+  )
+}
+
+onMounted(() => window.addEventListener('keydown', onKeydown, true))
+onUnmounted(() => window.removeEventListener('keydown', onKeydown, true))
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="preview-fade">
+      <div
+        v-if="target"
+        class="media-preview-mask fixed inset-0 z-[120] flex items-center justify-center"
+        @click.self="close"
+      >
+        <!-- 顶部操作栏 -->
+        <div class="absolute right-4 top-4 z-10 flex items-center gap-2">
+          <button
+            type="button"
+            class="preview-ctl"
+            title="下载"
+            @click.stop="download"
+          >
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+              <polyline points="7 10 12 15 17 10" />
+              <line x1="12" y1="15" x2="12" y2="3" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            class="preview-ctl"
+            title="关闭 (Esc)"
+            @click.stop="close"
+          >
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        <!-- 媒体主体 -->
+        <img
+          v-if="target.kind === 'image'"
+          :src="target.url"
+          :alt="target.label ?? ''"
+          class="preview-media select-none"
+          draggable="false"
+        >
+        <video
+          v-else-if="target.kind === 'video'"
+          :src="target.url"
+          controls
+          autoplay
+          class="preview-media"
+        />
+        <div v-else class="preview-audio-card">
+          <svg class="mx-auto mb-4 h-10 w-10 opacity-60" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 19V6l12-3v13M9 19a3 3 0 11-6 0 3 3 0 016 0zm12-3a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+          <audio :src="target.url" controls autoplay class="w-[320px]" />
+        </div>
+
+        <!-- 底部标题 -->
+        <p
+          v-if="target.label"
+          class="absolute bottom-4 left-1/2 max-w-[70vw] -translate-x-1/2 truncate rounded-full bg-black/55 px-4 py-1.5 text-xs text-white/85 backdrop-blur-sm"
+        >
+          {{ target.label }}
+        </p>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.media-preview-mask {
+  background: rgba(8, 8, 12, 0.82);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.preview-media {
+  max-width: min(90vw, 1400px);
+  max-height: 86vh;
+  border-radius: 12px;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.6);
+}
+
+.preview-audio-card {
+  padding: 32px 40px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(24, 24, 30, 0.9);
+  color: rgba(255, 255, 255, 0.85);
+  text-align: center;
+}
+
+.preview-ctl {
+  display: inline-flex;
+  width: 36px;
+  height: 36px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 12px;
+  background: rgba(20, 20, 26, 0.72);
+  color: rgba(255, 255, 255, 0.85);
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.preview-ctl:hover {
+  background: rgba(45, 45, 55, 0.9);
+  color: #fff;
+}
+
+.preview-fade-enter-active,
+.preview-fade-leave-active {
+  transition: opacity 0.18s ease;
+}
+
+.preview-fade-enter-from,
+.preview-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/apps/web/src/components/canvas/NodePanelDock.vue
+++ b/apps/web/src/components/canvas/NodePanelDock.vue
@@ -19,18 +19,11 @@ export type DockNodeType =
   | 'group'
   | 'shot'
 
-withDefaults(
-  defineProps<{
-    assets?: CanvasAssetItem[]
-  }>(),
-  { assets: () => [] },
-)
-
 const emit = defineEmits<{
   add: [type: DockNodeType]
   'open-settings': []
   'asset-apply': [asset: CanvasAssetItem]
-  'asset-upload': []
+  'history-locate': [recordId: string]
 }>()
 
 const showMenu = ref(false)
@@ -81,7 +74,7 @@ useClickOutside(rootRef, closePopovers)
     <div class="pointer-events-auto relative">
       <!-- 竖向面板：添加节点 + 资产库 + 任务历史 + 模型设置 -->
       <div
-        class="vertical-capsule neo-chrome flex flex-col items-stretch gap-0.5 rounded-2xl p-1"
+        class="vertical-capsule neo-glass-lite flex flex-col items-stretch gap-0.5 rounded-2xl p-1"
       >
         <button
           type="button"
@@ -122,12 +115,6 @@ useClickOutside(rootRef, closePopovers)
             </svg>
           </span>
           <span class="rail-btn-label">资产库</span>
-          <span
-            v-if="assets.length"
-            class="absolute right-1 top-0 flex h-3.5 min-w-[14px] items-center justify-center rounded-full bg-[var(--neo-accent)] px-0.5 text-[8px] font-semibold text-white"
-          >
-            {{ assets.length > 99 ? '99+' : assets.length }}
-          </span>
         </button>
 
         <button
@@ -208,11 +195,7 @@ useClickOutside(rootRef, closePopovers)
           class="asset-popover neo-popover absolute left-[calc(100%+10px)] top-0 overflow-hidden rounded-2xl"
           @click.stop
         >
-          <CanvasAssetPanel
-            :assets="assets"
-            @apply="emit('asset-apply', $event)"
-            @upload="emit('asset-upload')"
-          />
+          <CanvasAssetPanel @apply="emit('asset-apply', $event)" />
         </div>
       </Transition>
 
@@ -222,7 +205,7 @@ useClickOutside(rootRef, closePopovers)
           class="history-popover neo-popover absolute left-[calc(100%+10px)] top-0 overflow-hidden rounded-2xl"
           @click.stop
         >
-          <CanvasTaskHistoryPanel />
+          <CanvasTaskHistoryPanel @locate="emit('history-locate', $event)" />
         </div>
       </Transition>
     </div>
@@ -258,17 +241,17 @@ useClickOutside(rootRef, closePopovers)
   background: var(--neo-accent-soft);
 }
 
-/* 添加节点：品牌渐变凸显 */
+/* 添加节点：白色高亮凸显（浅色主题下自动转深色高亮） */
 .rail-circle-primary,
 .rail-btn:hover .rail-circle-primary,
 .rail-btn.is-active .rail-circle-primary {
   border-color: transparent;
-  background: var(--neo-brand-gradient);
-  color: #fff;
-  box-shadow: 0 0 16px rgba(109, 93, 252, 0.45);
+  background: var(--neo-hi-bg);
+  color: var(--neo-hi-text);
+  box-shadow: var(--neo-hi-shadow);
 }
 .rail-btn:hover .rail-circle-primary {
-  box-shadow: 0 0 22px rgba(109, 93, 252, 0.6);
+  filter: brightness(1.06);
 }
 
 .rail-btn-label {

--- a/apps/web/src/components/canvas/dock-studio/shared/DockGenerateButton.vue
+++ b/apps/web/src/components/canvas/dock-studio/shared/DockGenerateButton.vue
@@ -58,11 +58,11 @@ const emit = defineEmits<{
   justify-content: center;
   border: none;
   border-radius: 999px;
-  background: var(--neo-brand-gradient);
-  color: #fff;
+  background: var(--neo-hi-bg);
+  color: var(--neo-hi-text);
   cursor: pointer;
   pointer-events: auto;
-  box-shadow: 0 2px 12px rgba(109, 93, 252, 0.45);
+  box-shadow: var(--neo-hi-shadow);
   transition:
     transform 0.15s ease,
     opacity 0.15s ease,
@@ -71,9 +71,8 @@ const emit = defineEmits<{
 }
 
 .dock-generate-btn:hover:not(:disabled) {
-  filter: brightness(1.1);
+  filter: brightness(1.06);
   transform: scale(1.05);
-  box-shadow: 0 3px 16px rgba(109, 93, 252, 0.6);
 }
 
 .dock-generate-btn:disabled {

--- a/apps/web/src/composables/useAssetLibrary.ts
+++ b/apps/web/src/composables/useAssetLibrary.ts
@@ -1,0 +1,31 @@
+import { ref } from 'vue'
+import { ElMessage } from 'element-plus'
+import { assetsApi, type SaveUserAssetPayload } from '@/services/assets-api'
+
+/** 资产库版本号：保存/删除成功后自增，资产库面板据此重新拉取 */
+export const assetLibraryVersion = ref(0)
+
+export function bumpAssetLibrary() {
+  assetLibraryVersion.value += 1
+}
+
+/** 把节点媒体保存进全局资产库（需登录；同一 URL 幂等） */
+export async function saveAssetToLibrary(payload: SaveUserAssetPayload) {
+  if (!localStorage.getItem('token')) {
+    ElMessage.warning('登录后才能保存到资产库')
+    return false
+  }
+  if (payload.url.startsWith('blob:')) {
+    ElMessage.warning('该文件尚未上传成功，无法保存到资产库')
+    return false
+  }
+  try {
+    await assetsApi.saveMine(payload)
+    bumpAssetLibrary()
+    ElMessage.success('已存入资产库')
+    return true
+  } catch {
+    ElMessage.error('保存失败，请稍后重试')
+    return false
+  }
+}

--- a/apps/web/src/composables/useCanvasMedia.ts
+++ b/apps/web/src/composables/useCanvasMedia.ts
@@ -1,4 +1,5 @@
 import type { Ref } from 'vue'
+import { resolveMediaUrl } from '@/services/api-base'
 
 export type FileNodeKind = 'text' | 'image' | 'video' | 'audio'
 
@@ -99,7 +100,7 @@ export async function downloadMediaPackage(
 
   for (const item of items) {
     try {
-      const res = await fetch(item.url)
+      const res = await fetch(resolveMediaUrl(item.url))
       const blob = await res.blob()
       triggerDownload(blob, item.fileName)
       await delay(280)
@@ -117,6 +118,27 @@ function triggerDownload(blob: Blob, filename: string) {
   anchor.download = filename
   anchor.click()
   URL.revokeObjectURL(url)
+}
+
+/** 下载单个媒体文件；跨域 fetch 失败时退化为新标签页打开 */
+export async function downloadMediaFile(url: string, filename: string) {
+  try {
+    const res = await fetch(url)
+    if (!res.ok) throw new Error(String(res.status))
+    triggerDownload(await res.blob(), filename)
+  } catch {
+    window.open(url, '_blank', 'noopener')
+  }
+}
+
+const EXT_BY_KIND: Record<string, string> = { image: 'png', video: 'mp4', audio: 'mp3' }
+
+/** 由 URL / label 推导下载文件名 */
+export function mediaDownloadName(url: string, kind: string, label?: string) {
+  const urlExt = /\.([a-z0-9]{2,5})(?:\?|#|$)/i.exec(url)?.[1]
+  const ext = urlExt ?? EXT_BY_KIND[kind] ?? 'bin'
+  const base = (label ?? 'lnkpi-media').replace(/[/\\?%*:|"<>]/g, '_').slice(0, 48) || 'lnkpi-media'
+  return base.toLowerCase().endsWith(`.${ext.toLowerCase()}`) ? base : `${base}.${ext}`
 }
 
 function delay(ms: number) {

--- a/apps/web/src/composables/useNodeGeneration.test.ts
+++ b/apps/web/src/composables/useNodeGeneration.test.ts
@@ -564,6 +564,7 @@ describe('useNodeGeneration', () => {
     expect(deps.patchNodeData).toHaveBeenCalledWith('image-1', {
       status: NODE_GENERATION_STATUS.error,
       errorMessage: '参考图尚未上传，请先上传后再生成',
+      errorCode: 'upload_required',
     })
   })
 
@@ -580,10 +581,11 @@ describe('useNodeGeneration', () => {
     await api.generateForNode(node)
 
     expect(studioApi.generateImage).not.toHaveBeenCalled()
-    expect(deps.patchNodeData).toHaveBeenCalledWith('image-1', {
+    expect(deps.patchNodeData).toHaveBeenCalledWith('image-1', expect.objectContaining({
       status: NODE_GENERATION_STATUS.error,
-      errorMessage: '参考图尚未上传，请先上传后再生成',
-    })
+      errorMessage: expect.stringContaining('未上传成功'),
+      errorCode: 'upload_required',
+    }))
   })
 
   it('passes shot-linked image child params to canvasApi.generateImage', async () => {
@@ -657,10 +659,11 @@ describe('useNodeGeneration', () => {
     await api.generateForNode(image)
 
     expect(canvasApi.generateImage).not.toHaveBeenCalled()
-    expect(deps.patchNodeData).toHaveBeenCalledWith('image-1', {
+    expect(deps.patchNodeData).toHaveBeenCalledWith('image-1', expect.objectContaining({
       status: NODE_GENERATION_STATUS.error,
-      errorMessage: '参考图尚未上传，请先上传后再生成',
-    })
+      errorMessage: expect.stringContaining('未上传成功'),
+      errorCode: 'upload_required',
+    }))
   })
 
   it('generateShot uses shot local prompt with shot refs', async () => {

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -123,13 +123,17 @@ function firstImageRefUrl(refs: StudioRefPayload[]): string {
   return ''
 }
 
-function hasBlobReference(refs: StudioRefPayload[], data: Record<string, unknown>): boolean {
+/** 找出仍是 blob 本地地址（未持久化上传）的引用，返回可读的错误消息；无问题时返回 null */
+function blobReferenceError(refs: StudioRefPayload[], data: Record<string, unknown>): string | null {
   const direct = String(data.referenceImageUrl ?? '').trim()
-  if (direct.startsWith('blob:')) return true
+  if (direct.startsWith('blob:')) return '参考图尚未上传，请先上传后再生成'
   for (const ref of refs) {
-    if (ref.url?.trim().startsWith('blob:')) return true
+    if (ref.url?.trim().startsWith('blob:')) {
+      const label = ref.label ? `（${ref.label}）` : ''
+      return `参考图 @${ref.refKey}${label}未上传成功，请在来源节点重新上传后再生成`
+    }
   }
-  return false
+  return null
 }
 
 function findNodeById(nodes: EditableFlowNode[], id: string) {
@@ -506,10 +510,12 @@ async function cancelRemoteGeneration(nodeId: string) {
       return
     }
 
-    if (hasBlobReference(refs, data)) {
+    const blobError = blobReferenceError(refs, data)
+    if (blobError) {
       deps.patchNodeData(node.id, {
         status: NODE_GENERATION_STATUS.error,
-        errorMessage: '参考图尚未上传，请先上传后再生成',
+        errorMessage: blobError,
+        errorCode: 'upload_required',
       })
       return
     }
@@ -915,10 +921,12 @@ async function cancelRemoteGeneration(nodeId: string) {
       if (!items.length) return
 
       for (const item of items) {
-        if (hasBlobReference(item.refs ?? [], {})) {
+        const itemBlobError = blobReferenceError(item.refs ?? [], {})
+        if (itemBlobError) {
           deps.patchNodeData(node.id, {
             status: NODE_GENERATION_STATUS.error,
-            errorMessage: '参考图尚未上传，请先上传后再生成',
+            errorMessage: itemBlobError,
+            errorCode: 'upload_required',
           })
           return
         }

--- a/apps/web/src/composables/useNodeMediaUpload.ts
+++ b/apps/web/src/composables/useNodeMediaUpload.ts
@@ -36,6 +36,17 @@ export function useNodeMediaUpload(nodeId: string, kind: NodeMediaKind) {
       return
     }
     const payload = await fileToPersistedPayload(file)
+    // 登录态下上传失败会回退成 blob 本地地址：立即报错，
+    // 避免静默落下 blob 后在下游生成时才报「参考图尚未上传」
+    if (payload.url.startsWith('blob:') && localStorage.getItem('token')) {
+      flashReject()
+      patchNode(nodeId, {
+        status: 'error',
+        errorMessage: '文件上传失败，请重试',
+        errorCode: 'upload_required',
+      })
+      return
+    }
     patchNode(nodeId, {
       url: payload.url,
       status: 'idle',

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -22,6 +22,7 @@ import '@vue-flow/core/dist/style.css'
 import '@vue-flow/core/dist/theme-default.css'
 import '@vue-flow/minimap/dist/style.css'
 import type { Session, CanvasAction } from '@lnkpi/shared'
+import { ElMessage } from 'element-plus'
 import { api } from '@/services/api'
 import { useAuthStore } from '@/stores/auth'
 import { useCanvasEditorStore } from '@/stores/canvasEditor'
@@ -90,6 +91,7 @@ import {
 } from '@/composables/canvasNodeActions'
 import type { CanvasAssetItem } from '@/components/canvas/CanvasAssetPanel.vue'
 import AIImageEditor from '@/components/canvas/AIImageEditor.vue'
+import MediaPreviewOverlay from '@/components/canvas/MediaPreviewOverlay.vue'
 import CanvasContextMenu from '@/components/canvas/CanvasContextMenu.vue'
 import StoryboardDialog, { type StoryboardShot } from '@/components/canvas/StoryboardDialog.vue'
 import PublishNeoTVDialog from '@/components/works/PublishNeoTVDialog.vue'
@@ -143,12 +145,37 @@ const upstreamEdgeIds = computed(() => {
   return ids
 })
 
+/** 选中单个节点时，顺流其全部下游连线（暖橙高亮，与上游电流青区分） */
+const downstreamEdgeIds = computed(() => {
+  const ids = new Set<string>()
+  const source = multiSelectedIds.value.length === 1 ? multiSelectedIds.value[0] : null
+  if (!source) return ids
+  const visited = new Set<string>([source])
+  const queue = [source]
+  while (queue.length) {
+    const nodeId = queue.pop()!
+    for (const edge of edges.value) {
+      if (edge.source !== nodeId || ids.has(edge.id)) continue
+      ids.add(edge.id)
+      if (!visited.has(edge.target)) {
+        visited.add(edge.target)
+        queue.push(edge.target)
+      }
+    }
+  }
+  return ids
+})
+
 const flowEdges = computed(() => {
   const upstream = upstreamEdgeIds.value
-  if (!upstream.size) return edges.value as unknown as Edge[]
-  return edges.value.map((edge) =>
-    upstream.has(edge.id) ? { ...edge, class: 'neo-edge-upstream' } : edge,
-  ) as unknown as Edge[]
+  const downstream = downstreamEdgeIds.value
+  if (!upstream.size && !downstream.size) return edges.value as unknown as Edge[]
+  return edges.value.map((edge) => {
+    // 环路中同属上下游时，上游电流优先
+    if (upstream.has(edge.id)) return { ...edge, class: 'neo-edge-upstream' }
+    if (downstream.has(edge.id)) return { ...edge, class: 'neo-edge-downstream' }
+    return edge
+  }) as unknown as Edge[]
 })
 
 const { selectNode, clearEditorSelection, clearSelection, patchNodeData, selectedNodeId } = useSelectedNodeEditor(nodes)
@@ -268,32 +295,6 @@ watch(
     edges.value = edges.value.map((edge) => ({ ...edge, animated }))
   },
 )
-
-const canvasAssets = computed((): CanvasAssetItem[] => {
-  const out: CanvasAssetItem[] = []
-  for (const node of nodes.value) {
-    const data = node.data as Record<string, unknown>
-    const url = String(data.url ?? '').trim()
-    if (!url) continue
-    const type = String(node.type ?? '')
-    if (!['image', 'video', 'audio'].includes(type)) continue
-    let kind: CanvasAssetItem['kind'] = 'other'
-    if (type === 'image') kind = url.match(/\.(mp4|webm|mov)/i) ? 'video' : 'image'
-    else if (type === 'video') kind = 'video'
-    else if (type === 'audio') kind = 'audio'
-    const createdAt = Number(data.createdAt ?? 0)
-    out.push({
-      id: `${node.id}-asset`,
-      nodeId: node.id,
-      url,
-      label: String(data.title ?? data.fileName ?? data.prompt ?? node.id),
-      kind,
-      createdAt: Number.isFinite(createdAt) && createdAt > 0 ? createdAt : undefined,
-      source: 'user',
-    })
-  }
-  return out
-})
 
 const canvasInteractionEnabled = computed(() => canvasMode.value === 'vueflow' && !viewportSettings.value.viewLocked)
 
@@ -1247,6 +1248,10 @@ async function createFileNodeAt(payload: MediaFilePayload, clientPos: { x: numbe
     mimeType: payload.mimeType,
     title,
   }
+  // 媒体文件上传失败（url 为空）时创建 error 节点提示重传，而不是静默落 blob
+  const mediaStatus = payload.url
+    ? { url: payload.url, status: 'completed' }
+    : { status: 'error', errorMessage: '文件上传失败，请重试', errorCode: 'upload_required' }
   let id: string | null = null
 
   switch (payload.kind) {
@@ -1260,8 +1265,7 @@ async function createFileNodeAt(payload: MediaFilePayload, clientPos: { x: numbe
       break
     case 'image':
       id = addNode('image', {
-        url: payload.url,
-        status: 'completed',
+        ...mediaStatus,
         ...meta,
         prompt: '',
         imageModel: getProviderConfig('image').model,
@@ -1269,8 +1273,7 @@ async function createFileNodeAt(payload: MediaFilePayload, clientPos: { x: numbe
       break
     case 'video':
       id = addNode('video', {
-        url: payload.url,
-        status: 'completed',
+        ...mediaStatus,
         ...meta,
         prompt: '',
         videoModel: getProviderConfig('video').model,
@@ -1278,8 +1281,7 @@ async function createFileNodeAt(payload: MediaFilePayload, clientPos: { x: numbe
       break
     case 'audio':
       id = addNode('audio', {
-        url: payload.url,
-        status: 'completed',
+        ...mediaStatus,
         ...meta,
         prompt: '',
         audioModel: getProviderConfig('audio').model,
@@ -1295,16 +1297,13 @@ async function createFileNodeAt(payload: MediaFilePayload, clientPos: { x: numbe
 
 async function ingestMediaFile(file: File, clientPos: { x: number; y: number }) {
   const payload = await fileToPersistedPayload(file)
-  if (tryApplyUploadToSelectedNode(payload)) return
-  await createFileNodeAt(payload, clientPos)
-}
-
-function triggerMediaUpload(clientX?: number, clientY?: number) {
-  pendingMediaPos.value = {
-    x: clientX ?? window.innerWidth / 2,
-    y: clientY ?? window.innerHeight / 2,
+  // 登录态下媒体上传失败会回退成 blob 本地地址：清空 url 走 error 节点提示，
+  // 避免 blob 引用在下游生成时才报「参考图尚未上传」
+  if (payload.kind !== 'text' && payload.url.startsWith('blob:') && localStorage.getItem('token')) {
+    payload.url = ''
   }
-  mediaInputRef.value?.click()
+  if (payload.url && tryApplyUploadToSelectedNode(payload)) return
+  await createFileNodeAt(payload, clientPos)
 }
 
 async function onMediaFileSelected(event: Event) {
@@ -1324,6 +1323,14 @@ async function handleMediaInputUpload(file: File) {
   try {
     const payload = await fileToPersistedPayload(file)
     if (payload.kind === 'other' || payload.kind === 'text') return
+    if (payload.url.startsWith('blob:') && localStorage.getItem('token')) {
+      patchNodeData(node.id, {
+        status: 'error',
+        errorMessage: '文件上传失败，请重试',
+        errorCode: 'upload_required',
+      })
+      return
+    }
     const mediaKind = inferMediaInputKind(payload.mimeType, payload.url)
     patchNodeData(node.id, {
       url: payload.url,
@@ -1367,6 +1374,20 @@ async function handleMediaInputConvert(targetType: 'image' | 'video' | 'audio') 
   selectOnlyNode(childId)
   await saveCanvas()
   await focusNodeById(childId)
+}
+
+/** 历史记录「定位」：按 generationRecordId / materialId 反查画布节点并聚焦 */
+async function handleHistoryLocate(recordId: string) {
+  const node = nodes.value.find((n) => {
+    const data = n.data as Record<string, unknown>
+    return data.generationRecordId === recordId || data.materialId === recordId
+  })
+  if (!node) {
+    ElMessage.warning('当前画布中没有找到该任务对应的节点')
+    return
+  }
+  selectOnlyNode(node.id)
+  await focusNodeById(node.id)
 }
 
 async function handleAssetApply(asset: CanvasAssetItem) {
@@ -1860,14 +1881,29 @@ onMounted(() => {
 
   const area = canvasAreaRef.value
   if (area) {
-    area.addEventListener('dragover', mediaHandlers.onDragOver)
+    area.addEventListener('dragover', (event) => {
+      // 资产库条目拖入画布 / dock-studio 时允许 drop
+      if (event.dataTransfer?.types.includes('application/lnkpi-asset')) {
+        event.preventDefault()
+        event.dataTransfer.dropEffect = 'copy'
+        return
+      }
+      mediaHandlers.onDragOver(event)
+    })
     area.addEventListener('drop', (event) => {
       const assetRaw = event.dataTransfer?.getData('application/lnkpi-asset')
       if (assetRaw) {
         event.preventDefault()
         try {
           const asset = JSON.parse(assetRaw) as CanvasAssetItem
-          if (tryApplyAssetToSelectedNode(asset)) return
+          // 落在 dock-studio 上 = 作为芯片引用挂到当前编辑节点；落在画布上 = 新建节点
+          const onDock = (event.target as HTMLElement | null)?.closest('.dock-studio-toolbar')
+          if (onDock) {
+            if (!tryApplyAssetToSelectedNode(asset)) {
+              ElMessage.warning('当前节点不支持该类型的引用')
+            }
+            return
+          }
           const payload = assetPayloadFromItem(asset)
           if (payload) {
             void createFileNodeAt(payload, { x: event.clientX, y: event.clientY })
@@ -2020,11 +2056,10 @@ onMounted(() => {
         />
 
         <NodePanelDock
-          :assets="canvasAssets"
           @add="handleDockAdd"
           @open-settings="showModelSettings = true"
           @asset-apply="handleAssetApply"
-          @asset-upload="triggerMediaUpload()"
+          @history-locate="handleHistoryLocate"
         />
 
         <div class="pointer-events-none absolute right-3 top-3 z-[50] flex items-center gap-2">
@@ -2111,6 +2146,7 @@ onMounted(() => {
       @published="loadSessions"
     />
     <AIImageEditor @apply="handleImageEditorApply" />
+    <MediaPreviewOverlay />
     <CanvasContextMenu
       v-if="contextMenu"
       :x="contextMenu.x"

--- a/apps/web/src/services/assets-api.ts
+++ b/apps/web/src/services/assets-api.ts
@@ -8,7 +8,29 @@ export interface PublicAssetItem {
   publishedAt: string
 }
 
+export interface UserAssetItem {
+  id: string
+  url: string
+  label: string
+  kind: 'image' | 'video' | 'audio'
+  sourceNodeId?: string | null
+  createdAt: string
+}
+
+export interface SaveUserAssetPayload {
+  kind: 'image' | 'video' | 'audio'
+  url: string
+  label?: string
+  sourceNodeId?: string
+}
+
 export const assetsApi = {
   listPublic: (params?: { kind?: string; search?: string }) =>
     api.get<{ code: number; data: { items: PublicAssetItem[] } }>('/assets/public', { params }),
+  listMine: () =>
+    api.get<{ code: number; data: { items: UserAssetItem[] } }>('/assets/mine'),
+  saveMine: (payload: SaveUserAssetPayload) =>
+    api.post<{ code: number; data: UserAssetItem }>('/assets/mine', payload),
+  removeMine: (id: string) =>
+    api.delete<{ code: number; data: { id: string } }>(`/assets/mine/${id}`),
 }

--- a/apps/web/src/stores/canvasEditor.ts
+++ b/apps/web/src/stores/canvasEditor.ts
@@ -7,8 +7,15 @@ export interface ImageEditTarget {
   prompt?: string
 }
 
+export interface MediaPreviewTarget {
+  url: string
+  kind: 'image' | 'video' | 'audio'
+  label?: string
+}
+
 export const useCanvasEditorStore = defineStore('canvasEditor', () => {
   const imageTarget = ref<ImageEditTarget | null>(null)
+  const previewTarget = ref<MediaPreviewTarget | null>(null)
 
   function openImageEditor(target: ImageEditTarget) {
     imageTarget.value = target
@@ -18,5 +25,20 @@ export const useCanvasEditorStore = defineStore('canvasEditor', () => {
     imageTarget.value = null
   }
 
-  return { imageTarget, openImageEditor, closeImageEditor }
+  function openMediaPreview(target: MediaPreviewTarget) {
+    previewTarget.value = target
+  }
+
+  function closeMediaPreview() {
+    previewTarget.value = null
+  }
+
+  return {
+    imageTarget,
+    openImageEditor,
+    closeImageEditor,
+    previewTarget,
+    openMediaPreview,
+    closeMediaPreview,
+  }
 })

--- a/apps/web/src/styles/main.css
+++ b/apps/web/src/styles/main.css
@@ -94,6 +94,16 @@
     color: var(--neo-text-primary);
   }
 
+  /* 轻量玻璃轨道：左侧小菜单 / 底部小地图工具条，比 dock 更透、能看清画布 */
+  .neo-glass-lite {
+    border: 1px solid var(--neo-glass-lite-border);
+    background: var(--neo-glass-lite-bg);
+    box-shadow: var(--neo-glass-lite-shadow);
+    backdrop-filter: blur(var(--neo-glass-lite-blur)) saturate(1.4);
+    -webkit-backdrop-filter: blur(var(--neo-glass-lite-blur)) saturate(1.4);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+
   /* 弹出卡片 / 下拉菜单 / popover 统一表面 */
   .neo-popover {
     border: 1px solid var(--neo-border);

--- a/apps/web/src/styles/neo-node.css
+++ b/apps/web/src/styles/neo-node.css
@@ -403,8 +403,51 @@
   color: rgba(255, 255, 255, 0.85);
 }
 
-.neo-node-upload-target:hover .neo-node-replace-btn {
+/* 与替换按钮同款的下载按钮：错开位置，hover 时一起浮现 */
+.neo-node-download-btn {
+  position: absolute;
+  top: 6px;
+  right: 34px;
+  z-index: 2;
+  display: none;
+  width: 24px;
+  height: 24px;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.55);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+/* 存入资产库按钮：排在下载按钮左侧 */
+.neo-node-save-btn {
+  position: absolute;
+  top: 6px;
+  right: 62px;
+  z-index: 2;
+  display: none;
+  width: 24px;
+  height: 24px;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.55);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.neo-node-upload-target:hover .neo-node-replace-btn,
+.neo-node-upload-target:hover .neo-node-download-btn,
+.neo-node-upload-target:hover .neo-node-save-btn {
   display: inline-flex;
+}
+
+.neo-node-replace-btn:hover,
+.neo-node-download-btn:hover,
+.neo-node-save-btn:hover {
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
 }
 
 .neo-node-placeholder {
@@ -983,13 +1026,23 @@
   animation: neo-edge-flow 0.5s linear infinite;
 }
 
-/* 选中节点后其上游链路：电流进入效果 */
+/* 选中节点后其上游链路：电流进入效果（电流青） */
 .vue-flow__edge.neo-edge-upstream .vue-flow__edge-path {
   stroke: var(--neo-electric) !important;
   stroke-width: 2px;
   stroke-dasharray: 6 10;
   stroke-linecap: round;
   filter: drop-shadow(0 0 4px var(--neo-electric-glow));
+  animation: neo-edge-flow 0.9s linear infinite;
+}
+
+/* 选中节点后其下游链路：电流流出效果（暖橙），与上游青色区分 */
+.vue-flow__edge.neo-edge-downstream .vue-flow__edge-path {
+  stroke: var(--neo-warm) !important;
+  stroke-width: 2px;
+  stroke-dasharray: 6 10;
+  stroke-linecap: round;
+  filter: drop-shadow(0 0 4px var(--neo-warm-soft));
   animation: neo-edge-flow 0.9s linear infinite;
 }
 

--- a/apps/web/src/styles/neowow-tokens.css
+++ b/apps/web/src/styles/neowow-tokens.css
@@ -66,18 +66,36 @@
   --neo-edge-hover: rgba(178, 181, 210, 0.55);
   --neo-edge-selected: #8a7dff;
 
-  /* ---- 毛玻璃 dock（与 aimarket creation-panel 一致的配方） ---- */
-  --neo-glass-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.07) 0%, rgba(9, 9, 11, 0.76) 50%, rgba(9, 9, 11, 0.92) 100%);
-  --neo-glass-border: rgba(255, 255, 255, 0.12);
-  --neo-glass-border-hover: rgba(255, 255, 255, 0.2);
-  --neo-glass-blur: 40px;
-  --neo-glass-topline: rgba(255, 255, 255, 0.25);
+  /* ---- 毛玻璃 dock：高透明度 + 低模糊（透过卡片能看清画布），
+          立体感靠内侧顶部高光 + 内侧底部暗边 + 双层投影 ---- */
+  --neo-glass-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.06) 0%, rgba(10, 10, 14, 0.42) 45%, rgba(10, 10, 14, 0.58) 100%);
+  --neo-glass-border: rgba(255, 255, 255, 0.14);
+  --neo-glass-border-hover: rgba(255, 255, 255, 0.22);
+  --neo-glass-blur: 18px;
+  --neo-glass-topline: rgba(255, 255, 255, 0.32);
   --neo-glass-shadow:
-    0 12px 48px rgba(0, 0, 0, 0.5),
-    inset 0 0 0 1px rgba(255, 255, 255, 0.05),
-    0 -18px 42px rgba(245, 158, 11, 0.06),
-    0 12px 48px rgba(109, 93, 252, 0.06);
+    0 20px 44px rgba(0, 0, 0, 0.42),
+    0 2px 6px rgba(0, 0, 0, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.14),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.3),
+    0 -18px 42px rgba(245, 158, 11, 0.05),
+    0 12px 48px rgba(109, 93, 252, 0.05);
   --neo-glass-glow: 0 0 18px 1px rgba(170, 178, 205, 0.22);
+
+  /* ---- 轻量玻璃轨道（左侧小菜单 / 底部小地图工具条）：比 dock 更透 ---- */
+  --neo-glass-lite-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.05) 0%, rgba(12, 12, 16, 0.32) 100%);
+  --neo-glass-lite-border: rgba(255, 255, 255, 0.12);
+  --neo-glass-lite-blur: 12px;
+  --neo-glass-lite-shadow:
+    0 10px 28px rgba(0, 0, 0, 0.32),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.22);
+
+  /* ---- 中性高亮（替代紫色的滑条 / 白色高亮控件） ---- */
+  --neo-slider-accent: #ffffff;
+  --neo-hi-bg: #ffffff;
+  --neo-hi-text: #17181d;
+  --neo-hi-shadow: 0 2px 10px rgba(0, 0, 0, 0.32), 0 0 14px rgba(255, 255, 255, 0.22);
 }
 
 /* ============================================================
@@ -117,14 +135,29 @@
   --neo-edge-hover: rgba(23, 25, 35, 0.45);
   --neo-edge-selected: #6d5dfc;
 
-  --neo-glass-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.88) 0%, rgba(255, 255, 255, 0.8) 50%, rgba(246, 247, 251, 0.92) 100%);
-  --neo-glass-border: rgba(23, 25, 35, 0.1);
-  --neo-glass-border-hover: rgba(23, 25, 35, 0.18);
-  --neo-glass-topline: rgba(255, 255, 255, 0.9);
+  --neo-glass-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.62) 0%, rgba(255, 255, 255, 0.44) 50%, rgba(248, 249, 253, 0.56) 100%);
+  --neo-glass-border: rgba(23, 25, 35, 0.12);
+  --neo-glass-border-hover: rgba(23, 25, 35, 0.2);
+  --neo-glass-topline: rgba(255, 255, 255, 0.95);
   --neo-glass-shadow:
-    0 12px 40px rgba(23, 25, 35, 0.14),
-    inset 0 0 0 1px rgba(255, 255, 255, 0.65),
-    0 -18px 42px rgba(245, 158, 11, 0.05),
-    0 12px 48px rgba(109, 93, 252, 0.07);
+    0 20px 40px rgba(23, 25, 35, 0.16),
+    0 2px 6px rgba(23, 25, 35, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.85),
+    inset 0 -1px 0 rgba(23, 25, 35, 0.08),
+    0 -18px 42px rgba(245, 158, 11, 0.04),
+    0 12px 48px rgba(109, 93, 252, 0.06);
   --neo-glass-glow: 0 0 18px 1px rgba(109, 93, 252, 0.14);
+
+  --neo-glass-lite-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.55) 0%, rgba(255, 255, 255, 0.35) 100%);
+  --neo-glass-lite-border: rgba(23, 25, 35, 0.1);
+  --neo-glass-lite-shadow:
+    0 10px 24px rgba(23, 25, 35, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.9),
+    inset 0 -1px 0 rgba(23, 25, 35, 0.06);
+
+  /* 浅色主题下白色高亮改为深色高亮（白底上白色不可见） */
+  --neo-slider-accent: #17181d;
+  --neo-hi-bg: #17181d;
+  --neo-hi-text: #ffffff;
+  --neo-hi-shadow: 0 2px 10px rgba(23, 25, 35, 0.28);
 }


### PR DESCRIPTION
## Summary
- 服务端新增 `UserAsset` 表与 `/assets/mine` CRUD 接口（列表 / 幂等保存 / 删除），资产库改为全局逻辑：画布内容不再自动同步，用户在节点上选择性保存，任何画布可调用
- 图 / 视频 / 音频节点 hover 新增「下载」「存入资产库」按钮，图片节点双击全屏预览（`MediaPreviewOverlay`）
- 资产库面板全局化：按时间线分组、点击预览、hover 加载到画布 / 重命名 / 删除、上传直接入库、拖到画布新建节点、拖到 dock-studio 作芯片引用
- 任务历史面板：点击查看详情，hover 定位到画布对应节点
- 连线高亮：选中节点同时高亮上游（电流青）与下游（暖橙）整条链路，点空白取消
- 媒体上传失败不再静默回退 blob 本地地址；生成时给出具体参考图错误（@refKey + 文件名）
- 玻璃拟态透明度与白色高亮按钮视觉调整（左侧面板 / 小地图 / dock-studio / 生成按钮）

## Test plan
- [x] pnpm build（web + server + agent 全部通过）
- [x] pnpm --filter @lnkpi/agent test（50 通过）
- [x] apps/web vitest（82 通过）
- [x] vue-tsc / tsc 类型检查通过
- [ ] 生产复测：节点存入资产库 → 跨画布可见 → 预览 / 重命名 / 删除 / 拖拽

Made with [Cursor](https://cursor.com)