### PR TITLE
fix(web): undo 快照克隆兼容 Vue Proxy，恢复生成按钮

### DIFF
--- a/apps/web/src/composables/useCanvasUndoStack.test.ts
+++ b/apps/web/src/composables/useCanvasUndoStack.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { reactive } from 'vue'
 import {
   createCanvasUndoStack,
   GENERATION_HISTORY_SKIP_KEYS,
@@ -43,6 +44,46 @@ function makeStack(initial: CanvasSnapshot, maxDepth = 3) {
 }
 
 describe('canvas undo stack', () => {
+  it('commitAfterChange tolerates nested Vue reactive node data', () => {
+    const nested = reactive({
+      prompt: 'scene',
+      settings: { duration: 5, aspectRatio: '16:9' },
+      localRefs: [{ id: 'r1', label: 'A' }],
+    })
+    // Shallow spread mimics getCanvasHistorySnapshot / stripGenerationFieldsFromData
+    let current: CanvasSnapshot = {
+      nodes: [
+        {
+          id: 'v1',
+          type: 'video',
+          position: { x: 0, y: 0 },
+          data: { ...nested },
+        },
+      ],
+      edges: [],
+    }
+    const stack = createCanvasUndoStack({
+      maxDepth: 10,
+      getSnapshot: () => current,
+      applySnapshot: (s) => {
+        current = s
+      },
+    })
+    expect(() => stack.commitAfterChange()).not.toThrow()
+    current = {
+      ...current,
+      nodes: [
+        {
+          ...current.nodes[0]!,
+          data: { ...nested, settings: reactive({ duration: 10, aspectRatio: '16:9' }) },
+        },
+      ],
+    }
+    expect(() => stack.commitAfterChange()).not.toThrow()
+    expect(stack.undo()).toBe(true)
+    expect((current.nodes[0]!.data as { settings: { duration: number } }).settings.duration).toBe(5)
+  })
+
   it('undo restores previous snapshot', () => {
     const ctx = makeStack({
       nodes: [{ id: 'a', position: { x: 0, y: 0 } }],

--- a/apps/web/src/composables/useCanvasUndoStack.ts
+++ b/apps/web/src/composables/useCanvasUndoStack.ts
@@ -110,8 +110,14 @@ export function resolveGenerationFieldsForApply(
   return { ...(cache.get(nodeId) ?? {}) }
 }
 
+/**
+ * Deep-clone snapshots without structuredClone.
+ * Node `data` is often a shallow copy of Vue reactive state, so nested fields
+ * remain Proxies — structuredClone throws DataCloneError and aborts callers
+ * (e.g. generate → flush → commitAfterChange).
+ */
 function cloneSnapshot(snapshot: CanvasSnapshot): CanvasSnapshot {
-  return structuredClone(toRaw(snapshot)) as CanvasSnapshot
+  return JSON.parse(JSON.stringify(toRaw(snapshot))) as CanvasSnapshot
 }
 
 function snapshotKey(snapshot: CanvasSnapshot): string {

--- a/apps/web/src/composables/useDebouncedNodePatch.ts
+++ b/apps/web/src/composables/useDebouncedNodePatch.ts
@@ -28,11 +28,16 @@ export function useDebouncedNodePatch(
   }
 
   async function flush() {
+    const hadPending = timer !== undefined
     if (timer) {
       clearTimeout(timer)
       timer = undefined
     }
-    await settle()
+    // Only commit undo history when a debounced edit was pending.
+    // Generate always flushes first; committing on empty flush previously
+    // ran cloneSnapshot and could throw before generateForNode ran.
+    if (hadPending) options?.onHistoryCommit?.()
+    await persist()
   }
 
   onUnmounted(() => {


### PR DESCRIPTION
## Summary
- `cloneSnapshot` 改用 `JSON` 深拷贝，避免节点 `data` 中嵌套 Vue Proxy 触发 `DataCloneError`
- `flush()` 仅在有待 debounce 的编辑时提交 undo，避免点「生成」时空 flush 触发克隆
- 增加含嵌套 reactive 数据的回归测试

## Root cause
PR #44 引入 Undo 后，`handleNodeGenerate` → `debouncedNodePatch.flush()` → `commitAfterChange()` → `structuredClone(toRaw(snapshot))`。节点 `data` 多为 reactive 的浅拷贝，嵌套对象仍是 Proxy，`structuredClone` 抛错，生成逻辑未执行。

## Test plan
- [x] `pnpm --filter @lnkpi/web exec vitest run src/composables/useCanvasUndoStack.test.ts`
- [x] `pnpm build`
- [ ] 打开 dock-studio，图片/视频/音频节点点「生成」应发起任务
- [ ] 编辑 prompt 后生成仍正常；Cmd+Z 可撤销参数编辑


Made with [Cursor](https://cursor.com)