### PR TITLE
fix(agent): confirm classifier + new-chat thread reset

### DIFF
--- a/apps/server/src/agent/agent.controller.ts
+++ b/apps/server/src/agent/agent.controller.ts
@@ -10,6 +10,11 @@ class ConversationDto {
 
   @IsString()
   message!: string
+
+  /** LangGraph thread；新建对话时前端换新 id，与画布 sessionId 解耦 */
+  @IsOptional()
+  @IsString()
+  threadId?: string
 }
 
 class OptimizePromptDto {
@@ -59,6 +64,7 @@ export class AgentController {
         dto.sessionId,
         dto.message,
         req.user.sub,
+        dto.threadId,
       )) {
         res.write(`data: ${JSON.stringify(event)}\n\n`)
       }

--- a/apps/server/src/agent/agent.service.test.ts
+++ b/apps/server/src/agent/agent.service.test.ts
@@ -65,33 +65,46 @@ describe('AgentService streamConversation', () => {
   it('uses Runtime when AGENT_RUNTIME_URL healthy', async () => {
     process.env.AGENT_RUNTIME_URL = 'http://127.0.0.1:8000'
     const runSpy = vi.spyOn(CanvasAgent.prototype, 'run')
+    const streamRun = vi.fn(async function* () {
+      yield { type: 'text_delta', data: { text: 'from-runtime' } }
+      yield {
+        type: 'canvas_action',
+        data: {
+          type: 'add_node',
+          payload: {
+            id: 'prompt-1',
+            nodeType: 'prompt',
+            data: { prompt: '方案' },
+            position: { x: 0, y: 0 },
+          },
+        },
+      }
+      yield { type: 'done', data: {} }
+    })
 
     vi.spyOn(service, 'createRuntimeClient').mockReturnValue({
       healthOk: vi.fn().mockResolvedValue(true),
-      streamRun: async function* () {
-        yield { type: 'text_delta', data: { text: 'from-runtime' } }
-        yield {
-          type: 'canvas_action',
-          data: {
-            type: 'add_node',
-            payload: {
-              id: 'prompt-1',
-              nodeType: 'prompt',
-              data: { prompt: '方案' },
-              position: { x: 0, y: 0 },
-            },
-          },
-        }
-        yield { type: 'done', data: {} }
-      },
+      streamRun,
     } as unknown as AgentRuntimeClient)
 
     const events: Array<{ type: string; data?: unknown }> = []
-    for await (const event of service.streamConversation('s1', '营销', 'u1')) {
+    for await (const event of service.streamConversation(
+      's1',
+      '营销',
+      'u1',
+      's1:thread-a',
+    )) {
       events.push(event)
     }
 
     expect(runSpy).not.toHaveBeenCalled()
+    expect(streamRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 's1',
+        threadId: 's1:thread-a',
+        message: '营销',
+      }),
+    )
     expect(events.map((e) => e.type)).toEqual([
       'text_delta',
       'canvas_action',

--- a/apps/server/src/agent/agent.service.ts
+++ b/apps/server/src/agent/agent.service.ts
@@ -49,6 +49,7 @@ export class AgentService {
     sessionId: string,
     userMessage: string,
     userId?: string,
+    threadId?: string,
   ): AsyncGenerator<AgentStreamEvent> {
     await this.prisma.agentMessage.create({
       data: { sessionId, role: 'user', content: userMessage },
@@ -58,7 +59,13 @@ export class AgentService {
     if (runtimeUrl && userId) {
       const client = this.createRuntimeClient(runtimeUrl)
       if (await client.healthOk()) {
-        yield* this.streamFromRuntime(client, sessionId, userMessage, userId)
+        yield* this.streamFromRuntime(
+          client,
+          sessionId,
+          userMessage,
+          userId,
+          threadId,
+        )
         return
       }
     }
@@ -79,6 +86,7 @@ export class AgentService {
     sessionId: string,
     userMessage: string,
     userId: string,
+    threadId?: string,
   ): AsyncGenerator<AgentStreamEvent> {
     let assistantText = ''
     const canvasActions: CanvasAction[] = []
@@ -87,7 +95,8 @@ export class AgentService {
       sessionId,
       userId,
       message: userMessage,
-      threadId: sessionId,
+      // 新建对话应换 thread，避免 MemorySaver 把旧 await_confirm 状态续上
+      threadId: threadId?.trim() || sessionId,
     })) {
       if (event.type === 'text_delta') {
         assistantText += (event.data as { text: string }).text

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -26,6 +26,8 @@ const agent = useAgentStore()
 const auth = useAuthStore()
 const input = ref('')
 const chatContainer = ref<HTMLElement>()
+/** Runtime LangGraph thread；与画布 sessionId 解耦，新建对话时重置 */
+const agentThreadId = ref(`${props.sessionId}:main`)
 
 /** 面板是否展开（收缩态只保留右下角 logo FAB） */
 const open = ref(false)
@@ -170,6 +172,7 @@ function startResize(event: MouseEvent) {
 function newAgentSession() {
   agent.clear()
   input.value = ''
+  agentThreadId.value = `${props.sessionId}:${crypto.randomUUID()}`
 }
 
 async function loadHistory() {
@@ -218,7 +221,12 @@ async function send() {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`,
       },
-      body: JSON.stringify({ sessionId: props.sessionId, message, model: agentModel.value }),
+      body: JSON.stringify({
+        sessionId: props.sessionId,
+        message,
+        model: agentModel.value,
+        threadId: agentThreadId.value,
+      }),
     })
 
     const reader = res.body?.getReader()
@@ -243,6 +251,10 @@ async function send() {
   } catch (err) {
     agent.appendText(`\n\n⚠️ 请求失败: ${err}`)
   } finally {
+    const last = agent.messages[agent.messages.length - 1]
+    if (last?.role === 'assistant' && !last.content.trim()) {
+      agent.appendText('（本轮无文本回复。若在确认方案，可再发「确认」；或点「新建对话」后重试。）')
+    }
     agent.finishStreaming()
     const actions = agent.flushActions()
     if (actions.length) emit('canvasActions', actions)

--- a/services/agent-runtime/app/graph/nodes/await_confirm.py
+++ b/services/agent-runtime/app/graph/nodes/await_confirm.py
@@ -32,7 +32,22 @@ _REVISE_HINTS = (
     "重新",
     "revise",
     "改一下",
-    "偏",
+    "更偏",
+)
+# 「等我确认」出现在长需求里时，应视为新 brief，而非对本轮方案确认
+_FRESH_BRIEF_HINTS = (
+    "请为",
+    "写一份",
+    "帮我设计",
+    "帮我做",
+    "帮我写",
+)
+_CONFIRM_NEGATIONS = (
+    "无修改",
+    "不修改",
+    "不用改",
+    "无需修改",
+    "没有修改",
 )
 
 
@@ -51,10 +66,17 @@ def classify_user_decision(text: str) -> Decision | None:
     if not lowered:
         return "none"
 
+    # 「无修改 / 不修改」是确认，不能因子串「修改」误判为 revise
+    if any(n in lowered for n in _CONFIRM_NEGATIONS):
+        return "confirm"
+
     # Prefer revise when both signals appear (e.g. "确认前先改成…")
     if any(h in lowered for h in _REVISE_HINTS):
         return "revise"
     if any(h in lowered for h in _CONFIRM_HINTS):
+        # 长需求里的「先等我确认」是未来动作，不是对本轮方案的确认
+        if len(lowered) > 24 and any(h in lowered for h in _FRESH_BRIEF_HINTS):
+            return None
         return "confirm"
 
     # Fresh planning requests are not confirmations

--- a/services/agent-runtime/tests/test_await_confirm.py
+++ b/services/agent-runtime/tests/test_await_confirm.py
@@ -51,3 +51,26 @@ def test_classify_confirm_and_revise():
     assert classify_user_decision("确认，按这个拆") == "confirm"
     assert classify_user_decision("改成天猫详情页") == "revise"
     assert classify_user_decision("你是谁") is None
+
+
+def test_classify_wu_xiugai_is_confirm_not_revise():
+    """「无修改 / 不修改」是确认语义，不能因子串「修改」误判为 revise。"""
+    assert classify_user_decision("可以，无修改") == "confirm"
+    assert classify_user_decision("可以，无修改。请按上一份方案拆解画布并自动出图。") == "confirm"
+    assert classify_user_decision("不修改，确认拆图") == "confirm"
+    assert classify_user_decision("请修改卖点文案") == "revise"
+
+
+def test_classify_brief_mentioning_confirm_is_not_confirm():
+    """长需求里「等我确认」是未来动作，不能直接当成对本轮方案的确认。"""
+    brief = (
+        "请为便携咖啡机写一份极简天猫详情页方案："
+        "只需定位一句话 + 两个画面。方案写完后先等我确认再拆画布出图。"
+    )
+    assert classify_user_decision(brief) != "confirm"
+
+
+def test_classify_pianhao_is_not_revise():
+    """「偏好」不能因子串「偏」误判为 revise。"""
+    assert classify_user_decision("按我的偏好出图，确认") == "confirm"
+    assert classify_user_decision("改成更偏天猫详情页") == "revise"


### PR DESCRIPTION
## Summary
- 修复 `await_confirm` 启发式误判：`无修改` 因子串「修改」、`偏好` 因子串「偏」被当成 revise；长需求里的「等我确认」不再直接 confirm。
- 「新建对话」生成新的 `threadId` 并传给 Runtime，避免 MemorySaver 把旧 `await_confirm` 状态续到清空后的 UI 会话。
- 空回复时侧栏补一句可见提示，避免再次出现空白气泡。

## Test plan
- [x] `pytest services/agent-runtime/tests/test_await_confirm.py`
- [x] `vitest` `agent.service.test.ts`
- [x] `pnpm --filter @lnkpi/server --filter @lnkpi/web build`
- [ ] 合并后 `enable_agent_runtime=true` 重建 Runtime
- [ ] 页面：新建对话 → 出方案 → 回复「确认」→ 应拆图；节点 `imageModel` 对齐账户默认


Made with [Cursor](https://cursor.com)