### PR TITLE
fix(web): 文本换模型后同步完成态，避免节点卡在生成中

### DIFF
--- a/apps/web/src/composables/useNodeGeneration.test.ts
+++ b/apps/web/src/composables/useNodeGeneration.test.ts
@@ -1037,6 +1037,50 @@ describe('useNodeGeneration', () => {
     )
   })
 
+  it('applies new text result after prior failed recordId (model switch)', async () => {
+    const model = encodeChannelModel('ch-user-1', 'deepseek-v4-pro')
+    const node = createNode(
+      'text',
+      {
+        prompt: 'rewrite after fail',
+        content: '',
+        textModel: model,
+        status: NODE_GENERATION_STATUS.error,
+        errorMessage: '生成失败',
+        generationRecordId: 'cmrxhe8sk005kny01qbl02zky',
+      },
+      'text-9',
+    )
+    const completed = {
+      id: 'cmrxhfe7m005ony013k0s8mxm',
+      type: 'text' as const,
+      prompt: 'rewrite after fail',
+      status: NODE_GENERATION_STATUS.completed,
+      metadata: JSON.stringify({ text: '新模型生成成功内容' }),
+      url: null,
+      createdAt: '2026-07-23T12:23:08.722Z',
+    }
+    vi.mocked(studioApi.generateText).mockResolvedValue(mockAxiosResponse({ data: completed }))
+    const { api, deps } = createDeps([node])
+
+    await api.generateForNode(node)
+
+    expect(deps.patchNodeData).toHaveBeenCalledWith(
+      'text-9',
+      expect.objectContaining({ generationRecordId: completed.id }),
+    )
+    expect(deps.patchNodeData).toHaveBeenCalledWith(
+      'text-9',
+      expect.objectContaining({
+        status: NODE_GENERATION_STATUS.completed,
+        content: '新模型生成成功内容',
+        generationRecordId: completed.id,
+      }),
+    )
+    expect(node.data?.status).toBe(NODE_GENERATION_STATUS.completed)
+    expect(node.data?.content).toBe('新模型生成成功内容')
+  })
+
   it('applies terminal studio resolve when node already error with same generationRecordId', async () => {
     const requestFallbackConfirm = vi.fn(async () => 'confirm' as const)
     vi.mocked(studioApi.confirmPlatformFallback).mockResolvedValue(

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -562,6 +562,9 @@ async function cancelRemoteGeneration(nodeId: string) {
           canvasScope(node.id),
         )
         if (signal.aborted) return
+        // Bump record id before resolve — otherwise poll gate treats the new
+        // result as stale when the node still holds a prior failed recordId.
+        deps.patchNodeData(node.id, { generationRecordId: res.data.id })
         await resolveStudioRecord(node.id, res.data)
         return
       }
@@ -585,6 +588,7 @@ async function cancelRemoteGeneration(nodeId: string) {
           canvasScope(node.id),
         )
         if (signal.aborted) return
+        deps.patchNodeData(node.id, { generationRecordId: res.data.id })
         await resolveStudioRecord(node.id, res.data)
         return
       }
@@ -605,6 +609,7 @@ async function cancelRemoteGeneration(nodeId: string) {
           pitch: typeof data.audioPitch === 'number' ? data.audioPitch : 0,
         }, refs, mentionedKeys, signal, canvasScope(node.id))
         if (signal.aborted) return
+        deps.patchNodeData(node.id, { generationRecordId: res.data.id })
         await resolveStudioRecord(node.id, res.data)
         return
       }

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -29,7 +29,7 @@ import { useCanvasEditorStore } from '@/stores/canvasEditor'
 import { applyActionsToFlow, flowToCanvasData } from '@/composables/useCanvasActions'
 import { annotateEdgesForSelection } from '@/utils/edgeHighlight'
 import { useShotPolling } from '@/composables/useShotPolling'
