### PR TITLE
fix(deploy): compose 只 up api，避免 agent-runtime 缺镜像卡死

### DIFF
--- a/deploy/cvm-recover.sh
+++ b/deploy/cvm-recover.sh
@@ -42,7 +42,8 @@ if [[ -d "${DEPLOY_DIR}/deploy" ]]; then
       export LNKPI_API_IMAGE="lnkpi-api:${LATEST_TAG}"
     fi
     log "using image ${LNKPI_API_IMAGE}"
-    docker compose -f deploy/docker-compose.prod.yml up -d --no-build --force-recreate --remove-orphans 2>/dev/null || true
+    # 只起 api，避免缺 agent-runtime 镜像时整次 recover 卡住
+    docker compose -f deploy/docker-compose.prod.yml up -d --no-build --force-recreate --remove-orphans api 2>/dev/null || true
   fi
 fi
 

--- a/deploy/deploy-remote-build.sh
+++ b/deploy/deploy-remote-build.sh
@@ -55,7 +55,8 @@ fi
 docker tag "${LNKPI_API_IMAGE}" lnkpi-api:latest
 
 log "=== Starting container ==="
-$COMPOSE up -d --no-build --force-recreate --remove-orphans
+# 只起 api：agent-runtime 需按 AGENT_RUNTIME_PRODUCTION.md 手动 build/up，避免缺镜像时 up 阻塞
+$COMPOSE up -d --no-build --force-recreate --remove-orphans api
 
 log "=== Port binding ==="
 ss -tlnp | grep ':5100' || true

--- a/deploy/deploy-remote.sh
+++ b/deploy/deploy-remote.sh
@@ -23,14 +23,15 @@ done
 set -euo pipefail
 
 for i in 1 2 3 4 5; do
-  if TCR_REGISTRY="$TCR_REGISTRY" TCR_NAMESPACE="$TCR_NAMESPACE" IMAGE_TAG="$IMAGE_TAG" $COMPOSE pull; then
+  if TCR_REGISTRY="$TCR_REGISTRY" TCR_NAMESPACE="$TCR_NAMESPACE" IMAGE_TAG="$IMAGE_TAG" $COMPOSE pull api; then
     break
   fi
   [[ "$i" -eq 5 ]] && { echo "pull failed"; exit 1; }
   sleep $((i * 20))
 done
 
-TCR_REGISTRY="$TCR_REGISTRY" TCR_NAMESPACE="$TCR_NAMESPACE" IMAGE_TAG="$IMAGE_TAG" $COMPOSE up -d --no-build
+# 只起 api；agent-runtime 不走 TCR 自动部署
+TCR_REGISTRY="$TCR_REGISTRY" TCR_NAMESPACE="$TCR_NAMESPACE" IMAGE_TAG="$IMAGE_TAG" $COMPOSE up -d --no-build api
 
 echo "等待健康检查..."
 for i in 1 2 3 4 5 6 7 8 9 10; do

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -5,7 +5,8 @@
 # 服务器（CVM 本地 build，推荐）:
 #   export IMAGE_TAG=<git-sha> LNKPI_API_IMAGE=lnkpi-api:<git-sha>
 #   docker compose -f deploy/docker-compose.prod.yml build api
-#   docker compose -f deploy/docker-compose.prod.yml up -d --no-build
+#   docker compose -f deploy/docker-compose.prod.yml up -d --no-build api
+#   # agent-runtime 勿随 api 自动 up；见 AGENT_RUNTIME_PRODUCTION.md
 # 服务器（TCR 镜像，备选）:
 #   export IMAGE_TAG=<git-sha> TCR_REGISTRY=ccr.ccs.tencentyun.com TCR_NAMESPACE=lnkpi
 #   docker compose -f deploy/docker-compose.prod.yml -f deploy/docker-compose.prod.images.yml pull


### PR DESCRIPTION
## Summary
- `deploy-remote-build.sh` / `cvm-recover.sh` / `deploy-remote.sh` 的 `compose up`（及 TCR `pull`）改为只针对 **`api`**
- 避免 #48 引入的 `agent-runtime` 在镜像未构建时导致 `up --no-build` 拉取/卡住，进而把线上 API 停掉且 Actions 空等 90 分钟
- Runtime 仍按 `deploy/AGENT_RUNTIME_PRODUCTION.md` 手动部署

## Test plan
- [ ] `bash -n` 三个脚本通过
- [ ] CI 绿
- [ ] 合并后 cancel 卡住的 deploy（若仍在跑），再跑一次正常 deploy 或 `recover_only`
- [ ] `http://<cvm>:5100/api/health` 恢复 200


Made with [Cursor](https://cursor.com)