### PR TITLE
fix(deploy): 放宽 CVM 构建缓存清理窗口至一周，加速部署构建

### DIFF
--- a/deploy/cvm-recover.sh
+++ b/deploy/cvm-recover.sh
@@ -21,7 +21,8 @@ pkill -f "docker compose.*build" 2>/dev/null || true
 sleep 2
 
 log "=== Docker cleanup (prune builder + dangling) ==="
-docker builder prune -f --filter 'until=2h' 2>/dev/null || true
+# 保留一周内的构建缓存以加速后续 CVM 构建，只清理更早的
+docker builder prune -f --filter 'until=168h' 2>/dev/null || true
 docker image prune -f 2>/dev/null || true
 
 log "=== Restart lnkpi-api with existing image if present ==="

--- a/deploy/deploy-remote-build.sh
+++ b/deploy/deploy-remote-build.sh
@@ -40,7 +40,8 @@ df -h / /var/lib/docker 2>/dev/null || df -h /
 
 log "=== Prune unused Docker data ==="
 docker image prune -f >/dev/null 2>&1 || true
-docker builder prune -f --filter 'until=24h' >/dev/null 2>&1 || true
+# 保留一周内的构建缓存以复用 pnpm/编译层，磁盘充足时不要激进清理
+docker builder prune -f --filter 'until=168h' >/dev/null 2>&1 || true
 docker images lnkpi-api --format '{{.Tag}}' 2>/dev/null | while read -r tag; do
   [[ -z "$tag" || "$tag" == "<none>" ]] && continue
   [[ "$tag" == "$IMAGE_TAG" || "$tag" == "latest" ]] && continue


### PR DESCRIPTION
## Summary
- `cvm-recover.sh` 在每次部署的 Recover 步骤都会执行 `docker builder prune --filter until=2h`，把上一次构建攒下的 BuildKit 缓存几乎清空，导致 CVM 每次都近乎全量重建（pnpm 安装、tsc 编译全部重来），这是部署工作流耗时久的主因
- 将 `cvm-recover.sh` 与 `deploy-remote-build.sh` 的缓存清理窗口统一放宽到 168h（一周），一周内的缓存层可持续复用
- CVM 磁盘当前仅使用 47%（剩余 22G），保留 3~5GB 构建缓存无压力；历史镜像已由现有逻辑自动清理，无堆积

## Test plan
- [x] pnpm build 本地通过
- [x] bash -n 语法校验两个脚本
- [ ] 合并后观察下一次及再下一次 deploy.yml 的构建耗时（第二次起应明显下降）

Made with [Cursor](https://cursor.com)