### PR TITLE
fix(agent-runtime): reject concurrent same-thread confirm runs

### DIFF
--- a/services/agent-runtime/app/graph/nodes/await_confirm.py
+++ b/services/agent-runtime/app/graph/nodes/await_confirm.py
@@ -136,6 +136,10 @@ def make_await_confirm_node(*, llm: Any) -> Callable:
         }
         if decision == "none":
             out["messages"] = [AIMessage(content=_NONE_DECISION_TIP)]
+        elif decision == "confirm":
+            # Immediate tip so SSE stays visibly busy while split/orchestrate_gen runs
+            out["messages"] = [
+                AIMessage(content="正在按方案拆解画布并出图，请稍候…")
+            ]
         return out
-
     return await_confirm

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -19,6 +19,29 @@ EmitFn = Callable[[dict[str, Any]], Awaitable[None]]
 
 _checkpointer = MemorySaver()
 
+# Same-thread concurrent turns (e.g. double「确认」while orchestrate_gen runs)
+# must not start a second graph — that clears await_confirm and re-plans.
+THREAD_BUSY_TIP = "上一轮仍在处理中，请稍候；拆解出图通常需要一两分钟。"
+
+_thread_locks: dict[str, asyncio.Lock] = {}
+_thread_locks_meta = asyncio.Lock()
+
+
+async def _try_acquire_thread(thread_id: str) -> bool:
+    """Acquire per-thread lock without waiting. False if another run holds it."""
+    async with _thread_locks_meta:
+        lock = _thread_locks.setdefault(thread_id, asyncio.Lock())
+        if lock.locked():
+            return False
+        await lock.acquire()
+        return True
+
+
+def _release_thread(thread_id: str) -> None:
+    lock = _thread_locks.get(thread_id)
+    if lock is not None and lock.locked():
+        lock.release()
+
 
 class RunRequest(BaseModel):
     session_id: str
@@ -119,6 +142,11 @@ async def stream_run_events(
 ) -> AsyncIterator[dict[str, Any]]:
     """Yield AgentStreamEvent-shaped dicts for one user turn."""
     thread_id = req.thread_id or req.session_id
+    if not await _try_acquire_thread(thread_id):
+        yield {"type": "text_delta", "data": {"text": THREAD_BUSY_TIP}}
+        yield {"type": "done", "data": {}}
+        return
+
     queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
 
     async def emit(event: dict[str, Any]) -> None:
@@ -185,6 +213,7 @@ async def stream_run_events(
                 break
             yield item
     finally:
+        _release_thread(thread_id)
         if not task.done():
             task.cancel()
             try:

--- a/services/agent-runtime/tests/test_await_confirm.py
+++ b/services/agent-runtime/tests/test_await_confirm.py
@@ -33,7 +33,18 @@ async def test_none_decision_adds_tip_message():
 
 
 @pytest.mark.asyncio
-async def test_post_plan_ai_turn_skips_tip():
+async def test_confirm_decision_adds_progress_tip():
+    node = make_await_confirm_node(llm=_FakeLLM())
+    out = await node(
+        {
+            "messages": [HumanMessage(content="确认")],
+            "awaiting_user": True,
+            "phase": "await_confirm",
+        }
+    )
+    assert out["user_decision"] == "confirm"
+    assert out["awaiting_user"] is False
+    assert "拆解" in out["messages"][0].content
     """Same-turn plan → await_confirm must not re-prompt before user replies."""
     node = make_await_confirm_node(llm=_FakeLLM())
     out = await node(

--- a/services/agent-runtime/tests/test_thread_busy.py
+++ b/services/agent-runtime/tests/test_thread_busy.py
@@ -1,0 +1,110 @@
+"""Concurrent runs on the same thread must not clobber await_confirm state."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from app.runs import RunRequest, stream_run_events
+
+
+class _SlowNest:
+    """Blocks inside upsert so a second concurrent turn can race."""
+
+    def __init__(self, gate: asyncio.Event, release: asyncio.Event) -> None:
+        self.gate = gate
+        self.release = release
+        self.upserts = 0
+
+    async def close(self) -> None:
+        return None
+
+    async def upsert_prompt_node(self, **kwargs: Any) -> dict[str, Any]:
+        self.upserts += 1
+        self.gate.set()
+        await self.release.wait()
+        return {"nodeId": "plan-1", "actions": []}
+
+    async def get_node(self, node_id: str) -> dict[str, Any]:
+        return {"id": node_id, "data": {"content": "# plan"}}
+
+    async def add_nodes_batch(self, items: list[dict[str, Any]]) -> dict[str, Any]:
+        return {"nodes": [], "actions": []}
+
+    async def connect_nodes(self, edges: list[dict[str, Any]]) -> dict[str, Any]:
+        return {"actions": []}
+
+    async def set_node_prompt(self, node_id: str, prompt: str) -> dict[str, Any]:
+        return {"nodeId": node_id, "actions": []}
+
+    async def attach_refs(self, node_id: str, ref_order: list[str]) -> dict[str, Any]:
+        return {"nodeId": node_id, "actions": []}
+
+    async def run_image_generation(self, node_id: str) -> dict[str, Any]:
+        return {"nodeId": node_id, "status": "completed", "actions": []}
+
+
+class _FakeLLM:
+    async def ainvoke(self, messages: Any, **kwargs: Any) -> AIMessage:
+        return AIMessage(content="# 方案\n蓝牙音箱\n")
+
+
+async def _collect(req: RunRequest, nest: Any, llm: Any) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    async for ev in stream_run_events(req, nest=nest, llm=llm, skills_dir="skills"):
+        events.append(ev)
+    return events
+
+
+@pytest.mark.asyncio
+async def test_concurrent_same_thread_returns_busy_tip():
+    """Second run on the same thread must tip and exit without starting intake/plan."""
+    from app.runs import THREAD_BUSY_TIP
+
+    gate = asyncio.Event()
+    release = asyncio.Event()
+    nest = _SlowNest(gate, release)
+    llm = _FakeLLM()
+    tid = "thread-busy-1"
+    sid = "sess-busy-1"
+
+    async def first() -> list[dict[str, Any]]:
+        return await _collect(
+            RunRequest(
+                session_id=sid,
+                user_id="u1",
+                thread_id=tid,
+                message="帮我规划蓝牙音箱电商主图",
+            ),
+            nest,
+            llm,
+        )
+
+    task1 = asyncio.create_task(first())
+    await asyncio.wait_for(gate.wait(), timeout=5)
+
+    events2 = await _collect(
+        RunRequest(
+            session_id=sid,
+            user_id="u1",
+            thread_id=tid,
+            message="确认",
+        ),
+        nest,
+        llm,
+    )
+    release.set()
+    await task1
+
+    texts = [
+        str((e.get("data") or {}).get("text") or "")
+        for e in events2
+        if e.get("type") == "text_delta"
+    ]
+    assert any(THREAD_BUSY_TIP in t for t in texts)
+    assert any(e.get("type") == "done" for e in events2)
+    # Second turn must not kick another upsert/plan while first holds the lock
+    assert nest.upserts == 1


### PR DESCRIPTION
## Summary
- 同一 `thread_id` 并发第二轮（出图未完成时再发「确认」）会冲掉 `await_confirm`，误走 intake→plan，回成「请提供产品类别…」
- Runtime 加 per-thread 非阻塞锁：忙时直接提示「上一轮仍在处理中」
- `confirm` 决策立即发「正在按方案拆解…」进度文案，减少空窗再点

## Test plan
- [x] `pytest tests/test_thread_busy.py tests/test_await_confirm.py`
- [ ] 部署 Runtime（`enable_agent_runtime=true`）后：方案 → 确认 → 出图中勿连点；连点应收到忙时提示
- [ ] 确认成功后画布节点 `imageModel`/`imageAspect` 仍匹配账户偏好


Made with [Cursor](https://cursor.com)