-import { useGenerationPolling, parseRecordText, parseRecordUrl, parseRecordUrls, type GenerationPollTask } from '@/composables/useGenerationPolling'
+import { useGenerationPolling, parseRecordPromptContent, parseRecordText, parseRecordUrl, parseRecordUrls, type GenerationPollTask } from '@/composables/useGenerationPolling'
 import { useNodeGeneration } from '@/composables/useNodeGeneration'
 import { createInitialSceneComposerNodeData } from '@/utils/sceneComposer'
 import { resolveCompositionTracks, mergeCompositionTracks, compositionTracksToNodePatch } from '@/utils/compositionUpstream'
@@ -551,9 +551,15 @@ const generationPolling = useGenerationPolling((results) => {
       const patch: Record<string, unknown> = {
         url: urls[0] ?? parseRecordUrl(record),
         status: NODE_GENERATION_STATUS.completed,
+        errorMessage: null,
+        generationRecordId: record.id,
       }
       if (record.type === 'text') {
         patch.content = parseRecordText(record)
+      } else if (record.type === 'prompt') {
+        const parsed = parseRecordPromptContent(record)
+        patch.content = parsed.content
+        patch.promptMode = parsed.mode
       } else if (urls.length) {
         patch.images = urls
       }
@@ -584,7 +590,15 @@ function startPollingForGeneratingShots() {
 function startPollingForGeneratingRecords() {
   const tasks: GenerationPollTask[] = []
   for (const n of nodes.value) {
-    if (n.type !== 'video' && n.type !== 'image') continue
+    if (
+      n.type !== 'video' &&
+      n.type !== 'image' &&
+      n.type !== 'text' &&
+      n.type !== 'prompt' &&
+      n.type !== 'audio'
+    ) {
+      continue
+    }
     const data = n.data as Record<string, unknown>
     if (data.status === NODE_GENERATION_STATUS.generating && data.generationRecordId) {
       tasks.push({ recordId: String(data.generationRecordId), nodeId: n.id })

--- a/apps/web/src/utils/generationPollGate.test.ts
+++ b/apps/web/src/utils/generationPollGate.test.ts
@@ -24,6 +24,18 @@ describe('shouldApplyGenerationPoll', () => {
     ).toBe(false)
   })
 
+  it('rejects newer completed id while node still points at older failed id', () => {
+    // Repro: text/prompt/audio forgot to bump generationRecordId before resolve.
+    expect(
+      shouldApplyGenerationPoll({
+        nodeStatus: 'generating',
+        nodeRecordId: 'cmrxhe8sk005kny01qbl02zky',
+        incomingRecordId: 'cmrxhfe7m005ony013k0s8mxm',
+        incomingStatus: 'completed',
+      }),
+    ).toBe(false)
+  })
+
   it('ignores writes after cancel to draft', () => {
     expect(
       shouldApplyGenerationPoll({


### PR DESCRIPTION
## Summary
- 生产复现：`text-9` 任务 `cmrxhfe7m005ony013k0s8mxm` 已成功，节点仍显示生成中（计时器空转）；前序 `cmrxhe8sk005kny01qbl02zky` 失败后换模型触发
- 根因：text/prompt/audio 在 `resolveStudioRecord` 前未写入新 `generationRecordId`，`shouldApplyGenerationPoll` 把新完成结果当 stale 丢弃；且 `startPollingForGeneratingRecords` 只恢复 image/video
- 修复：与 image/video 对齐，先写 recordId 再 resolve；加载时恢复 text/prompt/audio poll；completed poll 补齐 prompt 内容与 recordId

## Test plan
- [x] vitest `useNodeGeneration` / `generationPollGate`
- [x] `pnpm build`
- [ ] 文本节点：故意失败 → 换模型再生成 → 节点应变为完成并写入内容
- [ ] 刷新仍 generating 的 text 节点应恢复 poll 并落到终态
- [ ] 已卡住的 `text-9`：取消后再生成一次即可恢复


Made with [Cursor](https://cursor.com)