### PR TITLE
feat(agent): phase-1 chat UX — skill gate, progress, confirm chips

### DIFF
--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -4,14 +4,10 @@ import { useAgentStore } from '@/stores/agent'
 import { useAuthStore } from '@/stores/auth'
 import { apiUrl } from '@/services/api-base'
 import NeoAgentLogo from '@/components/agent/NeoAgentLogo.vue'
-import UniversalModelSelector from '@/components/canvas/UniversalModelSelector.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
-import DockCreditBadge from '@/components/canvas/dock-studio/shared/DockCreditBadge.vue'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
-import { useModelProviderSettings } from '@/composables/useModelProviderSettings'
 import { useClickOutside } from '@/composables/useClickOutside'
-import { estimateTextCredits } from '@/constants/credits'
 
 const props = defineProps<{
   sessionId: string
@@ -28,6 +24,13 @@ const input = ref('')
 const chatContainer = ref<HTMLElement>()
 /** Runtime LangGraph thread；与画布 sessionId 解耦，新建对话时重置 */
 const agentThreadId = ref(`${props.sessionId}:main`)
+
+/** 方案确认门：侧栏展示快捷钮（一期口头 HITL，不打通 skillId） */
+const awaitingConfirm = computed(() => {
+  if (agent.isStreaming) return false
+  const last = [...agent.messages].reverse().find((m) => m.role === 'assistant')
+  return Boolean(last?.content?.includes('请确认是否按此方案拆解画布并出图'))
+})
 
 /** 面板是否展开（收缩态只保留右下角 logo FAB） */
 const open = ref(false)
@@ -50,10 +53,7 @@ function clamp(v: number, min: number, max: number) {
   return Math.min(Math.max(v, min), max)
 }
 
-const { getConfig } = useModelProviderSettings()
-const agentModel = ref(getConfig('text').model)
 const speech = useSpeechRecognition()
-const credits = estimateTextCredits()
 
 /* ---- 技能选择 ---- */
 interface AgentSkill {
@@ -207,6 +207,20 @@ async function send() {
   const skillPrefix = activeSkillId.value === 'canvas' ? '' : `【技能：${activeSkill.value.label}】`
   const message = `${skillPrefix}${input.value.trim()}`
   input.value = ''
+  await sendMessage(message)
+}
+
+async function sendPreset(text: string) {
+  if (agent.isStreaming || !text.trim()) return
+  if (!auth.isLoggedIn) {
+    auth.openLogin()
+    return
+  }
+  input.value = ''
+  await sendMessage(text.trim())
+}
+
+async function sendMessage(message: string) {
   agent.addUserMessage(message)
   agent.isStreaming = true
   agent.startAssistantMessage()
@@ -224,7 +238,6 @@ async function send() {
       body: JSON.stringify({
         sessionId: props.sessionId,
         message,
-        model: agentModel.value,
         threadId: agentThreadId.value,
       }),
     })
@@ -256,9 +269,27 @@ async function send() {
       agent.appendText('（本轮无文本回复。若在确认方案，可再发「确认」；或点「新建对话」后重试。）')
     }
     agent.finishStreaming()
+    await reconcileLatestAssistant()
     const actions = agent.flushActions()
     if (actions.length) emit('canvasActions', actions)
     scrollToBottom()
+  }
+}
+
+/** 流结束后用 DB 历史补齐（避免只看到 busy / 截断） */
+async function reconcileLatestAssistant() {
+  try {
+    const res = await fetch(apiUrl(`/api/agent/chat/user/messages?sessionId=${props.sessionId}`))
+    const json = await res.json()
+    const rows = (json.data || []) as Array<{ role: string; content: string }>
+    const lastDb = [...rows].reverse().find((m) => m.role === 'assistant')
+    if (!lastDb?.content?.trim()) return
+    const lastLocal = agent.messages[agent.messages.length - 1]
+    if (lastLocal?.role === 'assistant' && lastDb.content.length > (lastLocal.content?.length || 0)) {
+      lastLocal.content = lastDb.content
+    }
+  } catch {
+    // ignore
   }
 }
 
@@ -453,6 +484,24 @@ defineExpose({ openPanel })
 
           <!-- 底部输入 dock：与节点 dock-studio 同款毛玻璃 -->
           <div class="agent-input-area px-2.5 pb-2.5 pt-1">
+            <div v-if="awaitingConfirm" class="mb-2 flex flex-wrap gap-2 px-0.5">
+              <button
+                type="button"
+                class="neo-ctl rounded-lg px-3 py-1.5 text-xs font-medium text-[var(--neo-accent-text)]"
+                :disabled="agent.isStreaming"
+                @click="sendPreset('确认')"
+              >
+                确认拆图
+              </button>
+              <button
+                type="button"
+                class="neo-ctl rounded-lg px-3 py-1.5 text-xs"
+                :disabled="agent.isStreaming"
+                @click="sendPreset('我要修改：')"
+              >
+                要修改
+              </button>
+            </div>
             <div class="agent-input-dock">
               <textarea
                 v-model="input"
@@ -464,15 +513,15 @@ defineExpose({ openPanel })
               />
 
               <div class="agent-dock-actions">
-                <!-- 模型选择 -->
-                <UniversalModelSelector v-model="agentModel" type="text" />
+                <!-- 一期不打通规划模型选择：避免停用模型误导 -->
+                <span class="px-1 text-[10px] opacity-50">规划模型由服务端配置</span>
 
-                <!-- 技能选择 -->
+                <!-- 技能选择（一期仅文案前缀装饰，未打通 Runtime skillId） -->
                 <div ref="skillMenuRef" class="relative">
                   <button
                     type="button"
                     class="neo-ctl flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-xs"
-                    title="技能"
+                    title="技能（一期未打通 Runtime）"
                     @click="skillMenuOpen = !skillMenuOpen"
                   >
                     <svg viewBox="0 0 24 24" class="h-3.5 w-3.5 text-[var(--neo-accent-text)]" fill="none" stroke="currentColor" stroke-width="1.75">
@@ -517,15 +566,11 @@ defineExpose({ openPanel })
                 </div>
 
                 <div class="ml-auto flex items-center gap-2">
-                  <!-- 积分消耗 -->
-                  <DockCreditBadge :credits="credits" />
-                  <!-- 语音输入 -->
                   <DockMicButton
                     :listening="speech.listening.value"
                     :disabled="agent.isStreaming"
                     @toggle="toggleVoice"
                   />
-                  <!-- 生成 -->
                   <DockGenerateButton
                     :generating="agent.isStreaming"
                     :disabled="!agent.isStreaming && !input.trim()"

