### PR TITLE
fix(agent): pin task progress card after split

### DIFF
--- a/apps/web/api/proxy.ts
+++ b/apps/web/api/proxy.ts
@@ -165,7 +165,11 @@ async function pipeUpstreamStream(
     while (true) {
       const { done, value } = await reader.read()
       if (done) break
-      if (value?.byteLength) res.write(Buffer.from(value))
+      if (value?.byteLength) {
+        res.write(Buffer.from(value))
+        const flush = (res as VercelResponse & { flush?: () => void }).flush
+        if (typeof flush === 'function') flush()
+      }
     }
     res.end()
   } catch (err) {

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -10,6 +10,10 @@ import {
   emptyTaskProgress,
   type AgentTaskProgressState,
 } from '@/components/agent/agentTaskProgress'
+import {
+  looksLikeConfirmTurn,
+  shouldApplyReconciledAssistant,
+} from '@/components/agent/assistantReconcile'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
@@ -291,8 +295,9 @@ async function sendMessage(message: string) {
 }
 
 const BUSY_TIP_SNIPPET = '上一轮仍在处理中'
+const EXEC_PROGRESS_SNIPPET = '出图成功'
 
-/** 流结束后用 DB 历史补齐（避免只看到 busy / 截断） */
+/** 流结束后用 DB 历史补齐（避免只看到 busy / 截断 / 被旧确认文案覆盖） */
 async function reconcileLatestAssistant() {
   const pull = async () => {
     const res = await fetch(apiUrl(`/api/agent/chat/user/messages?sessionId=${props.sessionId}`))
@@ -301,7 +306,10 @@ async function reconcileLatestAssistant() {
     const lastDb = [...rows].reverse().find((m) => m.role === 'assistant')
     if (!lastDb?.content?.trim()) return null
     const lastLocal = agent.messages[agent.messages.length - 1]
-    if (lastLocal?.role === 'assistant' && lastDb.content.length > (lastLocal.content?.length || 0)) {
+    if (
+      lastLocal?.role === 'assistant'
+      && shouldApplyReconciledAssistant(lastLocal.content || '', lastDb.content)
+    ) {
       lastLocal.content = lastDb.content
     }
     return lastDb.content
@@ -309,12 +317,21 @@ async function reconcileLatestAssistant() {
 
   try {
     let content = await pull()
-    // 若刚落到 busy tip，首轮拆图可能仍在写 DB：短轮询补齐长进度文案
-    if (content?.includes(BUSY_TIP_SNIPPET)) {
-      for (let i = 0; i < 24; i++) {
+    const lastUser = [...agent.messages].reverse().find((m) => m.role === 'user')
+    const confirmTurn = lastUser ? looksLikeConfirmTurn(lastUser.content || '') : false
+    // busy tip：首轮仍在写 DB；确认拆图：Nest 可能在 Vercel 断流后继续跑完
+    const shouldPoll =
+      content?.includes(BUSY_TIP_SNIPPET)
+      || (confirmTurn && !content?.includes(EXEC_PROGRESS_SNIPPET) && !content?.includes('自动出图'))
+    if (shouldPoll) {
+      for (let i = 0; i < 36; i++) {
         await new Promise((r) => setTimeout(r, 5_000))
         content = await pull()
-        if (content && !content.includes(BUSY_TIP_SNIPPET) && content.length > 40) {
+        if (
+          content
+          && !content.includes(BUSY_TIP_SNIPPET)
+          && (content.includes(EXEC_PROGRESS_SNIPPET) || content.includes('自动出图') || content.length > 80)
+        ) {
           scrollToBottom()
           break
         }

--- a/apps/web/src/components/agent/assistantReconcile.test.ts
+++ b/apps/web/src/components/agent/assistantReconcile.test.ts
@@ -1,0 +1,38 @@
+/** @vitest-environment node */
+import { describe, expect, it } from 'vitest'
+import {
+  looksLikeConfirmTurn,
+  shouldApplyReconciledAssistant,
+} from './assistantReconcile'
+
+describe('shouldApplyReconciledAssistant', () => {
+  it('rejects stale confirm-gate overwrite of in-progress exec tip', () => {
+    const local = '正在按方案拆解画布并出图，请稍候…'
+    const db =
+      '定位：露营折叠椅\n请确认是否按此方案拆解画布并出图；如需修改请直接说明。'
+    expect(shouldApplyReconciledAssistant(local, db)).toBe(false)
+  })
+
+  it('accepts longer completed progress from DB', () => {
+    const local = '正在按方案拆解画布并出图，请稍候…'
+    const db =
+      '正在按方案拆解画布并出图，请稍候…已按方案拆解 9 个画布节点骨架\n· 主图：出图成功'
+    expect(shouldApplyReconciledAssistant(local, db)).toBe(true)
+  })
+
+  it('accepts db when local empty', () => {
+    expect(shouldApplyReconciledAssistant('', 'hello')).toBe(true)
+  })
+})
+
+describe('looksLikeConfirmTurn', () => {
+  it('matches chip confirm', () => {
+    expect(looksLikeConfirmTurn('确认')).toBe(true)
+  })
+
+  it('rejects long brief', () => {
+    expect(
+      looksLikeConfirmTurn('请为保温杯写一份方案，写完后先等我确认。'),
+    ).toBe(false)
+  })
+})

--- a/apps/web/src/components/agent/assistantReconcile.ts
+++ b/apps/web/src/components/agent/assistantReconcile.ts
@@ -1,0 +1,31 @@
+/** Pure helpers for post-stream assistant message reconcile. */
+
+export const CONFIRM_GATE_SNIPPET = '请确认是否按此方案拆解画布并出图'
+export const EXEC_TIP_SNIPPET = '正在按方案拆解'
+
+/**
+ * Whether DB assistant text should replace the local streaming bubble.
+ * Avoids a race: confirm-turn stream dies early while Nest still runs;
+ * last DB row may still be the previous confirm-gate message (longer),
+ * which would wipe the in-progress tip and re-show confirm chips.
+ */
+export function shouldApplyReconciledAssistant(localContent: string, dbContent: string): boolean {
+  const local = localContent.trim()
+  const db = dbContent.trim()
+  if (!db) return false
+  if (!local) return true
+  if (db.length <= local.length) return false
+  const localIsExec = local.includes(EXEC_TIP_SNIPPET) || local.includes('已按方案拆解')
+  const dbIsStaleGate = db.includes(CONFIRM_GATE_SNIPPET) && !db.includes(EXEC_TIP_SNIPPET)
+  if (localIsExec && dbIsStaleGate) return false
+  return true
+}
+
+export function looksLikeConfirmTurn(userText: string): boolean {
+  const t = userText.trim()
+  if (!t) return false
+  if (/^(确认|同意|可以|没问题|开始拆|出图|ok|okay|yes|confirm)\s*$/i.test(t)) return true
+  // Long briefs that merely mention「确认」are planning turns, not confirm chips
+  if (/请为|写一份|帮我设计|帮我做|帮我写/.test(t)) return false
+  return t.length <= 16 && t.includes('确认')
+}

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -40,6 +40,9 @@ export interface AgentStreamEvent {
     | 'tool_result'
     | 'canvas_action'
     | 'node_status'
+    | 'task_list'
+    | 'task_update'
+    | 'task_summary'
     | 'done'
     | 'error'
   data: unknown

--- a/services/agent-runtime/app/graph/nodes/split.py
+++ b/services/agent-runtime/app/graph/nodes/split.py
@@ -111,6 +111,22 @@ def make_split_node(*, nest: Any, skills_dir: Path) -> Callable:
             + (f"（{title_hint}…）" if title_hint else "。")
             + "\n开始按依赖自动出图，请稍候…"
         )
+        # Pin task card as soon as skeleton exists (before long orchestrate_gen),
+        # so Vercel 120s SSE cutoff still leaves the card visible.
+        emit_list = getattr(nest, "emit_task_list", None)
+        if emit_list is not None:
+            await emit_list(
+                [
+                    {
+                        "id": str(item["key"]),
+                        "title": str(item.get("title") or item["key"]),
+                        "nodeId": str(item.get("node_id") or ""),
+                        "kind": str(item.get("target_type") or "image"),
+                    }
+                    for item in manifest
+                    if item.get("key")
+                ]
+            )
         return {
             "phase": "split",
             "split_manifest": manifest,

--- a/services/agent-runtime/tests/test_graph_plan_split.py
+++ b/services/agent-runtime/tests/test_graph_plan_split.py
@@ -115,6 +115,18 @@ class FakeNest:
         self.calls.append(("run_video_generation", {"node_id": node_id}))
         return {"nodeId": node_id, "status": "completed", "url": "https://cdn.example/v.mp4", "actions": []}
 
+    async def emit_task_list(self, items: list[dict[str, Any]]) -> None:
+        self.calls.append(("emit_task_list", items))
+
+    async def emit_task_update(self, **payload: Any) -> None:
+        self.calls.append(("emit_task_update", payload))
+
+    async def emit_task_summary(self, **payload: Any) -> None:
+        self.calls.append(("emit_task_summary", payload))
+
+    async def emit_text(self, text: str) -> None:
+        self.calls.append(("emit_text", text))
+
 
 def _batch_keys(nest: FakeNest) -> set[str]:
     for name, payload in nest.calls:
@@ -171,6 +183,10 @@ async def test_confirm_then_split_creates_image_skeletons():
     }
     assert video_calls
     assert any(c[1]["node_id"] in video_ids for c in video_calls)
+    # task card list must be pinned at end of split (before long gen)
+    task_lists = [c for c in nest.calls if c[0] == "emit_task_list"]
+    assert task_lists
+    assert any(item.get("id") == "white_bg" for item in task_lists[0][1])
     # State must not hold full canvas nodes/edges
     assert "nodes" not in state2
     assert "edges" not in state2


### PR DESCRIPTION
## Summary
- Emit `task_list` at end of `split` so the side-rail card pins before long `orchestrate_gen` (survives Vercel ~120s SSE cutoff).
- Harden `reconcileLatestAssistant`: never overwrite an in-progress exec tip with a stale confirm-gate message; poll DB after confirm turns.
- Flush Vercel proxy stream chunks; add `task_*` to `AgentStreamEvent`.

## Test plan
- [x] `vitest` assistantReconcile + agentTaskProgress
- [x] `pytest` confirm→split emits `task_list`
- [x] `@lnkpi/web` build
- [ ] CI green
- [ ] Prod clean canvas: plan → 确认拆图 → card appears with items; no ghost confirm chips; append skeleton visible


Made with [Cursor](https://cursor.com)