### PR TITLE
fix: upload, audio→video refs, video covers, BYOK diagnostics

### DIFF
--- a/apps/server/src/canvas/material.service.ts
+++ b/apps/server/src/canvas/material.service.ts
@@ -249,11 +249,20 @@ export class MaterialService {
     err: unknown,
     extra: Record<string, unknown> = {},
   ) {
+    const raw = errMessage(err).slice(0, 8000)
+    const failureClass = classifyByokFailure(err)
     return {
       ...extra,
       channelId: resolved.channelId,
-      failureClass: classifyByokFailure(err),
+      failureClass,
       confirmMessage: BYOK_FALLBACK_CONFIRM_MESSAGE,
+      byokErrorRaw: raw,
+      errorRaw: raw,
+      errorCode: 'fallback_pending' as ErrorCode,
+      userMessage: raw
+        ? `BYOK 上游失败（${failureClass}）：${raw.slice(0, 240)}`
+        : 'BYOK 上游失败，可改用平台模型继续',
+      failedAt: new Date().toISOString(),
     }
   }
 
@@ -585,11 +594,25 @@ export class MaterialService {
           : this.platformFallbackCost(material.type, meta)
       await this.points.refund(userId, cost, '平台回退取消退款')
     }
-    const cancelledMeta = applyFailureDiagnosticMeta(
-      { ...meta, cancelled: true },
-      new Error('已取消'),
-      { errorCode: 'cancelled', userMessage: '已取消' },
-    )
+    const cancelledMeta: Record<string, unknown> = (() => {
+      const byokErrorRaw =
+        (typeof meta.byokErrorRaw === 'string' && meta.byokErrorRaw.trim()
+          ? meta.byokErrorRaw
+          : undefined)
+        ?? (typeof meta.errorRaw === 'string' && meta.errorRaw.trim() && meta.errorRaw !== '已取消'
+          ? meta.errorRaw
+          : undefined)
+      return {
+        ...meta,
+        cancelled: true,
+        ...(byokErrorRaw ? { byokErrorRaw, errorRaw: byokErrorRaw } : {}),
+        errorCode: 'cancelled',
+        userMessage: byokErrorRaw
+          ? `已取消平台回退。原 BYOK 错误：${byokErrorRaw.slice(0, 500)}`
+          : '已取消',
+        failedAt: new Date().toISOString(),
+      }
+    })()
     return this.prisma.material.update({
       where: { id: material.id },
       data: {
@@ -634,15 +657,24 @@ export class MaterialService {
       include: { shot: { include: { session: true } } },
     })
     if (!material) throw new NotFoundException('素材不存在')
-    if (material.status !== 'failed' && material.status !== 'error') {
+    if (
+      material.status !== 'failed'
+      && material.status !== 'error'
+      && material.status !== 'fallback_pending'
+    ) {
       throw new NotFoundException('诊断不可用')
     }
     const meta = parseMeta(material.metadata)
-    const errRaw = meta.errorRaw != null ? String(meta.errorRaw) : ''
+    const errRaw =
+      (typeof meta.byokErrorRaw === 'string' && meta.byokErrorRaw.trim()
+        ? meta.byokErrorRaw
+        : '')
+      || (meta.errorRaw != null ? String(meta.errorRaw) : '')
     const code =
       (typeof meta.errorCode === 'string' ? (meta.errorCode as ErrorCode) : undefined) ??
       mapMessageToErrorCode(errRaw)
-    const defaultMessage = '生成失败'
+    const defaultMessage =
+      material.status === 'fallback_pending' ? '平台回退待确认' : '生成失败'
     const userMessage =
       (typeof meta.userMessage === 'string' && meta.userMessage.trim()
         ? meta.userMessage
@@ -668,7 +700,10 @@ export class MaterialService {
       httpStatus: typeof meta.httpStatus === 'number' ? meta.httpStatus : null,
       occurredAt,
       providerSnippet: errRaw ? redactProviderSnippet(errRaw) : null,
-      hint: hintForCode(code),
+      hint:
+        material.status === 'fallback_pending'
+          ? '请确认是否使用平台回退继续，或取消本次生成。'
+          : hintForCode(code),
     }
   }
 

--- a/apps/server/src/studio/studio.diagnostic.test.ts
+++ b/apps/server/src/studio/studio.diagnostic.test.ts
@@ -58,6 +58,29 @@ describe('StudioService.getGenerationDiagnostic', () => {
     await expect(svc.getGenerationDiagnostic('u1', 'g1')).rejects.toBeInstanceOf(NotFoundException)
   })
 
+  it('getGenerationDiagnostic allows fallback_pending with BYOK error', async () => {
+    generationFindFirst.mockResolvedValue({
+      id: 'g-fp',
+      userId: 'u1',
+      status: 'fallback_pending',
+      model: 'user-byok',
+      createdAt: new Date('2026-07-21T00:00:00.000Z'),
+      metadata: JSON.stringify({
+        errorCode: 'fallback_pending',
+        byokErrorRaw: 'upstream 502 Bad Gateway',
+        errorRaw: 'upstream 502 Bad Gateway',
+        userMessage: 'BYOK 上游失败（upstream）：upstream 502 Bad Gateway',
+        channelId: 'ch1',
+        failedAt: '2026-07-21T01:00:00.000Z',
+      }),
+    })
+
+    const d = await svc.getGenerationDiagnostic('u1', 'g-fp')
+    expect(d.code).toBe('fallback_pending')
+    expect(d.providerSnippet).toContain('502')
+    expect(d.userMessage).toContain('BYOK')
+  })
+
   it('getGenerationDiagnostic redacts provider snippet', async () => {
     generationFindFirst.mockResolvedValue({
       id: 'g1',

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -252,12 +252,21 @@ export class StudioService {
     err: unknown,
     extra: Record<string, unknown> = {},
   ) {
+    const raw = errMessage(err).slice(0, 8000)
+    const failureClass = classifyByokFailure(err)
     return {
       ...extra,
       channelId: resolved.channelId,
-      failureClass: classifyByokFailure(err),
+      failureClass,
       confirmMessage: BYOK_FALLBACK_CONFIRM_MESSAGE,
       originalModel: extra.originalModel,
+      byokErrorRaw: raw,
+      errorRaw: raw,
+      errorCode: 'fallback_pending' as ErrorCode,
+      userMessage: raw
+        ? `BYOK 上游失败（${failureClass}）：${raw.slice(0, 240)}`
+        : 'BYOK 上游失败，可改用平台模型继续',
+      failedAt: new Date().toISOString(),
     }
   }
 
@@ -531,15 +540,24 @@ export class StudioService {
 
   async getGenerationDiagnostic(userId: string, id: string): Promise<GenerationDiagnostic> {
     const record = await this.getGeneration(userId, id)
-    if (record.status !== 'failed' && record.status !== 'error') {
+    if (
+      record.status !== 'failed'
+      && record.status !== 'error'
+      && record.status !== 'fallback_pending'
+    ) {
       throw new NotFoundException('诊断不可用')
     }
     const meta = parseMeta(record.metadata)
-    const errRaw = meta.errorRaw != null ? String(meta.errorRaw) : ''
+    const errRaw =
+      (typeof meta.byokErrorRaw === 'string' && meta.byokErrorRaw.trim()
+        ? meta.byokErrorRaw
+        : '')
+      || (meta.errorRaw != null ? String(meta.errorRaw) : '')
     const code =
       (typeof meta.errorCode === 'string' ? (meta.errorCode as ErrorCode) : undefined) ??
       mapMessageToErrorCode(errRaw)
-    const defaultMessage = '生成失败'
+    const defaultMessage =
+      record.status === 'fallback_pending' ? '平台回退待确认' : '生成失败'
     const userMessage =
       (typeof meta.userMessage === 'string' && meta.userMessage.trim()
         ? meta.userMessage
@@ -560,7 +578,10 @@ export class StudioService {
       httpStatus: typeof meta.httpStatus === 'number' ? meta.httpStatus : null,
       occurredAt,
       providerSnippet: errRaw ? redactProviderSnippet(errRaw) : null,
-      hint: hintForCode(code),
+      hint:
+        record.status === 'fallback_pending'
+          ? '请确认是否使用平台回退继续，或取消本次生成。'
+          : hintForCode(code),
     }
   }
 
@@ -1282,11 +1303,23 @@ export class StudioService {
           : this.platformFallbackCost(record.type, meta)
       await this.points.refund(userId, cost, '平台回退取消退款')
     }
-    const cancelledMeta = applyFailureDiagnosticMeta(
-      { ...meta, cancelled: true },
-      new Error('已取消'),
-      { errorCode: 'cancelled', userMessage: '已取消' },
-    )
+    const byokErrorRaw =
+      (typeof meta.byokErrorRaw === 'string' && meta.byokErrorRaw.trim()
+        ? meta.byokErrorRaw
+        : undefined)
+      ?? (typeof meta.errorRaw === 'string' && meta.errorRaw.trim() && meta.errorRaw !== '已取消'
+        ? meta.errorRaw
+        : undefined)
+    const cancelledMeta: Record<string, unknown> = {
+      ...meta,
+      cancelled: true,
+      ...(byokErrorRaw ? { byokErrorRaw, errorRaw: byokErrorRaw } : {}),
+      errorCode: 'cancelled',
+      userMessage: byokErrorRaw
+        ? `已取消平台回退。原 BYOK 错误：${byokErrorRaw.slice(0, 500)}`
+        : '已取消',
+      failedAt: new Date().toISOString(),
+    }
     return this.prisma.generationRecord.update({
       where: { id: record.id },
       data: {

--- a/apps/server/src/upload/upload.controller.ts
+++ b/apps/server/src/upload/upload.controller.ts
@@ -1,4 +1,5 @@
 import {
+  Body,
   Controller,
   Inject,
   Post,
@@ -8,9 +9,44 @@ import {
   UseInterceptors,
 } from '@nestjs/common'
 import { FileInterceptor } from '@nestjs/platform-express'
+import { IsInt, IsOptional, IsString, Min } from 'class-validator'
 import { memoryStorage } from 'multer'
 import { AuthGuard } from '../auth/auth.guard'
 import { UploadService } from './upload.service'
+
+class InitChunkDto {
+  @IsString()
+  fileName!: string
+
+  @IsOptional()
+  @IsString()
+  mimeType?: string
+
+  @IsInt()
+  @Min(1)
+  size!: number
+
+  @IsInt()
+  @Min(1)
+  totalChunks!: number
+}
+
+class ChunkDto {
+  @IsString()
+  uploadId!: string
+
+  @IsInt()
+  @Min(0)
+  index!: number
+
+  @IsString()
+  data!: string
+}
+
+class CompleteChunkDto {
+  @IsString()
+  uploadId!: string
+}
 
 @Controller('upload')
 export class UploadController {
@@ -37,6 +73,33 @@ export class UploadController {
       file.originalname,
       file.mimetype,
     )
+    return { code: 0, message: 'ok', data }
+  }
+
+  /** 经 Vercel JSON 代理的大文件分片上传 — 绕过 ~4.5MB multipart 限制 */
+  @Post('init')
+  @UseGuards(AuthGuard)
+  async initChunk(@Req() req: { user: { sub: string } }, @Body() dto: InitChunkDto) {
+    const data = await this.uploadService.initChunkedUpload(req.user.sub, {
+      fileName: dto.fileName,
+      mimeType: dto.mimeType ?? 'application/octet-stream',
+      size: dto.size,
+      totalChunks: dto.totalChunks,
+    })
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('chunk')
+  @UseGuards(AuthGuard)
+  async saveChunk(@Req() req: { user: { sub: string } }, @Body() dto: ChunkDto) {
+    const data = await this.uploadService.saveChunk(req.user.sub, dto.uploadId, dto.index, dto.data)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('complete')
+  @UseGuards(AuthGuard)
+  async completeChunk(@Req() req: { user: { sub: string } }, @Body() dto: CompleteChunkDto) {
+    const data = await this.uploadService.completeChunkedUpload(req.user.sub, dto.uploadId)
     return { code: 0, message: 'ok', data }
   }
 }

--- a/apps/server/src/upload/upload.service.ts
+++ b/apps/server/src/upload/upload.service.ts
@@ -1,26 +1,165 @@
-import { mkdir, writeFile } from 'fs/promises'
+import { mkdir, writeFile, unlink, readFile } from 'fs/promises'
 import { join, extname } from 'path'
 import { randomUUID } from 'crypto'
-import { Injectable } from '@nestjs/common'
+import { BadRequestException, Injectable } from '@nestjs/common'
+
+const MAX_UPLOAD_BYTES = 50 * 1024 * 1024
+/** 分片经 Vercel JSON 代理时，单片 base64 需落在 ~4.5MB 请求体限制内 */
+export const UPLOAD_CHUNK_RAW_BYTES = 2 * 1024 * 1024
+
+type ChunkSession = {
+  userId: string
+  fileName: string
+  mimeType: string
+  size: number
+  totalChunks: number
+  dir: string
+  received: Set<number>
+  createdAt: number
+}
 
 @Injectable()
 export class UploadService {
   private readonly rootDir = join(process.cwd(), 'uploads')
+  private readonly chunkSessions = new Map<string, ChunkSession>()
 
   async saveUserFile(userId: string, buffer: Buffer, originalName: string, mimeType: string) {
+    if (buffer.length > MAX_UPLOAD_BYTES) {
+      throw new BadRequestException(`文件过大，上限 ${Math.floor(MAX_UPLOAD_BYTES / 1024 / 1024)}MB`)
+    }
     const safeExt = extname(originalName).slice(0, 12) || this.extFromMime(mimeType)
     const fileName = `${Date.now()}-${randomUUID().slice(0, 8)}${safeExt}`
     const userDir = join(this.rootDir, userId)
     await mkdir(userDir, { recursive: true })
     const absPath = join(userDir, fileName)
     await writeFile(absPath, buffer)
-    const relativeUrl = `/api/uploads/${userId}/${fileName}`
+    return this.toResult(userId, fileName, originalName, mimeType, buffer.length)
+  }
+
+  async initChunkedUpload(
+    userId: string,
+    opts: { fileName: string; mimeType: string; size: number; totalChunks: number },
+  ) {
+    const size = Number(opts.size) || 0
+    const totalChunks = Number(opts.totalChunks) || 0
+    if (!opts.fileName?.trim()) throw new BadRequestException('缺少文件名')
+    if (size <= 0 || size > MAX_UPLOAD_BYTES) {
+      throw new BadRequestException(`文件大小无效或超过 ${Math.floor(MAX_UPLOAD_BYTES / 1024 / 1024)}MB`)
+    }
+    if (totalChunks <= 0 || totalChunks > 200) {
+      throw new BadRequestException('分片数量无效')
+    }
+    this.gcChunkSessions()
+    const uploadId = randomUUID()
+    const dir = join(this.rootDir, '_chunks', uploadId)
+    await mkdir(dir, { recursive: true })
+    this.chunkSessions.set(uploadId, {
+      userId,
+      fileName: opts.fileName.trim(),
+      mimeType: opts.mimeType || 'application/octet-stream',
+      size,
+      totalChunks,
+      dir,
+      received: new Set(),
+      createdAt: Date.now(),
+    })
+    return { uploadId, chunkSize: UPLOAD_CHUNK_RAW_BYTES }
+  }
+
+  async saveChunk(userId: string, uploadId: string, index: number, dataBase64: string) {
+    const session = this.chunkSessions.get(uploadId)
+    if (!session || session.userId !== userId) {
+      throw new BadRequestException('上传会话不存在或已过期')
+    }
+    if (!Number.isInteger(index) || index < 0 || index >= session.totalChunks) {
+      throw new BadRequestException('分片序号无效')
+    }
+    if (!dataBase64 || typeof dataBase64 !== 'string') {
+      throw new BadRequestException('分片数据为空')
+    }
+    let buf: Buffer
+    try {
+      buf = Buffer.from(dataBase64, 'base64')
+    } catch {
+      throw new BadRequestException('分片数据解码失败')
+    }
+    if (buf.length === 0 || buf.length > UPLOAD_CHUNK_RAW_BYTES + 64 * 1024) {
+      throw new BadRequestException('分片过大')
+    }
+    await writeFile(join(session.dir, `${index}.part`), buf)
+    session.received.add(index)
+    return { received: session.received.size, totalChunks: session.totalChunks }
+  }
+
+  async completeChunkedUpload(userId: string, uploadId: string) {
+    const session = this.chunkSessions.get(uploadId)
+    if (!session || session.userId !== userId) {
+      throw new BadRequestException('上传会话不存在或已过期')
+    }
+    if (session.received.size !== session.totalChunks) {
+      throw new BadRequestException(`分片不完整：${session.received.size}/${session.totalChunks}`)
+    }
+    const parts: Buffer[] = []
+    let total = 0
+    for (let i = 0; i < session.totalChunks; i++) {
+      const part = await readFile(join(session.dir, `${i}.part`))
+      parts.push(part)
+      total += part.length
+    }
+    if (total !== session.size) {
+      // 允许轻微偏差（末片）；严格校验上限
+      if (total > MAX_UPLOAD_BYTES) {
+        throw new BadRequestException('合并后文件过大')
+      }
+    }
+    const buffer = Buffer.concat(parts, total)
+    const result = await this.saveUserFile(userId, buffer, session.fileName, session.mimeType)
+    await this.cleanupChunkSession(uploadId)
+    return result
+  }
+
+  private async cleanupChunkSession(uploadId: string) {
+    const session = this.chunkSessions.get(uploadId)
+    this.chunkSessions.delete(uploadId)
+    if (!session) return
+    for (let i = 0; i < session.totalChunks; i++) {
+      try {
+        await unlink(join(session.dir, `${i}.part`))
+      } catch {
+        /* ignore */
+      }
+    }
+    try {
+      const { rmdir } = await import('fs/promises')
+      await rmdir(session.dir)
+    } catch {
+      /* ignore */
+    }
+  }
+
+  private gcChunkSessions() {
+    const cutoff = Date.now() - 60 * 60 * 1000
+    for (const [id, s] of this.chunkSessions) {
+      if (s.createdAt < cutoff) {
+        void this.cleanupChunkSession(id)
+      }
+    }
+  }
+
+  private toResult(
+    userId: string,
+    storedName: string,
+    originalName: string,
+    mimeType: string,
+    size: number,
+  ) {
+    const relativeUrl = `/api/uploads/${userId}/${storedName}`
     const publicBase = process.env.API_PUBLIC_URL?.replace(/\/$/, '')
     return {
       url: publicBase ? `${publicBase}${relativeUrl}` : relativeUrl,
       fileName: originalName,
       mimeType: mimeType || 'application/octet-stream',
-      size: buffer.length,
+      size,
     }
   }
 

--- a/apps/web/api/proxy.ts
+++ b/apps/web/api/proxy.ts
@@ -1,11 +1,14 @@
-import type { IncomingHttpHeaders } from 'node:http'
+import type { IncomingHttpHeaders, IncomingMessage } from 'node:http'
 
 const API_ORIGIN = process.env.LNKPI_API_ORIGIN ?? 'http://119.29.173.89:5100'
 const DEFAULT_UPSTREAM_TIMEOUT_MS = 20_000
 const MAX_ATTEMPTS = 3
 
-/** Vercel Serverless 最大执行时长（秒），需与上游超时匹配 */
+/** Vercel Serverless：关闭 bodyParser，保留 multipart / 二进制原始流 */
 export const config = {
+  api: {
+    bodyParser: false,
+  },
   maxDuration: 120,
 }
 
@@ -16,9 +19,10 @@ const LONG_RUNNING_PATHS: Array<{ pattern: RegExp; timeoutMs: number }> = [
   { pattern: /\/studio\/image\/variation$/i, timeoutMs: 120_000 },
   { pattern: /\/studio\/video\/generate$/i, timeoutMs: 90_000 },
   { pattern: /\/studio\/audio\/generate$/i, timeoutMs: 60_000 },
+  { pattern: /\/upload(\/|$)/i, timeoutMs: 120_000 },
 ]
 
-type VercelRequest = {
+type VercelRequest = IncomingMessage & {
   method?: string
   headers: IncomingHttpHeaders
   query?: Record<string, string | string[] | undefined>
@@ -86,12 +90,20 @@ function buildUpstreamHeaders(req: VercelRequest) {
   return headers
 }
 
-function buildUpstreamBody(req: VercelRequest) {
+async function readRawBody(req: VercelRequest): Promise<Buffer | undefined> {
   const method = req.method?.toUpperCase() ?? 'GET'
   if (method === 'GET' || method === 'HEAD') return undefined
-  if (req.body == null || req.body === '') return undefined
-  if (typeof req.body === 'string') return req.body
-  return JSON.stringify(req.body)
+
+  if (Buffer.isBuffer(req.body)) return req.body
+  if (typeof req.body === 'string') {
+    return req.body.length ? Buffer.from(req.body) : undefined
+  }
+  // bodyParser:false → 从请求流读取原始字节（multipart / JSON / octet-stream）
+  const chunks: Buffer[] = []
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  }
+  return chunks.length ? Buffer.concat(chunks) : undefined
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -99,12 +111,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const upstreamPath = buildUpstreamPath(req.query)
   const target = buildUpstreamUrl(req)
   const headers = buildUpstreamHeaders(req)
-  const body = buildUpstreamBody(req)
+  const body = await readRawBody(req)
   const timeoutMs = resolveUpstreamTimeoutMs(upstreamPath)
   const maxAttempts = isStudioGeneratePost(method, upstreamPath) ? 1 : MAX_ATTEMPTS
 
-  if (body != null && !headers.has('content-type')) {
+  if (body != null && body.length > 0 && !headers.has('content-type')) {
     headers.set('content-type', 'application/json')
+  }
+  if (body != null) {
+    headers.set('content-length', String(body.length))
   }
 
   let lastError: unknown
@@ -113,7 +128,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       const upstream = await fetch(target, {
         method,
         headers,
-        body,
+        body: body && body.length > 0 ? body : undefined,
         redirect: 'manual',
         signal: AbortSignal.timeout(timeoutMs),
       })

--- a/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
+++ b/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
@@ -99,6 +99,9 @@ interface RecordMeta {
   userMessage?: string
   text?: string
   content?: string
+  errorRaw?: string
+  byokErrorRaw?: string
+  failureClass?: string
 }
 
 function statusMeta(status: string) {
@@ -160,7 +163,11 @@ function recordFailureMessage(record: GenerationRecord): string | null {
   }
   const meta = parseRecordMeta(record)
   if (meta.userMessage) return meta.userMessage
-  if (record.status === NODE_GENERATION_STATUS.fallback_pending) return '平台回退待确认'
+  const byok = meta.byokErrorRaw || meta.errorRaw
+  if (record.status === NODE_GENERATION_STATUS.fallback_pending) {
+    return byok ? `平台回退待确认：${byok.slice(0, 240)}` : '平台回退待确认'
+  }
+  if (byok) return byok.slice(0, 240)
   return '生成失败'
 }
 
@@ -256,13 +263,18 @@ function previewDetailMedia(record: GenerationRecord) {
 function buildFallbackDiagnostic(record: GenerationRecord): GenerationDiagnostic {
   const meta = parseRecordMeta(record)
   const isFallback = record.status === NODE_GENERATION_STATUS.fallback_pending
+  const byok = meta.byokErrorRaw || meta.errorRaw || ''
   return {
     userMessage: meta.userMessage || recordFailureMessage(record) || '生成失败',
-    code: isFallback ? 'fallback_pending' : ((parseErrorCodeFromMetadata(record.metadata) as ErrorCode | undefined) || 'unknown'),
+    code: isFallback
+      ? 'fallback_pending'
+      : ((parseErrorCodeFromMetadata(record.metadata) as ErrorCode | undefined) || 'unknown'),
     taskKind: 'generation',
     taskId: record.id,
     occurredAt: record.createdAt,
-    providerSnippet: null,
+    channelId: meta.channelId ?? null,
+    model: record.model ?? meta.originalModel ?? null,
+    providerSnippet: byok ? byok.slice(0, 2048) : null,
     hint: isFallback ? '请确认是否使用平台回退继续，或取消本次生成。' : undefined,
   }
 }

--- a/apps/web/src/components/works/PublishNeoTVDialog.vue
+++ b/apps/web/src/components/works/PublishNeoTVDialog.vue
@@ -165,7 +165,20 @@ async function handlePublish() {
             class="!mr-0 !h-auto w-full rounded-lg border border-white/8 bg-white/[0.03] px-3 py-2"
           >
             <div class="flex items-center gap-3">
-              <img :src="node.preview" :alt="node.label" class="h-10 w-16 rounded object-cover" />
+              <video
+                v-if="node.type === 'video'"
+                :src="node.preview"
+                muted
+                playsinline
+                preload="metadata"
+                class="h-10 w-16 rounded object-cover bg-black/40"
+              />
+              <img
+                v-else
+                :src="node.preview"
+                :alt="node.label"
+                class="h-10 w-16 rounded object-cover"
+              />
               <span class="text-sm">{{ node.label }}</span>
             </div>
           </el-radio>

--- a/apps/web/src/components/works/WorkCard.vue
+++ b/apps/web/src/components/works/WorkCard.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+import { computed, ref } from 'vue'
 import type { Work } from '@lnkpi/shared'
+import { resolveMediaUrl } from '@/services/api-base'
 
-defineProps<{
+const props = defineProps<{
   work: Work
 }>()
 
@@ -12,16 +14,61 @@ defineEmits<{
   viewAuthor: [authorId: string]
   viewShare: [workId: string]
 }>()
+
+const videoRef = ref<HTMLVideoElement | null>(null)
+
+const isVideoPlayback = computed(
+  () => props.work.playbackKind === 'video' && !!(props.work.playbackUrl || props.work.coverUrl),
+)
+
+const mediaSrc = computed(() =>
+  resolveMediaUrl(props.work.playbackUrl || props.work.coverUrl || ''),
+)
+
+async function onHoverEnter() {
+  const el = videoRef.value
+  if (!el) return
+  try {
+    el.currentTime = 0
+    await el.play()
+  } catch {
+    /* autoplay may be blocked */
+  }
+}
+
+function onHoverLeave() {
+  const el = videoRef.value
+  if (!el) return
+  el.pause()
+  try {
+    el.currentTime = 0
+  } catch {
+    /* ignore */
+  }
+}
 </script>
 
 <template>
   <article
     class="group cursor-pointer overflow-hidden rounded-2xl border border-white/[0.08] bg-[#1a1a1a] transition hover:border-[#6366f1]/30 hover:shadow-lg hover:shadow-[#6366f1]/5"
     @click="$emit('viewWork', work.id)"
+    @mouseenter="onHoverEnter"
+    @mouseleave="onHoverLeave"
   >
     <div class="relative aspect-video overflow-hidden bg-[#242424]">
+      <video
+        v-if="isVideoPlayback"
+        ref="videoRef"
+        :src="mediaSrc"
+        muted
+        playsinline
+        loop
+        preload="metadata"
+        class="h-full w-full object-cover transition duration-500 group-hover:scale-105"
+      />
       <img
-        :src="work.coverUrl"
+        v-else
+        :src="resolveMediaUrl(work.coverUrl)"
         :alt="work.title"
         class="h-full w-full object-cover transition duration-500 group-hover:scale-105"
       />

--- a/apps/web/src/composables/useMediaUpload.test.ts
+++ b/apps/web/src/composables/useMediaUpload.test.ts
@@ -16,11 +16,14 @@ describe('persistMediaUrl', () => {
     vi.mocked(uploadApi.upload).mockReset()
   })
 
-  it('throws when upload returns non-zero code', async () => {
+  it('throws when upload returns empty url', async () => {
     vi.mocked(uploadApi.upload).mockResolvedValue({
-      data: { code: 1, message: '未收到文件', data: undefined as never },
-    } as never)
-    await expect(persistMediaUrl(new File(['x'], 'a.png'), 'blob:x')).rejects.toThrow(/未收到文件|上传/)
+      url: '',
+      fileName: 'a.png',
+      mimeType: 'image/png',
+      size: 1,
+    })
+    await expect(persistMediaUrl(new File(['x'], 'a.png'), 'blob:x')).rejects.toThrow(/上传/)
   })
 
   it('throws when logged-in upload network-fails (no blob fallback)', async () => {
@@ -30,8 +33,11 @@ describe('persistMediaUrl', () => {
 
   it('returns server url on success', async () => {
     vi.mocked(uploadApi.upload).mockResolvedValue({
-      data: { code: 0, data: { url: '/uploads/u/a.png', fileName: 'a.png', mimeType: 'image/png', size: 1 } },
-    } as never)
+      url: '/uploads/u/a.png',
+      fileName: 'a.png',
+      mimeType: 'image/png',
+      size: 1,
+    })
     await expect(persistMediaUrl(new File(['x'], 'a.png'), 'blob:x')).resolves.toBe('/uploads/u/a.png')
   })
 })

--- a/apps/web/src/composables/useMediaUpload.ts
+++ b/apps/web/src/composables/useMediaUpload.ts
@@ -14,14 +14,11 @@ export async function persistMediaUrl(
   const allowBlobFallback = opts?.allowBlobFallback ?? false
 
   try {
-    const { data } = await uploadApi.upload(file, { onProgress: opts?.onProgress })
-    if (data.code !== undefined && data.code !== 0) {
-      throw new Error(data.message || '上传失败')
+    const result = await uploadApi.upload(file, { onProgress: opts?.onProgress })
+    if (!result?.url) {
+      throw new Error('上传失败')
     }
-    if (!data.data?.url) {
-      throw new Error(data.message || '上传失败')
-    }
-    return resolveMediaUrl(data.data.url)
+    return resolveMediaUrl(result.url)
   } catch (err) {
     if (allowBlobFallback) return fallbackUrl
     throw err

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -1173,7 +1173,7 @@ function canAcceptLocalRef(nodeType: string, mediaType: LocalRefBinding['mediaTy
   if (mediaType === 'text') return nodeType === 'text' || nodeType === 'prompt'
   if (mediaType === 'image') return nodeType === 'text' || nodeType === 'image' || nodeType === 'video'
   if (mediaType === 'video') return nodeType === 'video'
-  if (mediaType === 'audio') return nodeType === 'audio'
+  if (mediaType === 'audio') return nodeType === 'audio' || nodeType === 'video'
   return false
 }
 
@@ -1186,6 +1186,8 @@ function previewPatchForLocalRef(
   if (mediaType === 'image' && nodeType === 'video') return { referenceImageUrl: url }
   if (mediaType === 'video' && nodeType === 'video') return { url, status: 'completed' }
   if (mediaType === 'audio' && nodeType === 'audio') return { url, status: 'completed' }
+  // audio → video：仅作引用芯片，不覆盖成片 url
+  if (mediaType === 'audio' && nodeType === 'video') return {}
   return {}
 }
 

--- a/apps/web/src/services/upload-api.ts
+++ b/apps/web/src/services/upload-api.ts
@@ -1,4 +1,6 @@
+import type { AxiosError } from 'axios'
 import { api } from './api'
+import { getApiBaseUrl } from './api-base'
 
 export interface UploadResult {
   url: string
@@ -7,15 +9,120 @@ export interface UploadResult {
   size: number
 }
 
-export const uploadApi = {
-  upload: (file: File, opts?: { onProgress?: (pct: number) => void }) => {
-    const form = new FormData()
-    form.append('file', file)
-    return api.post<{ code?: number; message?: string; data: UploadResult }>('/upload', form, {
+/** 经 Vercel 代理时单请求体约 4.5MB；分片 raw 取 2MB（base64 后仍安全） */
+const CHUNK_RAW_BYTES = 2 * 1024 * 1024
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer)
+  const chunk = 0x8000
+  let binary = ''
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk))
+  }
+  return btoa(binary)
+}
+
+function uploadErrorMessage(err: unknown): string {
+  const ax = err as AxiosError<{ message?: string }>
+  const status = ax.response?.status
+  const msg = ax.response?.data?.message || ax.message || '上传失败'
+  if (status === 413) {
+    return '文件过大（网关限制约 4.5MB/请求）。请改用分片上传或压缩后再试。'
+  }
+  if (status === 400 && /multipart|form/i.test(String(msg))) {
+    return '上传通道异常，请刷新后重试；若仍失败请缩小文件或联系管理员。'
+  }
+  return typeof msg === 'string' ? msg : '上传失败'
+}
+
+async function uploadMultipart(
+  file: File,
+  opts?: { onProgress?: (pct: number) => void },
+): Promise<UploadResult> {
+  const form = new FormData()
+  form.append('file', file)
+  const { data } = await api.post<{ code?: number; message?: string; data: UploadResult }>(
+    '/upload',
+    form,
+    {
       onUploadProgress: (e) => {
         if (!opts?.onProgress || !e.total) return
         opts.onProgress(Math.min(100, Math.round((e.loaded / e.total) * 100)))
       },
-    })
+    },
+  )
+  if (data.code != null && data.code !== 0) {
+    throw new Error(data.message || '上传失败')
+  }
+  return data.data
+}
+
+async function uploadChunked(
+  file: File,
+  opts?: { onProgress?: (pct: number) => void },
+): Promise<UploadResult> {
+  const totalChunks = Math.max(1, Math.ceil(file.size / CHUNK_RAW_BYTES))
+  const { data: initRes } = await api.post<{
+    code?: number
+    data: { uploadId: string; chunkSize: number }
+  }>('/upload/init', {
+    fileName: file.name,
+    mimeType: file.type || 'application/octet-stream',
+    size: file.size,
+    totalChunks,
+  })
+  if (initRes.code != null && initRes.code !== 0) {
+    throw new Error('初始化分片上传失败')
+  }
+  const uploadId = initRes.data.uploadId
+
+  for (let index = 0; index < totalChunks; index++) {
+    const start = index * CHUNK_RAW_BYTES
+    const end = Math.min(file.size, start + CHUNK_RAW_BYTES)
+    const slice = file.slice(start, end)
+    const buf = await slice.arrayBuffer()
+    const b64 = arrayBufferToBase64(buf)
+    await api.post('/upload/chunk', { uploadId, index, data: b64 }, { timeout: 120_000 })
+    opts?.onProgress?.(Math.min(99, Math.round(((index + 1) / totalChunks) * 100)))
+  }
+
+  const { data: done } = await api.post<{ code?: number; message?: string; data: UploadResult }>(
+    '/upload/complete',
+    { uploadId },
+    { timeout: 120_000 },
+  )
+  if (done.code != null && done.code !== 0) {
+    throw new Error(done.message || '合并分片失败')
+  }
+  opts?.onProgress?.(100)
+  return done.data
+}
+
+function preferChunked(file: File): boolean {
+  const base = getApiBaseUrl()
+  // 生产走 Vercel `/api` 代理：一律分片，避开 multipart 破坏与 4.5MB 硬限
+  if (base === '/api') return true
+  return file.size > 40 * 1024 * 1024
+}
+
+export const uploadApi = {
+  upload: async (file: File, opts?: { onProgress?: (pct: number) => void }) => {
+    try {
+      if (preferChunked(file)) {
+        return await uploadChunked(file, opts)
+      }
+      try {
+        return await uploadMultipart(file, opts)
+      } catch (err) {
+        // multipart 仍失败时回退分片（兼容旧代理）
+        const status = (err as AxiosError).response?.status
+        if (status === 400 || status === 413) {
+          return await uploadChunked(file, opts)
+        }
+        throw err
+      }
+    } catch (err) {
+      throw Object.assign(new Error(uploadErrorMessage(err)), { cause: err })
+    }
   },
 }


### PR DESCRIPTION
## Summary
- **Upload 413/400**: Vercel proxy now streams raw body (`bodyParser: false`); production uploads use chunked JSON (`/upload/init|chunk|complete`) to bypass multipart corruption and ~4.5MB limits
- **Audio→video dock**: `canAcceptLocalRef` allows audio refs on video nodes (aligned with edge chips)
- **Publish / homepage**: video primary nodes use `<video preload=metadata>`; `WorkCard` uses `playbackKind` + hover autoplay
- **BYOK fallback diagnostics**: pending meta stores `byokErrorRaw`/`errorRaw`; diagnostic API allows `fallback_pending`; cancel keeps upstream error in copy/detail

## Test plan
- [ ] Asset library / canvas drop / dock drop upload (small + >5MB) succeeds on production after deploy
- [ ] Drag audio asset onto video dock → chip accepted
- [ ] Publish dialog shows video frame for video primary; homepage card hover plays muted
- [ ] Trigger BYOK fallback → cancel → task detail / 复制诊断 shows upstream BYOK error text
- [ ] `pnpm build` + diagnostic/fallback unit tests


Made with [Cursor](https://cursor.com)