--- a/docs/superpowers/plans/2026-07-24-agent-chat-ux-phase1.md
+++ b/docs/superpowers/plans/2026-07-24-agent-chat-ux-phase1.md
@@ -1,0 +1,133 @@
+# Agent Chat UX Phase-1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship phase-1 Agent chat UX: skill gate → casual `chat`, readable confirm summary, streaming progress, actionable gen results, dock de-misleading, confirm chips, history reconcile.
+
+**Architecture:** Runtime-first copy/events (`text_delta`); Web only for dock hide, confirm chips, and post-stream history pull. No interrupt()/skillId/`/` invoke.
+
+**Tech Stack:** LangGraph Runtime (Python), Nest SSE passthrough, Vue `AgentSideRail`, pytest + existing graph tests.
+
+**Spec:** `docs/superpowers/specs/2026-07-24-agent-chat-ux-phase1-design.md`  
+**Parent:** `docs/superpowers/specs/2026-07-23-agent-runtime-langgraph-design.md` §5/§12
+
+## Global Constraints
+
+- Do **not** fallback `intake` to `entries[0]` when no marketing intent.
+- Do **not** crop `canvas-manifest`; only announce N in confirm copy.
+- Do **not** wire dock `model`/`skillId`/credits to Runtime (phase 2).
+- Keep per-thread busy lock behavior.
+- TDD: failing test → implement → pass → commit per task group.
+- Branch: `feature/agent-chat-ux-phase1` from `main`.
+
+## File map
+
+| File | Role |
+| --- | --- |
+| `services/agent-runtime/app/graph/nodes/intake.py` | Marketing intent gate; `skill_id` or null |
+| `services/agent-runtime/app/graph/nodes/chat.py` | NEW casual reply node |
+| `services/agent-runtime/app/graph/builder.py` | `chat` node + routing after intake |
+| `services/agent-runtime/app/graph/nodes/plan.py` | Readable summary (定位 + assets + N) |
+| `services/agent-runtime/app/graph/nodes/split.py` | Standalone split progress message |
+| `services/agent-runtime/app/graph/nodes/orchestrate_gen.py` | Per-image progress + richer failures |
+| `services/agent-runtime/app/graph/nodes/done.py` | Actionable per-node summary |
+| `services/agent-runtime/app/graph/state.py` | Optional `phase` values already cover |
+| `apps/web/src/components/agent/AgentSideRail.vue` | Hide dock, chips, reconcile |
+| Tests under `services/agent-runtime/tests/` | Gate, chat, summary, progress |
+
+---
+
+### Task 1: Skill gate + `chat` node
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/nodes/chat.py`
+- Modify: `services/agent-runtime/app/graph/nodes/intake.py`
+- Modify: `services/agent-runtime/app/graph/builder.py`
+- Test: `services/agent-runtime/tests/test_intake_gate.py` (create)
+
+**Interfaces:**
+- Produces: `intake` returns `skill_id: str | None`; when None, route to `chat`
+- `chat(state) -> {phase, messages, awaiting_user: False}`
+- Consumes: `default_llm` via `make_chat_node(llm=...)`
+
+- [ ] **Step 1:** Write failing tests: `"你好"` → no skill / routes to chat; marketing brief → `enterprise-marketing-campaign`; never set skill from `entries[0]` alone
+- [ ] **Step 2:** Run pytest — expect fail
+- [ ] **Step 3:** Implement gate + `chat` + builder edges (`route_after_intake`)
+- [ ] **Step 4:** pytest pass
+- [ ] **Step 5:** Commit `feat(agent-runtime): gate non-marketing turns to chat`
+
+---
+
+### Task 2: Readable plan summary (P0-2, P1-3)
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/nodes/plan.py`
+- Test: `services/agent-runtime/tests/test_plan_summary.py` (create) or extend `test_graph_plan_split.py`
+
+**Interfaces:**
+- `_build_confirm_message(plan_md, skill) -> str` includes: 定位摘录, asset titles from `canvas_manifest`, `N=len(items)`, 画布指引
+
+- [ ] **Step 1:** Failing test asserts confirm message contains asset titles / `将拆解` / `营销方案`
+- [ ] **Step 2:** pytest fail
+- [ ] **Step 3:** Implement summary builder (prefer manifest titles over truncating LLM opener)
+- [ ] **Step 4:** pytest pass
+- [ ] **Step 5:** Commit `feat(agent-runtime): readable confirm summary with asset list`
+
+---
+
+### Task 3: Progress + actionable results (P0-1, P0-3, P2-1)
+
+**Files:**
+- Modify: `split.py`, `orchestrate_gen.py`, `done.py`, possibly `await_confirm.py` (keep confirm tip)
+- Modify: `NestEventProxy` / stream only if needed for mid-gen emits (orchestrate already can append messages per completion — emit via returned messages each update; if graph only yields node end, emit incremental AIMessages from orchestrate by yielding multiple updates OR nest proxy already emits `node_status` — **prefer AIMessage progress lines inside orchestrate loop via astream updates**: return progressive state is hard in one node; **emit through nest proxy callback** or collect lines and join with `\n\n` at end of each logical phase while emitting mid-flight via `emit` if available)
+
+**Preferred approach for mid-gen progress:** extend `NestEventProxy` or pass `emit` into orchestrate to call `emit({type:text_delta,...})` per image; keep final `done` message for summary. If emit not in node factory today, add optional `emit` to `make_orchestrate_gen_node`.
+
+- Test: unit tests for summary formatter + orchestrate failure classification (`fallback_pending`)
+
+- [ ] **Step 1:** Failing tests for split message standalone; done/orchestrate summary mentions `待确认平台兜底` when status is `fallback_pending`
+- [ ] **Step 2:** pytest fail
+- [ ] **Step 3:** Implement formatters + emit progress; classify Nest soft statuses
+- [ ] **Step 4:** pytest pass
+- [ ] **Step 5:** Commit `feat(agent-runtime): streaming gen progress and actionable summary`
+
+---
+
+### Task 4: Web dock + confirm chips + history reconcile (P1-1, P1-2, P2-2)
+
+**Files:**
+- Modify: `apps/web/src/components/agent/AgentSideRail.vue`
+- Optional small test if web vitest exists for component; otherwise manual checklist
+
+**Interfaces:**
+- `awaitingConfirm` computed from last assistant message containing `请确认是否按此方案`
+- Chips call `sendRaw('确认')` / `sendRaw('我要修改：')` focusing input for revise
+- `finally` after stream: fetch messages and if latest assistant content longer, replace
+
+- [ ] **Step 1:** Hide `UniversalModelSelector` + `DockCreditBadge`; add muted「规划模型由服务端配置」
+- [ ] **Step 2:** Add confirm/revise chips when `awaitingConfirm && !isStreaming`
+- [ ] **Step 3:** After stream ends, reconcile from `GET /api/agent/chat/user/messages?sessionId=`
+- [ ] **Step 4:** Manual smoke on page (or skip if no harness)
+- [ ] **Step 5:** Commit `feat(web): agent dock de-misleading, confirm chips, history reconcile`
+
+---
+
+### Task 5: PR + CI
+
+- [ ] **Step 1:** `pnpm build` (or scoped) + full runtime pytest
+- [ ] **Step 2:** Push branch, `gh pr create` referencing UX spec
+- [ ] **Step 3:** Watch CI green
+
+---
+
+## Manual test plan
+
+1. New canvas → Agent：「你好」→ short chat, **no** 营销方案 node  
+2. 「便携蓝牙音箱天猫详情页方案…」→ summary lists assets + N  
+3. Click「确认拆图」once → progress lines → per-node result including fallback wording if any  
+4. Double confirm → busy tip  
+5. Dock does not show disabled gemini selector  
+
+## Out of scope
+
+- `/skill` invoke, sidebar `skillId`, manifest crop, interrupt HITL, video auto-gen

