### PR TITLE
feat(web): publish primary node locate & preview

### DIFF
--- a/apps/web/src/components/works/PublishNeoTVDialog.vue
+++ b/apps/web/src/components/works/PublishNeoTVDialog.vue
@@ -3,6 +3,9 @@ import { computed, ref, watch } from 'vue'
 import { WORK_CATEGORIES } from '@lnkpi/shared'
 import { api } from '@/services/api'
 import { worksApi } from '@/services/works-api'
+import { resolveMediaUrl } from '@/services/api-base'
+import { useCanvasEditorStore } from '@/stores/canvasEditor'
+import MediaPreviewOverlay from '@/components/canvas/MediaPreviewOverlay.vue'
 
 const props = defineProps<{
   modelValue: boolean
@@ -14,6 +17,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   'update:modelValue': [v: boolean]
   published: []
+  'locate-node': [payload: { sessionId: string; nodeId: string }]
 }>()
 
 interface PrimaryNodeOption {
@@ -22,6 +26,8 @@ interface PrimaryNodeOption {
   label: string
   preview: string
 }
+
+const editor = useCanvasEditorStore()
 
 const visible = computed({
   get: () => props.modelValue,
@@ -58,7 +64,7 @@ async function loadPrimaryNodes(sid: string) {
         id: n.id,
         type: n.type as 'image' | 'video',
         label: `${n.id} · ${n.type === 'video' ? '视频' : '图片'}`,
-        preview: n.data?.coverUrl || n.data?.url || '',
+        preview: resolveMediaUrl(n.data?.coverUrl || n.data?.url || ''),
       }))
     if (!primaryNodes.value.some((n) => n.id === primaryNodeId.value)) {
       primaryNodeId.value = primaryNodes.value[0]?.id ?? ''
@@ -88,6 +94,25 @@ watch(
 watch(activeSessionId, (sid) => {
   if (props.modelValue) void loadPrimaryNodes(sid)
 })
+
+function previewNode(node: PrimaryNodeOption, e: Event) {
+  e.preventDefault()
+  e.stopPropagation()
+  if (!node.preview) return
+  editor.openMediaPreview({
+    url: node.preview,
+    kind: node.type === 'video' ? 'video' : 'image',
+    label: node.label,
+  })
+}
+
+function locateNode(node: PrimaryNodeOption, e: Event) {
+  e.preventDefault()
+  e.stopPropagation()
+  const sid = activeSessionId.value
+  if (!sid) return
+  emit('locate-node', { sessionId: sid, nodeId: node.id })
+}
 
 async function handlePublish() {
   const sid = activeSessionId.value
@@ -162,24 +187,42 @@ async function handlePublish() {
             v-for="node in primaryNodes"
             :key="node.id"
             :value="node.id"
-            class="!mr-0 !h-auto w-full rounded-lg border border-white/8 bg-white/[0.03] px-3 py-2"
+            class="primary-node-radio !mr-0 !h-auto w-full rounded-lg border border-white/8 bg-white/[0.03] px-3 py-2"
           >
-            <div class="flex items-center gap-3">
+            <div class="flex w-full min-w-0 items-center gap-3">
               <video
                 v-if="node.type === 'video'"
                 :src="node.preview"
                 muted
                 playsinline
                 preload="metadata"
-                class="h-10 w-16 rounded object-cover bg-black/40"
+                class="h-10 w-16 shrink-0 rounded object-cover bg-black/40"
               />
               <img
                 v-else
                 :src="node.preview"
                 :alt="node.label"
-                class="h-10 w-16 rounded object-cover"
+                class="h-10 w-16 shrink-0 rounded object-cover"
               />
-              <span class="text-sm">{{ node.label }}</span>
+              <span class="min-w-0 flex-1 truncate text-sm">{{ node.label }}</span>
+              <div class="flex shrink-0 items-center gap-1" @click.stop>
+                <button
+                  type="button"
+                  class="rounded-md px-2 py-1 text-[11px] text-white/55 transition hover:bg-white/10 hover:text-white"
+                  title="预览"
+                  @click="previewNode(node, $event)"
+                >
+                  预览
+                </button>
+                <button
+                  type="button"
+                  class="rounded-md px-2 py-1 text-[11px] text-white/55 transition hover:bg-white/10 hover:text-white"
+                  title="定位到画布"
+                  @click="locateNode(node, $event)"
+                >
+                  定位
+                </button>
+              </div>
             </div>
           </el-radio>
         </el-radio-group>
@@ -191,6 +234,7 @@ async function handlePublish() {
       </div>
     </form>
   </el-dialog>
+  <MediaPreviewOverlay />
 </template>
 
 <style>
@@ -200,5 +244,9 @@ async function handlePublish() {
 }
 .publish-dialog .el-dialog__title {
   color: #fff;
+}
+.publish-dialog .primary-node-radio .el-radio__label {
+  width: 100%;
+  padding-left: 8px;
 }
 </style>

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted, computed, defineAsyncComponent, nextTick, provide, watch } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import {
   VueFlow,
   Panel,
@@ -105,6 +105,7 @@ const PlayCanvasView = defineAsyncComponent(
 )
 
 const route = useRoute()
+const router = useRouter()
 const auth = useAuthStore()
 const canvasEditor = useCanvasEditorStore()
 const sessionId = computed(() => route.params.sessionId as string)
@@ -825,6 +826,41 @@ function resolveNewNodePosition(type: string) {
 async function focusNodeById(id: string) {
   await nextTick()
   await vueFlowRef.value?.fitView({ nodes: [id], padding: 0.45, duration: 320, maxZoom: 1.05 })
+}
+
+/** 发布弹窗「定位」：选中节点并聚焦；可选关闭弹窗 */
+async function handlePublishLocateNode(payload: { sessionId: string; nodeId: string }) {
+  if (payload.sessionId !== sessionId.value) {
+    await router.push({
+      name: 'canvas',
+      params: { sessionId: payload.sessionId },
+      query: { focusNode: payload.nodeId },
+    })
+    return
+  }
+  const node = nodes.value.find((n) => n.id === payload.nodeId)
+  if (!node) {
+    ElMessage.warning('当前画布中没有找到该节点')
+    return
+  }
+  showPublish.value = false
+  selectOnlyNode(payload.nodeId)
+  await focusNodeById(payload.nodeId)
+}
+
+async function consumeFocusNodeQuery() {
+  const focusId = typeof route.query.focusNode === 'string' ? route.query.focusNode : ''
+  if (!focusId) return
+  const node = nodes.value.find((n) => n.id === focusId)
+  if (!node) {
+    ElMessage.warning('当前画布中没有找到该节点')
+  } else {
+    selectOnlyNode(focusId)
+    await focusNodeById(focusId)
+  }
+  const nextQuery = { ...route.query }
+  delete nextQuery.focusNode
+  await router.replace({ query: nextQuery })
 }
 
 function handleDockAdd(type: DockNodeType) {
@@ -2024,6 +2060,7 @@ async function loadSession() {
   }
   startPollingForGeneratingShots()
   startPollingForGeneratingRecords()
+  await consumeFocusNodeQuery()
 }
 
 async function loadSessions() {
@@ -2328,6 +2365,7 @@ onMounted(() => {
       :session-id="sessionId"
       :default-title="sessionTitle"
       @published="loadSessions"
+      @locate-node="handlePublishLocateNode"
     />
     <AIImageEditor @apply="handleImageEditorApply" />
     <MediaPreviewOverlay />

--- a/apps/web/src/pages/WorkflowPage.vue
+++ b/apps/web/src/pages/WorkflowPage.vue
@@ -31,6 +31,14 @@ const openMenuId = ref<string | null>(null)
 const menuRefs = new Map<string, HTMLElement>()
 const greeting = getGreeting()
 
+function handlePublishLocateNode(payload: { sessionId: string; nodeId: string }) {
+  showPublish.value = false
+  void router.push({
+    name: 'canvas',
+    params: { sessionId: payload.sessionId },
+    query: { focusNode: payload.nodeId },
+  })
+}
 function getGreeting() {
   const hour = new Date().getHours()
   if (hour < 12) return '上午好'
@@ -409,6 +417,7 @@ watch(() => auth.isLoggedIn, () => {
       :sessions="userSessions"
       :default-title="prompt || userSessions[0]?.title"
       @published="fetchWorks"
+      @locate-node="handlePublishLocateNode"
     />
   </div>
 </template>


### PR DESCRIPTION
## Summary
- Publish dialog primary-node cards gain **预览** (media overlay) and **定位** (focus node on canvas)
- From homepage publish: locate navigates to `/workflow/:sessionId?focusNode=…` and canvas consumes the query after load

## Test plan
- [ ] On canvas: open publish → 预览 image/video → overlay works
- [ ] On canvas: 定位 → dialog closes, node selected + fitView
- [ ] On homepage: publish with session → 定位 → opens canvas focused on that node
- [ ] Radio selection still works when clicking the card (not the buttons)


Made with [Cursor](https://cursor.com)