### PR TITLE
feat: canvas upload, session tasks, homepage & works

### DIFF
--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -113,7 +113,11 @@ model GenerationRecord {
   url       String?
   status    String   @default("completed")
   metadata  String?
+  sessionId String?
+  nodeId    String?
   createdAt DateTime @default(now())
+
+  @@index([userId, sessionId, createdAt])
 }
 
 model Story {

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -189,18 +189,20 @@ model AgentMessage {
 }
 
 model Work {
-  id         String   @id @default(cuid())
-  title      String
-  coverUrl   String
-  type       String   @default("canvas")
-  authorId   String
-  author     User     @relation(fields: [authorId], references: [id])
-  sessionId  String?
-  session    Session? @relation(fields: [sessionId], references: [id])
-  likes      Int      @default(0)
-  views      Int      @default(0)
-  category   String?
-  createdAt  DateTime @default(now())
+  id           String   @id @default(cuid())
+  title        String
+  coverUrl     String
+  playbackUrl  String?
+  playbackKind String?
+  type         String   @default("canvas")
+  authorId     String
+  author       User     @relation(fields: [authorId], references: [id])
+  sessionId    String?
+  session      Session? @relation(fields: [sessionId], references: [id])
+  likes        Int      @default(0)
+  views        Int      @default(0)
+  category     String?
+  createdAt    DateTime @default(now())
 }
 
 model VerificationCode {

--- a/apps/server/src/sessions/sessions.controller.ts
+++ b/apps/server/src/sessions/sessions.controller.ts
@@ -63,4 +63,11 @@ export class SessionsController {
     const data = await this.sessionsService.remove(id, req.user.sub)
     return { code: 0, message: 'ok', data }
   }
+
+  @Post(':id/duplicate')
+  @UseGuards(AuthGuard)
+  async duplicate(@Param('id') id: string, @Req() req: { user: { sub: string } }) {
+    const data = await this.sessionsService.duplicate(req.user.sub, id)
+    return { code: 0, message: 'ok', data }
+  }
 }

--- a/apps/server/src/sessions/sessions.service.ts
+++ b/apps/server/src/sessions/sessions.service.ts
@@ -69,6 +69,19 @@ export class SessionsService {
     return { message: '已删除' }
   }
 
+  async duplicate(userId: string, id: string) {
+    const src = await this.prisma.session.findFirst({ where: { id, userId } })
+    if (!src) throw new NotFoundException('会话不存在')
+    const session = await this.prisma.session.create({
+      data: {
+        userId,
+        title: `${src.title || '未命名画布'} 副本`,
+        canvasData: src.canvasData,
+      },
+    })
+    return this.formatSession(session)
+  }
+
   private formatSession(session: {
     id: string
     title: string

--- a/apps/server/src/studio/studio.controller.ts
+++ b/apps/server/src/studio/studio.controller.ts
@@ -25,7 +25,17 @@ class StudioRefDto {
   url?: string
 }
 
-class GenerateImageDto {
+class CanvasScopeFields {
+  @IsOptional()
+  @IsString()
+  sessionId?: string
+
+  @IsOptional()
+  @IsString()
+  nodeId?: string
+}
+
+class GenerateImageDto extends CanvasScopeFields {
   @IsString()
   prompt!: string
 
@@ -57,7 +67,7 @@ class GenerateImageDto {
   mentionedKeys?: string[]
 }
 
-class GenerateVideoDto {
+class GenerateVideoDto extends CanvasScopeFields {
   @IsString()
   prompt!: string
 
@@ -93,7 +103,7 @@ class GenerateVideoDto {
   mentionedKeys?: string[]
 }
 
-class GenerateAudioDto {
+class GenerateAudioDto extends CanvasScopeFields {
   @IsString()
   text!: string
 
@@ -137,7 +147,7 @@ class GenerateAudioDto {
   mentionedKeys?: string[]
 }
 
-class GenerateTextDto {
+class GenerateTextDto extends CanvasScopeFields {
   @IsString()
   prompt!: string
 
@@ -165,7 +175,7 @@ class GenerateTextDto {
   thinkingEffort?: 'high' | 'max'
 }
 
-class GeneratePromptDto {
+class GeneratePromptDto extends CanvasScopeFields {
   @IsString()
   prompt!: string
 
@@ -174,7 +184,7 @@ class GeneratePromptDto {
   model?: string
 }
 
-class ImageVariationDto {
+class ImageVariationDto extends CanvasScopeFields {
   @IsString()
   prompt!: string
 
@@ -193,8 +203,12 @@ export class StudioController {
 
   @Get('generations')
   @UseGuards(AuthGuard)
-  async list(@Req() req: { user: { sub: string } }, @Query('type') type?: string) {
-    const data = await this.studioService.listGenerations(req.user.sub, type)
+  async list(
+    @Req() req: { user: { sub: string } },
+    @Query('type') type?: string,
+    @Query('sessionId') sessionId?: string,
+  ) {
+    const data = await this.studioService.listGenerations(req.user.sub, type, sessionId)
     return { code: 0, message: 'ok', data }
   }
 
@@ -214,6 +228,7 @@ export class StudioController {
       cancel,
       dto.thinking,
       dto.thinkingEffort,
+      { sessionId: dto.sessionId, nodeId: dto.nodeId },
     )
     return { code: 0, message: 'ok', data }
   }
@@ -225,7 +240,13 @@ export class StudioController {
     @Body() dto: GeneratePromptDto,
   ) {
     const cancel = createCancelFlag(req)
-    const data = await this.studioService.generatePrompt(req.user.sub, dto.prompt, dto.model, cancel)
+    const data = await this.studioService.generatePrompt(
+      req.user.sub,
+      dto.prompt,
+      dto.model,
+      cancel,
+      { sessionId: dto.sessionId, nodeId: dto.nodeId },
+    )
     return { code: 0, message: 'ok', data }
   }
 
@@ -242,6 +263,7 @@ export class StudioController {
       dto.basePrompt,
       dto.model,
       cancel,
+      { sessionId: dto.sessionId, nodeId: dto.nodeId },
     )
     return { code: 0, message: 'ok', data }
   }
@@ -274,6 +296,7 @@ export class StudioController {
       dto.mentionedKeys,
       dto.resolution,
       dto.count,
+      { sessionId: dto.sessionId, nodeId: dto.nodeId },
     )
     return { code: 0, message: 'ok', data }
   }
@@ -291,6 +314,7 @@ export class StudioController {
       dto.mentionedKeys,
       dto.resolution,
       dto.crop,
+      { sessionId: dto.sessionId, nodeId: dto.nodeId },
     )
     return { code: 0, message: 'ok', data }
   }
@@ -317,6 +341,7 @@ export class StudioController {
       dto.refs,
       dto.mentionedKeys,
       cancel,
+      { sessionId: dto.sessionId, nodeId: dto.nodeId },
     )
     return { code: 0, message: 'ok', data }
   }

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -190,6 +190,19 @@ function throwGenerationFailure(opts: {
 
 type CancelFlag = { isCancelled(): boolean }
 
+export type CanvasGenerationScope = {
+  sessionId?: string
+  nodeId?: string
+}
+
+function withCanvasScope(scope?: CanvasGenerationScope) {
+  if (!scope?.sessionId && !scope?.nodeId) return {}
+  return {
+    ...(scope.sessionId ? { sessionId: scope.sessionId } : {}),
+    ...(scope.nodeId ? { nodeId: scope.nodeId } : {}),
+  }
+}
+
 @Injectable()
 export class StudioService {
   constructor(
@@ -198,9 +211,13 @@ export class StudioService {
     @Inject(ProviderResolverService) private readonly resolver: ProviderResolverService,
   ) {}
 
-  async listGenerations(userId: string, type?: string) {
+  async listGenerations(userId: string, type?: string, sessionId?: string) {
     return this.prisma.generationRecord.findMany({
-      where: { userId, ...(type ? { type } : {}) },
+      where: {
+        userId,
+        ...(type ? { type } : {}),
+        ...(sessionId ? { sessionId } : {}),
+      },
       orderBy: { createdAt: 'desc' },
       take: 50,
     })
@@ -292,6 +309,7 @@ export class StudioService {
     cancel?: CancelFlag,
     thinking?: boolean,
     thinkingEffort?: 'high' | 'max',
+    scope?: CanvasGenerationScope,
   ) {
     const cost = 5
     const chargeReason = '文本生成'
@@ -352,6 +370,7 @@ export class StudioService {
           url: null,
           status: 'completed',
           metadata: JSON.stringify(applyChargeMeta({ ...baseMeta, text }, cost)),
+          ...withCanvasScope(scope),
         },
       })
     } catch (err) {
@@ -371,6 +390,7 @@ export class StudioService {
             url: null,
             status: 'failed',
             metadata: JSON.stringify(failedMeta),
+            ...withCanvasScope(scope),
           },
         })
         throwGenerationFailure({
@@ -395,12 +415,19 @@ export class StudioService {
               ...baseMeta,
             }),
           ),
+          ...withCanvasScope(scope),
         },
       })
     }
   }
 
-  async generatePrompt(userId: string, prompt: string, model?: string, cancel?: CancelFlag) {
+  async generatePrompt(
+    userId: string,
+    prompt: string,
+    model?: string,
+    cancel?: CancelFlag,
+    scope?: CanvasGenerationScope,
+  ) {
     const trimmed = prompt?.trim()
     if (!trimmed) throw new BadRequestException('prompt 不能为空')
     const cost = 5
@@ -441,6 +468,7 @@ export class StudioService {
           url: null,
           status: 'completed',
           metadata: JSON.stringify(applyChargeMeta({ ...baseMeta, mode, content }, cost)),
+          ...withCanvasScope(scope),
         },
       })
     } catch (err) {
@@ -460,6 +488,7 @@ export class StudioService {
             url: null,
             status: 'failed',
             metadata: JSON.stringify(failedMeta),
+            ...withCanvasScope(scope),
           },
         })
         throwGenerationFailure({
@@ -484,6 +513,7 @@ export class StudioService {
               ...baseMeta,
             }),
           ),
+          ...withCanvasScope(scope),
         },
       })
     }
@@ -543,6 +573,7 @@ export class StudioService {
     mentionedKeys?: string[],
     resolution = '1K',
     count = 1,
+    scope?: CanvasGenerationScope,
   ) {
     const n = Math.max(1, Math.min(4, Number(count) || 1))
     const cost = 10 * n
@@ -595,6 +626,7 @@ export class StudioService {
             cost,
           ),
         ),
+        ...withCanvasScope(scope),
       },
     })
     const completion = this.completeImage(
@@ -695,6 +727,7 @@ export class StudioService {
     basePrompt?: string,
     model?: string,
     cancel?: CancelFlag,
+    scope?: CanvasGenerationScope,
   ) {
     const cost = 10
     const chargeReason = '图像变体'
@@ -730,6 +763,7 @@ export class StudioService {
               cost,
             ),
           ),
+          ...withCanvasScope(scope),
         },
       })
     } catch (err) {
@@ -760,6 +794,7 @@ export class StudioService {
             url: null,
             status: 'failed',
             metadata: JSON.stringify(failedMeta),
+            ...withCanvasScope(scope),
           },
         })
         throwGenerationFailure({
@@ -785,6 +820,7 @@ export class StudioService {
               basePrompt,
             }),
           ),
+          ...withCanvasScope(scope),
         },
       })
     }
@@ -800,6 +836,7 @@ export class StudioService {
     mentionedKeys?: string[],
     resolution = '720p',
     crop = 'none',
+    scope?: CanvasGenerationScope,
   ) {
     const durationCredits = this.videoDurationCredits(duration)
     const chargeReason = '视频生成'
@@ -851,6 +888,7 @@ export class StudioService {
             durationCredits,
           ),
         ),
+        ...withCanvasScope(scope),
       },
     })
     this.completeVideo(
@@ -887,6 +925,7 @@ export class StudioService {
     refs?: StudioRefInput[],
     mentionedKeys?: string[],
     cancel?: CancelFlag,
+    scope?: CanvasGenerationScope,
   ) {
     const cost = 5
     const chargeReason = '音频生成'
@@ -955,6 +994,7 @@ export class StudioService {
               cost,
             ),
           ),
+          ...withCanvasScope(scope),
         },
       })
       return { ...record, url }
@@ -992,6 +1032,7 @@ export class StudioService {
             url: null,
             status: 'failed',
             metadata: JSON.stringify(failedMeta),
+            ...withCanvasScope(scope),
           },
         })
         throwGenerationFailure({
@@ -1024,6 +1065,7 @@ export class StudioService {
               audioOptions: audioOpts,
             }),
           ),
+          ...withCanvasScope(scope),
         },
       })
       return record