--- a/docs/superpowers/specs/2026-07-23-agent-runtime-langgraph-design.md
+++ b/docs/superpowers/specs/2026-07-23-agent-runtime-langgraph-design.md
@@ -20,8 +20,10 @@
 | 一期验收 | Skill 规划 → 确认 → 拆骨架（边/prompt/refs）→ **按拓扑自动出图**（URI 回写节点） |
 | 自动生成编排 | **一期包含自动出图**（`orchestrate_gen`）；**自动出视频留二期** |
 | 规划 LLM | **一期平台配置**：Runtime `LNKPI_OPENAI_*`（密钥/base_url/model）；**非**用户 UI 选择 / 对话 BYOK |
-| Agent 底栏 dock 参数 | **一期不打通**（模型选择器、技能下拉、文本积分徽章等为旧 UI 遗留；见 §1.2 / §10） |
+| Agent 底栏 dock 参数 | **一期不打通**（见 §1.2 / §10）；**一期须去误导**：隐藏模型选择器与积分徽章（见 `2026-07-24-agent-chat-ux-phase1-design.md`） |
 | 账户级画布生成默认 | **一期纳入**：左栏 `UserAiPreferences`（图/视/文/音模型 + 图比例/分辨率/张数 + 视频比例/时长/分辨率/裁剪 + 已有音频参数）；拆骨架/新建节点写入 `node.data`；Agent 自动出图按「节点字段 > 账户默认 > 硬编码」回退 |
+| Skill 门控 | **一期**：仅强营销意图进入营销 Skill；否则 **日常对话**（`chat`）；**禁止** fallback 到唯一 Skill 包。`/技能名` 与侧栏 `skillId` 仍二期（见 UX 规格 §2） |
+| 对话 UX（进度/摘要/结果） | **一期纳入**：见 `2026-07-24-agent-chat-ux-phase1-design.md`（P0–P2） |
 | 与「不自动级联」关系 | 引用变更仍**不**静默重跑下游；仅在用户确认方案后由 Agent **显式**执行出图工作流 |
 | 现有 `@lnkpi/agent` | 保留为 Nest 侧兼容/工具适配层；新控制面迁到 Python Runtime，不一夜删除 |
 
@@ -173,18 +175,25 @@ class AgentRuntimeState(TypedDict):
 ## 5. 一期 Graph 拓扑
 
 ```text
-intake → plan → await_confirm ─┬─ revise → plan
-                               └─ confirm → split → orchestrate_gen → done
+START
+  ├─ (await_confirm 续轮) → await_confirm → …
+  └─ intake
+        ├─ 强营销意图 → plan → await_confirm ─┬─ revise → plan
+        │                                      └─ confirm → split → orchestrate_gen → done
+        └─ 否则 → chat → END
 ```
 
 | Graph 节点 | 职责 | 主要副作用 |
 | --- | --- | --- |
-| `intake` | 识别企业营销意图；加载 Skill；必要时追问品类/渠道/投放位 | 更新 `skill_id` / `messages` |
-| `plan` | 按 Skill 生成方案 Markdown；写摘要到对话 | `upsert_prompt_node` → `plan_node_id` |
+| `intake` | **门控**：强营销意图才设 `skill_id`；否则进入日常对话。**禁止**唯一 Skill 兜底 | 更新 `skill_id`（可 null） |
+| `chat` | 非 Skill 短答（同规划 LLM）；可提示如何发起营销方案 | 仅对话 `messages` |
+| `plan` | 按 Skill 生成方案 Markdown；写**可读摘要**（定位 + 将拆资产列表 + N + 画布指引） | `upsert_prompt_node` → `plan_node_id` |
 | `await_confirm` | 征询确认/修改；`awaiting_user=True` | 无强制画布写 |
-| `split` | 读方案；写 `split_manifest`；批量建下游 | 建节点/边/prompt/refs |
-| `orchestrate_gen` | 从 manifest + 边得到 `gen_queue`；逐个/有限并发出图 | `run_image_generation`；进度写入对话 |
-| `done` | 汇总成功/失败；提示可手动补跑或改 prompt | `phase=done` |
+| `split` | 读方案；写 `split_manifest`；批量建下游；独立进度话术 | 建节点/边/prompt/refs |
+| `orchestrate_gen` | 从 manifest + 边得到 `gen_queue`；逐个/有限并发出图；**按张进度** | `run_image_generation`；进度写入对话 |
+| `done` | **按节点**汇总成功/失败/平台兜底；提示画布操作 | `phase=done` |
+
+详情与验收见 `2026-07-24-agent-chat-ux-phase1-design.md`。
 
 **出图规则（一期）：**
 
@@ -470,6 +479,8 @@ Nest 在工具成功后：更新 `Session.canvasData`；经 Agent SSE 推送 `ca
 6. LangGraph State 无完整画布 JSON、无 Base64。
 7. `revise` 更新同一 `plan_node_id`；Skills 包符合 agentskills.io（`SKILL.md` + 可选 `scripts/`/`references/`/`assets/`）；缺 `SKILL.md` 的目录不被加载；顶层无非标准 frontmatter 也能被索引。
 8. **账户默认**：拆骨架 image 节点写入用户 `defaultImageModel` / 比例 / 分辨率 / 张数（`canvasImageCount` clamp 1–4）；`run_image_generation` 在节点缺字段时回退同一偏好；video/text/audio 骨架同样写入对应账户默认（不要求一期自动生成视频）。
+9. **Skill 门控**：非营销闲聊走 `chat`，不建方案/不拆图；强营销意图才进 Skill（见 UX 规格 §2 / §6）。
+10. **对话 UX**：确认后有分段进度；摘要可读；出图汇总可行动；Dock 去误导；确认快捷钮；流结束可补齐历史（见 UX 规格 §4 / §6）。
 
 ---
 
@@ -494,3 +505,4 @@ Nest 在工具成功后：更新 `Session.canvasData`；经 Agent SSE 推送 `ca
 | 2026-07-24 | 规格确认；§13 开放问题锁定；进入实现计划 |
 | 2026-07-24 | 明确 **Agent 底栏 dock（model/skillId/积分）不在一期**；列入 §1.2 非目标与 §10 二期遗留 |
 | 2026-07-24 | 一期纳入 **账户级画布生成默认（全模态）**：偏好字段、拆骨架写入、`run_image_generation` 回退；与侧栏对话 dock 区分 |
+| 2026-07-24 | 增补 **对话 UX P0–P2** 与 **Skill 门控（非营销→chat）**：见 `2026-07-24-agent-chat-ux-phase1-design.md`；修订 §0/§5/§12 |

--- a/docs/superpowers/specs/2026-07-24-agent-chat-ux-phase1-design.md
+++ b/docs/superpowers/specs/2026-07-24-agent-chat-ux-phase1-design.md
@@ -1,0 +1,155 @@
+# Agent 对话一期 UX 与 Skill 门控设计
+
+> 状态：**已确认**（2026-07-24）  
+> 日期：2026-07-24  
+> 前置：`2026-07-23-agent-runtime-langgraph-design.md`（Runtime / Skills / 出图）  
+> 依据：干净画布复测 `cmryyhm580003lj01f50e83na` + UX 审视（P0–P2）  
+> 范围：对话可感知进度、可读确认摘要、可行动出图结果、Dock 去误导、确认快捷钮、规模提示、历史补齐、**非营销日常对话门控**  
+> 非范围：`/` 显式唤起 Skill、侧栏 `skillId` 打通、按 brief 裁剪 manifest、`interrupt()` 正式 HITL、自动出视频、dock model/积分真实计费
+
+---
+
+## 0. 决策摘要
+
+| 项 | 结论 |
+| --- | --- |
+| 实现路径 | **Runtime 话术 / 事件为主** + Web 少量 UI；不引入二期 interrupt |
+| 非营销输入 | **日常对话**（短答，不进 plan→拆图）；**禁止** `intake` fallback 到「唯一 Skill」 |
+| Skill 进入 | 一期仅 **强营销意图**（关键词/启发式）；`/技能名` 与侧栏 `skillId` **二期** |
+| 拆解规模 | 确认门 **只提示将拆 N 项**；仍按 Skill `canvas-manifest` 全量拆，不裁剪 |
+| Dock | 一期 **隐藏**模型选择器与积分徽章；可选一行「规划模型由服务端配置」 |
+| 确认交互 | 方案后快捷钮「确认拆图」「要修改」→ 发送固定文案，同一 `threadId` |
+
+---
+
+## 1. 问题陈述（复测证据）
+
+1. 确认后约数分钟空白，用户连发「确认」；busy 锁已挡二次，但首轮仍缺持续进度。  
+2. 侧栏摘要被截成客套句，完整方案只在画布节点。  
+3. 「成功 3 / 失败 4」无节点、无 `fallback_pending` 行动指引。  
+4. 底栏显示停用模型，规划实际走服务端配置 → 误导。  
+5. 只能打字确认；极简 brief 仍拆 9 骨架（规模需提示，本期不裁剪）。  
+6. **任何话都可能进营销 Skill**（`intake` 在未命中关键词时仍 `entries[0]`）。
+
+---
+
+## 2. Skill 门控 vs 日常对话
+
+### 2.1 模式
+
+| 模式 | 条件（一期） | Graph 行为 |
+| --- | --- | --- |
+| **日常对话** | 无强营销意图，且未处于 `await_confirm` / 出图中 | `intake` → **`chat`** → END；`skill_id=null`；不写方案节点、不拆图 |
+| **营销 Skill 工作流** | 强营销意图（见 §2.2） | 现有 `intake` → `plan` → `await_confirm` → … |
+| **续轮确认/修改** | `awaiting_user && phase=await_confirm` | 现有 `route_entry` → `await_confirm`（不变） |
+
+### 2.2 强营销意图（启发式，可测）
+
+命中任一即可进入营销 Skill（可与现有 `_MARKETING_HINTS` 合并扩展）：
+
+- 关键词：营销、主图、详情页、banner、campaign、电商、天猫、方案+出图/拆画布 等  
+- 或明确「做一套…详情页/主图方案」类编排诉求  
+
+**不**仅因「音箱」「产品」等名词进 Skill。
+
+### 2.3 明确禁止
+
+- `elif entries: skill_id = entries[0].skill_id` 这类 **唯一包兜底**。  
+- 日常对话路径调用 `upsert_prompt_node` / `add_nodes_batch` / `run_image_generation`。
+
+### 2.4 二期（本设计不实现）
+
+- `/enterprise-marketing-campaign` 或侧栏 `skillId` 显式唤起  
+- 低置信意图先追问「是否按营销 Skill 拆画布出图？」  
+- UI 技能菜单驱动 Runtime（替换文案前缀）
+
+### 2.5 `chat` 节点职责
+
+- 使用同一规划 LLM（`LNKPI_OPENAI_*`）短答用户问题  
+- 可提示：若要做电商详情页/主图方案，可直接说「帮我做一套…营销方案」  
+- 输出 `messages` AI 文本；`phase=done`；`awaiting_user=False`
+
+---
+
+## 3. Graph 拓扑修订
+
+```text
+START
+  ├─ (await_confirm 续轮) → await_confirm → …
+  └─ intake
+        ├─ skill 命中 → plan → await_confirm → …
+        └─ 未命中   → chat → END
+```
+
+`route_entry` 仍优先：`awaiting_user && phase==await_confirm` → `await_confirm`。
+
+---
+
+## 4. 对话 UX（P0–P2）
+
+### 4.1 P0 — 必须
+
+| ID | 项 | 行为 |
+| --- | --- | --- |
+| P0-1 | 进度可感知 | confirm 后立即进度文案；`split` 完成独立一条；`orchestrate_gen` 每张成功/失败短进度；结束汇总 |
+| P0-2 | 可读确认摘要 | 定位一句 + **将拆资产列表（manifest 标题）** +「完整方案见画布『营销方案』节点」+「确认后将拆解 N 项并自动出图」 |
+| P0-3 | 出图结果可行动 | 按节点列成功 / 失败 / **待确认平台兜底**；引导用户点画布节点处理 fallback |
+
+### 4.2 P1 — 强烈建议（一期做）
+
+| ID | 项 | 行为 |
+| --- | --- | --- |
+| P1-1 | Dock 去误导 | 隐藏 `UniversalModelSelector` 与 `DockCreditBadge`；可显示静态说明「规划模型由服务端配置」 |
+| P1-2 | 确认快捷钮 | 处于确认门时展示「确认拆图」「要修改」；分别发送约定文案（如「确认」「我要修改」） |
+| P1-3 | 规模提示 | 仅话术提示 N；**不**裁剪 manifest（已锁定） |
+
+### 4.3 P2 — 顺手（一期做）
+
+| ID | 项 | 行为 |
+| --- | --- | --- |
+| P2-1 | 分段 | 各阶段独立 `text_delta`，换行/分段，禁止粘成一句 |
+| P2-2 | 历史补齐 | 流结束后 `GET /api/agent/chat/user/messages?sessionId=` 合并最新助手消息，避免只见 busy |
+
+### 4.4 同 thread 并发
+
+保持已上线 busy 锁：第二轮立即提示「上一轮仍在处理中…」，不冲掉 checkpoint。
+
+---
+
+## 5. 主要改动面
+
+| 层 | 文件/模块 | 改动 |
+| --- | --- | --- |
+| Runtime | `builder.py` / `intake.py` | 门控；新增 `chat` 节点与边 |
+| Runtime | `plan.py` | 摘要结构（定位 + 资产列表 + N + 画布指引） |
+| Runtime | `split.py` / `orchestrate_gen.py` / `done.py` | 分段进度与可行动汇总；识别 `fallback_pending` |
+| Runtime | tests | 门控、摘要、进度、汇总文案 |
+| Web | `AgentSideRail.vue` | 隐藏 dock 误导控件；确认快捷钮；流结束补拉历史 |
+| Spec | 本文 + 主设计 §5/§12 交叉引用 | 验收项 |
+
+---
+
+## 6. 验收标准
+
+1. 「你好」/无关闲聊 → **不出现**方案节点、不拆图；有日常短答。  
+2. 「帮我做一套蓝牙音箱天猫详情页方案」→ 进营销 Skill；摘要含资产列表与 N。  
+3. 「确认」后 数秒内可见进度文案；完成后侧栏有按节点的成功/失败/兜底说明。  
+4. 底栏不再展示可误导的停用模型选择器与静态积分徽章（或等价不可点说明）。  
+5. 确认门可见快捷钮；点击等价于发送约定文案。  
+6. 二次连发「确认」仍得 busy 提示；首轮仍能完成拆图。  
+7. 人为断开/慢网后，流结束补拉能使侧栏最终与 DB 助手消息一致（成功长文可见）。
+
+---
+
+## 7. 与主规格关系
+
+- 修订 `2026-07-23-agent-runtime-langgraph-design.md`：`intake` 职责、拓扑、`§12` 验收、修订记录。  
+- 主规格 §10「`/` / skillId」仍属二期；一期门控以本文 §2 为准。
+
+---
+
+## 8. 文档修订记录
+
+| 日期 | 说明 |
+| --- | --- |
+| 2026-07-24 | 初稿：P0–P2 UX + 日常对话门控（选项 1）+ 规模仅提示（选项 1） |