--- a/apps/server/src/works/works.controller.ts
+++ b/apps/server/src/works/works.controller.ts
@@ -20,6 +20,9 @@ class PublishWorkDto {
   @IsString()
   title!: string
 
+  @IsString()
+  primaryNodeId!: string
+
   @IsOptional()
   @IsString()
   category?: string
@@ -39,6 +42,26 @@ export class WorksController {
   @UseGuards(AuthGuard)
   async publish(@Req() req: { user: { sub: string } }, @Body() dto: PublishWorkDto) {
     const data = await this.worksService.publish(req.user.sub, dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Get(':id/canvas')
+  async getCanvas(@Param('id') id: string) {
+    const data = await this.worksService.getCanvas(id)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post(':id/like')
+  @UseGuards(AuthGuard)
+  async like(@Param('id') id: string, @Req() req: { user: { sub: string } }) {
+    const data = await this.worksService.like(req.user.sub, id)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post(':id/fork-canvas')
+  @UseGuards(AuthGuard)
+  async forkCanvas(@Param('id') id: string, @Req() req: { user: { sub: string } }) {
+    const data = await this.worksService.forkCanvas(req.user.sub, id)
     return { code: 0, message: 'ok', data }
   }
 

--- a/apps/server/src/works/works.service.ts
+++ b/apps/server/src/works/works.service.ts
@@ -1,5 +1,11 @@
-import { Inject, Injectable, NotFoundException } from '@nestjs/common'
+import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common'
 import { PrismaService } from '../prisma/prisma.service'
+
+type CanvasNode = {
+  id?: string
+  type?: string
+  data?: { url?: string; coverUrl?: string }
+}
 
 @Injectable()
 export class WorksService {
@@ -47,18 +53,24 @@ export class WorksService {
     return this.formatWork(work)
   }
 
-  async publish(userId: string, data: { sessionId: string; title: string; category?: string }) {
+  async publish(
+    userId: string,
+    data: { sessionId: string; title: string; category?: string; primaryNodeId: string },
+  ) {
     const session = await this.prisma.session.findFirst({
       where: { id: data.sessionId, userId },
-      include: { shots: { include: { materials: true }, orderBy: { order: 'asc' } } },
     })
     if (!session) throw new NotFoundException('会话不存在')
 
-    const coverUrl = this.resolveCoverUrl(session)
+    const primary = this.resolvePrimaryNode(session.canvasData, data.primaryNodeId)
+    if (!primary) throw new BadRequestException('请选择主成片节点')
+
     const work = await this.prisma.work.create({
       data: {
         title: data.title,
-        coverUrl,
+        coverUrl: primary.coverUrl,
+        playbackUrl: primary.playbackUrl,
+        playbackKind: primary.playbackKind,
         authorId: userId,
         sessionId: data.sessionId,
         category: data.category ?? '精选作品',
@@ -69,37 +81,80 @@ export class WorksService {
     return this.formatWork(work)
   }
 
-  private resolveCoverUrl(session: {
-    canvasData: string | null
-    shots: Array<{ materials: Array<{ url: string | null; thumbnail: string | null }> }>
-  }) {
-    const fallback = 'https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?w=800&q=80'
-    if (session.canvasData) {
-      try {
-        const canvas = JSON.parse(session.canvasData) as {
-          nodes?: Array<{ type?: string; data?: { url?: string; coverUrl?: string } }>
-        }
-        for (const node of canvas.nodes ?? []) {
-          if (node.data?.coverUrl) return node.data.coverUrl
-          if (node.type === 'image' && node.data?.url) return node.data.url
-        }
-      } catch {
-        // ignore parse errors
-      }
+  async like(_userId: string, workId: string) {
+    const existing = await this.prisma.work.findUnique({ where: { id: workId } })
+    if (!existing) throw new NotFoundException('作品不存在')
+    const work = await this.prisma.work.update({
+      where: { id: workId },
+      data: { likes: { increment: 1 } },
+      include: { author: true },
+    })
+    return this.formatWork(work)
+  }
+
+  async getCanvas(workId: string) {
+    const work = await this.prisma.work.findUnique({
+      where: { id: workId },
+      include: { session: true },
+    })
+    if (!work?.session?.canvasData) throw new NotFoundException('画布不存在')
+    try {
+      return JSON.parse(work.session.canvasData)
+    } catch {
+      throw new NotFoundException('画布数据无效')
     }
-    for (const shot of session.shots) {
-      for (const material of shot.materials) {
-        if (material.url) return material.url
-        if (material.thumbnail) return material.thumbnail
-      }
+  }
+
+  async forkCanvas(userId: string, workId: string) {
+    const work = await this.prisma.work.findUnique({
+      where: { id: workId },
+      include: { session: true },
+    })
+    if (!work?.session?.canvasData) throw new NotFoundException('作品不存在')
+
+    const session = await this.prisma.session.create({
+      data: {
+        userId,
+        title: `${work.title} 副本`,
+        canvasData: work.session.canvasData,
+      },
+    })
+
+    return {
+      id: session.id,
+      title: session.title,
+      userId: session.userId,
+      canvasData: session.canvasData ? JSON.parse(session.canvasData) : undefined,
+      createdAt: session.createdAt.toISOString(),
+      updatedAt: session.updatedAt.toISOString(),
     }
-    return fallback
+  }
+
+  private resolvePrimaryNode(canvasData: string | null, primaryNodeId: string) {
+    if (!primaryNodeId || !canvasData) return null
+    try {
+      const canvas = JSON.parse(canvasData) as { nodes?: CanvasNode[] }
+      const node = canvas.nodes?.find((n) => n.id === primaryNodeId)
+      if (!node) return null
+      if (node.type !== 'image' && node.type !== 'video') return null
+      const url = node.data?.url
+      if (!url) return null
+      return {
+        playbackUrl: url,
+        playbackKind: node.type as 'image' | 'video',
+        coverUrl: node.data?.coverUrl || url,
+      }
+    } catch {
+      return null
+    }
   }
 
   private formatWork(work: {
     id: string
     title: string
     coverUrl: string
+    playbackUrl?: string | null
+    playbackKind?: string | null
     type: string
     authorId: string
     sessionId: string | null
@@ -113,6 +168,8 @@ export class WorksService {
       id: work.id,
       title: work.title,
       coverUrl: work.coverUrl,
+      playbackUrl: work.playbackUrl ?? undefined,
+      playbackKind: (work.playbackKind as 'image' | 'video' | null) ?? undefined,
       type: work.type,
       authorId: work.authorId,
       authorName: work.author.nickname,

--- a/apps/web/src/components/canvas/CanvasAssetPanel.vue
+++ b/apps/web/src/components/canvas/CanvasAssetPanel.vue
@@ -38,6 +38,7 @@ const publicAssets = ref<CanvasAssetItem[]>([])
 const publicLoading = ref(false)
 const publicLoaded = ref(false)
 const uploading = ref(false)
+const uploadProgress = ref(0)
 const fileInput = ref<HTMLInputElement | null>(null)
 
 const loggedIn = computed(() => Boolean(localStorage.getItem('token')))
@@ -234,19 +235,23 @@ async function onUploadChange(event: Event) {
   input.value = ''
   if (!file) return
   uploading.value = true
+  uploadProgress.value = 0
   try {
-    const payload = await fileToPersistedPayload(file)
+    const payload = await fileToPersistedPayload(file, {
+      onProgress: (p) => {
+        uploadProgress.value = p
+      },
+    })
     if (payload.kind !== 'image' && payload.kind !== 'video' && payload.kind !== 'audio') {
       ElMessage.warning('仅支持图片、视频、音频文件')
       return
     }
-    if (payload.url.startsWith('blob:')) {
-      ElMessage.error('文件上传失败，请重试')
-      return
-    }
     await saveAssetToLibrary({ kind: payload.kind, url: payload.url, label: payload.fileName })
+  } catch (err) {
+    ElMessage.error(err instanceof Error ? err.message : '上传失败')
   } finally {
     uploading.value = false
+    uploadProgress.value = 0
   }
 }
 
@@ -290,7 +295,7 @@ function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
         <svg class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M12 4v12m0-12l-4 4m4-4l4 4" />
         </svg>
-        {{ uploading ? '上传中...' : '上传' }}
+        {{ uploading ? (uploadProgress > 0 ? `上传 ${uploadProgress}%` : '上传中...') : '上传' }}
       </button>
       <input
         ref="fileInput"

--- a/apps/web/src/components/canvas/CanvasNodeAudio.vue
+++ b/apps/web/src/components/canvas/CanvasNodeAudio.vue
@@ -14,6 +14,7 @@ const props = defineProps<{
   data: {
     url?: string
     status: string
+    uploadProgress?: number
     prompt?: string
     label?: string
     errorMessage?: string
@@ -132,12 +133,13 @@ function saveToLibrary() {
         class="neo-node-placeholder"
         :class="{
           'is-generating': data.status === 'generating',
+          'is-uploading': data.status === 'uploading',
           'is-failed': data.status === 'failed' || data.status === 'error',
         }"
       >
         <div class="neo-placeholder-content">
           <button
-            v-if="data.status !== 'generating'"
+            v-if="data.status !== 'generating' && data.status !== 'uploading'"
             type="button"
             class="neo-node-upload-btn nodrag"
             title="上传音频"
@@ -152,8 +154,17 @@ function saveToLibrary() {
             </svg>
           </button>
           <span class="neo-placeholder-text">
-            {{ data.status === 'generating' ? '生成中...' : '上传或等待生成' }}
+            {{
+              data.status === 'uploading'
+                ? `上传中 ${data.uploadProgress ?? 0}%`
+                : data.status === 'generating'
+                  ? '生成中...'
+                  : '上传或等待生成'
+            }}
           </span>
+          <div v-if="data.status === 'uploading'" class="neo-upload-progress">
+            <div class="neo-upload-progress-bar" :style="{ width: `${data.uploadProgress ?? 0}%` }" />
+          </div>
         </div>
       </div>
       <p v-if="data.prompt" class="line-clamp-2 text-[11px] text-white/45">{{ data.prompt }}</p>

--- a/apps/web/src/components/canvas/CanvasNodeImage.vue
+++ b/apps/web/src/components/canvas/CanvasNodeImage.vue
@@ -15,6 +15,7 @@ const props = defineProps<{
   data: {
     url?: string
     status: string
+    uploadProgress?: number
     prompt?: string
     label?: string
     errorMessage?: string
@@ -159,12 +160,13 @@ function saveToLibrary() {
         class="neo-node-placeholder"
         :class="{
           'is-generating': data.status === 'generating',
+          'is-uploading': data.status === 'uploading',
           'is-failed': data.status === 'failed' || data.status === 'error',
         }"
       >
         <div class="neo-placeholder-content">
           <button
-            v-if="data.status !== 'generating'"
+            v-if="data.status !== 'generating' && data.status !== 'uploading'"
             type="button"
             class="neo-node-upload-btn nodrag"
             title="上传图片"
@@ -179,8 +181,17 @@ function saveToLibrary() {
             </svg>
           </button>
           <span class="neo-placeholder-text">
-            {{ data.status === 'generating' ? '生成中...' : '上传或等待生成' }}
+            {{
+              data.status === 'uploading'
+                ? `上传中 ${data.uploadProgress ?? 0}%`
+                : data.status === 'generating'
+                  ? '生成中...'
+                  : '上传或等待生成'
+            }}
           </span>
+          <div v-if="data.status === 'uploading'" class="neo-upload-progress">
+            <div class="neo-upload-progress-bar" :style="{ width: `${data.uploadProgress ?? 0}%` }" />
+          </div>
         </div>
       </div>
       <input

--- a/apps/web/src/components/canvas/CanvasNodeVideo.vue
+++ b/apps/web/src/components/canvas/CanvasNodeVideo.vue
@@ -14,6 +14,7 @@ const props = defineProps<{
   data: {
     url?: string
     status: string
+    uploadProgress?: number
     duration?: number
     label?: string
     errorMessage?: string
@@ -127,12 +128,13 @@ function saveToLibrary() {
         class="neo-node-placeholder"
         :class="{
           'is-generating': data.status === 'generating',
+          'is-uploading': data.status === 'uploading',
           'is-failed': data.status === 'failed' || data.status === 'error',
         }"
       >
         <div class="neo-placeholder-content">
           <button
-            v-if="data.status !== 'generating'"
+            v-if="data.status !== 'generating' && data.status !== 'uploading'"
             type="button"
             class="neo-node-upload-btn nodrag"
             title="上传视频"
@@ -147,8 +149,17 @@ function saveToLibrary() {
             </svg>
           </button>
           <span class="neo-placeholder-text">
-            {{ data.status === 'generating' ? '视频生成中...' : '上传或等待生成' }}
+            {{
+              data.status === 'uploading'
+                ? `上传中 ${data.uploadProgress ?? 0}%`
+                : data.status === 'generating'
+                  ? '视频生成中...'
+                  : '上传或等待生成'
+            }}
           </span>
+          <div v-if="data.status === 'uploading'" class="neo-upload-progress">
+            <div class="neo-upload-progress-bar" :style="{ width: `${data.uploadProgress ?? 0}%` }" />
+          </div>
           <span v-if="data.duration" class="text-[11px] text-white/35">{{ data.duration }}s</span>
         </div>
       </div>

--- a/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
+++ b/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
@@ -223,6 +223,7 @@ async function openFailurePopover(record: GenerationRecord, e: Event) {
     return
   }
   failurePopoverId.value = record.id
+  failureDiag.value = null
   failureDiagLoading.value = true
   failureCopyLabel.value = '复制诊断'
   try {

--- a/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
+++ b/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import type { ErrorCode, GenerationDiagnostic } from '@lnkpi/shared'
 import { modelOptionName } from '@lnkpi/shared'
@@ -28,12 +28,22 @@ const sessionId = computed(() => route.params.sessionId as string | undefined)
 const loading = ref(false)
 const error = ref('')
 const records = ref<GenerationRecord[]>([])
+const lifecycle = ref<'todo' | 'doing' | 'done'>('doing')
 const filter = ref<'all' | 'text' | 'image' | 'video' | 'audio'>('all')
 const detailRecord = ref<GenerationRecord | null>(null)
 const failurePopoverId = ref<string | null>(null)
 const failureDiagLoading = ref(false)
 const failureDiag = ref<GenerationDiagnostic | null>(null)
 const failureCopyLabel = ref('复制诊断')
+
+const LIFECYCLE_TABS = [
+  { key: 'todo', label: '排队' },
+  { key: 'doing', label: '进行中' },
+  { key: 'done', label: '已完成' },
+] as const
+
+const TODO_STATUSES = new Set(['pending'])
+const DOING_STATUSES = new Set(['generating', 'fallback_pending', 'processing', 'running'])
 
 const FILTERS = [
   { key: 'all', label: '全部' },
@@ -42,6 +52,21 @@ const FILTERS = [
   { key: 'video', label: '视频' },
   { key: 'audio', label: '音频' },
 ] as const
+
+const EMPTY_BY_LIFECYCLE: Record<'todo' | 'doing' | 'done', string> = {
+  todo: '暂无排队任务',
+  doing: '暂无进行中的任务',
+  done: '暂无已完成任务',
+}
+
+const POLL_MS = 4000
+let pollTimer: ReturnType<typeof setInterval> | null = null
+
+function lifecycleOf(status: string): 'todo' | 'doing' | 'done' {
+  if (TODO_STATUSES.has(status)) return 'todo'
+  if (DOING_STATUSES.has(status)) return 'doing'
+  return 'done'
+}
 
 const TYPE_LABELS: Record<string, string> = {
   text: '文本',
@@ -169,25 +194,51 @@ function formatFullTime(iso: string): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
 }
 
-const filtered = computed(() => {
-  if (filter.value === 'all') return records.value
-  if (filter.value === 'text') {
-    return records.value.filter((r) => r.type === 'text' || r.type === 'prompt')
+const lifecycleCounts = computed(() => {
+  const counts = { todo: 0, doing: 0, done: 0 }
+  for (const r of records.value) {
+    counts[lifecycleOf(r.status)] += 1
   }
-  return records.value.filter((r) => r.type === filter.value)
+  return counts
 })
 
-async function load() {
-  loading.value = true
+const filtered = computed(() => {
+  const byLife = records.value.filter((r) => lifecycleOf(r.status) === lifecycle.value)
+  if (filter.value === 'all') return byLife
+  if (filter.value === 'text') {
+    return byLife.filter((r) => r.type === 'text' || r.type === 'prompt')
+  }
+  return byLife.filter((r) => r.type === filter.value)
+})
+
+async function load(opts?: { silent?: boolean }) {
+  if (!opts?.silent) loading.value = true
   error.value = ''
   try {
     const params = sessionId.value ? { sessionId: sessionId.value } : undefined
     const { data } = await studioApi.listGenerations(params)
     records.value = data.data
   } catch {
-    error.value = '加载失败，请确认已登录'
+    if (!opts?.silent) error.value = '加载失败，请确认已登录'
   } finally {
-    loading.value = false
+    if (!opts?.silent) loading.value = false
+  }
+}
+
+function startPolling() {
+  stopPolling()
+  pollTimer = setInterval(() => {
+    if (lifecycle.value === 'done' && lifecycleCounts.value.todo + lifecycleCounts.value.doing === 0) {
+      return
+    }
+    void load({ silent: true })
+  }, POLL_MS)
+}
+
+function stopPolling() {
+  if (pollTimer) {
+    clearInterval(pollTimer)
+    pollTimer = null
   }
 }
 
@@ -274,7 +325,17 @@ const failurePopoverHint = computed(() => {
   return undefined
 })
 
-onMounted(load)
+onMounted(() => {
+  void load().then(() => {
+    if (lifecycleCounts.value.doing === 0) {
+      if (lifecycleCounts.value.todo > 0) lifecycle.value = 'todo'
+      else if (lifecycleCounts.value.done > 0) lifecycle.value = 'done'
+    }
+    startPolling()
+  })
+})
+
+onUnmounted(stopPolling)
 </script>
 
 <template>
@@ -391,18 +452,37 @@ onMounted(load)
 
     <template v-else>
       <div class="flex items-center gap-2 border-b border-[var(--neo-border)] px-3 py-2.5">
-        <span class="text-[13px] font-medium text-[var(--neo-text-primary)]">任务历史</span>
-        <span class="text-[10px] text-[var(--neo-text-muted)]">最近 {{ records.length }} 条</span>
+        <span class="text-[13px] font-medium text-[var(--neo-text-primary)]">任务</span>
+        <span class="text-[10px] text-[var(--neo-text-muted)]">本会话 {{ records.length }} 条</span>
         <button
           type="button"
           class="ml-auto flex h-6 w-6 items-center justify-center rounded-lg text-[var(--neo-text-muted)] transition hover:bg-[var(--neo-active-bg)] hover:text-[var(--neo-text-primary)]"
           title="刷新"
           :disabled="loading"
-          @click="load"
+          @click="load()"
         >
           <svg class="h-3.5 w-3.5" :class="loading ? 'animate-spin' : ''" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h5M20 20v-5h-5M5.5 9A7.5 7.5 0 0 1 19 8.5M18.5 15A7.5 7.5 0 0 1 5 15.5" />
           </svg>
+        </button>
+      </div>
+
+      <div class="flex gap-1 border-b border-[var(--neo-border)] px-3 py-2">
+        <button
+          v-for="tab in LIFECYCLE_TABS"
+          :key="tab.key"
+          type="button"
+          class="flex flex-1 items-center justify-center gap-1 rounded-lg px-2 py-1.5 text-[11px] transition"
+          :class="lifecycle === tab.key ? 'bg-[var(--neo-accent-soft)] text-[var(--neo-accent-text)]' : 'text-[var(--neo-text-muted)] hover:bg-[var(--neo-hover-bg)] hover:text-[var(--neo-text-secondary)]'"
+          @click="lifecycle = tab.key"
+        >
+          <span>{{ tab.label }}</span>
+          <span
+            class="min-w-[1.1rem] rounded-md px-1 text-center text-[9px] tabular-nums"
+            :class="lifecycle === tab.key ? 'bg-[var(--neo-accent-border)]/30' : 'bg-[var(--neo-active-bg)]'"
+          >
+            {{ lifecycleCounts[tab.key] }}
+          </span>
         </button>
       </div>
 
@@ -422,7 +502,7 @@ onMounted(load)
       <div class="min-h-0 flex-1 overflow-y-auto px-3 pb-3">
         <p v-if="error" class="py-8 text-center text-[11px] text-[var(--neo-text-muted)]">{{ error }}</p>
         <p v-else-if="loading && !records.length" class="py-8 text-center text-[11px] text-[var(--neo-text-muted)]">加载中...</p>
-        <p v-else-if="!filtered.length" class="py-8 text-center text-[11px] text-[var(--neo-text-muted)]">暂无任务记录</p>
+        <p v-else-if="!filtered.length" class="py-8 text-center text-[11px] text-[var(--neo-text-muted)]">{{ EMPTY_BY_LIFECYCLE[lifecycle] }}</p>
         <div v-else class="grid grid-cols-2 gap-2">
           <div
             v-for="record in filtered"

--- a/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
+++ b/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
@@ -1,21 +1,39 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import type { ErrorCode, GenerationDiagnostic } from '@lnkpi/shared'
+import { modelOptionName } from '@lnkpi/shared'
 import { studioApi, type GenerationRecord } from '@/services/studio-api'
 import DockTypeIcon from '@/components/canvas/dock-studio/shared/DockTypeIcon.vue'
+import NodeDiagnosticPopover from '@/components/canvas/NodeDiagnosticPopover.vue'
 import { useCanvasEditorStore } from '@/stores/canvasEditor'
+import { useProviderBootstrap } from '@/composables/useProviderBootstrap'
+import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
+import {
+  buildCopyForNode,
+  parseErrorCodeFromMetadata,
+  sharedDiagnosticCache,
+} from '@/utils/generationDiagnostic'
 
 const emit = defineEmits<{
-  /** 请求定位到产生该记录的画布节点 */
   locate: [recordId: string]
 }>()
 
+const route = useRoute()
 const editor = useCanvasEditorStore()
+const { allChannels } = useProviderBootstrap()
+
+const sessionId = computed(() => route.params.sessionId as string | undefined)
 
 const loading = ref(false)
 const error = ref('')
 const records = ref<GenerationRecord[]>([])
 const filter = ref<'all' | 'text' | 'image' | 'video' | 'audio'>('all')
 const detailRecord = ref<GenerationRecord | null>(null)
+const failurePopoverId = ref<string | null>(null)
+const failureDiagLoading = ref(false)
+const failureDiag = ref<GenerationDiagnostic | null>(null)
+const failureCopyLabel = ref('复制诊断')
 
 const FILTERS = [
   { key: 'all', label: '全部' },
@@ -42,22 +60,99 @@ const STATUS_META: Record<string, { label: string; cls: string }> = {
   error: { label: '失败', cls: 'bg-red-500/15 text-red-300' },
 }
 
+interface RecordMeta {
+  aspectRatio?: string
+  resolution?: string
+  size?: string
+  count?: number
+  duration?: number
+  crop?: string
+  voice?: string
+  speed?: number
+  originalModel?: string
+  channelId?: string
+  userMessage?: string
+  text?: string
+  content?: string
+}
+
 function statusMeta(status: string) {
   return STATUS_META[status] ?? { label: status, cls: 'bg-[var(--neo-active-bg)] text-[var(--neo-text-muted)]' }
 }
 
-function recordModel(record: GenerationRecord): string {
-  if (record.model) return record.model
+function parseRecordMeta(record: GenerationRecord): RecordMeta {
   try {
-    const meta = JSON.parse(record.metadata ?? '{}') as {
-      modelId?: string
-      modelKey?: string
-      originalModel?: string
-    }
-    return meta.originalModel ?? meta.modelId ?? meta.modelKey ?? '—'
+    return JSON.parse(record.metadata ?? '{}') as RecordMeta
   } catch {
-    return '—'
+    return {}
   }
+}
+
+function recordModelName(record: GenerationRecord): string {
+  const meta = parseRecordMeta(record)
+  const raw = record.model ?? meta.originalModel ?? ''
+  return raw ? modelOptionName(raw) : '—'
+}
+
+function recordChannelName(record: GenerationRecord): string {
+  const channelId = parseRecordMeta(record).channelId
+  if (!channelId) return '—'
+  const ch = allChannels.value.find((c) => c.id === channelId)
+  return ch?.name || channelId.slice(0, 8)
+}
+
+function recordParamRows(record: GenerationRecord): Array<{ label: string; value: string }> {
+  const meta = parseRecordMeta(record)
+  const rows: Array<{ label: string; value: string }> = []
+  const add = (label: string, v: unknown) => {
+    if (v === undefined || v === null || v === '') return
+    rows.push({ label, value: String(v) })
+  }
+  if (record.type === 'image') {
+    add('比例', meta.aspectRatio)
+    add('分辨率', meta.resolution)
+    add('尺寸', meta.size)
+    add('数量', meta.count)
+  } else if (record.type === 'video') {
+    add('时长', meta.duration != null ? `${meta.duration}s` : undefined)
+    add('分辨率', meta.resolution)
+    add('比例', meta.aspectRatio)
+    add('裁剪', meta.crop)
+  } else if (record.type === 'audio') {
+    add('音色', meta.voice)
+    add('语速', meta.speed)
+  }
+  return rows
+}
+
+function recordFailureMessage(record: GenerationRecord): string | null {
+  if (
+    record.status !== 'failed' &&
+    record.status !== 'error' &&
+    record.status !== NODE_GENERATION_STATUS.fallback_pending
+  ) {
+    return null
+  }
+  const meta = parseRecordMeta(record)
+  if (meta.userMessage) return meta.userMessage
+  if (record.status === NODE_GENERATION_STATUS.fallback_pending) return '平台回退待确认'
+  return '生成失败'
+}
+
+function isFailedStatus(status: string) {
+  return (
+    status === 'failed' ||
+    status === 'error' ||
+    status === NODE_GENERATION_STATUS.fallback_pending
+  )
+}
+
+function recordTextSnippet(record: GenerationRecord): string {
+  if (record.type === 'text' || record.type === 'prompt') {
+    const meta = parseRecordMeta(record)
+    return meta.text || meta.content || record.prompt || '—'
+  }
+  return record.prompt || '—'
 }
 
 function formatTime(iso: string): string {
@@ -86,7 +181,8 @@ async function load() {
   loading.value = true
   error.value = ''
   try {
-    const { data } = await studioApi.listGenerations()
+    const params = sessionId.value ? { sessionId: sessionId.value } : undefined
+    const { data } = await studioApi.listGenerations(params)
     records.value = data.data
   } catch {
     error.value = '加载失败，请确认已登录'
@@ -96,6 +192,7 @@ async function load() {
 }
 
 function openDetail(record: GenerationRecord) {
+  failurePopoverId.value = null
   detailRecord.value = record
 }
 
@@ -105,12 +202,82 @@ function previewDetailMedia(record: GenerationRecord) {
   editor.openMediaPreview({ url: record.url, kind, label: record.prompt })
 }
 
+function buildFallbackDiagnostic(record: GenerationRecord): GenerationDiagnostic {
+  const meta = parseRecordMeta(record)
+  const isFallback = record.status === NODE_GENERATION_STATUS.fallback_pending
+  return {
+    userMessage: meta.userMessage || recordFailureMessage(record) || '生成失败',
+    code: isFallback ? 'fallback_pending' : ((parseErrorCodeFromMetadata(record.metadata) as ErrorCode | undefined) || 'unknown'),
+    taskKind: 'generation',
+    taskId: record.id,
+    occurredAt: record.createdAt,
+    providerSnippet: null,
+    hint: isFallback ? '请确认是否使用平台回退继续，或取消本次生成。' : undefined,
+  }
+}
+
+async function openFailurePopover(record: GenerationRecord, e: Event) {
+  e.stopPropagation()
+  if (failurePopoverId.value === record.id) {
+    failurePopoverId.value = null
+    return
+  }
+  failurePopoverId.value = record.id
+  failureDiagLoading.value = true
+  failureCopyLabel.value = '复制诊断'
+  try {
+    failureDiag.value = await sharedDiagnosticCache.get('generation', record.id, () =>
+      studioApi.getGenerationDiagnostic(record.id),
+    )
+  } catch {
+    failureDiag.value = buildFallbackDiagnostic(record)
+  } finally {
+    failureDiagLoading.value = false
+  }
+}
+
+function closeFailurePopover() {
+  failurePopoverId.value = null
+}
+
+async function copyFailureDiagnostic(record: GenerationRecord) {
+  const payload = failureDiag.value || buildFallbackDiagnostic(record)
+  const text = buildCopyForNode(payload, {
+    nodeId: record.nodeId ?? undefined,
+    sessionId: sessionId.value,
+  })
+  try {
+    await navigator.clipboard.writeText(text)
+    failureCopyLabel.value = '已复制'
+    setTimeout(() => {
+      failureCopyLabel.value = '复制诊断'
+    }, 1500)
+  } catch {
+    failureCopyLabel.value = '复制失败'
+  }
+}
+
+const failurePopoverMessage = computed(() => {
+  if (!failurePopoverId.value) return ''
+  const record = records.value.find((r) => r.id === failurePopoverId.value)
+  if (!record) return ''
+  return failureDiag.value?.userMessage || recordFailureMessage(record) || '生成失败'
+})
+
+const failurePopoverHint = computed(() => {
+  if (failureDiag.value?.hint) return failureDiag.value.hint
+  const record = records.value.find((r) => r.id === failurePopoverId.value)
+  if (record?.status === NODE_GENERATION_STATUS.fallback_pending) {
+    return '请确认是否使用平台回退继续，或取消本次生成。'
+  }
+  return undefined
+})
+
 onMounted(load)
 </script>
 
 <template>
   <div class="canvas-task-history flex max-h-[min(520px,72vh)] w-[404px] flex-col">
-    <!-- 详情视图 -->
     <template v-if="detailRecord">
       <div class="flex items-center gap-2 border-b border-[var(--neo-border)] px-3 py-2.5">
         <button
@@ -161,19 +328,49 @@ onMounted(load)
               {{ detailRecord.prompt || '—' }}
             </p>
           </div>
+
           <div class="grid grid-cols-2 gap-2">
             <div>
               <p class="mb-0.5 text-[10px] text-[var(--neo-text-muted)]">类型</p>
               <p class="text-[var(--neo-text-secondary)]">{{ TYPE_LABELS[detailRecord.type] ?? detailRecord.type }}</p>
             </div>
             <div>
+              <p class="mb-0.5 text-[10px] text-[var(--neo-text-muted)]">节点</p>
+              <p class="truncate font-mono text-[var(--neo-text-secondary)]">{{ detailRecord.nodeId || '—' }}</p>
+            </div>
+            <div class="col-span-2">
               <p class="mb-0.5 text-[10px] text-[var(--neo-text-muted)]">模型</p>
-              <p class="truncate text-[var(--neo-text-secondary)]" :title="recordModel(detailRecord)">{{ recordModel(detailRecord) }}</p>
+              <p class="truncate text-[var(--neo-text-secondary)]" :title="recordModelName(detailRecord)">
+                {{ recordModelName(detailRecord) }}
+              </p>
+            </div>
+            <div class="col-span-2">
+              <p class="mb-0.5 text-[10px] text-[var(--neo-text-muted)]">渠道</p>
+              <p class="truncate text-[var(--neo-text-secondary)]" :title="recordChannelName(detailRecord)">
+                {{ recordChannelName(detailRecord) }}
+              </p>
             </div>
             <div class="col-span-2">
               <p class="mb-0.5 text-[10px] text-[var(--neo-text-muted)]">创建时间</p>
               <p class="tabular-nums text-[var(--neo-text-secondary)]">{{ formatFullTime(detailRecord.createdAt) }}</p>
             </div>
+          </div>
+
+          <div v-if="recordParamRows(detailRecord).length">
+            <p class="mb-1 text-[10px] uppercase tracking-wider text-[var(--neo-text-muted)]">参数</p>
+            <div class="grid grid-cols-2 gap-2 rounded-lg bg-[var(--neo-hover-bg)] p-2">
+              <div v-for="row in recordParamRows(detailRecord)" :key="row.label">
+                <p class="text-[9px] text-[var(--neo-text-muted)]">{{ row.label }}</p>
+                <p class="text-[var(--neo-text-secondary)]">{{ row.value }}</p>
+              </div>
+            </div>
+          </div>
+
+          <div v-if="recordFailureMessage(detailRecord)">
+            <p class="mb-1 text-[10px] uppercase tracking-wider text-[var(--neo-text-muted)]">失败原因</p>
+            <p class="whitespace-pre-wrap break-words rounded-lg bg-red-500/10 p-2 text-[11px] leading-relaxed text-red-300">
+              {{ recordFailureMessage(detailRecord) }}
+            </p>
           </div>
         </div>
 
@@ -191,7 +388,6 @@ onMounted(load)
       </div>
     </template>
 
-    <!-- 列表视图 -->
     <template v-else>
       <div class="flex items-center gap-2 border-b border-[var(--neo-border)] px-3 py-2.5">
         <span class="text-[13px] font-medium text-[var(--neo-text-primary)]">任务历史</span>
@@ -239,30 +435,71 @@ onMounted(load)
           >
             <div class="flex items-center gap-1.5">
               <span class="text-[var(--neo-text-muted)]"><DockTypeIcon :type="record.type" :size="13" /></span>
-              <span class="text-[11px] text-[var(--neo-text-secondary)]">{{ TYPE_LABELS[record.type] ?? record.type }}</span>
+              <span class="truncate font-mono text-[11px] text-[var(--neo-text-secondary)]">{{ record.nodeId || '—' }}</span>
               <span
                 class="ml-auto shrink-0 rounded-md px-1.5 py-0.5 text-[9px]"
                 :class="statusMeta(record.status).cls"
               >
                 {{ statusMeta(record.status).label }}
               </span>
+              <button
+                v-if="isFailedStatus(record.status)"
+                type="button"
+                class="relative z-10 flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-red-500/20 text-[10px] font-bold text-red-300 hover:bg-red-500/30"
+                title="查看错误"
+                @click="openFailurePopover(record, $event)"
+              >
+                !
+              </button>
             </div>
+
             <img
               v-if="record.type === 'image' && record.url"
               :src="record.url"
               class="mt-1.5 h-16 w-full rounded-lg object-cover"
               alt=""
               loading="lazy"
+            >
+            <video
+              v-else-if="record.type === 'video' && record.url"
+              :src="record.url"
+              muted
+              playsinline
+              preload="metadata"
+              class="mt-1.5 h-16 w-full rounded-lg object-cover"
             />
-            <p class="mt-1.5 line-clamp-2 min-h-[26px] text-[10px] leading-relaxed text-[var(--neo-text-muted)]">
-              {{ record.prompt || '—' }}
+            <div
+              v-else-if="record.type === 'audio'"
+              class="mt-1.5 flex h-16 w-full items-center justify-center rounded-lg bg-[var(--neo-active-bg)] text-[10px] text-[var(--neo-text-muted)]"
+            >
+              音频
+            </div>
+            <p
+              v-else-if="record.type === 'text' || record.type === 'prompt'"
+              class="mt-1.5 line-clamp-3 min-h-[48px] rounded-lg bg-[var(--neo-active-bg)] p-1.5 text-[10px] leading-relaxed text-[var(--neo-text-muted)]"
+            >
+              {{ recordTextSnippet(record) }}
             </p>
-            <div class="mt-1.5 flex items-center justify-between gap-2 text-[9px] text-[var(--neo-text-muted)]">
-              <span class="truncate" :title="recordModel(record)">{{ recordModel(record) }}</span>
-              <span class="shrink-0 tabular-nums">{{ formatTime(record.createdAt) }}</span>
+
+            <div class="mt-1.5 flex items-center justify-end text-[9px] tabular-nums text-[var(--neo-text-muted)]">
+              {{ formatTime(record.createdAt) }}
             </div>
 
-            <!-- hover 定位按钮 -->
+            <div
+              v-if="failurePopoverId === record.id"
+              class="absolute left-2 right-2 top-10 z-20"
+              @click.stop
+            >
+              <NodeDiagnosticPopover
+                :user-message="failurePopoverMessage"
+                :hint="failurePopoverHint"
+                :loading="failureDiagLoading"
+                :copy-label="failureCopyLabel"
+                @copy="copyFailureDiagnostic(record)"
+                @close="closeFailurePopover"
+              />
+            </div>
+
             <button
               type="button"
               class="absolute right-1.5 top-8 hidden h-6 w-6 items-center justify-center rounded-lg bg-black/60 text-white/85 transition hover:bg-black/85 hover:text-white group-hover:flex"

--- a/apps/web/src/components/canvas/NodePanelDock.vue
+++ b/apps/web/src/components/canvas/NodePanelDock.vue
@@ -72,7 +72,7 @@ useClickOutside(rootRef, closePopovers)
     class="node-panel-dock pointer-events-none absolute left-3 top-[60px] z-[50]"
   >
     <div class="pointer-events-auto relative">
-      <!-- 竖向面板：添加节点 + 资产库 + 任务历史 + 模型设置 -->
+      <!-- 竖向面板：添加节点 + 资产库 + 任务 + 模型设置 -->
       <div
         class="vertical-capsule neo-glass-lite flex flex-col items-stretch gap-0.5 rounded-2xl p-1"
       >
@@ -121,16 +121,20 @@ useClickOutside(rootRef, closePopovers)
           type="button"
           class="rail-btn"
           :class="showHistory ? 'is-active' : ''"
-          title="任务历史"
+          title="任务"
           @click.stop="toggleHistory"
         >
           <span class="rail-circle">
             <svg class="h-[16px] w-[16px]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <circle cx="12" cy="12" r="9" stroke-width="1.75" />
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" d="M12 7v5l3 2" />
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.75"
+                d="M9 5h11M9 12h11M9 19h11M5 5h.01M5 12h.01M5 19h.01"
+              />
             </svg>
           </span>
-          <span class="rail-btn-label">历史</span>
+          <span class="rail-btn-label">任务</span>
         </button>
 
         <span class="mx-auto my-0.5 h-px w-8 bg-[var(--neo-border)]" />

--- a/apps/web/src/components/canvas/dock-studio/panels/AudioDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/AudioDockPanel.vue
@@ -6,7 +6,8 @@ import type { MentionOption } from '@/components/canvas/MentionInput.vue'
 import UniversalModelSelector from '@/components/canvas/UniversalModelSelector.vue'
 import VoiceModelSelector from '@/components/canvas/VoiceModelSelector.vue'
 import AudioVoiceSettingsSelector from '@/components/canvas/AudioVoiceSettingsSelector.vue'
-import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
+import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
+import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import DockCreditBadge from '@/components/canvas/dock-studio/shared/DockCreditBadge.vue'
@@ -62,7 +63,8 @@ const voiceSettings = ref<AudioVoiceSettings>({
 const modelVoices = computed(() => getModelEntry(catalogModelKeyFromValue(audioModel.value))?.voices)
 
 const speech = useSpeechRecognition()
-const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)const credits = computed(() => estimateAudioCredits())
+const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
+const credits = computed(() => estimateAudioCredits())
 
 function syncVoiceToCatalog(emitPatch: boolean) {
   const voices = getModelEntry(catalogModelKeyFromValue(audioModel.value))?.voices

--- a/apps/web/src/components/canvas/dock-studio/panels/AudioDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/AudioDockPanel.vue
@@ -6,9 +6,7 @@ import type { MentionOption } from '@/components/canvas/MentionInput.vue'
 import UniversalModelSelector from '@/components/canvas/UniversalModelSelector.vue'
 import VoiceModelSelector from '@/components/canvas/VoiceModelSelector.vue'
 import AudioVoiceSettingsSelector from '@/components/canvas/AudioVoiceSettingsSelector.vue'
-import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
-import { dockFailureBindFromNode } from '@/components/canvas/dock-studio/shared/dockFailureChip'
-import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
+import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import DockCreditBadge from '@/components/canvas/dock-studio/shared/DockCreditBadge.vue'
@@ -64,9 +62,7 @@ const voiceSettings = ref<AudioVoiceSettings>({
 const modelVoices = computed(() => getModelEntry(catalogModelKeyFromValue(audioModel.value))?.voices)
 
 const speech = useSpeechRecognition()
-const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
-const failureBind = computed(() => dockFailureBindFromNode(props.node))
-const credits = computed(() => estimateAudioCredits())
+const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)const credits = computed(() => estimateAudioCredits())
 
 function syncVoiceToCatalog(emitPatch: boolean) {
   const voices = getModelEntry(catalogModelKeyFromValue(audioModel.value))?.voices
@@ -158,7 +154,7 @@ function onRefRemove(ref: NodeRef) {
 </script>
 
 <template>
-  <DockToolbarShell type="audio" v-bind="failureBind" @close="emit('close')">
+  <DockToolbarShell type="audio" @close="emit('close')">
     <DockRefStrip
       :refs="refs ?? []"
       @reorder="onRefReorder"

--- a/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
@@ -9,7 +9,8 @@ import ImageParamsSelector, {
   type ImageCount,
   type ImageResolution,
 } from '@/components/canvas/ImageParamsSelector.vue'
-import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
+import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
+import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import DockCreditBadge from '@/components/canvas/dock-studio/shared/DockCreditBadge.vue'
@@ -52,7 +53,8 @@ const refUploadProgress = ref(0)
 const refUploadError = ref('')
 
 const speech = useSpeechRecognition()
-const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)const credits = computed(() => estimateImageCredits(imageCount.value))
+const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
+const credits = computed(() => estimateImageCredits(imageCount.value))
 
 const effectiveRefUrl = computed(() => {
   const local = referenceImageUrl.value.trim()

--- a/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
@@ -9,9 +9,7 @@ import ImageParamsSelector, {
   type ImageCount,
   type ImageResolution,
 } from '@/components/canvas/ImageParamsSelector.vue'
-import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
-import { dockFailureBindFromNode } from '@/components/canvas/dock-studio/shared/dockFailureChip'
-import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
+import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import DockCreditBadge from '@/components/canvas/dock-studio/shared/DockCreditBadge.vue'
@@ -54,9 +52,7 @@ const refUploadProgress = ref(0)
 const refUploadError = ref('')
 
 const speech = useSpeechRecognition()
-const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
-const failureBind = computed(() => dockFailureBindFromNode(props.node))
-const credits = computed(() => estimateImageCredits(imageCount.value))
+const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)const credits = computed(() => estimateImageCredits(imageCount.value))
 
 const effectiveRefUrl = computed(() => {
   const local = referenceImageUrl.value.trim()
@@ -219,7 +215,7 @@ function clearReferenceImage() {
 </script>
 
 <template>
-  <DockToolbarShell type="image" v-bind="failureBind" @close="emit('close')">
+  <DockToolbarShell type="image" @close="emit('close')">
     <DockRefStrip
       :refs="stripRefs"
       @reorder="onRefReorder"

--- a/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
@@ -258,7 +258,9 @@ function clearReferenceImage() {
           @click="pickReferenceImage"
         >
           <DockTypeIcon v-if="!refUploading" icon="image" :size="13" />
-          <span v-else class="text-[9px] text-white/60">…</span>
+          <span v-else class="whitespace-nowrap text-[9px] text-white/60">
+            {{ refUploadProgress > 0 ? `上传中 ${refUploadProgress}%` : '上传中...' }}
+          </span>
         </button>
         <div
           v-if="effectiveRefUrl"

--- a/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
@@ -50,6 +50,7 @@ const imageCount = ref<ImageCount>(1)
 const referenceImageUrl = ref('')
 const refInput = ref<HTMLInputElement | null>(null)
 const refUploading = ref(false)
+const refUploadProgress = ref(0)
 const refUploadError = ref('')
 
 const speech = useSpeechRecognition()
@@ -175,19 +176,17 @@ async function onRefFileChange(event: Event) {
   if (!file || !file.type.startsWith('image/')) return
 
   refUploadError.value = ''
+  refUploadProgress.value = 0
   refUploading.value = true
   const blobUrl = URL.createObjectURL(file)
   referenceImageUrl.value = blobUrl
 
   try {
-    const url = await persistMediaUrl(file, blobUrl)
-    const loggedIn = !!localStorage.getItem('token')
-    if (url.startsWith('blob:') && loggedIn) {
-      refUploadError.value = '参考图上传失败，请重试'
-      URL.revokeObjectURL(blobUrl)
-      referenceImageUrl.value = ''
-      return
-    }
+    const url = await persistMediaUrl(file, blobUrl, {
+      onProgress: (p) => {
+        refUploadProgress.value = p
+      },
+    })
     if (url !== blobUrl) URL.revokeObjectURL(blobUrl)
 
     referenceImageUrl.value = url
@@ -203,12 +202,13 @@ async function onRefFileChange(event: Event) {
       localRefs: [...prev, binding],
       referenceImageUrl: url,
     })
-  } catch {
-    refUploadError.value = '参考图上传失败，请重试'
+  } catch (err) {
+    refUploadError.value = err instanceof Error ? err.message : '参考图上传失败，请重试'
     URL.revokeObjectURL(blobUrl)
     referenceImageUrl.value = ''
   } finally {
     refUploading.value = false
+    refUploadProgress.value = 0
   }
 }
 

--- a/apps/web/src/components/canvas/dock-studio/panels/MediaInputDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/MediaInputDockPanel.vue
@@ -3,9 +3,7 @@ import { computed, ref, watch } from 'vue'
 import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
 import type { MentionOption } from '@/components/canvas/MentionInput.vue'
-import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
-import { dockFailureBindFromNode } from '@/components/canvas/dock-studio/shared/dockFailureChip'
-import { inferMediaInputKind, type MediaInputKind } from '@/composables/useMediaUpload'
+import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'import { inferMediaInputKind, type MediaInputKind } from '@/composables/useMediaUpload'
 import { isNodeGenerating } from '@/constants/dockStudio'
 
 const props = defineProps<{
@@ -33,8 +31,6 @@ const fileInput = ref<HTMLInputElement | null>(null)
 const locked = computed(
   () => !!props.readonly || isNodeGenerating(props.node.data?.status) || props.node.data?.status === 'uploading',
 )
-const failureBind = computed(() => dockFailureBindFromNode(props.node))
-
 const canConvertVideo = computed(() => mediaKind.value === 'image' || mediaKind.value === 'video')
 const canConvertImage = computed(() => mediaKind.value === 'image')
 const canConvertAudio = computed(() => mediaKind.value === 'audio')
@@ -71,7 +67,7 @@ function onFileChange(event: Event) {
 <template>
   <DockToolbarShell
     type="mediaInput"
-    v-bind="failureBind"
+   
     show-title
     :title="title"
     title-placeholder="素材名称"

--- a/apps/web/src/components/canvas/dock-studio/panels/MediaInputDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/MediaInputDockPanel.vue
@@ -3,7 +3,8 @@ import { computed, ref, watch } from 'vue'
 import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
 import type { MentionOption } from '@/components/canvas/MentionInput.vue'
-import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'import { inferMediaInputKind, type MediaInputKind } from '@/composables/useMediaUpload'
+import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
+import { inferMediaInputKind, type MediaInputKind } from '@/composables/useMediaUpload'
 import { isNodeGenerating } from '@/constants/dockStudio'
 
 const props = defineProps<{
@@ -67,7 +68,6 @@ function onFileChange(event: Event) {
 <template>
   <DockToolbarShell
     type="mediaInput"
-   
     show-title
     :title="title"
     title-placeholder="素材名称"

--- a/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
@@ -4,7 +4,8 @@ import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
 import type { MentionOption } from '@/components/canvas/MentionInput.vue'
 import UniversalModelSelector from '@/components/canvas/UniversalModelSelector.vue'
-import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
+import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
+import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import DockCreditBadge from '@/components/canvas/dock-studio/shared/DockCreditBadge.vue'
@@ -46,7 +47,8 @@ const prompt = ref('')
 const textModel = ref(getConfig('text').model)
 
 const speech = useSpeechRecognition()
-const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)const promptMode = computed(() => {
+const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
+const promptMode = computed(() => {
   const mode = props.node.data?.promptMode
   return mode ? String(mode) : ''
 })

--- a/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
@@ -4,9 +4,7 @@ import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
 import type { MentionOption } from '@/components/canvas/MentionInput.vue'
 import UniversalModelSelector from '@/components/canvas/UniversalModelSelector.vue'
-import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
-import { dockFailureBindFromNode } from '@/components/canvas/dock-studio/shared/dockFailureChip'
-import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
+import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import DockCreditBadge from '@/components/canvas/dock-studio/shared/DockCreditBadge.vue'
@@ -48,9 +46,7 @@ const prompt = ref('')
 const textModel = ref(getConfig('text').model)
 
 const speech = useSpeechRecognition()
-const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
-const failureBind = computed(() => dockFailureBindFromNode(props.node))
-const promptMode = computed(() => {
+const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)const promptMode = computed(() => {
   const mode = props.node.data?.promptMode
   return mode ? String(mode) : ''
 })
@@ -133,7 +129,7 @@ function onRefRemove(ref: NodeRef) {
 </script>
 
 <template>
-  <DockToolbarShell type="prompt" v-bind="failureBind" @close="emit('close')">
+  <DockToolbarShell type="prompt" @close="emit('close')">
     <DockRefStrip
       :refs="textRefs"
       @reorder="onRefReorder"

--- a/apps/web/src/components/canvas/dock-studio/panels/SceneComposerDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/SceneComposerDockPanel.vue
@@ -3,9 +3,7 @@ import { computed, ref, watch } from 'vue'
 import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
 import type { MentionOption } from '@/components/canvas/MentionInput.vue'
-import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
-import { dockFailureBindFromNode } from '@/components/canvas/dock-studio/shared/dockFailureChip'
-import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
+import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockOptimizePrompt from '@/components/canvas/dock-studio/shared/DockOptimizePrompt.vue'
 import { isNodeGenerating } from '@/constants/dockStudio'
 import {
@@ -41,8 +39,6 @@ const activeSceneId = ref(payload.value.scenes[0]?.id ?? '')
 const locked = computed(
   () => !!props.readonly || isNodeGenerating(props.node.data?.status) || !!props.generating,
 )
-const failureBind = computed(() => dockFailureBindFromNode(props.node))
-
 const activeScene = computed(() =>
   payload.value.scenes.find((scene) => scene.id === activeSceneId.value) ?? payload.value.scenes[0],
 )
@@ -152,7 +148,7 @@ const canBatchGenerate = computed(() =>
     :title="payload.title ?? '场景编排'"
     title-placeholder="编排标题"
     :readonly="locked"
-    v-bind="failureBind"
+   
     @update:title="onTitleInput"
     @close="emit('close')"
   >

--- a/apps/web/src/components/canvas/dock-studio/panels/SceneComposerDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/SceneComposerDockPanel.vue
@@ -3,7 +3,8 @@ import { computed, ref, watch } from 'vue'
 import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
 import type { MentionOption } from '@/components/canvas/MentionInput.vue'
-import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
+import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
+import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockOptimizePrompt from '@/components/canvas/dock-studio/shared/DockOptimizePrompt.vue'
 import { isNodeGenerating } from '@/constants/dockStudio'
 import {
@@ -148,7 +149,6 @@ const canBatchGenerate = computed(() =>
     :title="payload.title ?? '场景编排'"
     title-placeholder="编排标题"
     :readonly="locked"
-   
     @update:title="onTitleInput"
     @close="emit('close')"
   >

--- a/apps/web/src/components/canvas/dock-studio/panels/ShotDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ShotDockPanel.vue
@@ -4,9 +4,7 @@ import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
 import type { MentionOption } from '@/components/canvas/MentionInput.vue'
 import VideoSettingsSelector from '@/components/canvas/VideoSettingsSelector.vue'
-import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
-import { dockFailureBindFromNode } from '@/components/canvas/dock-studio/shared/dockFailureChip'
-import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
+import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import DockOptimizePrompt from '@/components/canvas/dock-studio/shared/DockOptimizePrompt.vue'
@@ -38,8 +36,6 @@ const videoSettings = ref<VideoSettings>({ ...DEFAULT_VIDEO_SETTINGS })
 
 const speech = useSpeechRecognition()
 const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
-const failureBind = computed(() => dockFailureBindFromNode(props.node))
-
 const modeLabel = computed(
   () => SHOT_GENERATE_MODE_OPTIONS.find((m) => m.value === shotGenerateMode.value)?.label ?? '自动',
 )
@@ -106,7 +102,7 @@ function toggleVoice() {
     show-title
     :title="title"
     title-placeholder="分镜标题"
-    v-bind="failureBind"
+   
     @update:title="onTitleInput"
     @close="emit('close')"
   >

--- a/apps/web/src/components/canvas/dock-studio/panels/ShotDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ShotDockPanel.vue
@@ -4,7 +4,8 @@ import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
 import type { MentionOption } from '@/components/canvas/MentionInput.vue'
 import VideoSettingsSelector from '@/components/canvas/VideoSettingsSelector.vue'
-import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
+import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
+import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import DockOptimizePrompt from '@/components/canvas/dock-studio/shared/DockOptimizePrompt.vue'
@@ -102,7 +103,6 @@ function toggleVoice() {
     show-title
     :title="title"
     title-placeholder="分镜标题"
-   
     @update:title="onTitleInput"
     @close="emit('close')"
   >

--- a/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
@@ -4,9 +4,7 @@ import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
 import type { MentionOption } from '@/components/canvas/MentionInput.vue'
 import UniversalModelSelector from '@/components/canvas/UniversalModelSelector.vue'
-import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
-import { dockFailureBindFromNode } from '@/components/canvas/dock-studio/shared/dockFailureChip'
-import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
+import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import DockCreditBadge from '@/components/canvas/dock-studio/shared/DockCreditBadge.vue'
@@ -45,9 +43,7 @@ const textThinkingEffort = ref<'high' | 'max'>('high')
 const legacySeededForId = ref<string | null>(null)
 
 const speech = useSpeechRecognition()
-const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
-const failureBind = computed(() => dockFailureBindFromNode(props.node))
-const wordCount = computed(() => prompt.value.replace(/\s/g, '').length)
+const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)const wordCount = computed(() => prompt.value.replace(/\s/g, '').length)
 const credits = computed(() => estimateTextCredits())
 const showThinkingControls = computed(() => isDeepSeekV4Model(textModel.value))
 
@@ -145,7 +141,7 @@ function onRefRemove(ref: NodeRef) {
 </script>
 
 <template>
-  <DockToolbarShell type="text" v-bind="failureBind" @close="emit('close')">
+  <DockToolbarShell type="text" @close="emit('close')">
     <DockRefStrip
       :refs="refs ?? []"
       @reorder="onRefReorder"

--- a/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
@@ -4,7 +4,8 @@ import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
 import type { MentionOption } from '@/components/canvas/MentionInput.vue'
 import UniversalModelSelector from '@/components/canvas/UniversalModelSelector.vue'
-import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
+import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
+import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import DockCreditBadge from '@/components/canvas/dock-studio/shared/DockCreditBadge.vue'
@@ -43,7 +44,8 @@ const textThinkingEffort = ref<'high' | 'max'>('high')
 const legacySeededForId = ref<string | null>(null)
 
 const speech = useSpeechRecognition()
-const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)const wordCount = computed(() => prompt.value.replace(/\s/g, '').length)
+const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
+const wordCount = computed(() => prompt.value.replace(/\s/g, '').length)
 const credits = computed(() => estimateTextCredits())
 const showThinkingControls = computed(() => isDeepSeekV4Model(textModel.value))
 

--- a/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
@@ -257,7 +257,9 @@ function onRefRemove(ref: NodeRef) {
             @click="pickReferenceImage"
           >
             <DockTypeIcon v-if="!refUploading" icon="image" :size="13" />
-            <span v-else class="text-[9px] text-white/60">…</span>
+            <span v-else class="whitespace-nowrap text-[9px] text-white/60">
+              {{ refUploadProgress > 0 ? `上传中 ${refUploadProgress}%` : '上传中...' }}
+            </span>
           </button>
           <div
             v-if="effectiveRefUrl"

--- a/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
@@ -9,7 +9,8 @@ import {
 import type { MentionOption } from '@/components/canvas/MentionInput.vue'
 import UniversalModelSelector from '@/components/canvas/UniversalModelSelector.vue'
 import VideoSettingsSelector from '@/components/canvas/VideoSettingsSelector.vue'
-import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
+import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
+import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import DockCreditBadge from '@/components/canvas/dock-studio/shared/DockCreditBadge.vue'
@@ -52,7 +53,8 @@ const refUploadProgress = ref(0)
 const refUploadError = ref('')
 
 const speech = useSpeechRecognition()
-const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)const credits = computed(() => estimateVideoCredits(videoSettings.value.duration))
+const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
+const credits = computed(() => estimateVideoCredits(videoSettings.value.duration))
 
 const effectiveRefUrl = computed(() => {
   const local = referenceImageUrl.value.trim()

--- a/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
@@ -9,9 +9,7 @@ import {
 import type { MentionOption } from '@/components/canvas/MentionInput.vue'
 import UniversalModelSelector from '@/components/canvas/UniversalModelSelector.vue'
 import VideoSettingsSelector from '@/components/canvas/VideoSettingsSelector.vue'
-import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'
-import { dockFailureBindFromNode } from '@/components/canvas/dock-studio/shared/dockFailureChip'
-import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
+import DockToolbarShell from '@/components/canvas/dock-studio/shared/DockToolbarShell.vue'import DockPromptSection from '@/components/canvas/dock-studio/shared/DockPromptSection.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import DockCreditBadge from '@/components/canvas/dock-studio/shared/DockCreditBadge.vue'
@@ -54,9 +52,7 @@ const refUploadProgress = ref(0)
 const refUploadError = ref('')
 
 const speech = useSpeechRecognition()
-const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
-const failureBind = computed(() => dockFailureBindFromNode(props.node))
-const credits = computed(() => estimateVideoCredits(videoSettings.value.duration))
+const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)const credits = computed(() => estimateVideoCredits(videoSettings.value.duration))
 
 const effectiveRefUrl = computed(() => {
   const local = referenceImageUrl.value.trim()
@@ -198,7 +194,7 @@ function onRefRemove(ref: NodeRef) {
 </script>
 
 <template>
-  <DockToolbarShell type="video" v-bind="failureBind" @close="emit('close')">
+  <DockToolbarShell type="video" @close="emit('close')">
     <DockRefStrip
       :refs="refs ?? []"
       @reorder="onRefReorder"

--- a/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
@@ -50,6 +50,7 @@ const videoMode = ref<VideoGenerationMode>('text_to_video')
 const referenceImageUrl = ref('')
 const refInput = ref<HTMLInputElement | null>(null)
 const refUploading = ref(false)
+const refUploadProgress = ref(0)
 const refUploadError = ref('')
 
 const speech = useSpeechRecognition()
@@ -143,20 +144,18 @@ async function onRefFileChange(event: Event) {
   if (!file || !file.type.startsWith('image/')) return
 
   refUploadError.value = ''
+  refUploadProgress.value = 0
   refUploading.value = true
   const blobUrl = URL.createObjectURL(file)
   referenceImageUrl.value = blobUrl
   videoMode.value = 'image_to_video'
 
   try {
-    const url = await persistMediaUrl(file, blobUrl)
-    const loggedIn = !!localStorage.getItem('token')
-    if (url.startsWith('blob:') && loggedIn) {
-      refUploadError.value = '参考图上传失败，请重试'
-      URL.revokeObjectURL(blobUrl)
-      referenceImageUrl.value = ''
-      return
-    }
+    const url = await persistMediaUrl(file, blobUrl, {
+      onProgress: (p) => {
+        refUploadProgress.value = p
+      },
+    })
     if (url !== blobUrl) URL.revokeObjectURL(blobUrl)
 
     referenceImageUrl.value = url
@@ -173,12 +172,13 @@ async function onRefFileChange(event: Event) {
       referenceImageUrl: url,
       videoMode: 'image_to_video',
     })
-  } catch {
-    refUploadError.value = '参考图上传失败，请重试'
+  } catch (err) {
+    refUploadError.value = err instanceof Error ? err.message : '参考图上传失败，请重试'
     URL.revokeObjectURL(blobUrl)
     referenceImageUrl.value = ''
   } finally {
     refUploading.value = false
+    refUploadProgress.value = 0
   }
 }
 

--- a/apps/web/src/components/canvas/dock-studio/shared/DockToolbarShell.vue
+++ b/apps/web/src/components/canvas/dock-studio/shared/DockToolbarShell.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import type { TaskKind } from '@lnkpi/shared'
-import DockFailureChip from './DockFailureChip.vue'
 import DockTypeIcon from './DockTypeIcon.vue'
 import { DOCK_TYPE_LABELS, dockTypeToIcon } from './dockIcons'
 
@@ -14,14 +12,6 @@ const props = defineProps<{
   title?: string
   titlePlaceholder?: string
   readonly?: boolean
-  /** Selected node id — enables quiet failure chip under header */
-  failureNodeId?: string
-  failureStatus?: unknown
-  failureMessage?: string
-  failureErrorCode?: string
-  failureTaskKind?: TaskKind
-  failureTaskId?: string
-  failureNodeLabel?: string
 }>()
 
 const emit = defineEmits<{
@@ -34,8 +24,6 @@ const tooltip = computed(() => {
   if (props.type && DOCK_TYPE_LABELS[props.type]) return DOCK_TYPE_LABELS[props.type]
   return props.typeLabel ?? '节点'
 })
-
-const showDefaultFailureChip = computed(() => Boolean(props.failureNodeId))
 </script>
 
 <template>
@@ -64,18 +52,6 @@ const showDefaultFailureChip = computed(() => Boolean(props.failureNodeId))
         </svg>
       </button>
     </div>
-    <slot name="failure">
-      <DockFailureChip
-        v-if="showDefaultFailureChip && failureNodeId"
-        :node-id="failureNodeId"
-        :status="failureStatus"
-        :error-message="failureMessage"
-        :error-code="failureErrorCode"
-        :task-kind="failureTaskKind"
-        :task-id="failureTaskId"
-        :node-label="failureNodeLabel"
-      />
-    </slot>
     <slot />
   </div>
 </template>

--- a/apps/web/src/components/works/PublishNeoTVDialog.vue
+++ b/apps/web/src/components/works/PublishNeoTVDialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { WORK_CATEGORIES } from '@lnkpi/shared'
+import { api } from '@/services/api'
 import { worksApi } from '@/services/works-api'
 
 const props = defineProps<{
@@ -15,6 +16,13 @@ const emit = defineEmits<{
   published: []
 }>()
 
+interface PrimaryNodeOption {
+  id: string
+  type: 'image' | 'video'
+  label: string
+  preview: string
+}
+
 const visible = computed({
   get: () => props.modelValue,
   set: (v) => emit('update:modelValue', v),
@@ -23,9 +31,45 @@ const visible = computed({
 const title = ref('')
 const category = ref('精选作品')
 const selectedSessionId = ref('')
+const primaryNodeId = ref('')
+const primaryNodes = ref<PrimaryNodeOption[]>([])
+const loadingNodes = ref(false)
 const loading = ref(false)
 const error = ref('')
 const success = ref(false)
+
+const activeSessionId = computed(() => props.sessionId ?? selectedSessionId.value)
+const canSubmit = computed(() => !!title.value.trim() && !!activeSessionId.value && !!primaryNodeId.value)
+
+async function loadPrimaryNodes(sid: string) {
+  if (!sid) {
+    primaryNodes.value = []
+    primaryNodeId.value = ''
+    return
+  }
+  loadingNodes.value = true
+  try {
+    const { data } = await api.get<{ data: { canvasData?: { nodes?: Array<{ id: string; type?: string; data?: { url?: string; coverUrl?: string } }> } } }>(
+      `/sessions/${sid}`,
+    )
+    primaryNodes.value = (data.data.canvasData?.nodes ?? [])
+      .filter((n) => (n.type === 'image' || n.type === 'video') && n.data?.url)
+      .map((n) => ({
+        id: n.id,
+        type: n.type as 'image' | 'video',
+        label: `${n.id} · ${n.type === 'video' ? '视频' : '图片'}`,
+        preview: n.data?.coverUrl || n.data?.url || '',
+      }))
+    if (!primaryNodes.value.some((n) => n.id === primaryNodeId.value)) {
+      primaryNodeId.value = primaryNodes.value[0]?.id ?? ''
+    }
+  } catch {
+    primaryNodes.value = []
+    primaryNodeId.value = ''
+  } finally {
+    loadingNodes.value = false
+  }
+}
 
 watch(
   () => props.modelValue,
@@ -36,13 +80,18 @@ watch(
       selectedSessionId.value = props.sessionId ?? props.sessions?.[0]?.id ?? ''
       error.value = ''
       success.value = false
+      void loadPrimaryNodes(activeSessionId.value)
     }
   },
 )
 
+watch(activeSessionId, (sid) => {
+  if (props.modelValue) void loadPrimaryNodes(sid)
+})
+
 async function handlePublish() {
-  const sid = props.sessionId ?? selectedSessionId.value
-  if (!title.value.trim() || !sid) return
+  const sid = activeSessionId.value
+  if (!canSubmit.value || !sid) return
   loading.value = true
   error.value = ''
   try {
@@ -50,12 +99,13 @@ async function handlePublish() {
       sessionId: sid,
       title: title.value.trim(),
       category: category.value,
+      primaryNodeId: primaryNodeId.value,
     })
     success.value = true
     emit('published')
     setTimeout(() => { visible.value = false }, 1200)
   } catch {
-    error.value = '发布失败，请确认已登录且画布有效'
+    error.value = '发布失败，请确认已登录、已选择主成片且画布有效'
   } finally {
     loading.value = false
   }
@@ -101,10 +151,30 @@ async function handlePublish() {
           />
         </el-select>
       </div>
+      <div>
+        <label class="mb-1 block text-xs text-white/50">主成片节点 <span class="text-red-400">*</span></label>
+        <div v-if="loadingNodes" class="py-4 text-center text-sm text-white/40">加载节点中…</div>
+        <div v-else-if="!primaryNodes.length" class="rounded-lg border border-dashed border-white/10 p-4 text-sm text-white/40">
+          当前画布没有可发布的图片/视频节点，请先生成或上传媒体
+        </div>
+        <el-radio-group v-else v-model="primaryNodeId" class="flex w-full flex-col gap-2">
+          <el-radio
+            v-for="node in primaryNodes"
+            :key="node.id"
+            :value="node.id"
+            class="!mr-0 !h-auto w-full rounded-lg border border-white/8 bg-white/[0.03] px-3 py-2"
+          >
+            <div class="flex items-center gap-3">
+              <img :src="node.preview" :alt="node.label" class="h-10 w-16 rounded object-cover" />
+              <span class="text-sm">{{ node.label }}</span>
+            </div>
+          </el-radio>
+        </el-radio-group>
+      </div>
       <p v-if="error" class="text-sm text-red-400">{{ error }}</p>
       <div class="flex justify-end gap-2 pt-2">
         <el-button @click="visible = false">取消</el-button>
-        <el-button type="primary" :loading="loading" native-type="submit">发布</el-button>
+        <el-button type="primary" :loading="loading" :disabled="!canSubmit" native-type="submit">发布</el-button>
       </div>
     </form>
   </el-dialog>

--- a/apps/web/src/components/works/WorkCard.vue
+++ b/apps/web/src/components/works/WorkCard.vue
@@ -6,7 +6,9 @@ defineProps<{
 }>()
 
 defineEmits<{
-  viewProcess: [sessionId: string]
+  viewWork: [workId: string]
+  viewWatch: [workId: string]
+  viewProcess: [workId: string]
   viewAuthor: [authorId: string]
   viewShare: [workId: string]
 }>()
@@ -14,7 +16,8 @@ defineEmits<{
 
 <template>
   <article
-    class="group overflow-hidden rounded-2xl border border-white/[0.08] bg-[#1a1a1a] transition hover:border-[#6366f1]/30 hover:shadow-lg hover:shadow-[#6366f1]/5"
+    class="group cursor-pointer overflow-hidden rounded-2xl border border-white/[0.08] bg-[#1a1a1a] transition hover:border-[#6366f1]/30 hover:shadow-lg hover:shadow-[#6366f1]/5"
+    @click="$emit('viewWork', work.id)"
   >
     <div class="relative aspect-video overflow-hidden bg-[#242424]">
       <img
@@ -30,13 +33,21 @@ defineEmits<{
         </span>
       </div>
 
-      <button
-        v-if="work.sessionId"
-        class="absolute bottom-3 left-3 rounded-lg bg-white/10 px-3 py-1.5 text-xs backdrop-blur-sm transition hover:bg-white/20"
-        @click.stop="$emit('viewProcess', work.sessionId!)"
-      >
-        查看创作过程
-      </button>
+      <div class="absolute bottom-3 left-3 flex gap-2">
+        <button
+          class="rounded-lg bg-[#6366f1] px-3 py-1.5 text-xs font-medium backdrop-blur-sm transition hover:bg-[#5558e3]"
+          @click.stop="$emit('viewWatch', work.id)"
+        >
+          立即观看
+        </button>
+        <button
+          v-if="work.sessionId"
+          class="rounded-lg bg-white/10 px-3 py-1.5 text-xs backdrop-blur-sm transition hover:bg-white/20"
+          @click.stop="$emit('viewProcess', work.id)"
+        >
+          制作过程
+        </button>
+      </div>
       <button
         class="absolute bottom-3 right-3 rounded-lg bg-black/40 px-2 py-1 text-[10px] backdrop-blur-sm transition hover:bg-black/60"
         @click.stop="$emit('viewShare', work.id)"
@@ -49,11 +60,11 @@ defineEmits<{
       <div class="mb-2 flex items-center gap-2">
         <button
           class="flex h-6 w-6 items-center justify-center rounded-full bg-[#6366f1]/30 text-[10px] hover:bg-[#6366f1]/50"
-          @click="$emit('viewAuthor', work.authorId)"
+          @click.stop="$emit('viewAuthor', work.authorId)"
         >
           {{ work.authorName[0] }}
         </button>
-        <button class="text-xs text-white/50 hover:text-[#818cf8]" @click="$emit('viewAuthor', work.authorId)">
+        <button class="text-xs text-white/50 hover:text-[#818cf8]" @click.stop="$emit('viewAuthor', work.authorId)">
           @{{ work.authorName }}
         </button>
       </div>

--- a/apps/web/src/composables/useMediaUpload.test.ts
+++ b/apps/web/src/composables/useMediaUpload.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { persistMediaUrl } from './useMediaUpload'
+
+vi.mock('@/services/upload-api', () => ({
+  uploadApi: { upload: vi.fn() },
+}))
+vi.mock('@/services/api-base', () => ({
+  resolveMediaUrl: (u: string) => u,
+}))
+
+import { uploadApi } from '@/services/upload-api'
+
+describe('persistMediaUrl', () => {
+  beforeEach(() => {
+    localStorage.setItem('token', 't')
+    vi.mocked(uploadApi.upload).mockReset()
+  })
+
+  it('throws when upload returns non-zero code', async () => {
+    vi.mocked(uploadApi.upload).mockResolvedValue({
+      data: { code: 1, message: '未收到文件', data: undefined as never },
+    } as never)
+    await expect(persistMediaUrl(new File(['x'], 'a.png'), 'blob:x')).rejects.toThrow(/未收到文件|上传/)
+  })
+
+  it('throws when logged-in upload network-fails (no blob fallback)', async () => {
+    vi.mocked(uploadApi.upload).mockRejectedValue(new Error('Network Error'))
+    await expect(persistMediaUrl(new File(['x'], 'a.png'), 'blob:x')).rejects.toThrow()
+  })
+
+  it('returns server url on success', async () => {
+    vi.mocked(uploadApi.upload).mockResolvedValue({
+      data: { code: 0, data: { url: '/uploads/u/a.png', fileName: 'a.png', mimeType: 'image/png', size: 1 } },
+    } as never)
+    await expect(persistMediaUrl(new File(['x'], 'a.png'), 'blob:x')).resolves.toBe('/uploads/u/a.png')
+  })
+})

--- a/apps/web/src/composables/useMediaUpload.ts
+++ b/apps/web/src/composables/useMediaUpload.ts
@@ -2,7 +2,7 @@ import { uploadApi } from '@/services/upload-api'
 import { resolveMediaUrl } from '@/services/api-base'
 import { detectFileKind, type MediaFilePayload } from '@/composables/useCanvasMedia'
 
-/** 登录态下上传到服务端，失败或未登录时保留 blob URL */
+/** 有 token 时上传到服务端，失败则抛错；未登录时返回 fallbackUrl */
 export async function persistMediaUrl(
   file: File,
   fallbackUrl: string,

--- a/apps/web/src/composables/useMediaUpload.ts
+++ b/apps/web/src/composables/useMediaUpload.ts
@@ -3,21 +3,38 @@ import { resolveMediaUrl } from '@/services/api-base'
 import { detectFileKind, type MediaFilePayload } from '@/composables/useCanvasMedia'
 
 /** 登录态下上传到服务端，失败或未登录时保留 blob URL */
-export async function persistMediaUrl(file: File, fallbackUrl: string): Promise<string> {
+export async function persistMediaUrl(
+  file: File,
+  fallbackUrl: string,
+  opts?: { onProgress?: (pct: number) => void; allowBlobFallback?: boolean },
+): Promise<string> {
   const token = localStorage.getItem('token')
   if (!token) return fallbackUrl
+
+  const allowBlobFallback = opts?.allowBlobFallback ?? false
+
   try {
-    const { data } = await uploadApi.upload(file)
+    const { data } = await uploadApi.upload(file, { onProgress: opts?.onProgress })
+    if (data.code !== undefined && data.code !== 0) {
+      throw new Error(data.message || '上传失败')
+    }
+    if (!data.data?.url) {
+      throw new Error(data.message || '上传失败')
+    }
     return resolveMediaUrl(data.data.url)
-  } catch {
-    return fallbackUrl
+  } catch (err) {
+    if (allowBlobFallback) return fallbackUrl
+    throw err
   }
 }
 
-export async function fileToPersistedPayload(file: File): Promise<MediaFilePayload> {
+export async function fileToPersistedPayload(
+  file: File,
+  opts?: { onProgress?: (pct: number) => void; allowBlobFallback?: boolean },
+): Promise<MediaFilePayload> {
   const kind = detectFileKind(file)
   const blobUrl = URL.createObjectURL(file)
-  const url = await persistMediaUrl(file, blobUrl)
+  const url = await persistMediaUrl(file, blobUrl, opts)
   const payload: MediaFilePayload = {
     url,
     fileName: file.name,

--- a/apps/web/src/composables/useNodeGeneration.test.ts
+++ b/apps/web/src/composables/useNodeGeneration.test.ts
@@ -110,6 +110,10 @@ function createDeps(nodes: EditableFlowNode[], overrides: Record<string, unknown
   return { api, deps }
 }
 
+function canvasScope(nodeId: string) {
+  return { sessionId: 'session-1', nodeId }
+}
+
 describe('useNodeGeneration', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -253,6 +257,7 @@ describe('useNodeGeneration', () => {
       [],
       [],
       expect.any(AbortSignal),
+      canvasScope('audio-1'),
     )
   })
 
@@ -277,6 +282,7 @@ describe('useNodeGeneration', () => {
       '2K',
       3,
       expect.any(AbortSignal),
+      canvasScope('image-1'),
     )
   })
 
@@ -301,6 +307,7 @@ describe('useNodeGeneration', () => {
       '1K',
       1,
       expect.any(AbortSignal),
+      canvasScope('image-1'),
     )
   })
 
@@ -326,6 +333,7 @@ describe('useNodeGeneration', () => {
       '2K',
       1,
       expect.any(AbortSignal),
+      canvasScope('image-1'),
     )
   })
 
@@ -750,6 +758,7 @@ describe('useNodeGeneration', () => {
       expect.any(AbortSignal),
       false,
       undefined,
+      canvasScope('text-1'),
     )
     expect(deps.patchNodeData).toHaveBeenCalledWith(
       'text-1',
@@ -1160,6 +1169,7 @@ describe('useNodeGeneration', () => {
       '2K',
       2,
       expect.any(AbortSignal),
+      canvasScope('image-1'),
     )
     expect(canvasApi.generateImage).not.toHaveBeenCalled()
   })

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -18,7 +18,7 @@ import {
 } from '@/composables/useGenerationPolling'
 import { parseRefMentions } from '@/composables/useRefMentions'
 import { canvasApi } from '@/services/canvas-api'
-import { studioApi, type GenerationRecord, type StudioRefPayload } from '@/services/studio-api'
+import { studioApi, type CanvasGenerationScope, type GenerationRecord, type StudioRefPayload } from '@/services/studio-api'
 import {
   resolveGenerationModel,
   type StudioModality,
@@ -491,6 +491,10 @@ async function cancelRemoteGeneration(nodeId: string) {
     return false
   }
 
+  function canvasScope(nodeId: string): CanvasGenerationScope {
+    return { sessionId: deps.sessionId.value, nodeId }
+  }
+
   async function generateForNode(node: EditableFlowNode) {
     if (isNodeBusy(node.id) || isNodeGenerating(node.data?.status)) {
       cancelGeneration(node.id)
@@ -536,6 +540,7 @@ async function cancelRemoteGeneration(nodeId: string) {
           local,
           resolveGenerationModel('text', data.textModel as string | undefined),
           signal,
+          canvasScope(node.id),
         )
         if (signal.aborted) return
         await resolveStudioRecord(node.id, res.data)
@@ -558,6 +563,7 @@ async function cancelRemoteGeneration(nodeId: string) {
           signal,
           thinking,
           thinking ? thinkingEffort : undefined,
+          canvasScope(node.id),
         )
         if (signal.aborted) return
         await resolveStudioRecord(node.id, res.data)
@@ -578,7 +584,7 @@ async function cancelRemoteGeneration(nodeId: string) {
           speed: typeof data.audioSpeed === 'number' ? data.audioSpeed : 1,
           volume: typeof data.audioVolume === 'number' ? data.audioVolume : 1,
           pitch: typeof data.audioPitch === 'number' ? data.audioPitch : 0,
-        }, refs, mentionedKeys, signal)
+        }, refs, mentionedKeys, signal, canvasScope(node.id))
         if (signal.aborted) return
         await resolveStudioRecord(node.id, res.data)
         return
@@ -676,6 +682,7 @@ async function cancelRemoteGeneration(nodeId: string) {
         resolution,
         count,
         signal,
+        canvasScope(node.id),
       )
       if (signal?.aborted) return
       deps.patchNodeData(node.id, {
@@ -699,6 +706,7 @@ async function cancelRemoteGeneration(nodeId: string) {
       settings?.resolution,
       settings?.crop,
       signal,
+      canvasScope(node.id),
     )
     if (signal?.aborted) return
     deps.patchNodeData(node.id, {

--- a/apps/web/src/composables/useNodeMediaUpload.ts
+++ b/apps/web/src/composables/useNodeMediaUpload.ts
@@ -35,25 +35,32 @@ export function useNodeMediaUpload(nodeId: string, kind: NodeMediaKind) {
       flashReject()
       return
     }
-    const payload = await fileToPersistedPayload(file)
-    // 登录态下上传失败会回退成 blob 本地地址：立即报错，
-    // 避免静默落下 blob 后在下游生成时才报「参考图尚未上传」
-    if (payload.url.startsWith('blob:') && localStorage.getItem('token')) {
-      flashReject()
+    patchNode(nodeId, {
+      status: 'uploading',
+      uploadProgress: 0,
+      errorMessage: undefined,
+      errorCode: undefined,
+    })
+    try {
+      const payload = await fileToPersistedPayload(file, {
+        onProgress: (p) => patchNode(nodeId, { uploadProgress: p }),
+      })
+      patchNode(nodeId, {
+        url: payload.url,
+        status: 'idle',
+        fileName: payload.fileName,
+        mimeType: payload.mimeType,
+        source: 'upload',
+        uploadProgress: undefined,
+      })
+    } catch (err) {
       patchNode(nodeId, {
         status: 'error',
-        errorMessage: '文件上传失败，请重试',
+        errorMessage: err instanceof Error ? err.message : '文件上传失败，请重试',
         errorCode: 'upload_required',
+        uploadProgress: undefined,
       })
-      return
     }
-    patchNode(nodeId, {
-      url: payload.url,
-      status: 'idle',
-      fileName: payload.fileName,
-      mimeType: payload.mimeType,
-      source: 'upload',
-    })
   }
 
   function openPicker() {

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -1345,20 +1345,38 @@ async function ingestMediaFile(file: File, clientPos: { x: number; y: number }) 
       ? canAcceptLocalRef(String(selectedNode.type ?? ''), 'text')
       : canAcceptLocalRef(String(selectedNode.type ?? ''), kind))
 
+  const selectedNodeId = wouldApplyToSelected ? selectedNode!.id : null
+  const isMediaKind = kind === 'image' || kind === 'video' || kind === 'audio'
+
   let uploadingNodeId: string | null = null
-  if (!wouldApplyToSelected && (kind === 'image' || kind === 'video' || kind === 'audio')) {
+  if (!wouldApplyToSelected && isMediaKind) {
     uploadingNodeId = createUploadingMediaNodeAt(file, clientPos, kind)
     if (uploadingNodeId) selectOnlyNode(uploadingNodeId)
+  }
+
+  if (selectedNodeId && isMediaKind) {
+    patchNodeData(selectedNodeId, {
+      status: 'uploading',
+      uploadProgress: 0,
+      errorMessage: undefined,
+      errorCode: undefined,
+    })
   }
 
   try {
     const payload = await fileToPersistedPayload(file, {
       onProgress: (p) => {
         if (uploadingNodeId) patchNodeData(uploadingNodeId, { uploadProgress: p })
+        if (selectedNodeId && isMediaKind) patchNodeData(selectedNodeId, { uploadProgress: p })
       },
     })
 
-    if (payload.url && tryApplyUploadToSelectedNode(payload)) return
+    if (payload.url && tryApplyUploadToSelectedNode(payload)) {
+      if (selectedNodeId && isMediaKind) {
+        patchNodeData(selectedNodeId, { uploadProgress: undefined, status: 'idle' })
+      }
+      return
+    }
 
     if (uploadingNodeId) {
       patchNodeData(uploadingNodeId, {
@@ -1384,6 +1402,13 @@ async function ingestMediaFile(file: File, clientPos: { x: number; y: number }) 
         uploadProgress: undefined,
       })
       void saveCanvas()
+      return
+    }
+    if (wouldApplyToSelected) {
+      if (selectedNodeId && isMediaKind) {
+        patchNodeData(selectedNodeId, { uploadProgress: undefined, status: 'idle' })
+      }
+      ElMessage.error(msg)
       return
     }
     if (kind === 'text') {

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -27,6 +27,7 @@ import { api } from '@/services/api'
 import { useAuthStore } from '@/stores/auth'
 import { useCanvasEditorStore } from '@/stores/canvasEditor'
 import { applyActionsToFlow, flowToCanvasData } from '@/composables/useCanvasActions'
+import { annotateEdgesForSelection } from '@/utils/edgeHighlight'
 import { useShotPolling } from '@/composables/useShotPolling'
 import { useGenerationPolling, parseRecordText, parseRecordUrl, parseRecordUrls, type GenerationPollTask } from '@/composables/useGenerationPolling'
 import { useNodeGeneration } from '@/composables/useNodeGeneration'
@@ -166,17 +167,13 @@ const downstreamEdgeIds = computed(() => {
   return ids
 })
 
-const flowEdges = computed(() => {
-  const upstream = upstreamEdgeIds.value
-  const downstream = downstreamEdgeIds.value
-  if (!upstream.size && !downstream.size) return edges.value as unknown as Edge[]
-  return edges.value.map((edge) => {
-    // 环路中同属上下游时，上游电流优先
-    if (upstream.has(edge.id)) return { ...edge, class: 'neo-edge-upstream' }
-    if (downstream.has(edge.id)) return { ...edge, class: 'neo-edge-downstream' }
-    return edge
-  }) as unknown as Edge[]
-})
+const flowEdges = computed(() =>
+  annotateEdgesForSelection(
+    edges.value,
+    upstreamEdgeIds.value,
+    downstreamEdgeIds.value,
+  ) as unknown as Edge[],
+)
 
 const { selectNode, clearEditorSelection, clearSelection, patchNodeData, selectedNodeId } = useSelectedNodeEditor(nodes)
 const sessionTitle = ref('未命名画布')
@@ -1113,6 +1110,8 @@ function onPaneDoubleClick(event: MouseEvent) {
 }
 
 function onEdgeClick({ edge, event }: EdgeMouseEvent) {
+  multiSelectedIds.value = []
+  clearSelection()
   selectedEdgeId.value = edge.id
   const coords = getEventCoords(event)
   selectedEdgePos.value = { x: coords.x, y: coords.y }

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -1482,18 +1482,17 @@ async function onMediaFileSelected(event: Event) {
 async function handleMediaInputUpload(file: File) {
   const node = editorNode.value
   if (!node || node.type !== 'mediaInput') return
-  patchNodeData(node.id, { status: 'uploading' })
+  patchNodeData(node.id, {
+    status: 'uploading',
+    uploadProgress: 0,
+    errorMessage: undefined,
+    errorCode: undefined,
+  })
   try {
-    const payload = await fileToPersistedPayload(file)
+    const payload = await fileToPersistedPayload(file, {
+      onProgress: (p) => patchNodeData(node.id, { uploadProgress: p }),
+    })
     if (payload.kind === 'other' || payload.kind === 'text') return
-    if (payload.url.startsWith('blob:') && localStorage.getItem('token')) {
-      patchNodeData(node.id, {
-        status: 'error',
-        errorMessage: '文件上传失败，请重试',
-        errorCode: 'upload_required',
-      })
-      return
-    }
     const mediaKind = inferMediaInputKind(payload.mimeType, payload.url)
     patchNodeData(node.id, {
       url: payload.url,
@@ -1502,10 +1501,17 @@ async function handleMediaInputUpload(file: File) {
       mediaKind,
       title: payload.fileName.replace(/\.[^.]+$/, '') || payload.fileName,
       status: 'completed',
+      uploadProgress: undefined,
     })
     await saveCanvas()
-  } catch {
-    patchNodeData(node.id, { status: 'error' })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : '上传失败'
+    patchNodeData(node.id, {
+      status: 'error',
+      errorMessage: msg,
+      errorCode: 'upload_required',
+      uploadProgress: undefined,
+    })
   }
 }
 

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -80,7 +80,7 @@ import EdgeScissorsOverlay from '@/components/canvas/EdgeScissorsOverlay.vue'
 import { useCanvasViewportSettings, type CanvasViewportSettings } from '@/composables/useCanvasViewportSettings'
 import { useCanvasTheme } from '@/composables/useCanvasTheme'
 import { useCanvasKeyboard } from '@/composables/useCanvasKeyboard'
-import { downloadMediaPackage, setupCanvasMediaHandlers, type MediaFilePayload } from '@/composables/useCanvasMedia'
+import { downloadMediaPackage, detectFileKind, setupCanvasMediaHandlers, type MediaFilePayload } from '@/composables/useCanvasMedia'
 import { fileToPersistedPayload, inferMediaInputKind } from '@/composables/useMediaUpload'
 import { useDebouncedNodePatch } from '@/composables/useDebouncedNodePatch'
 import {
@@ -1248,7 +1248,6 @@ async function createFileNodeAt(payload: MediaFilePayload, clientPos: { x: numbe
     mimeType: payload.mimeType,
     title,
   }
-  // 媒体文件上传失败（url 为空）时创建 error 节点提示重传，而不是静默落 blob
   const mediaStatus = payload.url
     ? { url: payload.url, status: 'completed' }
     : { status: 'error', errorMessage: '文件上传失败，请重试', errorCode: 'upload_required' }
@@ -1295,15 +1294,155 @@ async function createFileNodeAt(payload: MediaFilePayload, clientPos: { x: numbe
   await focusNodeById(id)
 }
 
-async function ingestMediaFile(file: File, clientPos: { x: number; y: number }) {
-  const payload = await fileToPersistedPayload(file)
-  // 登录态下媒体上传失败会回退成 blob 本地地址：清空 url 走 error 节点提示，
-  // 避免 blob 引用在下游生成时才报「参考图尚未上传」
-  if (payload.kind !== 'text' && payload.url.startsWith('blob:') && localStorage.getItem('token')) {
-    payload.url = ''
+function createUploadingMediaNodeAt(
+  file: File,
+  clientPos: { x: number; y: number },
+  kind: 'image' | 'video' | 'audio',
+): string | null {
+  const title = file.name.replace(/\.[^.]+$/, '') || file.name
+  const meta = {
+    fileName: file.name,
+    mimeType: file.type || 'application/octet-stream',
+    title,
   }
-  if (payload.url && tryApplyUploadToSelectedNode(payload)) return
-  await createFileNodeAt(payload, clientPos)
+  const uploading = { status: 'uploading', uploadProgress: 0, prompt: '' }
+
+  switch (kind) {
+    case 'image':
+      return addNode('image', {
+        ...meta,
+        ...uploading,
+        imageModel: getProviderConfig('image').model,
+      }, { position: resolveDropPosition(clientPos, kind) })
+    case 'video':
+      return addNode('video', {
+        ...meta,
+        ...uploading,
+        videoModel: getProviderConfig('video').model,
+      }, { position: resolveDropPosition(clientPos, kind) })
+    case 'audio':
+      return addNode('audio', {
+        ...meta,
+        ...uploading,
+        audioModel: getProviderConfig('audio').model,
+      }, { position: resolveDropPosition(clientPos, kind) })
+    default:
+      return null
+  }
+}
+
+async function ingestMediaFile(file: File, clientPos: { x: number; y: number }) {
+  const kind = detectFileKind(file)
+  if (kind === 'other') {
+    ElMessage.warning('不支持的文件类型')
+    return
+  }
+
+  const selectedNode = editorNode.value
+  const wouldApplyToSelected =
+    !!selectedNode &&
+    (kind === 'text'
+      ? canAcceptLocalRef(String(selectedNode.type ?? ''), 'text')
+      : canAcceptLocalRef(String(selectedNode.type ?? ''), kind))
+
+  let uploadingNodeId: string | null = null
+  if (!wouldApplyToSelected && (kind === 'image' || kind === 'video' || kind === 'audio')) {
+    uploadingNodeId = createUploadingMediaNodeAt(file, clientPos, kind)
+    if (uploadingNodeId) selectOnlyNode(uploadingNodeId)
+  }
+
+  try {
+    const payload = await fileToPersistedPayload(file, {
+      onProgress: (p) => {
+        if (uploadingNodeId) patchNodeData(uploadingNodeId, { uploadProgress: p })
+      },
+    })
+
+    if (payload.url && tryApplyUploadToSelectedNode(payload)) return
+
+    if (uploadingNodeId) {
+      patchNodeData(uploadingNodeId, {
+        url: payload.url,
+        status: 'completed',
+        uploadProgress: undefined,
+        fileName: payload.fileName,
+        mimeType: payload.mimeType,
+      })
+      void saveCanvas()
+      await focusNodeById(uploadingNodeId)
+      return
+    }
+
+    await createFileNodeAt(payload, clientPos)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : '上传失败'
+    if (uploadingNodeId) {
+      patchNodeData(uploadingNodeId, {
+        status: 'error',
+        errorMessage: msg,
+        errorCode: 'upload_required',
+        uploadProgress: undefined,
+      })
+      void saveCanvas()
+      return
+    }
+    if (kind === 'text') {
+      ElMessage.error(msg)
+      return
+    }
+    await createFileNodeAt(
+      {
+        url: '',
+        fileName: file.name,
+        mimeType: file.type || 'application/octet-stream',
+        kind,
+      },
+      clientPos,
+    )
+  }
+}
+
+async function handleDockFileDrop(file: File) {
+  let closeToast: () => void = () => {}
+  const showProgress = (pct: number) => {
+    closeToast()
+    const toast = ElMessage.info({
+      message: pct > 0 ? `上传 ${pct}%` : '上传中...',
+      duration: 0,
+      showClose: false,
+    })
+    closeToast = () => {
+      toast.close()
+    }
+  }
+
+  try {
+    showProgress(0)
+    const payload = await fileToPersistedPayload(file, {
+      onProgress: showProgress,
+    })
+    closeToast()
+
+    if (payload.kind !== 'image' && payload.kind !== 'video' && payload.kind !== 'audio') {
+      ElMessage.warning('当前节点不支持该类型的引用')
+      return
+    }
+
+    const binding: LocalRefBinding = {
+      id: createLocalRefId('upload'),
+      mediaType: payload.kind,
+      sourceKind: 'upload',
+      label: payload.fileName,
+      url: payload.url,
+    }
+
+    if (!applyLocalRefToSelectedNode(binding)) {
+      ElMessage.warning('当前节点不支持该类型的引用')
+    }
+  } catch (err) {
+    closeToast()
+    ElMessage.error(err instanceof Error ? err.message : '上传失败')
+  }
 }
 
 async function onMediaFileSelected(event: Event) {
@@ -1888,6 +2027,12 @@ onMounted(() => {
         event.dataTransfer.dropEffect = 'copy'
         return
       }
+      const onDock = (event.target as HTMLElement | null)?.closest('.dock-studio-toolbar')
+      if (onDock && event.dataTransfer?.types.includes('Files')) {
+        event.preventDefault()
+        event.dataTransfer.dropEffect = 'copy'
+        return
+      }
       mediaHandlers.onDragOver(event)
     })
     area.addEventListener('drop', (event) => {
@@ -1911,6 +2056,13 @@ onMounted(() => {
         } catch {
           // ignore
         }
+        return
+      }
+      const onDock = (event.target as HTMLElement | null)?.closest('.dock-studio-toolbar')
+      const file = event.dataTransfer?.files?.[0]
+      if (onDock && file) {
+        event.preventDefault()
+        void handleDockFileDrop(file)
         return
       }
       void mediaHandlers.onDrop(event)

--- a/apps/web/src/pages/CanvasReadonlyPage.vue
+++ b/apps/web/src/pages/CanvasReadonlyPage.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { VueFlow, type Edge, type Node } from '@vue-flow/core'
+import { Background } from '@vue-flow/background'
+import '@vue-flow/core/dist/style.css'
+import '@vue-flow/core/dist/theme-default.css'
+import { ElMessage } from 'element-plus'
+import type { Work } from '@lnkpi/shared'
+import { worksApi } from '@/services/works-api'
+import { useAuthStore } from '@/stores/auth'
+import CanvasNodePrompt from '@/components/canvas/CanvasNodePrompt.vue'
+import CanvasNodeImage from '@/components/canvas/CanvasNodeImage.vue'
+import CanvasNodeVideo from '@/components/canvas/CanvasNodeVideo.vue'
+import CanvasNodeText from '@/components/canvas/CanvasNodeText.vue'
+import CanvasNodeShot from '@/components/canvas/CanvasNodeShot.vue'
+import CanvasNodeGroup from '@/components/canvas/CanvasNodeGroup.vue'
+import CanvasNodeAudio from '@/components/canvas/CanvasNodeAudio.vue'
+import CanvasNodeDirector from '@/components/canvas/CanvasNodeDirector.vue'
+import CanvasNodeMediaInput from '@/components/canvas/CanvasNodeMediaInput.vue'
+import CanvasNodeVideoComposition from '@/components/canvas/CanvasNodeVideoComposition.vue'
+import CanvasNodeWorldModel from '@/components/canvas/CanvasNodeWorldModel.vue'
+
+const route = useRoute()
+const router = useRouter()
+const auth = useAuthStore()
+
+const workId = computed(() => route.params.id as string)
+const work = ref<Work | null>(null)
+const nodes = ref<Node[]>([])
+const edges = ref<Edge[]>([])
+const loading = ref(true)
+const forking = ref(false)
+
+const nodeTypes = {
+  prompt: CanvasNodePrompt,
+  image: CanvasNodeImage,
+  video: CanvasNodeVideo,
+  text: CanvasNodeText,
+  shot: CanvasNodeShot,
+  group: CanvasNodeGroup,
+  audio: CanvasNodeAudio,
+  director: CanvasNodeDirector,
+  mediaInput: CanvasNodeMediaInput,
+  videoComposition: CanvasNodeVideoComposition,
+  worldModel: CanvasNodeWorldModel,
+}
+
+onMounted(async () => {
+  try {
+    const [workRes, canvasRes] = await Promise.all([
+      worksApi.get(workId.value),
+      worksApi.getCanvas(workId.value),
+    ])
+    work.value = workRes.data.data
+    nodes.value = (canvasRes.data.data.nodes ?? []) as Node[]
+    edges.value = (canvasRes.data.data.edges ?? []) as Edge[]
+  } catch {
+    work.value = null
+  } finally {
+    loading.value = false
+  }
+})
+
+async function forkToMyCanvas() {
+  if (!auth.isLoggedIn) {
+    auth.openLogin()
+    return
+  }
+  forking.value = true
+  try {
+    const { data } = await worksApi.forkCanvas(workId.value)
+    ElMessage.success('已复制到你的画布')
+    router.push(`/workflow/${data.data.id}`)
+  } catch {
+    ElMessage.error('复制失败，请确认已登录')
+  } finally {
+    forking.value = false
+  }
+}
+
+function backToShare() {
+  router.push(`/share/${workId.value}`)
+}
+</script>
+
+<template>
+  <div class="flex h-[calc(100vh-4rem)] flex-col">
+    <div class="flex items-center justify-between border-b border-white/8 bg-[#141414] px-4 py-3">
+      <div class="flex items-center gap-3">
+        <button class="text-sm text-white/50 hover:text-white" @click="backToShare">← 返回详情</button>
+        <span class="rounded-md bg-amber-500/10 px-2 py-0.5 text-xs text-amber-300">只读 · 制作过程</span>
+        <span v-if="work" class="text-sm text-white/60">{{ work.title }}</span>
+      </div>
+      <button class="btn-primary text-sm" :disabled="forking" @click="forkToMyCanvas">
+        {{ forking ? '复制中…' : '复制到我的画布' }}
+      </button>
+    </div>
+
+    <div v-if="loading" class="flex flex-1 items-center justify-center text-white/40">加载中…</div>
+    <div v-else-if="!work" class="flex flex-1 items-center justify-center text-white/40">作品不存在</div>
+    <div v-else class="relative flex-1">
+      <VueFlow
+        :nodes="nodes"
+        :edges="edges"
+        :node-types="nodeTypes as any"
+        :nodes-draggable="false"
+        :nodes-connectable="false"
+        :elements-selectable="false"
+        :pan-on-drag="true"
+        :zoom-on-scroll="true"
+        fit-view-on-init
+        class="canvas-flow h-full w-full bg-[#0a0a0a]"
+      >
+        <Background pattern-color="#333" :gap="20" />
+      </VueFlow>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.canvas-flow :deep(.vue-flow__pane) {
+  cursor: grab;
+}
+</style>

--- a/apps/web/src/pages/CanvasReadonlyPage.vue
+++ b/apps/web/src/pages/CanvasReadonlyPage.vue
@@ -122,4 +122,9 @@ function backToShare() {
 .canvas-flow :deep(.vue-flow__pane) {
   cursor: grab;
 }
+
+/* Block node edit chrome (upload/replace/save/edit/rename) while keeping pan/zoom on the pane */
+.canvas-flow :deep(.vue-flow__node) {
+  pointer-events: none;
+}
 </style>

--- a/apps/web/src/pages/CommunityPage.vue
+++ b/apps/web/src/pages/CommunityPage.vue
@@ -24,8 +24,16 @@ async function fetchWorks() {
   }
 }
 
-function viewProcess(sessionId: string) {
-  router.push(`/replay/${sessionId}`)
+function viewWork(workId: string) {
+  router.push(`/share/${workId}`)
+}
+
+function viewWatch(workId: string) {
+  router.push(`/share/${workId}`)
+}
+
+function viewProcess(workId: string) {
+  router.push(`/share/${workId}/process`)
 }
 
 function viewAuthor(authorId: string) {
@@ -67,6 +75,8 @@ onMounted(fetchWorks)
         v-for="work in works"
         :key="work.id"
         :work="work"
+        @view-work="viewWork"
+        @view-watch="viewWatch"
         @view-process="viewProcess"
         @view-author="viewAuthor"
         @view-share="viewShare"

--- a/apps/web/src/pages/CreatorPage.vue
+++ b/apps/web/src/pages/CreatorPage.vue
@@ -24,8 +24,24 @@ onMounted(async () => {
   }
 })
 
-function viewProcess(sessionId: string) {
-  router.push(`/replay/${sessionId}`)
+function viewWork(workId: string) {
+  router.push(`/share/${workId}`)
+}
+
+function viewWatch(workId: string) {
+  router.push(`/share/${workId}`)
+}
+
+function viewProcess(workId: string) {
+  router.push(`/share/${workId}/process`)
+}
+
+function viewAuthor(authorId: string) {
+  router.push(`/creator/${authorId}`)
+}
+
+function viewShare(workId: string) {
+  router.push(`/share/${workId}`)
 }
 </script>
 
@@ -58,7 +74,11 @@ function viewProcess(sessionId: string) {
           v-for="work in profile.works"
           :key="work.id"
           :work="{ ...work, authorId: profile.user.id, authorName: profile.user.nickname }"
+          @view-work="viewWork"
+          @view-watch="viewWatch"
           @view-process="viewProcess"
+          @view-author="viewAuthor"
+          @view-share="viewShare"
         />
       </div>
       <p v-if="!profile.works.length" class="py-16 text-center text-white/40">暂无发布作品</p>

--- a/apps/web/src/pages/SharePage.vue
+++ b/apps/web/src/pages/SharePage.vue
@@ -1,13 +1,20 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { ElMessage } from 'element-plus'
 import type { Work } from '@lnkpi/shared'
 import { worksApi } from '@/services/works-api'
+import { useAuthStore } from '@/stores/auth'
 
 const route = useRoute()
 const router = useRouter()
+const auth = useAuthStore()
 const work = ref<Work | null>(null)
 const loading = ref(true)
+const liking = ref(false)
+
+const mediaUrl = computed(() => work.value?.playbackUrl || work.value?.coverUrl)
+const isVideo = computed(() => work.value?.playbackKind === 'video')
 
 onMounted(async () => {
   try {
@@ -18,12 +25,39 @@ onMounted(async () => {
   }
 })
 
-function viewReplay() {
-  if (work.value?.sessionId) router.push(`/replay/${work.value.sessionId}`)
+function viewProcess() {
+  if (work.value) router.push(`/share/${work.value.id}/process`)
 }
 
 function viewCreator() {
   if (work.value?.authorId) router.push(`/creator/${work.value.authorId}`)
+}
+
+async function handleLike() {
+  if (!work.value) return
+  if (!auth.isLoggedIn) {
+    auth.openLogin()
+    return
+  }
+  liking.value = true
+  try {
+    const { data } = await worksApi.like(work.value.id)
+    work.value = data.data
+    ElMessage.success('已点赞')
+  } catch {
+    ElMessage.error('点赞失败')
+  } finally {
+    liking.value = false
+  }
+}
+
+async function handleShare() {
+  try {
+    await navigator.clipboard.writeText(window.location.href)
+    ElMessage.success('链接已复制')
+  } catch {
+    ElMessage.error('复制失败')
+  }
 }
 </script>
 
@@ -33,10 +67,38 @@ function viewCreator() {
 
     <template v-else-if="work">
       <div class="overflow-hidden rounded-2xl border border-white/8 bg-[#1a1a1a]">
-        <img :src="work.coverUrl" :alt="work.title" class="aspect-video w-full object-cover" />
+        <div class="bg-black">
+          <video
+            v-if="isVideo && mediaUrl"
+            :src="mediaUrl"
+            controls
+            class="aspect-video w-full object-contain"
+          />
+          <img
+            v-else-if="mediaUrl"
+            :src="mediaUrl"
+            :alt="work.title"
+            class="aspect-video w-full object-contain"
+          />
+        </div>
         <div class="p-6">
           <h1 class="text-2xl font-semibold">{{ work.title }}</h1>
-          <button class="mt-2 text-sm text-[#818cf8] hover:underline" @click="viewCreator">
+          <button
+            class="mt-3 flex items-center gap-2 text-sm text-[#818cf8] hover:underline"
+            @click="viewCreator"
+          >
+            <span
+              v-if="work.authorAvatar"
+              class="inline-block h-6 w-6 overflow-hidden rounded-full"
+            >
+              <img :src="work.authorAvatar" :alt="work.authorName" class="h-full w-full object-cover" />
+            </span>
+            <span
+              v-else
+              class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-[#6366f1]/30 text-xs"
+            >
+              {{ work.authorName[0] }}
+            </span>
             @{{ work.authorName }}
           </button>
           <div class="mt-4 flex gap-4 text-sm text-white/40">
@@ -44,12 +106,16 @@ function viewCreator() {
             <span>{{ work.views }} 浏览</span>
           </div>
           <div class="mt-6 flex flex-wrap gap-3">
+            <button class="btn-primary" @click="handleLike" :disabled="liking">
+              {{ liking ? '点赞中…' : '点赞' }}
+            </button>
+            <button class="btn-ghost" @click="handleShare">分享</button>
             <button
               v-if="work.sessionId"
-              class="btn-primary"
-              @click="viewReplay"
+              class="btn-ghost"
+              @click="viewProcess"
             >
-              查看创作过程
+              查看制作过程
             </button>
             <button class="btn-ghost" @click="router.push('/workflow')">我也要创作</button>
           </div>

--- a/apps/web/src/pages/WorkflowPage.vue
+++ b/apps/web/src/pages/WorkflowPage.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
-import { ref, onMounted, watch } from 'vue'
+import { ref, onMounted, onBeforeUnmount, watch } from 'vue'
 import { useRouter } from 'vue-router'
+import { ElMessage, ElMessageBox } from 'element-plus'
 import type { Work } from '@lnkpi/shared'
 import { WORK_CATEGORIES } from '@lnkpi/shared'
 import { api } from '@/services/api'
+import { sessionsApi } from '@/services/sessions-api'
 import { useAuthStore } from '@/stores/auth'
 import { useSessionRedirect } from '@/composables/useSessionRedirect'
 import WorkCard from '@/components/works/WorkCard.vue'
@@ -25,6 +27,8 @@ const loading = ref(false)
 const showPublish = ref(false)
 const userSessions = ref<Session[]>([])
 const mySessions = ref<Session[]>([])
+const openMenuId = ref<string | null>(null)
+const menuRefs = new Map<string, HTMLElement>()
 const greeting = getGreeting()
 
 function getGreeting() {
@@ -82,10 +86,90 @@ async function fetchMySessions() {
     return
   }
   try {
-    const { data } = await api.get<{ data: Session[] }>('/sessions')
+    const { data } = await sessionsApi.list()
     mySessions.value = data.data
   } catch {
     mySessions.value = []
+  }
+}
+
+function setMenuRef(id: string, el: HTMLElement | null) {
+  if (el) menuRefs.set(id, el)
+  else menuRefs.delete(id)
+}
+
+function toggleMenu(sessionId: string) {
+  openMenuId.value = openMenuId.value === sessionId ? null : sessionId
+}
+
+function closeMenu() {
+  openMenuId.value = null
+}
+
+function onDocumentPointerDown(event: PointerEvent) {
+  if (!openMenuId.value) return
+  const el = menuRefs.get(openMenuId.value)
+  if (el && !el.contains(event.target as Node)) closeMenu()
+}
+
+async function renameSession(session: Session) {
+  closeMenu()
+  let value: string
+  try {
+    const result = await ElMessageBox.prompt('输入新的画布名称', '重命名', {
+      inputValue: session.title || '未命名画布',
+      inputPattern: /\S/,
+      inputErrorMessage: '名称不能为空',
+      confirmButtonText: '保存',
+      cancelButtonText: '取消',
+    })
+    value = result.value.trim()
+  } catch {
+    return
+  }
+  if (!value || value === session.title) return
+  try {
+    await sessionsApi.update(session.id, { title: value })
+    await fetchMySessions()
+    ElMessage.success('已重命名')
+  } catch {
+    ElMessage.error('重命名失败，请稍后重试')
+  }
+}
+
+async function duplicateSession(session: Session) {
+  closeMenu()
+  try {
+    const { data } = await sessionsApi.duplicate(session.id)
+    await fetchMySessions()
+    ElMessage.success('已复制副本')
+    router.push(`/workflow/${data.data.id}`)
+  } catch {
+    ElMessage.error('复制失败，请稍后重试')
+  }
+}
+
+async function deleteSession(session: Session) {
+  closeMenu()
+  try {
+    await ElMessageBox.confirm(
+      `确定删除「${session.title || '未命名画布'}」？此操作不可恢复。`,
+      '删除画布',
+      {
+        confirmButtonText: '删除',
+        cancelButtonText: '取消',
+        type: 'warning',
+      },
+    )
+  } catch {
+    return
+  }
+  try {
+    await sessionsApi.remove(session.id)
+    await fetchMySessions()
+    ElMessage.success('已删除')
+  } catch {
+    ElMessage.error('删除失败，请稍后重试')
   }
 }
 
@@ -113,7 +197,7 @@ async function createCanvas() {
     return
   }
   try {
-    const { data } = await api.post<{ data: { id: string } }>('/sessions', {
+    const { data } = await sessionsApi.create({
       title: prompt.value || '未命名画布',
       prompt: prompt.value,
     })
@@ -146,7 +230,7 @@ async function openPublish() {
     return
   }
   try {
-    const { data } = await api.get<{ data: Session[] }>('/sessions')
+    const { data } = await sessionsApi.list()
     userSessions.value = data.data
     if (!userSessions.value.length) {
       await createCanvas()
@@ -161,6 +245,11 @@ async function openPublish() {
 onMounted(() => {
   fetchWorks()
   void fetchMySessions()
+  document.addEventListener('pointerdown', onDocumentPointerDown, true)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', onDocumentPointerDown, true)
 })
 
 watch(() => auth.isLoggedIn, () => {
@@ -204,25 +293,74 @@ watch(() => auth.isLoggedIn, () => {
           </svg>
           <span class="text-xs font-medium">新建画布</span>
         </button>
-        <button
+        <div
           v-for="session in mySessions.slice(0, 11)"
           :key="session.id"
-          type="button"
-          class="group flex aspect-[4/3] flex-col justify-between overflow-hidden rounded-2xl border border-white/[0.08] bg-[#1a1a1a] p-3 text-left transition hover:border-[#6366f1]/40 hover:bg-[#1f1f24]"
-          @click="openCanvas(session.id)"
+          class="group relative flex aspect-[4/3] flex-col justify-between overflow-hidden rounded-2xl border border-white/[0.08] bg-[#1a1a1a] p-3 text-left transition hover:border-[#6366f1]/40 hover:bg-[#1f1f24]"
         >
-          <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-[#6366f1]/15 text-[#818cf8]">
-            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" d="M4 5a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1V5zm10 0a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1V5zM4 15a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1v-4zm10 2h6m-3-3v6" />
-            </svg>
+          <div
+            :ref="(el) => setMenuRef(session.id, el as HTMLElement | null)"
+            class="absolute right-2 top-2 z-10"
+          >
+            <button
+              type="button"
+              class="flex h-7 w-7 items-center justify-center rounded-lg bg-black/50 text-white/70 opacity-0 transition hover:bg-black/70 hover:text-white group-hover:opacity-100"
+              :class="{ 'opacity-100': openMenuId === session.id }"
+              title="更多操作"
+              @click.stop="toggleMenu(session.id)"
+            >
+              <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+                <circle cx="5" cy="12" r="2" />
+                <circle cx="12" cy="12" r="2" />
+                <circle cx="19" cy="12" r="2" />
+              </svg>
+            </button>
+            <div
+              v-if="openMenuId === session.id"
+              class="neo-popover absolute right-0 top-full mt-1 min-w-[120px] rounded-xl py-1"
+              @click.stop
+            >
+              <button
+                type="button"
+                class="neo-popover-item flex w-full px-3 py-2 text-left text-xs"
+                @click="renameSession(session)"
+              >
+                重命名
+              </button>
+              <button
+                type="button"
+                class="neo-popover-item flex w-full px-3 py-2 text-left text-xs"
+                @click="duplicateSession(session)"
+              >
+                复制副本
+              </button>
+              <button
+                type="button"
+                class="neo-popover-item flex w-full px-3 py-2 text-left text-xs text-red-400"
+                @click="deleteSession(session)"
+              >
+                删除
+              </button>
+            </div>
           </div>
-          <div class="min-w-0">
-            <p class="truncate text-[13px] font-medium text-white/85 group-hover:text-white">
-              {{ session.title || '未命名画布' }}
-            </p>
-            <p class="mt-0.5 text-[10px] text-white/35">{{ formatSessionTime(session.updatedAt) }}</p>
-          </div>
-        </button>
+          <button
+            type="button"
+            class="flex flex-1 flex-col justify-between text-left"
+            @click="openCanvas(session.id)"
+          >
+            <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-[#6366f1]/15 text-[#818cf8]">
+              <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" d="M4 5a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1V5zm10 0a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1V5zM4 15a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1v-4zm10 2h6m-3-3v6" />
+              </svg>
+            </div>
+            <div class="min-w-0">
+              <p class="truncate text-[13px] font-medium text-white/85 group-hover:text-white">
+                {{ session.title || '未命名画布' }}
+              </p>
+              <p class="mt-0.5 text-[10px] text-white/35">{{ formatSessionTime(session.updatedAt) }}</p>
+            </div>
+          </button>
+        </div>
       </div>
     </section>
 

--- a/apps/web/src/pages/WorkflowPage.vue
+++ b/apps/web/src/pages/WorkflowPage.vue
@@ -207,8 +207,16 @@ async function createCanvas() {
   }
 }
 
-function viewProcess(sessionId: string) {
-  router.push(`/replay/${sessionId}`)
+function viewWork(workId: string) {
+  router.push(`/share/${workId}`)
+}
+
+function viewWatch(workId: string) {
+  router.push(`/share/${workId}`)
+}
+
+function viewProcess(workId: string) {
+  router.push(`/share/${workId}/process`)
 }
 
 function viewAuthor(authorId: string) {
@@ -387,6 +395,8 @@ watch(() => auth.isLoggedIn, () => {
           v-for="work in works"
           :key="work.id"
           :work="work"
+          @view-work="viewWork"
+          @view-watch="viewWatch"
           @view-process="viewProcess"
           @view-author="viewAuthor"
           @view-share="viewShare"

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -38,6 +38,11 @@ const router = createRouter({
       component: () => import('@/pages/SharePage.vue'),
     },
     {
+      path: '/share/:id/process',
+      name: 'share-process',
+      component: () => import('@/pages/CanvasReadonlyPage.vue'),
+    },
+    {
       path: '/stories',
       name: 'stories',
       component: () => import('@/pages/StoriesPage.vue'),

--- a/apps/web/src/services/sessions-api.ts
+++ b/apps/web/src/services/sessions-api.ts
@@ -1,0 +1,12 @@
+import type { Session } from '@lnkpi/shared'
+import { api } from './api'
+
+export const sessionsApi = {
+  list: () => api.get<{ data: Session[] }>('/sessions'),
+  create: (data: { title?: string; prompt?: string }) =>
+    api.post<{ data: Session }>('/sessions', data),
+  update: (id: string, data: { title?: string; canvasData?: unknown }) =>
+    api.put<{ data: Session }>(`/sessions/${id}`, data),
+  remove: (id: string) => api.delete(`/sessions/${id}`),
+  duplicate: (id: string) => api.post<{ data: Session }>(`/sessions/${id}/duplicate`),
+}

--- a/apps/web/src/services/studio-api.ts
+++ b/apps/web/src/services/studio-api.ts
@@ -3,6 +3,11 @@ import type { GenerationDiagnostic, GenerationRefPayload } from '@lnkpi/shared'
 
 export type StudioRefPayload = GenerationRefPayload
 
+export interface CanvasGenerationScope {
+  sessionId?: string
+  nodeId?: string
+}
+
 export interface GenerationRecord {
   id: string
   type: string
@@ -11,6 +16,8 @@ export interface GenerationRecord {
   url?: string | null
   status: string
   metadata?: string | null
+  sessionId?: string | null
+  nodeId?: string | null
   createdAt: string
 }
 
@@ -24,9 +31,19 @@ export interface AudioGenerateOptions {
   model?: string
 }
 
+function scopeBody(scope?: CanvasGenerationScope) {
+  if (!scope?.sessionId && !scope?.nodeId) return {}
+  return {
+    ...(scope.sessionId ? { sessionId: scope.sessionId } : {}),
+    ...(scope.nodeId ? { nodeId: scope.nodeId } : {}),
+  }
+}
+
 export const studioApi = {
-  listGenerations: (type?: string) =>
-    api.get<{ data: GenerationRecord[] }>('/studio/generations', { params: { type } }),
+  listGenerations: (opts?: { type?: string; sessionId?: string } | string) => {
+    const params = typeof opts === 'string' ? { type: opts } : opts
+    return api.get<{ data: GenerationRecord[] }>('/studio/generations', { params })
+  },
   getGeneration: (id: string) =>
     api.get<{ data: GenerationRecord }>(`/studio/generations/${id}`),
   generateImage: (
@@ -38,14 +55,25 @@ export const studioApi = {
     resolution?: string,
     count?: number,
     signal?: AbortSignal,
+    scope?: CanvasGenerationScope,
   ) =>
     api.post<{ data: GenerationRecord }>(
       '/studio/image/generate',
-      { prompt, model, aspectRatio, refs, mentionedKeys, resolution, count },
+      { prompt, model, aspectRatio, refs, mentionedKeys, resolution, count, ...scopeBody(scope) },
       { timeout: 300_000, signal },
     ),
-  generateImageVariation: (prompt: string, basePrompt?: string, model?: string, signal?: AbortSignal) =>
-    api.post<{ data: GenerationRecord }>('/studio/image/variation', { prompt, basePrompt, model }, { timeout: 300_000, signal }),
+  generateImageVariation: (
+    prompt: string,
+    basePrompt?: string,
+    model?: string,
+    signal?: AbortSignal,
+    scope?: CanvasGenerationScope,
+  ) =>
+    api.post<{ data: GenerationRecord }>(
+      '/studio/image/variation',
+      { prompt, basePrompt, model, ...scopeBody(scope) },
+      { timeout: 300_000, signal },
+    ),
   generateText: (
     prompt: string,
     model?: string,
@@ -54,14 +82,32 @@ export const studioApi = {
     signal?: AbortSignal,
     thinking?: boolean,
     thinkingEffort?: 'high' | 'max',
+    scope?: CanvasGenerationScope,
   ) =>
     api.post<{ data: GenerationRecord }>(
       '/studio/text/generate',
-      { prompt, model, refs, mentionedKeys, thinking, thinkingEffort },
+      {
+        prompt,
+        model,
+        refs,
+        mentionedKeys,
+        thinking,
+        thinkingEffort,
+        ...scopeBody(scope),
+      },
       { timeout: thinking ? 300_000 : 180_000, signal },
     ),
-  generatePrompt: (prompt: string, model?: string, signal?: AbortSignal) =>
-    api.post<{ data: GenerationRecord }>('/studio/prompt/generate', { prompt, model }, { timeout: 180_000, signal }),
+  generatePrompt: (
+    prompt: string,
+    model?: string,
+    signal?: AbortSignal,
+    scope?: CanvasGenerationScope,
+  ) =>
+    api.post<{ data: GenerationRecord }>(
+      '/studio/prompt/generate',
+      { prompt, model, ...scopeBody(scope) },
+      { timeout: 180_000, signal },
+    ),
   generateVideo: (
     prompt: string,
     model?: string,
@@ -72,16 +118,34 @@ export const studioApi = {
     resolution?: string,
     crop?: string,
     signal?: AbortSignal,
+    scope?: CanvasGenerationScope,
   ) =>
     api.post<{ data: GenerationRecord }>(
       '/studio/video/generate',
-      { prompt, model, duration, aspectRatio, refs, mentionedKeys, resolution, crop },
+      {
+        prompt,
+        model,
+        duration,
+        aspectRatio,
+        refs,
+        mentionedKeys,
+        resolution,
+        crop,
+        ...scopeBody(scope),
+      },
       { timeout: 60_000, signal },
     ),
-  generateAudio: (text: string, options?: AudioGenerateOptions, refs?: StudioRefPayload[], mentionedKeys?: string[], signal?: AbortSignal) =>
+  generateAudio: (
+    text: string,
+    options?: AudioGenerateOptions,
+    refs?: StudioRefPayload[],
+    mentionedKeys?: string[],
+    signal?: AbortSignal,
+    scope?: CanvasGenerationScope,
+  ) =>
     api.post<{ data: GenerationRecord & { url?: string } }>(
       '/studio/audio/generate',
-      { text, ...options, refs, mentionedKeys },
+      { text, ...options, refs, mentionedKeys, ...scopeBody(scope) },
       { timeout: 60_000, signal },
     ),
   confirmPlatformFallback: (id: string) =>

--- a/apps/web/src/services/upload-api.ts
+++ b/apps/web/src/services/upload-api.ts
@@ -8,11 +8,14 @@ export interface UploadResult {
 }
 
 export const uploadApi = {
-  upload: (file: File) => {
+  upload: (file: File, opts?: { onProgress?: (pct: number) => void }) => {
     const form = new FormData()
     form.append('file', file)
-    return api.post<{ data: UploadResult }>('/upload', form, {
-      headers: { 'Content-Type': 'multipart/form-data' },
+    return api.post<{ code?: number; message?: string; data: UploadResult }>('/upload', form, {
+      onUploadProgress: (e) => {
+        if (!opts?.onProgress || !e.total) return
+        opts.onProgress(Math.min(100, Math.round((e.loaded / e.total) * 100)))
+      },
     })
   },
 }

--- a/apps/web/src/services/works-api.ts
+++ b/apps/web/src/services/works-api.ts
@@ -1,9 +1,13 @@
+import type { Session, Work } from '@lnkpi/shared'
 import { api } from './api'
 
 export const worksApi = {
   list: (params?: { category?: string; search?: string }) =>
     api.get('/works', { params }),
-  get: (id: string) => api.get(`/works/${id}`),
-  publish: (data: { sessionId: string; title: string; category?: string }) =>
+  get: (id: string) => api.get<{ data: Work }>(`/works/${id}`),
+  publish: (data: { sessionId: string; title: string; category?: string; primaryNodeId: string }) =>
     api.post('/works/publish', data),
+  like: (id: string) => api.post<{ data: Work }>(`/works/${id}/like`),
+  getCanvas: (id: string) => api.get<{ data: { nodes: unknown[]; edges: unknown[] } }>(`/works/${id}/canvas`),
+  forkCanvas: (id: string) => api.post<{ data: Session }>(`/works/${id}/fork-canvas`),
 }

--- a/apps/web/src/styles/neo-node.css
+++ b/apps/web/src/styles/neo-node.css
@@ -466,6 +466,11 @@
   box-shadow: inset 0 0 0 1px rgba(138, 125, 255, 0.2);
 }
 
+.neo-node-placeholder.is-uploading {
+  border-color: var(--neo-accent-border);
+  background: var(--neo-accent-soft);
+}
+
 .neo-node-placeholder.is-failed {
   border-color: rgba(239, 68, 68, 0.3);
   background: rgba(239, 68, 68, 0.05);
@@ -477,6 +482,22 @@
   align-items: center;
   gap: 8px;
   padding: 16px;
+  width: 100%;
+}
+
+.neo-upload-progress {
+  width: min(160px, 80%);
+  height: 3px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  overflow: hidden;
+}
+
+.neo-upload-progress-bar {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--neo-accent-text, #8a7dff);
+  transition: width 0.15s ease;
 }
 
 .neo-placeholder-icon {

--- a/apps/web/src/utils/edgeHighlight.test.ts
+++ b/apps/web/src/utils/edgeHighlight.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { annotateEdgesForSelection } from '@/utils/edgeHighlight'
+
+describe('annotateEdgesForSelection', () => {
+  const edges = [
+    { id: 'e1', class: 'old-class' },
+    { id: 'e2' },
+    { id: 'e3' },
+  ]
+
+  it('sets upstream and downstream classes', () => {
+    const result = annotateEdgesForSelection(
+      edges,
+      new Set(['e1']),
+      new Set(['e2']),
+    )
+    expect(result[0].class).toBe('neo-edge-upstream')
+    expect(result[1].class).toBe('neo-edge-downstream')
+    expect(result[2].class).toBeUndefined()
+  })
+
+  it('clears highlight classes when selection sets are empty', () => {
+    const highlighted = annotateEdgesForSelection(
+      edges,
+      new Set(['e1']),
+      new Set(['e2']),
+    )
+    const cleared = annotateEdgesForSelection(highlighted, new Set(), new Set())
+    expect(cleared.every((edge) => edge.class === undefined)).toBe(true)
+  })
+})

--- a/apps/web/src/utils/edgeHighlight.ts
+++ b/apps/web/src/utils/edgeHighlight.ts
@@ -1,0 +1,11 @@
+export function annotateEdgesForSelection<T extends { id: string; class?: string }>(
+  edges: T[],
+  upstream: Set<string>,
+  downstream: Set<string>,
+): T[] {
+  return edges.map((edge) => {
+    if (upstream.has(edge.id)) return { ...edge, class: 'neo-edge-upstream' }
+    if (downstream.has(edge.id)) return { ...edge, class: 'neo-edge-downstream' }
+    return { ...edge, class: undefined }
+  })
+}

--- a/docs/superpowers/plans/2026-07-22-canvas-upload-history-works.md
+++ b/docs/superpowers/plans/2026-07-22-canvas-upload-history-works.md
@@ -1,0 +1,465 @@
+# Canvas Upload / History / Works Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix media upload failures with progress UX, repair edge-highlight residue, make task history session-scoped with richer cards/details, add homepage canvas […] actions, and ship publish-with-primary-asset + share detail (watch / readonly process / like / share / author).
+
+**Architecture:** One feature branch with five sequential commit gates matching the approved design. Shared upload core (`persistMediaUrl` + progress) feeds every media entry point. History and works get schema fields (`sessionId`/`nodeId` on GenerationRecord; `playbackUrl`/`playbackKind` on Work). Edge highlight is display-only and never written back into `edges.value` class.
+
+**Tech Stack:** Vue 3 + Pinia + Vue Flow, NestJS + Prisma (SQLite), axios, Element Plus, Vitest, pnpm monorepo.
+
+**Spec:** `docs/superpowers/specs/2026-07-22-canvas-upload-history-works-design.md`
+
+## Global Constraints
+
+- Delivery: same branch `feature/canvas-upload-history-works`, five semantic commits, one final PR
+- History node identity display: `node.id` (e.g. `image-3`)
+- Publish requires explicit primary media node selection
+- “制作过程” = readonly canvas snapshot + optional “复制到我的画布”
+- Model and channel shown as separate detail rows (both retained)
+- Remove `DockFailureChip` from dock-studio; keep node corner ⓘ diagnostic
+- Login-required uploads must not silently fall back to `blob:`
+- Chinese UI copy; no drive-by unrelated refactors
+
+## File map
+
+| Area | Create | Modify |
+|------|--------|--------|
+| Upload core | `apps/web/src/composables/useMediaUpload.test.ts` | `useMediaUpload.ts`, `upload-api.ts`, `useNodeMediaUpload.ts`, `CanvasAssetPanel.vue`, Image/Video dock panels, `CanvasPage.vue` drop handlers |
+| Edge highlight | — | `CanvasPage.vue` `flowEdges` / selection clear |
+| History | — | prisma `GenerationRecord`, studio list/create, `CanvasTaskHistoryPanel.vue`, remove DockFailureChip wiring |
+| Sessions | — | `sessions.service/controller`, `WorkflowPage.vue` |
+| Works | readonly canvas page (or mode) | prisma `Work`, works API/publish dialog, `SharePage.vue`, `WorkCard.vue` |
+
+---
+
+### Task 1: Upload core — no silent blob + progress API
+
+**Files:**
+- Modify: `apps/web/src/services/upload-api.ts`
+- Modify: `apps/web/src/composables/useMediaUpload.ts`
+- Create: `apps/web/src/composables/useMediaUpload.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `uploadApi.upload(file, opts?: { onProgress?: (pct: number) => void }): Promise<AxiosResponse<{ code?: number; data: UploadResult; message?: string }>>`
+  - `persistMediaUrl(file, fallbackUrl, opts?: { onProgress?: (pct: number) => void; allowBlobFallback?: boolean }): Promise<string>`
+  - `fileToPersistedPayload(file, opts?: { onProgress?: (pct: number) => void; allowBlobFallback?: boolean }): Promise<MediaFilePayload>`
+- Default: logged-in → `allowBlobFallback=false`; logged-out → blob fallback allowed
+
+- [ ] **Step 1: Write failing tests for persistMediaUrl**
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { persistMediaUrl } from './useMediaUpload'
+
+vi.mock('@/services/upload-api', () => ({
+  uploadApi: { upload: vi.fn() },
+}))
+vi.mock('@/services/api-base', () => ({
+  resolveMediaUrl: (u: string) => u,
+}))
+
+import { uploadApi } from '@/services/upload-api'
+
+describe('persistMediaUrl', () => {
+  beforeEach(() => {
+    localStorage.setItem('token', 't')
+    vi.mocked(uploadApi.upload).mockReset()
+  })
+
+  it('throws when upload returns non-zero code', async () => {
+    vi.mocked(uploadApi.upload).mockResolvedValue({
+      data: { code: 1, message: '未收到文件', data: undefined as never },
+    } as never)
+    await expect(persistMediaUrl(new File(['x'], 'a.png'), 'blob:x')).rejects.toThrow(/未收到文件|上传/)
+  })
+
+  it('throws when logged-in upload network-fails (no blob fallback)', async () => {
+    vi.mocked(uploadApi.upload).mockRejectedValue(new Error('Network Error'))
+    await expect(persistMediaUrl(new File(['x'], 'a.png'), 'blob:x')).rejects.toThrow()
+  })
+
+  it('returns server url on success', async () => {
+    vi.mocked(uploadApi.upload).mockResolvedValue({
+      data: { code: 0, data: { url: '/uploads/u/a.png', fileName: 'a.png', mimeType: 'image/png', size: 1 } },
+    } as never)
+    await expect(persistMediaUrl(new File(['x'], 'a.png'), 'blob:x')).resolves.toBe('/uploads/u/a.png')
+  })
+})
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+Run: `pnpm --dir apps/web exec vitest run src/composables/useMediaUpload.test.ts`
+Expected: FAIL (current code returns blob on catch)
+
+- [ ] **Step 3: Implement uploadApi + persistMediaUrl**
+
+`upload-api.ts`:
+
+```ts
+upload: (file: File, opts?: { onProgress?: (pct: number) => void }) => {
+  const form = new FormData()
+  form.append('file', file)
+  return api.post<{ code?: number; message?: string; data: UploadResult }>('/upload', form, {
+    onUploadProgress: (e) => {
+      if (!opts?.onProgress || !e.total) return
+      opts.onProgress(Math.min(100, Math.round((e.loaded / e.total) * 100)))
+    },
+  })
+},
+```
+
+`persistMediaUrl`: if no token → return fallback; else call upload; if `data.code` not 0/undefined-ok and no `data.data.url` throw `Error(message)`; on catch rethrow (no blob); resolve URL via `resolveMediaUrl`.
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `pnpm --dir apps/web exec vitest run src/composables/useMediaUpload.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/services/upload-api.ts apps/web/src/composables/useMediaUpload.ts apps/web/src/composables/useMediaUpload.test.ts
+git commit -m "fix(web): upload API surfaces errors and progress (no silent blob)"
+```
+
+---
+
+### Task 2: Wire all upload entry points + dock Files drop
+
+**Files:**
+- Modify: `apps/web/src/composables/useNodeMediaUpload.ts`
+- Modify: `apps/web/src/components/canvas/CanvasAssetPanel.vue`
+- Modify: `apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue`
+- Modify: `apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue`
+- Modify: `apps/web/src/pages/CanvasPage.vue` (ingestMediaFile, drop on dock for Files)
+- Modify: `apps/web/src/styles/neo-node.css` (optional uploading overlay styles)
+
+**Interfaces:**
+- Consumes: Task 1 `fileToPersistedPayload` / `persistMediaUrl` with `onProgress`
+- Produces: dock Files drop → `applyLocalRefToSelectedNode` / `appendLocalRef` after successful upload
+
+- [ ] **Step 1: Node card upload — status + progress + real errors**
+
+In `useNodeMediaUpload.applyFile`:
+1. `patchNode(nodeId, { status: 'uploading', uploadProgress: 0, errorMessage: undefined })`
+2. `fileToPersistedPayload(file, { onProgress: (p) => patchNode(..., { uploadProgress: p }) })`
+3. on success apply URL as today; clear `uploadProgress`
+4. on catch: `status:'error'`, `errorMessage: err.message`, `errorCode:'upload_required'`
+5. Remove the post-hoc “blob + token ⇒ error” branch (no longer needed if Task 1 throws)
+
+Show a thin progress bar or percentage in image/video/audio node placeholder when `status==='uploading'` (minimal UI in each node or NeoBaseNode).
+
+- [ ] **Step 2: Asset library upload**
+
+In `CanvasAssetPanel.onUploadChange`: wrap `fileToPersistedPayload` in try/catch; show `uploading` flag + progress on the Upload button (`上传 45%`); on error `ElMessage.error(err.message)`.
+
+- [ ] **Step 3: Dock reference image upload**
+
+In ImageDockPanel / VideoDockPanel reference upload handlers: pass `onProgress` into `persistMediaUrl`; keep `refUploading` / `refUploadError`; set error from `err.message`.
+
+- [ ] **Step 4: Canvas drop — clear blob-empty hack; show uploading**
+
+In `ingestMediaFile` / `createFileNodeAt`:
+- Remove “if blob && token then url=''” special-case
+- try/catch around `fileToPersistedPayload`; on failure create error node or ElMessage
+- Optionally create node first with `status:'uploading'` then patch URL
+
+- [ ] **Step 5: Dock Files drop**
+
+In `CanvasPage` area `dragover`/`drop` (same listener as asset MIME):
+- If `dataTransfer.files?.length` and target `.closest('.dock-studio-toolbar')`:
+  - `preventDefault`
+  - take first file → `fileToPersistedPayload` with progress toast or dock busy state
+  - build `LocalRefBinding` `{ id: createLocalRefId('upload'), mediaType, sourceKind:'upload', label:fileName, url }`
+  - `applyLocalRefToSelectedNode(binding)` or warn if type unsupported
+- If files drop on canvas (not dock): existing `mediaHandlers.onDrop`
+
+- [ ] **Step 6: Manual smoke checklist (dev)**
+
+Verify locally (or note in commit body): asset upload, node upload, dock picker, canvas drag, dock drag — each shows progress or clear error.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/composables/useNodeMediaUpload.ts apps/web/src/components/canvas/CanvasAssetPanel.vue apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue apps/web/src/pages/CanvasPage.vue apps/web/src/components/canvas/CanvasNodeImage.vue apps/web/src/components/canvas/CanvasNodeVideo.vue apps/web/src/components/canvas/CanvasNodeAudio.vue apps/web/src/styles/neo-node.css
+git commit -m "feat(web): upload progress on nodes/assets/dock and Files drop onto dock"
+```
+
+---
+
+### Task 3: Edge highlight — strip class every render
+
+**Files:**
+- Modify: `apps/web/src/pages/CanvasPage.vue` (`flowEdges`, `onEdgeClick`, selection clear)
+- Optional test: extract pure helper `apps/web/src/utils/edgeHighlight.ts` + test
+
+**Interfaces:**
+- Produces: `annotateEdgesForSelection(edges, upstreamIds: Set<string>, downstreamIds: Set<string>): EdgeLike[]` always sets `class` to highlight class or `undefined`
+
+- [ ] **Step 1: Add helper + test**
+
+```ts
+// edgeHighlight.ts
+export function annotateEdgesForSelection<T extends { id: string; class?: string }>(
+  edges: T[],
+  upstream: Set<string>,
+  downstream: Set<string>,
+): T[] {
+  return edges.map((edge) => {
+    if (upstream.has(edge.id)) return { ...edge, class: 'neo-edge-upstream' }
+    if (downstream.has(edge.id)) return { ...edge, class: 'neo-edge-downstream' }
+    return { ...edge, class: undefined }
+  })
+}
+```
+
+Test: after upstream annotation, second call with empty sets clears class.
+
+- [ ] **Step 2: Use helper in `flowEdges` computed**
+
+Always map via helper (even when both sets empty).
+
+- [ ] **Step 3: Clear highlight on edge click**
+
+In `onEdgeClick`: clear `multiSelectedIds` / `clearSelection()` (keep edge selection if product needs it, but node-link highlight must die).
+
+- [ ] **Step 4: Run unit test + commit**
+
+```bash
+pnpm --dir apps/web exec vitest run src/utils/edgeHighlight.test.ts
+git add apps/web/src/utils/edgeHighlight.ts apps/web/src/utils/edgeHighlight.test.ts apps/web/src/pages/CanvasPage.vue
+git commit -m "fix(web): clear upstream/downstream edge highlight when selection changes"
+```
+
+---
+
+### Task 4: History — session scope, cards, detail, failure UX, remove DockFailureChip
+
+**Files:**
+- Modify: `apps/server/prisma/schema.prisma` (`GenerationRecord.sessionId`, `nodeId` + index)
+- Modify: `apps/server/src/studio/studio.service.ts` + controller list query
+- Modify: studio generate DTOs / canvas generate callers to pass `sessionId` + `nodeId`
+- Modify: `apps/web/src/services/studio-api.ts`
+- Modify: `apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue`
+- Modify: `apps/web/src/components/canvas/dock-studio/shared/DockToolbarShell.vue` (remove failure chip)
+- Modify: panels that bind `DockFailureChip` / `dockFailureBindFromNode`
+- Run: `pnpm --dir apps/server exec prisma db push && prisma generate`
+
+**Interfaces:**
+- `listGenerations(userId, type?, sessionId?)` filters `where: { userId, sessionId }` when sessionId provided
+- `GenerationRecord` create paths accept optional `sessionId`, `nodeId`
+- Frontend `studioApi.listGenerations({ sessionId })`
+
+- [ ] **Step 1: Schema + db push**
+
+```prisma
+model GenerationRecord {
+  // existing fields...
+  sessionId String?
+  nodeId    String?
+  @@index([userId, sessionId, createdAt])
+}
+```
+
+- [ ] **Step 2: Server list + write**
+
+- `listGenerations`: if `sessionId` query present → filter equality; **do not** return rows with null sessionId for that query
+- All `generationRecord.create` from canvas generation: set `sessionId`, `nodeId` from request body (extend generate DTOs / agent canvas generate payloads already carrying node id)
+
+- [ ] **Step 3: Frontend list scoped**
+
+`CanvasTaskHistoryPanel`: `useRoute().params.sessionId` → `listGenerations({ sessionId })`.
+
+- [ ] **Step 4: Card UI**
+
+Default card:
+- Type icon + `record.nodeId || '—'`
+- Status pill; if failed, `!` button opens error popover (userMessage + copy diagnostic)
+- Thumb: image `url`; video element; audio placeholder; text snippet from metadata
+
+- [ ] **Step 5: Detail UI**
+
+Separate rows:
+- 模型: `modelOptionName(record.model ?? meta.originalModel ?? '')`
+- 渠道: resolve channel name from `meta.channelId` if available in client provider store; else short `channelId`
+- 节点: `nodeId`
+- 参数: aspectRatio / resolution / size / count / duration / crop / voice / speed when present
+- 失败原因 when status failed
+
+- [ ] **Step 6: Remove DockFailureChip**
+
+- Stop rendering in `DockToolbarShell`
+- Leave `NodeTaskCornerActions` ⓘ intact
+- Update/remove unit tests that assert dock chip presence (`dockFailureChip.test.ts` keep pure helpers if still used by history copy)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/server/prisma/schema.prisma apps/server/src/studio apps/web/src/services/studio-api.ts apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue apps/web/src/components/canvas/dock-studio apps/web/src/pages/CanvasPage.vue apps/web/src/composables/useNodeGeneration.ts
+git commit -m "feat: session-scoped generation history with richer cards and no dock failure chip"
+```
+
+---
+
+### Task 5: Homepage canvas […] menu (rename / delete / duplicate)
+
+**Files:**
+- Modify: `apps/server/src/sessions/sessions.service.ts`
+- Modify: `apps/server/src/sessions/sessions.controller.ts`
+- Modify: `apps/web/src/pages/WorkflowPage.vue`
+- Modify/create: web sessions API client if missing duplicate method
+
+**Interfaces:**
+- `POST /sessions/:id/duplicate` → `{ code:0, data: Session }` copies `canvasData`, title `${title} 副本`
+
+- [ ] **Step 1: Server duplicate**
+
+```ts
+async duplicate(userId: string, id: string) {
+  const src = await this.prisma.session.findFirst({ where: { id, userId } })
+  if (!src) throw new NotFoundException()
+  return this.prisma.session.create({
+    data: {
+      userId,
+      title: `${src.title || '未命名画布'} 副本`,
+      canvasData: src.canvasData,
+    },
+  })
+}
+```
+
+- [ ] **Step 2: WorkflowPage menu UI**
+
+On each canvas card:
+- Absolute `...` button visible on hover, `@click.stop`
+- Dropdown: 重命名 (ElMessageBox.prompt → PUT), 复制副本 (POST duplicate → refresh list / optional open), 删除 (confirm → DELETE)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/server/src/sessions apps/web/src/pages/WorkflowPage.vue apps/web/src/services
+git commit -m "feat: canvas list rename/delete/duplicate via hover menu"
+```
+
+---
+
+### Task 6: Works — primary asset publish + share detail + like + readonly process
+
+**Files:**
+- Modify: `packages/shared/src/index.ts` (`Work.playbackUrl?`, `playbackKind?`)
+- Modify: prisma `Work` model same fields
+- Modify: `apps/server/src/works/works.service.ts` / controller (`publish` body, `like`, public canvas snapshot read)
+- Modify: `apps/web/src/components/works/PublishNeoTVDialog.vue`
+- Modify: `apps/web/src/pages/SharePage.vue`
+- Modify: `apps/web/src/components/works/WorkCard.vue`
+- Create: `apps/web/src/pages/CanvasReadonlyPage.vue` (or route query `?readonly=1` on CanvasPage with guards)
+- Modify: router
+
+**Interfaces:**
+- `publish(userId, { sessionId, title, category?, primaryNodeId })`
+- Resolves node from `session.canvasData`, requires `url`, sets `playbackUrl`, `playbackKind`, `coverUrl`
+- `POST /works/:id/like` increments likes (auth)
+- `GET /works/:id/canvas` returns canvasData if work is published (public read)
+
+- [ ] **Step 1: Schema + shared types + db push**
+
+```prisma
+// Work
+playbackUrl  String?
+playbackKind String? // image | video
+```
+
+- [ ] **Step 2: Publish requires primaryNodeId**
+
+Server throws `BadRequestException('请选择主成片节点')` if missing/invalid/no url.
+
+Dialog: load session canvas nodes (image/video with url), radio/select required, disable submit until chosen.
+
+- [ ] **Step 3: SharePage — watch / share / like / author**
+
+- Video: `<video controls :src="playbackUrl">`; image: large img
+- Like button → API; Share → `navigator.clipboard.writeText(location.href)` + toast
+- Author block → `/creator/:authorId`
+- CTA「查看制作过程」→ `/workflow/:sessionId/readonly` or `/share/:id/process`
+
+- [ ] **Step 4: Readonly canvas**
+
+Load canvas via work canvas endpoint or session if owner; Vue Flow with `nodes-draggable=false`, hide dock generate, hide agent generate, show banner「只读 · 制作过程」+ button「复制到我的画布」→ `POST /sessions/:id/duplicate` (for owner’s session id on the work) then navigate to new id.
+
+If current user is not owner, duplicate should copy published snapshot into **their** new session (server: `duplicatePublishedWork(workId)` creating session for requester from work.session canvasData). Prefer one endpoint:
+
+`POST /works/:id/fork-canvas` → creates session for current user from work’s session canvasData.
+
+- [ ] **Step 5: WorkCard wiring**
+
+Ensure clicks hit SharePage; buttons for 立即观看 / 制作过程 / 分享 stop propagation correctly.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/shared apps/server/prisma apps/server/src/works apps/web/src/components/works apps/web/src/pages/SharePage.vue apps/web/src/pages/CanvasReadonlyPage.vue apps/web/src/router apps/web/src/services
+git commit -m "feat: publish primary asset, share watch/like/process readonly canvas"
+```
+
+---
+
+### Task 7: Branch validation + PR
+
+- [ ] **Step 1: Local validation**
+
+```bash
+pnpm --dir apps/server exec prisma generate
+pnpm build
+pnpm --filter @lnkpi/agent test
+pnpm --dir apps/web exec vitest run
+```
+
+Expected: build green; tests pass (fix any breakage from DockFailureChip removal / Work type).
+
+- [ ] **Step 2: Push + PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --base main --title "feat: 上传可观测性、历史画布级、主页画布菜单与作品详情" --body "$(cat <<'EOF'
+## Summary
+- 上传失败不再静默 blob；全入口进度；dock 支持本地文件拖放
+- 上下游连线高亮 class 残留修复
+- 历史改为 session 作用域；卡片/详情/失败 UX；下线 DockFailureChip
+- 主页画布 […] 重命名/删除/复制
+- 发布强制主成片；详情观看/点赞/分享/只读制作过程
+
+## Spec
+docs/superpowers/specs/2026-07-22-canvas-upload-history-works-design.md
+
+## Test plan
+- [ ] 登录后五条上传路径成功或明确报错+进度
+- [ ] 点节点高亮上下游；点空白/换节点熄灭
+- [ ] 历史仅本画布；卡片显示 node.id；失败可复制
+- [ ] 画布卡片 […] 三项
+- [ ] 发布选主成片后详情可观看/点赞/只读过程/复制画布
+EOF
+)"
+```
+
+---
+
+## Spec coverage check
+
+| Spec section | Task |
+|--------------|------|
+| 1–5 upload + dock Files | Task 1–2 |
+| 6 edge highlight | Task 3 |
+| 7–10 history + remove chip | Task 4 |
+| 11 canvas menu | Task 5 |
+| 12 publish/share/like/readonly | Task 6 |
+| build/PR | Task 7 |
+
+## Placeholder / consistency self-review
+
+- No TBD steps; upload signatures consistent across Task 1–2
+- `nodeId` / `sessionId` naming consistent in schema, API, UI
+- `playbackUrl` / `playbackKind` consistent shared + prisma + publish
+- Fork path standardized as `POST /works/:id/fork-canvas` for non-owner “复制到我的画布”

--- a/docs/superpowers/specs/2026-07-22-canvas-upload-history-works-design.md
+++ b/docs/superpowers/specs/2026-07-22-canvas-upload-history-works-design.md
@@ -1,0 +1,181 @@
+# 画布上传 / 历史 / 主页作品修复与增强
+
+**日期**：2026-07-22  
+**状态**：已批准（对话确认）  
+**范围**：问题 1–12 一轮交付（同分支连续提交，最后开一个 PR）
+
+## 已锁定决策
+
+| 项 | 决策 |
+|----|------|
+| 交付方式 | 方案 2：同 feature 分支按子系统连续提交，最后单一 PR |
+| 历史节点编号 | 展示 `node.id`（如 `image-3`） |
+| 发布主成片 | 发布弹窗强制选择主成片节点，未选不可发布 |
+| 查看制作过程 | 只读画布快照；可「复制到我的画布」 |
+| 历史模型/渠道 | 模型名与渠道分两行展示，均保留便于运维追踪 |
+
+## 子系统与提交顺序
+
+1. 上传可观测性 + dock 本地文件拖放（1–5）
+2. 连线高亮 class 残留修复（6）
+3. 历史画布级 + 卡片/详情/失败 UX，下线 DockFailureChip（7–10）
+4. 主页画布 `[...]` 菜单（11）
+5. 作品发布主成片 + 详情观看/过程/点赞/分享（12）
+
+---
+
+## 1. 上传与拖放（问题 1–5）
+
+### 问题
+
+登录态下 `persistMediaUrl` 失败会静默回退 `blob:`；各入口再把 blob 当硬失败，用户只看到笼统「上传失败」。全程无进度。Dock 对本地 `Files` 拖放未实现（仅支持资产库 MIME）。
+
+### 统一上传层
+
+- 改造 `persistMediaUrl` / `uploadApi.upload`：
+  - 校验响应 `code === 0` 与 `data.url`
+  - 失败抛出可读错误（网络、401、413/超 50MB、服务端 `message`）
+  - 支持 `onUploadProgress`（0–100%）
+- 登录态失败**不再**回退 blob
+- 未登录：节点/画布仍可用本地 blob；资产库上传仍要求登录
+
+### 进度感知
+
+- 节点卡、dock 参考图、资产库：进入 `uploading` + 百分比或不确定进度条
+- 上传未完成前禁用重复提交
+
+### 各入口行为
+
+| 入口 | 行为 |
+|------|------|
+| 资产库上传 | 统一上传成功后再 `saveMine`；失败 ElMessage 带原因 |
+| 图/视频/音频节点 | 同上；文本节点不支持节点卡上传（画布拖入文本文件仍可建 text 节点） |
+| Dock 参考图（Image/Video） | 文件选择器走统一上传 + 进度；失败可重试 |
+| 拖到画布空白 | 落点 uploading 占位 → 成功写 URL / 失败 error + 原因 |
+| 拖到选中节点 | 类型可接则挂 localRef（保留现逻辑） |
+| 拖到 dock-studio | **新增**：`Files` → 上传 → `appendLocalRef`；类型不匹配提示；与资产库拖入对称 |
+
+### 验收
+
+登录态图/视频/音频：资产库、节点卡、dock 选文件、画布拖放、dock 拖放五条路径均可成功或给出明确失败原因，并可见进度。
+
+---
+
+## 2. 连线高亮（问题 6）
+
+### 问题
+
+`flowEdges` 写入的高亮 `class` 经 `onEdgesChange` 污染 `edges.value`；非当前链路边未剥离 class → 点空白/换节点后残留，甚至多组同时亮。
+
+### 设计
+
+- **展示层与源数据分离**：`edges.value` 永不持久化高亮 class
+- `flowEdges` 每次按当前选中重算：
+  - 上游 → `neo-edge-upstream`
+  - 下游 → `neo-edge-downstream`
+  - 其余 → 显式 `class: undefined`，卸掉旧 class
+- 仅 `multiSelectedIds.length === 1` 时高亮该节点上下游
+- 熄灭：`onPaneClick`、切换到另一节点、点击连线时清空节点选中并熄灭链路高亮
+- 多选框选时不亮上下游
+
+### 验收
+
+点 A 亮 A；再点 B 只亮 B；点空白全部熄灭；无多节点链路同时高亮。
+
+---
+
+## 3. 历史面板（问题 7–10）
+
+### 7. 画布级作用域
+
+- `GenerationRecord` 增加可选字段：`sessionId`、`nodeId`（生成时写入）
+- `GET /studio/generations?sessionId=` 只返回当前画布任务
+- 面板用路由 `sessionId` 拉列表
+- 旧记录无 `sessionId` 的不进入当前画布列表（避免全局混入）
+
+### 8. 详情：模型 / 渠道 / 参数
+
+- **模型**：单独一行，可读名（`modelOptionName` / `originalModel`）
+- **渠道**：单独一行，渠道名称（可解析则用名称，否则 `channelId` 短码）——保留便于追踪
+- **节点**：单独一行 `nodeId`（如 `image-3`）
+- **参数**：按类型展示 metadata（有则显示）
+  - 图：resolution / aspectRatio / size / count
+  - 视频：duration / resolution / aspectRatio / crop
+  - 音频：voice / speed 等
+
+### 9. 失败任务
+
+- 列表「失败」旁感叹号；点击打开错误面板（`userMessage` + 可复制完整诊断）
+- 详情页展示失败原因
+- **下线** dock-studio `DockFailureChip`；节点角标 ⓘ 诊断保留
+
+### 10. 默认卡片
+
+- 类型图标 + **`node.id`**（无则「—」）+ 状态
+- 缩略图：图 url；视频 `<video>` 预览；音频类型占位；文本摘要块
+- 点击进详情；hover 定位仍按 `generationRecordId` / `nodeId` 聚焦节点
+
+### 验收
+
+只见本画布历史；卡片含 `image-3` 类 id 与缩略图；详情模型与渠道分列且有参数；失败可点叹号复制；dock 无失败胶囊。
+
+---
+
+## 4. 主页画布与作品（问题 11–12）
+
+### 11. 我的画布 `[...]` 菜单
+
+- Hover 右上角 `[...]`，`click.stop` 展开
+- **重命名** → 已有 `PUT /sessions/:id`
+- **删除** → 确认后已有 `DELETE /sessions/:id`
+- **复制副本** → 新增 `POST /sessions/:id/duplicate`（title 加「副本」+ 拷贝 `canvasData`）
+
+### 12. 发布与作品详情
+
+#### 发布弹窗
+
+- 强制选择主成片节点（列出有 URL 的 image/video）；未选不可发布
+- Work 写入：`playbackUrl`、`playbackKind`（image|video）、`sessionId`、封面
+
+#### 详情页 `/share/:id`
+
+- **立即观看**：video 播放器 / image 大图
+- **查看制作过程**：只读 Vue Flow 快照（禁编辑/生成）；「复制到我的画布」→ duplicate 到当前用户
+- **分享**：复制详情链接
+- **点赞**：`POST /works/:id/like`（需登录）；未登录引导登录
+- **作者**：头像/昵称，可进创作者页
+
+#### 首页作品卡
+
+- 点击进详情；卡片保留立即观看 / 制作过程 / 分享等可点击入口
+
+### 验收
+
+画布可重命名/删除/复制；发布必须选主成片；详情能看、能进只读过程、能赞、能分享、能看作者。
+
+---
+
+## 数据模型变更摘要
+
+| 模型 | 变更 |
+|------|------|
+| `GenerationRecord` | +`sessionId?`、+`nodeId?`；列表支持 `?sessionId=` |
+| `Work` | +`playbackUrl?`、+`playbackKind?`；like API |
+| `Session` | +`POST /:id/duplicate` |
+
+## 明确非目标（本轮不做）
+
+- 真实短信验证码改造
+- 资产库文件物理副本（仍存 URL 引用）
+- 系统级原生分享面板（本轮仅复制链接）
+- 将 Agent `/replay` 逐步回放作为「制作过程」主路径（只读画布快照为主）
+- 文本节点卡上的文件上传入口
+
+## 风险与缓解
+
+| 风险 | 缓解 |
+|------|------|
+| 生产上传仍失败（磁盘/反代 body） | 错误文案透出 HTTP/服务端 message，便于运维 |
+| 旧 GenerationRecord 无 sessionId | 不混入当前画布列表；新生成全部写入 |
+| 只读画布需公开读 canvas | 详情「制作过程」按 work.sessionId 鉴权：作者或已发布作品可读者 |
+| PR 体积大 | 同分支 5 次语义提交，review 按提交看 |

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -42,6 +42,8 @@ export interface Work {
   id: string
   title: string
   coverUrl: string
+  playbackUrl?: string
+  playbackKind?: 'image' | 'video'
   type: WorkType
   authorId: string
   authorName: string


### PR DESCRIPTION
## Summary
- Upload: progress UI, no silent blob fallback when logged in, Files drop onto dock refs
- Edges: clear upstream/downstream highlight when selection changes
- Tasks: rename rail「历史」→「任务」, session-scoped records with 排队 / 进行中 / 已完成 tabs + live poll
- Homepage canvases: hover menu rename / delete / duplicate
- Works: publish requires primary media node; share watch/like; readonly process canvas + fork

## Test plan
- [ ] `pnpm build` + agent tests pass
- [ ] Upload image/video to node/asset/dock and see progress; logged-in failure surfaces error (no silent blob)
- [ ] Select nodes with edges — highlight clears on deselection / pane click
- [ ] Open「任务」: tabs show generating under 进行中, completed/failed under 已完成; counts update while generating
- [ ] Homepage canvas card `[...]`: rename, delete, duplicate
- [ ] Publish NeoTV requires choosing primary node; share page watch/like; 制作过程 readonly + copy to my canvas


Made with [Cursor](https://cursor.com)