--- a/services/agent-runtime/app/graph/builder.py
+++ b/services/agent-runtime/app/graph/builder.py
@@ -7,6 +7,7 @@ from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, START, StateGraph
 
 from app.graph.nodes.await_confirm import make_await_confirm_node
+from app.graph.nodes.chat import make_chat_node
 from app.graph.nodes.done import make_done_node
 from app.graph.nodes.intake import make_intake_node
 from app.graph.nodes.orchestrate_gen import make_orchestrate_gen_node
@@ -19,6 +20,12 @@ def route_entry(state: AgentRuntimeState) -> str:
     if state.get("awaiting_user") and state.get("phase") == "await_confirm":
         return "await_confirm"
     return "intake"
+
+
+def route_after_intake(state: AgentRuntimeState) -> str:
+    if state.get("skill_id"):
+        return "plan"
+    return "chat"
 
 
 def route_after_confirm(state: AgentRuntimeState) -> str:
@@ -37,11 +44,12 @@ def build_agent_graph(
     skills_dir: str | Path,
     checkpointer: Any | None = None,
 ):
-    """Compile intake → plan → await_confirm → (revise→plan | confirm→split→orchestrate_gen→done)."""
+    """Compile intake → (chat | plan → await_confirm → …)."""
     skills_path = Path(skills_dir)
     graph = StateGraph(AgentRuntimeState)
 
     graph.add_node("intake", make_intake_node(skills_path))
+    graph.add_node("chat", make_chat_node(llm=llm))
     graph.add_node("plan", make_plan_node(nest=nest, llm=llm, skills_dir=skills_path))
     graph.add_node("await_confirm", make_await_confirm_node(llm=llm))
     graph.add_node("split", make_split_node(nest=nest, skills_dir=skills_path))
@@ -53,7 +61,12 @@ def build_agent_graph(
         route_entry,
         {"intake": "intake", "await_confirm": "await_confirm"},
     )
-    graph.add_edge("intake", "plan")
+    graph.add_conditional_edges(
+        "intake",
+        route_after_intake,
+        {"plan": "plan", "chat": "chat"},
+    )
+    graph.add_edge("chat", END)
     graph.add_edge("plan", "await_confirm")
     graph.add_conditional_edges(
         "await_confirm",

--- a/services/agent-runtime/app/graph/gen_copy.py
+++ b/services/agent-runtime/app/graph/gen_copy.py
@@ -1,0 +1,33 @@
+"""Helpers for actionable generation result copy."""
+
+from __future__ import annotations
+
+
+def format_gen_progress_line(*, title: str, status: str) -> str:
+    st = (status or "").lower()
+    if st in ("completed", "success", "ok"):
+        return f"· {title}：出图成功"
+    if st == "fallback_pending":
+        return f"· {title}：待确认平台兜底（请在画布节点上确认平台服务）"
+    if st in ("cancelled", "canceled"):
+        return f"· {title}：已取消"
+    return f"· {title}：失败（{status or 'error'}）"
+
+
+def format_gen_summary(
+    *,
+    lines: list[str],
+    success_n: int,
+    fail_n: int,
+    fallback_n: int,
+) -> str:
+    parts = [
+        "自动出图汇总：",
+        *lines,
+        f"合计：成功 {success_n}，失败/跳过 {fail_n}"
+        + (f"，待确认平台兜底 {fallback_n}" if fallback_n else "")
+        + "。",
+    ]
+    if fallback_n:
+        parts.append("请到画布对应节点点击确认平台服务后继续出图。")
+    return "\n".join(parts)

--- a/services/agent-runtime/app/graph/nodes/chat.py
+++ b/services/agent-runtime/app/graph/nodes/chat.py
@@ -1,0 +1,46 @@
+"""Casual chat path when no marketing Skill is selected."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+_SYSTEM = (
+    "你是 lnkpi 无限画布助手。用简洁中文回答用户。"
+    "当前未进入「企业营销方案」工作流，不要擅自创建画布方案或承诺自动出图。"
+    "若用户想做电商详情页/主图营销方案并拆画布出图，提示他们直接说："
+    "「帮我做一套…天猫详情页营销方案」。"
+)
+
+
+def _latest_user_text(messages: list[Any]) -> str:
+    for msg in reversed(messages or []):
+        role = getattr(msg, "type", None) or (msg.get("role") if isinstance(msg, dict) else None)
+        content = getattr(msg, "content", None) or (msg.get("content") if isinstance(msg, dict) else "")
+        if role in ("human", "user") and content:
+            return str(content)
+    return ""
+
+
+def make_chat_node(*, llm: Any) -> Callable:
+    async def chat(state: dict) -> dict:
+        text = _latest_user_text(state.get("messages") or []) or "你好"
+        ai = await llm.ainvoke(
+            [
+                SystemMessage(content=_SYSTEM),
+                HumanMessage(content=text),
+            ]
+        )
+        reply = str(getattr(ai, "content", ai) or "").strip() or (
+            "你好。需要做电商详情页/主图营销方案并拆画布出图时，直接说明品类与渠道即可。"
+        )
+        return {
+            "phase": "done",
+            "skill_id": None,
+            "awaiting_user": False,
+            "user_decision": "none",
+            "messages": [AIMessage(content=reply)],
+        }
+
+    return chat

--- a/services/agent-runtime/app/graph/nodes/done.py
+++ b/services/agent-runtime/app/graph/nodes/done.py
@@ -4,13 +4,33 @@ from typing import Callable
 
 from langchain_core.messages import AIMessage
 
+from app.graph.gen_copy import format_gen_progress_line, format_gen_summary
+
 
 def make_done_node() -> Callable:
     async def done(state: dict) -> dict:
         completed = state.get("gen_completed") or []
         failed = state.get("gen_failed") or []
         if completed or failed:
-            msg = f"流程结束。出图成功 {len(completed)}，失败 {len(failed)}。"
+            lines: list[str] = []
+            fallback_n = 0
+            for item in failed:
+                if not isinstance(item, dict):
+                    continue
+                title = str(item.get("title") or item.get("key") or "节点")
+                reason = str(item.get("reason") or "failed")
+                if reason.lower() == "fallback_pending":
+                    fallback_n += 1
+                lines.append(format_gen_progress_line(title=title, status=reason))
+            for _ in completed:
+                pass  # per-node success already streamed in orchestrate_gen
+            msg = format_gen_summary(
+                lines=lines or ["（详见上方出图进度）"],
+                success_n=len(completed),
+                fail_n=len(failed),
+                fallback_n=fallback_n,
+            )
+            msg = f"流程结束。\n{msg}"
         else:
             msg = "流程结束。本次无可汇总的出图结果；你也可手动在画布上生成。"
         return {

--- a/services/agent-runtime/app/graph/nodes/intake.py
+++ b/services/agent-runtime/app/graph/nodes/intake.py
@@ -14,7 +14,20 @@ _MARKETING_HINTS = (
     "洁具",
     "卫浴",
     "电商",
+    "天猫",
+    "拆画布",
+    "出图",
+    "分镜",
 )
+
+
+def marketing_intent(text: str) -> bool:
+    """True when the user asks for marketing/campaign canvas orchestration."""
+    lowered = (text or "").strip().lower()
+    if not lowered:
+        return False
+    # Require at least one campaign-ish signal; bare product nouns are not enough.
+    return any(h in lowered for h in _MARKETING_HINTS)
 
 
 def _latest_user_text(messages: list[Any]) -> str:
@@ -28,16 +41,18 @@ def _latest_user_text(messages: list[Any]) -> str:
 
 def make_intake_node(skills_dir: Path) -> Callable:
     async def intake(state: dict) -> dict:
-        text = _latest_user_text(state.get("messages") or []).lower()
+        text = _latest_user_text(state.get("messages") or [])
         entries = discover_skills(skills_dir)
-        skill_id = state.get("skill_id")
-        if not skill_id:
+        skill_id: str | None = None
+        if marketing_intent(text):
             preferred = "enterprise-marketing-campaign"
             by_id = {e.skill_id: e for e in entries}
-            if preferred in by_id and any(h in text for h in _MARKETING_HINTS):
+            if preferred in by_id:
                 skill_id = preferred
             elif entries:
+                # Only when intent matched: pick first available skill package
                 skill_id = entries[0].skill_id
+        # No unique-skill fallback when intent is weak — skill_id stays None → chat
 
         return {
             "phase": "intake",

--- a/services/agent-runtime/app/graph/nodes/orchestrate_gen.py
+++ b/services/agent-runtime/app/graph/nodes/orchestrate_gen.py
@@ -7,6 +7,7 @@ from typing import Any, Callable
 
 from langchain_core.messages import AIMessage
 
+from app.graph.gen_copy import format_gen_progress_line, format_gen_summary
 from app.graph.topo import topo_sort_image_keys
 
 DEFAULT_MAX_CONCURRENCY = 3
@@ -21,6 +22,8 @@ def _is_gen_success(result: Any) -> bool:
     if not isinstance(result, dict):
         return False
     status = str(result.get("status") or "").lower()
+    if status == "fallback_pending":
+        return False
     url = result.get("url")
     has_url = isinstance(url, str) and bool(url.strip())
     return status in ("completed", "success") or has_url
@@ -65,9 +68,16 @@ def make_orchestrate_gen_node(
         failed_keys: set[str] = set()
         gen_completed: list[str] = []
         gen_failed: list[dict] = []
+        progress_lines: list[str] = []
+        fallback_n = 0
         sem = asyncio.Semaphore(max(1, max_concurrency))
         remaining = set(ordered_keys)
         in_flight: dict[str, asyncio.Task] = {}
+
+        async def emit_line(text: str) -> None:
+            emit = getattr(nest, "emit_text", None)
+            if emit is not None:
+                await emit(text if text.endswith("\n") else text + "\n")
 
         async def run_one(key: str) -> tuple[str, str, str | None]:
             item = by_key[key]
@@ -83,7 +93,7 @@ def make_orchestrate_gen_node(
                             if isinstance(result, dict) and result.get("status") is not None
                             else "error"
                         )
-                        return key, "fail", f"nest_status:{status}"
+                        return key, "fail", status
                     return key, "ok", None
                 except Exception as exc:  # noqa: BLE001 — record per-node failure
                     return key, "fail", str(exc)
@@ -94,13 +104,18 @@ def make_orchestrate_gen_node(
                 if any(d in failed_keys for d in deps):
                     remaining.discard(key)
                     failed_keys.add(key)
+                    title = str(by_key[key].get("title") or key)
                     gen_failed.append(
                         {
                             "key": key,
                             "node_id": by_key[key].get("node_id"),
+                            "title": title,
                             "reason": "dependency_failed",
                         }
                     )
+                    line = format_gen_progress_line(title=title, status="dependency_failed")
+                    progress_lines.append(line)
+                    await emit_line(line)
                     continue
                 if not all(d in completed_keys for d in deps):
                     continue
@@ -108,16 +123,20 @@ def make_orchestrate_gen_node(
                 in_flight[key] = asyncio.create_task(run_one(key))
 
             if not in_flight:
-                # unmet deps that never failed (e.g. missing keys) — skip rest
                 for key in sorted(remaining):
                     failed_keys.add(key)
+                    title = str(by_key[key].get("title") or key)
                     gen_failed.append(
                         {
                             "key": key,
                             "node_id": by_key[key].get("node_id"),
+                            "title": title,
                             "reason": "dependency_failed",
                         }
                     )
+                    line = format_gen_progress_line(title=title, status="dependency_failed")
+                    progress_lines.append(line)
+                    await emit_line(line)
                 remaining.clear()
                 break
 
@@ -129,20 +148,37 @@ def make_orchestrate_gen_node(
                 del in_flight[key]
                 item = by_key[key]
                 node_id = str(item.get("node_id") or key)
+                title = str(item.get("title") or key)
                 if status == "ok":
                     completed_keys.add(key)
                     gen_completed.append(node_id)
+                    line = format_gen_progress_line(title=title, status="completed")
                 else:
                     failed_keys.add(key)
+                    reason = err or "failed"
+                    if str(reason).lower() == "fallback_pending":
+                        fallback_n += 1
                     gen_failed.append(
-                        {"key": key, "node_id": node_id, "reason": err or "failed"}
+                        {
+                            "key": key,
+                            "node_id": node_id,
+                            "title": title,
+                            "reason": reason,
+                        }
                     )
+                    line = format_gen_progress_line(title=title, status=str(reason))
+                progress_lines.append(line)
+                await emit_line(line)
 
-        msg = (
-            f"自动出图完成：成功 {len(gen_completed)}，失败/跳过 {len(gen_failed)}。"
-            if gen_queue
-            else "无可自动出图的图片节点。"
-        )
+        if gen_queue:
+            msg = format_gen_summary(
+                lines=progress_lines,
+                success_n=len(gen_completed),
+                fail_n=len(gen_failed),
+                fallback_n=fallback_n,
+            )
+        else:
+            msg = "无可自动出图的图片节点。"
         return {
             "phase": "orchestrate_gen",
             "gen_queue": gen_queue,

--- a/services/agent-runtime/app/graph/nodes/plan.py
+++ b/services/agent-runtime/app/graph/nodes/plan.py
@@ -17,14 +17,52 @@ def _latest_user_text(messages: list[Any]) -> str:
     return ""
 
 
+def _positioning_line(plan_md: str) -> str:
+    lines = [ln.strip() for ln in (plan_md or "").splitlines() if ln.strip()]
+    for i, ln in enumerate(lines):
+        if "定位" in ln.lstrip("# ").strip():
+            for nxt in lines[i + 1 : i + 4]:
+                cleaned = nxt.lstrip("#>*- ").strip()
+                if cleaned and "定位" not in cleaned:
+                    return cleaned[:120]
+    for ln in lines:
+        if not ln.startswith("#"):
+            return ln.lstrip("#>*- ").strip()[:120]
+    if lines:
+        return lines[0].lstrip("# ").strip()[:120]
+    return "（见画布方案节点）"
+
+
+def _manifest_titles(canvas_manifest: dict | None) -> list[str]:
+    if not canvas_manifest or not isinstance(canvas_manifest.get("items"), list):
+        return []
+    titles: list[str] = []
+    for raw in canvas_manifest["items"]:
+        if not isinstance(raw, dict):
+            continue
+        title = str(raw.get("title") or raw.get("key") or "").strip()
+        if title:
+            titles.append(title)
+    return titles
+
+
+def build_confirm_message(*, plan_md: str, canvas_manifest: dict | None) -> str:
+    """Readable confirm gate: positioning + asset list + N + canvas pointer."""
+    positioning = _positioning_line(plan_md)
+    titles = _manifest_titles(canvas_manifest)
+    n = len(titles)
+    asset_lines = "\n".join(f"- {t}" for t in titles) if titles else "- （Skill 未声明资产清单）"
+    return (
+        f"定位：{positioning}\n"
+        f"确认后将拆解 {n} 个画布节点并自动出图：\n"
+        f"{asset_lines}\n"
+        "完整方案已写入画布「营销方案」节点，可在画布查看全文。\n"
+        "请确认是否按此方案拆解画布并出图；如需修改请直接说明。"
+    )
+
+
 def _summarize(plan_md: str, limit: int = 280) -> str:
-    lines = [ln.strip() for ln in plan_md.splitlines() if ln.strip()]
-    if not lines:
-        return ""
-    summary = lines[0].lstrip("# ").strip()
-    if len(plan_md) > limit:
-        return summary + "…"
-    return summary or plan_md[:limit]
+    return _positioning_line(plan_md)[:limit]
 
 
 def make_plan_node(*, nest: Any, llm: Any, skills_dir: Path) -> Callable:
@@ -58,9 +96,9 @@ def make_plan_node(*, nest: Any, llm: Any, skills_dir: Path) -> Callable:
         )
         plan_node_id = result["nodeId"]
         summary = _summarize(plan_md)
-        confirm_msg = (
-            f"已生成方案摘要：{summary}\n"
-            "请确认是否按此方案拆解画布并出图；如需修改请直接说明。"
+        confirm_msg = build_confirm_message(
+            plan_md=plan_md,
+            canvas_manifest=skill.canvas_manifest,
         )
 
         return {

--- a/services/agent-runtime/app/graph/nodes/split.py
+++ b/services/agent-runtime/app/graph/nodes/split.py
@@ -104,16 +104,19 @@ def make_split_node(*, nest: Any, skills_dir: Path) -> Callable:
             await nest.attach_refs(nid, ref_order)
 
         focus = [i["node_id"] for i in manifest if i.get("node_id")]
+        titles = [str(i.get("title") or i.get("key") or "") for i in manifest]
+        title_hint = "、".join(t for t in titles if t)[:80]
+        split_msg = (
+            f"已按方案拆解 {len(manifest)} 个画布节点骨架"
+            + (f"（{title_hint}…）" if title_hint else "。")
+            + "\n开始按依赖自动出图，请稍候…"
+        )
         return {
             "phase": "split",
             "split_manifest": manifest,
             "focus_node_ids": focus,
             "awaiting_user": False,
-            "messages": [
-                AIMessage(
-                    content=f"已按方案拆解 {len(manifest)} 个画布节点骨架（含 white_bg / hero_main 等）。"
-                )
-            ],
+            "messages": [AIMessage(content=split_msg)],
         }
 
     return split

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -103,6 +103,11 @@ class NestEventProxy:
         await self._emit({"type": "node_status", "data": payload})
         return result
 
+    async def emit_text(self, text: str) -> None:
+        """Push a user-visible progress line mid-node (orchestrate_gen)."""
+        if text:
+            await self._emit({"type": "text_delta", "data": {"text": str(text)}})
+
     async def get_generation_status(self, node_id: str) -> dict[str, Any]:
         return await self._inner.get_generation_status(node_id)
 

--- a/services/agent-runtime/tests/test_gen_copy.py
+++ b/services/agent-runtime/tests/test_gen_copy.py
@@ -1,0 +1,22 @@
+"""Unit tests for actionable gen copy."""
+
+from __future__ import annotations
+
+from app.graph.gen_copy import format_gen_progress_line, format_gen_summary
+
+
+def test_fallback_pending_line_guides_user():
+    line = format_gen_progress_line(title="主图", status="fallback_pending")
+    assert "待确认平台兜底" in line
+    assert "画布" in line
+
+
+def test_summary_includes_fallback_hint():
+    text = format_gen_summary(
+        lines=["· 主图：待确认平台兜底（请在画布节点上确认平台服务）"],
+        success_n=1,
+        fail_n=0,
+        fallback_n=1,
+    )
+    assert "待确认平台兜底 1" in text
+    assert "确认平台服务" in text

--- a/services/agent-runtime/tests/test_intake_gate.py
+++ b/services/agent-runtime/tests/test_intake_gate.py
@@ -1,0 +1,41 @@
+"""Tests for intake skill gate (no unique-skill fallback)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from app.graph.nodes.intake import make_intake_node, marketing_intent
+
+SKILLS_DIR = Path(__file__).resolve().parents[1] / "skills"
+
+
+def test_marketing_intent_true_for_campaign_brief():
+    assert marketing_intent("帮我做一套蓝牙音箱天猫详情页营销方案并出图")
+
+
+def test_marketing_intent_false_for_hello():
+    assert not marketing_intent("你好")
+    assert not marketing_intent("这个音箱怎么样")
+
+
+@pytest.mark.asyncio
+async def test_intake_hello_sets_no_skill():
+    node = make_intake_node(SKILLS_DIR)
+    out = await node({"messages": [HumanMessage(content="你好")]})
+    assert out.get("skill_id") is None
+
+
+@pytest.mark.asyncio
+async def test_intake_marketing_sets_enterprise_skill():
+    node = make_intake_node(SKILLS_DIR)
+    out = await node(
+        {
+            "messages": [
+                HumanMessage(content="帮我设计一套卫生洁具的电商详情页营销方案")
+            ]
+        }
+    )
+    assert out.get("skill_id") == "enterprise-marketing-campaign"

--- a/services/agent-runtime/tests/test_orchestrate_gen.py
+++ b/services/agent-runtime/tests/test_orchestrate_gen.py
@@ -136,5 +136,5 @@ async def test_orchestrate_soft_error_status_skips_dependents():
     assert "hero_main" not in nest.calls
     assert result["gen_completed"] == []
     by_key = {f["key"]: f for f in result["gen_failed"]}
-    assert by_key["white_bg"]["reason"] == "nest_status:error"
+    assert by_key["white_bg"]["reason"] == "error"
     assert by_key["hero_main"]["reason"] == "dependency_failed"

--- a/services/agent-runtime/tests/test_plan_summary.py
+++ b/services/agent-runtime/tests/test_plan_summary.py
@@ -1,0 +1,25 @@
+"""Unit tests for readable plan confirm summary."""
+
+from __future__ import annotations
+
+from app.graph.nodes.plan import build_confirm_message
+
+
+def test_build_confirm_message_lists_assets_and_n():
+    skill_manifest = {
+        "items": [
+            {"key": "white_bg", "title": "白底图"},
+            {"key": "hero_main", "title": "主图"},
+            {"key": "scene", "title": "场景图"},
+        ]
+    }
+    msg = build_confirm_message(
+        plan_md="# 定位\n口袋里的澎湃声场\n\n## 其它\n很长…",
+        canvas_manifest=skill_manifest,
+    )
+    assert "白底图" in msg
+    assert "主图" in msg
+    assert "场景图" in msg
+    assert "将拆解 3" in msg or "拆解 3" in msg
+    assert "营销方案" in msg
+    assert "请确认是否按此方案拆解画布并出图" in msg


### PR DESCRIPTION
## Summary
- 非营销意图走日常 `chat`，禁止唯一 Skill 兜底（规格 §2）
- 确认摘要：定位 + 资产清单 + N + 画布指引；拆图/出图分段进度；`fallback_pending` 可行动汇总
- 侧栏：隐藏误导性模型/积分；「确认拆图 / 要修改」快捷钮；流结束补拉历史

## Spec / Plan
- `docs/superpowers/specs/2026-07-24-agent-chat-ux-phase1-design.md`
- `docs/superpowers/plans/2026-07-24-agent-chat-ux-phase1.md`

## Test plan
- [x] `services/agent-runtime` pytest（42 passed）
- [ ] 「你好」→ 日常短答，不建营销方案节点
- [ ] 营销 brief → 摘要含资产列表与 N → 确认拆图 → 进度与结果话术
- [ ] Dock 不再显示停用 gemini 选择器
- [ ] 部署 Runtime 时带 `enable_agent_runtime=true`


Made with [Cursor](https://cursor.com)