### PR TITLE
fix: harden agent confirm loop (copy HITL + reconcile)

### DIFF
--- a/apps/server/src/agent/agent-canvas-tools.controller.ts
+++ b/apps/server/src/agent/agent-canvas-tools.controller.ts
@@ -98,6 +98,20 @@ class SetNodePromptDto {
   prompt!: string
 }
 
+class SetNodeContentDto {
+  @IsString()
+  sessionId!: string
+
+  @IsString()
+  userId!: string
+
+  @IsString()
+  nodeId!: string
+
+  @IsString()
+  content!: string
+}
+
 class AttachRefsDto {
   @IsString()
   sessionId!: string
@@ -161,6 +175,12 @@ export class AgentCanvasToolsController {
   @Post('set-node-prompt')
   async setNodePrompt(@Body() dto: SetNodePromptDto) {
     const data = await this.tools.setNodePrompt(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('set-node-content')
+  async setNodeContent(@Body() dto: SetNodeContentDto) {
+    const data = await this.tools.setNodeContent(dto)
     return { code: 0, message: 'ok', data }
   }
 

--- a/apps/server/src/agent/agent-canvas-tools.service.test.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.test.ts
@@ -213,6 +213,22 @@ describe('AgentCanvasToolsService', () => {
     expect(canvas.nodes[0].data.prompt).toBe('白底产品图')
   })
 
+  it('setNodeContent writes content and completed status', async () => {
+    canvas = {
+      nodes: [{ id: 't1', type: 'text', position: { x: 0, y: 0 }, data: { prompt: '主文案' } }],
+      edges: [],
+    }
+    const result = await svc.setNodeContent({
+      sessionId: 's1',
+      userId: 'u1',
+      nodeId: 't1',
+      content: '静音·洁净·极简',
+    })
+    expect(result.actions.some((a) => a.type === 'update_node')).toBe(true)
+    expect(canvas.nodes.find((n) => n.id === 't1')?.data.content).toBe('静音·洁净·极简')
+    expect(canvas.nodes.find((n) => n.id === 't1')?.data.status).toBe('completed')
+  })
+
   it('attachRefs sets refOrder and ensures edges exist', async () => {
     canvas = {
       nodes: [

--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -354,6 +354,29 @@ export class AgentCanvasToolsService {
     return { actions }
   }
 
+  async setNodeContent(input: {
+    sessionId: string
+    userId: string
+    nodeId: string
+    content: string
+  }): Promise<{ actions: CanvasAction[] }> {
+    const { canvas } = await this.loadOwnedSession(input.sessionId, input.userId)
+    if (!canvas.nodes.some((n) => n.id === input.nodeId)) {
+      throw new NotFoundException('节点不存在')
+    }
+    const actions: CanvasAction[] = [
+      {
+        type: 'update_node',
+        payload: {
+          id: input.nodeId,
+          data: { content: input.content, status: 'completed' },
+        },
+      },
+    ]
+    await this.persist(input.sessionId, canvas, actions)
+    return { actions }
+  }
+
   async attachRefs(input: {
     sessionId: string
     nodeId: string

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -20,6 +20,7 @@ import {
   looksLikeConfirmTurn,
   shouldApplyReconciledAssistant,
 } from '@/components/agent/assistantReconcile'
+import { detectAgentChipSet } from '@/components/agent/agentChipSet'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
@@ -46,12 +47,14 @@ const agentThreadId = ref(`${props.sessionId}:main`)
 const taskProgress = ref<AgentTaskProgressState>(emptyTaskProgress())
 const showTaskCard = computed(() => taskProgress.value.items.length > 0)
 
-/** 方案确认门：侧栏展示快捷钮（一期口头 HITL，不打通 skillId） */
-const awaitingConfirm = computed(() => {
-  if (agent.isStreaming) return false
+/** 方案确认门 / 主文案确认门：侧栏快捷钮 */
+const chipSet = computed(() => {
+  if (agent.isStreaming) return null
   const last = [...agent.messages].reverse().find((m) => m.role === 'assistant')
-  return Boolean(last?.content?.includes('请确认是否按此方案拆解画布并出图'))
+  return detectAgentChipSet(last?.content || '')
 })
+const awaitingConfirm = computed(() => chipSet.value === 'plan')
+const awaitingCopyConfirm = computed(() => chipSet.value === 'copy')
 
 /** 面板是否展开（收缩态只保留右下角 logo FAB） */
 const open = ref(false)
@@ -580,6 +583,24 @@ defineExpose({ openPanel, reconcileFromNodes })
                 class="neo-ctl rounded-lg px-3 py-1.5 text-xs"
                 :disabled="agent.isStreaming"
                 @click="sendPreset('我要修改：')"
+              >
+                要修改
+              </button>
+            </div>
+            <div v-else-if="awaitingCopyConfirm" class="mb-2 flex flex-wrap gap-2 px-0.5">
+              <button
+                type="button"
+                class="neo-ctl rounded-lg px-3 py-1.5 text-xs font-medium text-[var(--neo-accent-text)]"
+                :disabled="agent.isStreaming"
+                @click="sendPreset('写入主文案')"
+              >
+                写入主文案
+              </button>
+              <button
+                type="button"
+                class="neo-ctl rounded-lg px-3 py-1.5 text-xs"
+                :disabled="agent.isStreaming"
+                @click="sendPreset('要修改：')"
               >
                 要修改
               </button>

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -11,6 +11,12 @@ import {
   type AgentTaskProgressState,
 } from '@/components/agent/agentTaskProgress'
 import {
+  reconcileTaskProgress,
+  shouldFinishTaskCard,
+  synthesizeSummary,
+  type CanvasNodeLike,
+} from '@/components/agent/taskProgressReconcile'
+import {
   looksLikeConfirmTurn,
   shouldApplyReconciledAssistant,
 } from '@/components/agent/assistantReconcile'
@@ -390,7 +396,20 @@ function onKeydown(e: KeyboardEvent) {
   }
 }
 
-defineExpose({ openPanel })
+function reconcileFromNodes(rawNodes: CanvasNodeLike[]) {
+  if (!taskProgress.value.items.length) return
+  let next = reconcileTaskProgress(taskProgress.value, rawNodes)
+  if (shouldFinishTaskCard(next, rawNodes) && !next.finished) {
+    next = {
+      ...next,
+      finished: true,
+      summary: next.summary ?? synthesizeSummary(next),
+    }
+  }
+  taskProgress.value = next
+}
+
+defineExpose({ openPanel, reconcileFromNodes })
 </script>
 
 <template>

--- a/apps/web/src/components/agent/agentChipSet.test.ts
+++ b/apps/web/src/components/agent/agentChipSet.test.ts
@@ -1,0 +1,21 @@
+/** @vitest-environment node */
+import { describe, expect, it } from 'vitest'
+import { detectAgentChipSet } from './agentChipSet'
+
+describe('detectAgentChipSet', () => {
+  it('detects plan confirm gate', () => {
+    expect(
+      detectAgentChipSet('…请确认是否按此方案拆解画布并出图；如需修改请直接说明。'),
+    ).toBe('plan')
+  })
+
+  it('detects copy draft gate and prefers copy over plan', () => {
+    expect(
+      detectAgentChipSet('【主文案草稿】\n静音\n\n请确认后回复「写入主文案」…'),
+    ).toBe('copy')
+  })
+
+  it('returns null for ordinary replies', () => {
+    expect(detectAgentChipSet('出图成功')).toBe(null)
+  })
+})

--- a/apps/web/src/components/agent/agentChipSet.ts
+++ b/apps/web/src/components/agent/agentChipSet.ts
@@ -1,0 +1,15 @@
+/** @vitest-environment node */
+
+export type AgentChipSet = 'plan' | 'copy' | null
+
+const PLAN_SNIPPET = '请确认是否按此方案拆解画布并出图'
+const COPY_SNIPPETS = ['【主文案草稿】', '写入主文案'] as const
+
+/** Which confirm chip row to show under the agent input. */
+export function detectAgentChipSet(assistantText: string): AgentChipSet {
+  const t = (assistantText || '').trim()
+  if (!t) return null
+  if (COPY_SNIPPETS.some((s) => t.includes(s))) return 'copy'
+  if (t.includes(PLAN_SNIPPET)) return 'plan'
+  return null
+}

--- a/apps/web/src/components/agent/taskProgressReconcile.test.ts
+++ b/apps/web/src/components/agent/taskProgressReconcile.test.ts
@@ -1,6 +1,6 @@
 /** @vitest-environment node */
 import { describe, expect, it } from 'vitest'
-import { emptyTaskProgress } from './agentTaskProgress'
+import { emptyTaskProgress, type AgentTaskProgressState } from './agentTaskProgress'
 import {
   reconcileTaskProgress,
   shouldFinishTaskCard,
@@ -9,7 +9,7 @@ import {
 
 describe('taskProgressReconcile', () => {
   it('maps completed+url to done and finishes when no generating images', () => {
-    let state = emptyTaskProgress()
+    let state: AgentTaskProgressState = emptyTaskProgress()
     state = {
       ...state,
       items: [
@@ -38,7 +38,7 @@ describe('taskProgressReconcile', () => {
   })
 
   it('does not finish while an image is generating', () => {
-    const state = {
+    const state: AgentTaskProgressState = {
       ...emptyTaskProgress(),
       items: [{ id: 'banner', title: 'Banner', nodeId: 'i1', kind: 'image', status: 'running' }],
     }

--- a/apps/web/src/components/agent/taskProgressReconcile.test.ts
+++ b/apps/web/src/components/agent/taskProgressReconcile.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { emptyTaskProgress } from './agentTaskProgress'
+import {
+  reconcileTaskProgress,
+  shouldFinishTaskCard,
+  synthesizeSummary,
+} from './taskProgressReconcile'
+
+describe('taskProgressReconcile', () => {
+  it('maps completed+url to done and finishes when no generating images', () => {
+    let state = emptyTaskProgress()
+    state = {
+      ...state,
+      items: [
+        { id: 'banner', title: 'Banner', nodeId: 'i1', kind: 'image', status: 'running' },
+        {
+          id: 'copy_main',
+          title: '主文案',
+          nodeId: 't1',
+          kind: 'text',
+          status: 'needs_user',
+          errorHint: '请确认主文案后写入',
+        },
+      ],
+    }
+    const nodes = [
+      { id: 'i1', type: 'image', data: { status: 'completed', url: 'https://x/a.png' } },
+      { id: 't1', type: 'text', data: { status: 'draft', content: '' } },
+    ]
+    state = reconcileTaskProgress(state, nodes)
+    expect(state.items[0].status).toBe('done')
+    expect(state.items[1].status).toBe('needs_user')
+    expect(shouldFinishTaskCard(state, nodes)).toBe(true)
+    const summary = synthesizeSummary(state)
+    expect(summary.success).toBe(1)
+    expect(summary.needsUser).toBe(1)
+  })
+
+  it('does not finish while an image is generating', () => {
+    const state = {
+      ...emptyTaskProgress(),
+      items: [{ id: 'banner', title: 'Banner', nodeId: 'i1', kind: 'image', status: 'running' }],
+    }
+    const nodes = [{ id: 'i1', type: 'image', data: { status: 'generating' } }]
+    expect(shouldFinishTaskCard(state, nodes)).toBe(false)
+  })
+})

--- a/apps/web/src/components/agent/taskProgressReconcile.test.ts
+++ b/apps/web/src/components/agent/taskProgressReconcile.test.ts
@@ -1,3 +1,4 @@
+/** @vitest-environment node */
 import { describe, expect, it } from 'vitest'
 import { emptyTaskProgress } from './agentTaskProgress'
 import {

--- a/apps/web/src/components/agent/taskProgressReconcile.ts
+++ b/apps/web/src/components/agent/taskProgressReconcile.ts
@@ -1,0 +1,95 @@
+import type { AgentTaskItem, AgentTaskProgressState, TaskItemStatus } from './agentTaskProgress'
+
+export type CanvasNodeLike = {
+  id: string
+  type?: string
+  data?: Record<string, unknown> | null
+}
+
+function mapNodeStatus(node: CanvasNodeLike, item: AgentTaskItem): TaskItemStatus {
+  const data = node.data || {}
+  const status = String(data.status || '')
+  const url = typeof data.url === 'string' ? data.url : ''
+  const content = typeof data.content === 'string' ? data.content.trim() : ''
+  const kind = item.kind || node.type || ''
+
+  if (status === 'generating') return 'running'
+  if (status === 'fallback_pending') return 'needs_user'
+  if (status === 'error' || status === 'failed') return 'failed'
+  if (status === 'completed' && (url || (kind === 'text' && content))) return 'done'
+  if (kind === 'text' || node.type === 'text') {
+    if (content) return 'done'
+    if (item.status === 'needs_user') return 'needs_user'
+  }
+  if (url) return 'done'
+  return item.status
+}
+
+function findNodeForItem(item: AgentTaskItem, nodes: CanvasNodeLike[]): CanvasNodeLike | undefined {
+  if (item.nodeId) {
+    const byId = nodes.find((n) => n.id === item.nodeId)
+    if (byId) return byId
+  }
+  const byKey = nodes.find((n) => String(n.data?.manifestKey || '') === item.id)
+  if (byKey) return byKey
+  return nodes.find((n) => String(n.data?.title || '') === item.title)
+}
+
+/** Image/video running|pending|retrying block finish; text needs_user does not. */
+export function shouldFinishTaskCard(
+  state: AgentTaskProgressState,
+  nodes: CanvasNodeLike[],
+): boolean {
+  if (state.finished) return true
+  if (!state.items.length) return false
+  for (const item of state.items) {
+    const node = findNodeForItem(item, nodes)
+    const mapped = node ? mapNodeStatus(node, item) : item.status
+    const kind = item.kind || node?.type || ''
+    if (kind === 'text' || mapped === 'needs_user' || mapped === 'skipped') continue
+    if (mapped === 'running' || mapped === 'pending' || mapped === 'retrying') return false
+  }
+  // Also block if any image/video node still generating even if not on card
+  for (const n of nodes) {
+    if (n.type !== 'image' && n.type !== 'video') continue
+    if (String(n.data?.status || '') === 'generating') return false
+  }
+  return true
+}
+
+export function reconcileTaskProgress(
+  state: AgentTaskProgressState,
+  nodes: CanvasNodeLike[],
+): AgentTaskProgressState {
+  if (!state.items.length) return state
+  const items = state.items.map((item) => {
+    const node = findNodeForItem(item, nodes)
+    if (!node) return item
+    return { ...item, status: mapNodeStatus(node, item) }
+  })
+  return { ...state, items }
+}
+
+export function synthesizeSummary(
+  state: AgentTaskProgressState,
+): NonNullable<AgentTaskProgressState['summary']> {
+  let success = 0
+  let failed = 0
+  let needsUser = 0
+  let skipped = 0
+  const lines: Array<{ id: string; status: string; title: string; hint?: string }> = []
+  for (const it of state.items) {
+    if (it.status === 'done') success += 1
+    else if (it.status === 'failed') failed += 1
+    else if (it.status === 'needs_user') {
+      needsUser += 1
+      lines.push({
+        id: it.id,
+        status: 'needs_user',
+        title: it.title,
+        hint: it.errorHint || '请确认或到节点处理',
+      })
+    } else if (it.status === 'skipped') skipped += 1
+  }
+  return { success, failed, needsUser, skipped, lines }
+}

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -107,6 +107,7 @@ import CanvasContextMenu from '@/components/canvas/CanvasContextMenu.vue'
 import StoryboardDialog, { type StoryboardShot } from '@/components/canvas/StoryboardDialog.vue'
 import PublishNeoTVDialog from '@/components/works/PublishNeoTVDialog.vue'
 import AgentSideRail from '@/components/agent/AgentSideRail.vue'
+import { mergeCanvasNodesFromServer } from '@/pages/canvas/canvasNodeMerge'
 import { useSelectedNodeEditor, type EditableFlowNode, EDITABLE_NODE_TYPES } from '@/composables/useSelectedNodeEditor'
 import { buildPollingFailurePatch } from '@/utils/generationDiagnostic'
 
@@ -2306,7 +2307,12 @@ async function loadSession() {
     )
     sessionTitle.value = data.data.title
     if (data.data.canvasData?.nodes?.length) {
-      nodes.value = data.data.canvasData.nodes as EditableFlowNode[]
+      const serverNodes = data.data.canvasData.nodes as EditableFlowNode[]
+      nodes.value = (
+        nodes.value.length
+          ? mergeCanvasNodesFromServer(nodes.value, serverNodes)
+          : serverNodes
+      ) as EditableFlowNode[]
       edges.value = hydrateCanvasEdges(
         (data.data.canvasData.edges ?? []) as CanvasEdge[],
         nodes.value,

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -993,6 +993,33 @@ async function handleAgentTurnComplete() {
   } catch {
     // ignore
   }
+  const snap = nodes.value.map((n) => ({
+    id: n.id,
+    type: n.type,
+    data: (n.data || {}) as Record<string, unknown>,
+  }))
+  agentRailRef.value?.reconcileFromNodes?.(snap)
+
+  // Poll a few times after SSE may have dropped (~120s) while Nest still finishes gens
+  let polls = 0
+  const maxPolls = 15
+  const timer = window.setInterval(() => {
+    void (async () => {
+      polls += 1
+      try {
+        await loadSession()
+        const nextSnap = nodes.value.map((n) => ({
+          id: n.id,
+          type: n.type,
+          data: (n.data || {}) as Record<string, unknown>,
+        }))
+        agentRailRef.value?.reconcileFromNodes?.(nextSnap)
+      } catch {
+        // ignore
+      }
+      if (polls >= maxPolls) window.clearInterval(timer)
+    })()
+  }, 4000)
 }
 
 function resolveNewNodePosition(type: string) {

--- a/apps/web/src/pages/canvas/canvasNodeMerge.test.ts
+++ b/apps/web/src/pages/canvas/canvasNodeMerge.test.ts
@@ -1,0 +1,25 @@
+/** @vitest-environment node */
+import { describe, expect, it } from 'vitest'
+import { mergeCanvasNodesFromServer } from './canvasNodeMerge'
+
+describe('mergeCanvasNodesFromServer', () => {
+  it('prefers server url over local empty', () => {
+    const merged = mergeCanvasNodesFromServer(
+      [{ id: 'i1', data: { url: '', status: 'draft' } }],
+      [{ id: 'i1', data: { url: 'https://x/a.png', status: 'completed' } }],
+    )
+    expect(merged[0].data?.url).toBe('https://x/a.png')
+    expect(merged[0].data?.status).toBe('completed')
+  })
+
+  it('appends server-only nodes', () => {
+    const merged = mergeCanvasNodesFromServer(
+      [{ id: 'a', data: {} }],
+      [
+        { id: 'a', data: {} },
+        { id: 'b', data: { title: '新' } },
+      ],
+    )
+    expect(merged.map((n) => n.id)).toEqual(['a', 'b'])
+  })
+})

--- a/apps/web/src/pages/canvas/canvasNodeMerge.ts
+++ b/apps/web/src/pages/canvas/canvasNodeMerge.ts
@@ -4,7 +4,6 @@ export type MergeNode = {
   id: string
   type?: string
   data?: Record<string, unknown> | null
-  [key: string]: unknown
 }
 
 export function mergeCanvasNodesFromServer<T extends MergeNode>(

--- a/apps/web/src/pages/canvas/canvasNodeMerge.ts
+++ b/apps/web/src/pages/canvas/canvasNodeMerge.ts
@@ -1,0 +1,45 @@
+/** Prefer server url/content/status over stale local empty values. */
+
+export type MergeNode = {
+  id: string
+  type?: string
+  data?: Record<string, unknown> | null
+  [key: string]: unknown
+}
+
+export function mergeCanvasNodesFromServer<T extends MergeNode>(
+  local: T[],
+  server: T[],
+): T[] {
+  const serverById = new Map(server.map((n) => [n.id, n]))
+  const merged = local.map((ln) => {
+    const sn = serverById.get(ln.id)
+    if (!sn) return ln
+    const ld = { ...(ln.data || {}) }
+    const sd = sn.data || {}
+    const sUrl = typeof sd.url === 'string' ? sd.url : ''
+    const lUrl = typeof ld.url === 'string' ? ld.url : ''
+    if (sUrl && (!lUrl || lUrl !== sUrl)) {
+      ld.url = sUrl
+      if (sd.status != null) ld.status = sd.status
+      if (sd.generationRecordId != null) ld.generationRecordId = sd.generationRecordId
+    }
+    const sContent = typeof sd.content === 'string' ? sd.content.trim() : ''
+    const lContent = typeof ld.content === 'string' ? ld.content.trim() : ''
+    if (sContent && sContent !== lContent) {
+      ld.content = sd.content
+      if (sd.status != null) ld.status = sd.status
+    }
+    if (!sUrl && sd.status === 'generating') {
+      ld.status = 'generating'
+      if (sd.generationRecordId != null) ld.generationRecordId = sd.generationRecordId
+    }
+    return { ...ln, data: ld }
+  })
+  // Append server-only nodes (e.g. new split skeletons)
+  const localIds = new Set(local.map((n) => n.id))
+  for (const sn of server) {
+    if (!localIds.has(sn.id)) merged.push(sn)
+  }
+  return merged
+}

--- a/docs/superpowers/plans/2026-07-25-agent-confirm-loop-hardening.md
+++ b/docs/superpowers/plans/2026-07-25-agent-confirm-loop-hardening.md
@@ -1,0 +1,594 @@
+# Agent Confirm-Loop Hardening + Copy HITL Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After confirm-split, keep a stable 9-item task card, draft main copy for user confirm-before-write, close the card after SSE drops, sync canvas image URLs, and strip plan-node preamble.
+
+**Architecture:** Extend LangGraph with `draft_copy` → (same run) `orchestrate_gen` → `done` while preserving `phase=await_copy_confirm`; next user turn hits `await_copy_confirm` → `write_copy_node`. Frontend reconciles `taskProgress` from session nodes after stream end; canvas merges server `url`/`content` on poll. Nest adds `set-node-content` for confirmed draft persistence (no second Studio bill).
+
+**Tech Stack:** LangGraph Runtime (Python/pytest), Nest Agent Canvas Tools (Vitest), Vue `AgentSideRail` / `CanvasPage` (Vitest), existing SSE `task_*`.
+
+**Spec:** `docs/superpowers/specs/2026-07-25-agent-confirm-loop-hardening-design.md`  
+**Related:** `docs/superpowers/specs/2026-07-25-agent-task-progress-card-design.md`
+
+## Global Constraints
+
+- Copy HITL: draft in chat first; write node only after user confirm; default write = persist `copy_draft` (no Studio regen on confirm).
+- Images/videos must not wait on copy confirm.
+- `done` must **not** clear `awaiting_user` / `phase=await_copy_confirm`.
+- `orchestrate_gen` must **not** emit a full replacing `task_list`.
+- Vercel Agent SSE ~120s; card close via reconcile/synthesize summary is required.
+- TDD per task; branch from `main`: `fix/agent-confirm-loop-hardening`.
+- Do not wire Agent dock model/skillId/credits.
+- Do not implement `task_summary` DB persistence (spec scheme B) in this plan.
+
+## File map
+
+| File | Role |
+| --- | --- |
+| `services/agent-runtime/app/graph/state.py` | Add phases + `copy_draft` / `copy_node_id` |
+| `services/agent-runtime/app/graph/builder.py` | Routes + edges `split→draft_copy→orchestrate_gen→done` |
+| `services/agent-runtime/app/graph/nodes/done.py` | Preserve copy gate flags |
+| `services/agent-runtime/app/graph/nodes/draft_copy.py` | NEW: LLM draft + needs_user task_update |
+| `services/agent-runtime/app/graph/nodes/await_copy_confirm.py` | NEW: confirm/revise/none gate |
+| `services/agent-runtime/app/graph/nodes/write_copy_node.py` | NEW: Nest set content |
+| `services/agent-runtime/app/graph/nodes/orchestrate_gen.py` | Remove second `task_list` emit |
+| `services/agent-runtime/app/graph/nodes/plan.py` | Strip preamble before upsert |
+| `services/agent-runtime/app/graph/plan_clean.py` | NEW: pure strip helper |
+| `services/agent-runtime/app/tools/nest_client.py` | `set_node_content` |
+| `services/agent-runtime/app/runs.py` | Proxy if needed for set_node_content tool |
+| `apps/server/.../agent-canvas-tools.service.ts` | `setNodeContent` |
+| `apps/server/.../agent-canvas-tools.controller.ts` | `POST set-node-content` |
+| `apps/web/.../agentTaskProgress.ts` | Merge helpers + synthesize summary |
+| `apps/web/.../taskProgressReconcile.ts` | NEW: map nodes → task items / finished |
+| `apps/web/.../AgentSideRail.vue` | Post-stream reconcile loop; copy chips |
+| `apps/web/.../CanvasPage.vue` | Poll `loadSession` merge; stop clobbering urls |
+| `apps/web/.../canvasMerge.ts` | NEW: merge server node data over local |
+
+---
+
+### Task 1: Preserve copy gate through `done` + entry routing
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/state.py`
+- Modify: `services/agent-runtime/app/graph/builder.py`
+- Modify: `services/agent-runtime/app/graph/nodes/done.py`
+- Test: `services/agent-runtime/tests/test_route_entry_copy_gate.py` (create)
+
+**Interfaces:**
+- Produces: `phase` includes `"draft_copy" | "await_copy_confirm" | "write_copy_node"`
+- Produces: state keys `copy_draft: str | None`, `copy_node_id: str | None`
+- Produces: `route_entry(state)` → `"await_copy_confirm"` when `awaiting_user and phase==await_copy_confirm` (before `await_confirm`)
+- Produces: `done(state)` keeps `awaiting_user=True` and `phase=await_copy_confirm` when those were set; otherwise existing behavior
+
+- [ ] **Step 1: Write failing route + done tests**
+
+```python
+# services/agent-runtime/tests/test_route_entry_copy_gate.py
+from app.graph.builder import route_entry
+from app.graph.nodes.done import make_done_node
+import asyncio
+
+def test_route_entry_prefers_copy_gate():
+    assert route_entry({
+        "awaiting_user": True,
+        "phase": "await_copy_confirm",
+    }) == "await_copy_confirm"
+
+def test_route_entry_still_supports_plan_confirm():
+    assert route_entry({
+        "awaiting_user": True,
+        "phase": "await_confirm",
+    }) == "await_confirm"
+
+def test_done_preserves_copy_gate():
+    done = make_done_node()
+    out = asyncio.get_event_loop().run_until_complete(
+        done({
+            "awaiting_user": True,
+            "phase": "await_copy_confirm",
+            "copy_draft": "主文案草稿",
+            "gen_completed": ["n1"],
+            "gen_failed": [],
+        })
+    )
+    assert out["awaiting_user"] is True
+    assert out["phase"] == "await_copy_confirm"
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+Run: `cd services/agent-runtime && python -m pytest tests/test_route_entry_copy_gate.py -v`  
+Expected: FAIL (`await_copy_confirm` not routed / done clears awaiting)
+
+- [ ] **Step 3: Implement state + route_entry + done preserve**
+
+In `state.py` extend `phase` Literal and add:
+
+```python
+copy_draft: str | None
+copy_node_id: str | None
+```
+
+In `builder.py`:
+
+```python
+def route_entry(state: AgentRuntimeState) -> str:
+    if state.get("awaiting_user") and state.get("phase") == "await_copy_confirm":
+        return "await_copy_confirm"
+    if state.get("awaiting_user") and state.get("phase") == "await_confirm":
+        return "await_confirm"
+    return "intake"
+```
+
+(Wire `await_copy_confirm` node in Task 4; for this task only update `route_entry` map keys when adding the node—or add a stub node that END so graph compiles.)
+
+In `done.py`:
+
+```python
+if state.get("phase") == "await_copy_confirm" or (
+    state.get("awaiting_user") and state.get("copy_draft")
+):
+    return {
+        "phase": "await_copy_confirm",
+        "awaiting_user": True,
+        "messages": [AIMessage(content=msg)],
+    }
+# else existing clear awaiting
+return {
+    "phase": "done",
+    "awaiting_user": False,
+    "messages": [AIMessage(content=msg)],
+}
+```
+
+- [ ] **Step 4: Re-run tests — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/agent-runtime/app/graph/state.py \
+  services/agent-runtime/app/graph/builder.py \
+  services/agent-runtime/app/graph/nodes/done.py \
+  services/agent-runtime/tests/test_route_entry_copy_gate.py
+git commit -m "fix(agent-runtime): preserve copy HITL gate across done"
+```
+
+---
+
+### Task 2: Nest `setNodeContent` internal API
+
+**Files:**
+- Modify: `apps/server/src/agent/agent-canvas-tools.service.ts`
+- Modify: `apps/server/src/agent/agent-canvas-tools.controller.ts`
+- Modify: `apps/server/src/agent/agent-canvas-tools.service.test.ts`
+- Modify: `services/agent-runtime/app/tools/nest_client.py`
+
+**Interfaces:**
+- Produces: `setNodeContent({ sessionId, userId, nodeId, content }) → { actions }`
+- Writes `data.content`, `data.status: 'completed'`
+- Ownership check same as `runImageGeneration` (`userId` must own session)
+- Runtime: `NestClient.set_node_content(node_id, content) → POST /agent/internal/set-node-content`
+
+- [ ] **Step 1: Write failing Nest test**
+
+```ts
+it('setNodeContent writes content and completed status', async () => {
+  // seed session owned by u1 with text node t1
+  const result = await svc.setNodeContent({
+    sessionId: 's1',
+    userId: 'u1',
+    nodeId: 't1',
+    content: '静音·洁净·极简',
+  })
+  expect(result.actions.some((a) => a.type === 'update_node')).toBe(true)
+  const canvas = await readCanvas('s1')
+  expect(canvas.nodes.find((n) => n.id === 't1')?.data.content).toBe('静音·洁净·极简')
+  expect(canvas.nodes.find((n) => n.id === 't1')?.data.status).toBe('completed')
+})
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `pnpm --filter @lnkpi/server exec vitest run src/agent/agent-canvas-tools.service.test.ts -t setNodeContent`
+
+- [ ] **Step 3: Implement service + controller + nest_client**
+
+```ts
+async setNodeContent(input: {
+  sessionId: string
+  userId: string
+  nodeId: string
+  content: string
+}): Promise<{ actions: CanvasAction[] }> {
+  const { canvas } = await this.loadOwnedSession(input.sessionId, input.userId)
+  if (!canvas.nodes.some((n) => n.id === input.nodeId)) {
+    throw new NotFoundException('节点不存在')
+  }
+  const actions: CanvasAction[] = [
+    {
+      type: 'update_node',
+      payload: {
+        id: input.nodeId,
+        data: { content: input.content, status: 'completed' },
+      },
+    },
+  ]
+  await this.persist(input.sessionId, canvas, actions)
+  return { actions }
+}
+```
+
+Controller: `@Post('set-node-content')` with DTO `sessionId`, `nodeId`, `content` (+ service token user binding as other internals).
+
+Python:
+
+```python
+async def set_node_content(self, node_id: str, content: str) -> dict[str, Any]:
+    return await self._post(
+        "/agent/internal/set-node-content",
+        {"sessionId": self.session_id, "nodeId": node_id, "content": content},
+    )
+```
+
+- [ ] **Step 4: Tests PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(server): internal set-node-content for copy HITL write"
+```
+
+---
+
+### Task 3: `draft_copy` node
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/nodes/draft_copy.py`
+- Create: `services/agent-runtime/tests/test_draft_copy.py`
+- Modify: `services/agent-runtime/app/graph/builder.py` (add node + edge from split)
+
+**Interfaces:**
+- Consumes: `split_manifest` (find `copy_main` or first `target_type==text`), `plan_summary`, `nest.emit_task_update`, `llm`
+- Produces: `copy_draft`, `copy_node_id`, `phase=await_copy_confirm`, `awaiting_user=True`, AIMessage with draft + chip hints
+- Emits: `task_update(id=copy_main, status=needs_user, errorHint="请确认主文案后写入")`
+
+- [ ] **Step 1: Failing test with FakeLLM / FakeNest**
+
+```python
+@pytest.mark.asyncio
+async def test_draft_copy_sets_gate_and_needs_user():
+    nest = FakeNest()
+    llm = FakeLLM(responses=["# 主文案\n静音·洁净·极简\n..."])
+    node = make_draft_copy_node(nest=nest, llm=llm)
+    out = await node({
+        "split_manifest": [
+            {"key": "copy_main", "title": "主文案", "target_type": "text", "node_id": "t1"},
+            {"key": "white_bg", "title": "白底图", "target_type": "image", "node_id": "i1"},
+        ],
+        "plan_summary": "卫生洁具方案",
+    })
+    assert out["phase"] == "await_copy_confirm"
+    assert out["awaiting_user"] is True
+    assert out["copy_node_id"] == "t1"
+    assert "静音" in (out["copy_draft"] or "")
+    assert any(c[0] == "emit_task_update" and c[1].get("status") == "needs_user" for c in nest.calls)
+```
+
+- [ ] **Step 2: Run — FAIL**
+
+- [ ] **Step 3: Implement `draft_copy.py`**
+
+System prompt: output only the ecommerce main-copy Markdown for the plan; no chitchat.  
+Emit draft via `nest.emit_text` / messages AIMessage including:
+
+```text
+【主文案草稿】
+{draft}
+
+请确认后回复「写入主文案」；如需修改请说明（例如「改成更强调节水」）。
+```
+
+If no text item in manifest: skip gate (`awaiting_user` unchanged / false), no draft.
+
+- [ ] **Step 4: Wire graph**
+
+```python
+graph.add_node("draft_copy", make_draft_copy_node(nest=nest, llm=llm))
+graph.add_edge("split", "draft_copy")
+graph.add_edge("draft_copy", "orchestrate_gen")
+# remove direct split → orchestrate_gen
+```
+
+- [ ] **Step 5: Tests PASS + commit**
+
+```bash
+git commit -m "feat(agent-runtime): draft_copy node before orchestrate_gen"
+```
+
+---
+
+### Task 4: `await_copy_confirm` + `write_copy_node`
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/nodes/await_copy_confirm.py`
+- Create: `services/agent-runtime/app/graph/nodes/write_copy_node.py`
+- Create: `services/agent-runtime/tests/test_await_copy_confirm.py`
+- Modify: `services/agent-runtime/app/graph/builder.py`
+
+**Interfaces:**
+- `classify_copy_decision(text) -> confirm|revise|none`
+  - confirm hints: `写入主文案`, `确认写入`, `写入`, `用这个`, `可以写入`
+  - revise: reuse revise hints from await_confirm (`改成`, `修改`, …)
+- `await_copy_confirm` → sets `user_decision`
+- `route_after_copy_confirm`: confirm→`write_copy_node`, revise→`draft_copy`, none→END
+- `write_copy_node`: `nest.set_node_content(copy_node_id, copy_draft)`; `task_update(done)`; clear `awaiting_user`; `phase=done`
+
+- [ ] **Step 1: Failing tests**
+
+```python
+def test_classify_write_copy():
+    assert classify_copy_decision("写入主文案") == "confirm"
+    assert classify_copy_decision("改成更强调节水") == "revise"
+
+@pytest.mark.asyncio
+async def test_write_copy_persists_draft():
+    nest = FakeNest()
+    node = make_write_copy_node(nest=nest)
+    out = await node({
+        "copy_node_id": "t1",
+        "copy_draft": "正文A",
+        "split_manifest": [{"key": "copy_main", "node_id": "t1", "title": "主文案"}],
+    })
+    assert any(c[0] == "set_node_content" and c[1] == ("t1", "正文A") for c in nest.calls)
+    assert out["awaiting_user"] is False
+```
+
+- [ ] **Step 2: Implement nodes + builder conditional edges from START including await_copy_confirm**
+
+```python
+graph.add_conditional_edges(
+    START,
+    route_entry,
+    {
+        "intake": "intake",
+        "await_confirm": "await_confirm",
+        "await_copy_confirm": "await_copy_confirm",
+    },
+)
+graph.add_conditional_edges(
+    "await_copy_confirm",
+    route_after_copy_confirm,
+    {"write_copy_node": "write_copy_node", "draft_copy": "draft_copy", "end": END},
+)
+graph.add_edge("write_copy_node", END)
+# revise path: draft_copy must END after re-draft when coming from copy gate
+```
+
+**Revise path detail:** When `draft_copy` runs after revise, it should END the turn (not re-enter long `orchestrate_gen`). Implement with a state flag `copy_revise_only: bool` set by await_copy_confirm on revise; `draft_copy` returns and builder uses conditional edge:
+
+```python
+def route_after_draft_copy(state):
+    if state.get("copy_revise_only"):
+        return "end"
+    return "orchestrate_gen"
+```
+
+- [ ] **Step 3: Tests PASS + commit**
+
+```bash
+git commit -m "feat(agent-runtime): await_copy_confirm and write_copy_node"
+```
+
+---
+
+### Task 5: Stop orchestrate from replacing `task_list`
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/nodes/orchestrate_gen.py`
+- Modify: `services/agent-runtime/tests/test_orchestrate_gen.py` / `test_graph_plan_split.py`
+
+**Interfaces:**
+- Produces: orchestrate emits only `task_update` / `task_summary` / text lines — **zero** `emit_task_list` calls
+
+- [ ] **Step 1: Assert in test that FakeNest has no `emit_task_list` during orchestrate**
+
+- [ ] **Step 2: Delete the `emit_task_list` block in `orchestrate_gen.py` (keep updates/summary)**
+
+- [ ] **Step 3: PASS + commit**
+
+```bash
+git commit -m "fix(agent-runtime): do not replace task_list in orchestrate_gen"
+```
+
+---
+
+### Task 6: Plan node preamble strip
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/plan_clean.py`
+- Create: `services/agent-runtime/tests/test_plan_clean.py`
+- Modify: `services/agent-runtime/app/graph/nodes/plan.py`
+
+**Interfaces:**
+- Produces: `strip_plan_preamble(md: str) -> str`
+  - If a line matching `^#\s+` exists, return from that line to end
+  - Also drop leading lines matching `/^(好的|当然|我将|下面给|以下是)/`
+
+- [ ] **Step 1: Unit tests for strip cases** (with/without `#`, chitchat only, already clean)
+
+- [ ] **Step 2: Implement + call in plan before `upsert_prompt_node`**
+
+- [ ] **Step 3: Strengthen plan LLM system/human: 「只输出方案 Markdown，禁止寒暄」**
+
+- [ ] **Step 4: PASS + commit**
+
+```bash
+git commit -m "fix(agent-runtime): strip chitchat before writing plan node"
+```
+
+---
+
+### Task 7: Frontend task progress reconcile + synthetic summary
+
+**Files:**
+- Create: `apps/web/src/components/agent/taskProgressReconcile.ts`
+- Create: `apps/web/src/components/agent/taskProgressReconcile.test.ts`
+- Modify: `apps/web/src/components/agent/agentTaskProgress.ts` (optional helpers)
+- Modify: `apps/web/src/components/agent/AgentSideRail.vue`
+
+**Interfaces:**
+- Produces: `reconcileTaskProgress(state, nodes): AgentTaskProgressState`
+  - Map by `manifestKey` or title/`nodeId`
+  - `completed`+url → `done`; `generating` → `running`; `fallback_pending` → `needs_user`; text with non-empty content → `done`; text empty while local item needs_user → keep `needs_user`
+- Produces: `shouldFinishTaskCard(state, nodes): boolean` — no running/pending/retrying among **image/video** items (needs_user text does not block finish)
+- Produces: `synthesizeSummary(state): summary` when finishing without SSE summary
+- SideRail: on stream end, if `taskProgress.items.length`, poll session nodes every 4s up to 15 times OR until `shouldFinishTaskCard`, apply reconcile; set `finished` + summary
+
+- [ ] **Step 1: Vitest cases for mapping + finish rules + synthesize**
+
+- [ ] **Step 2: Implement module**
+
+- [ ] **Step 3: Wire AgentSideRail finally/turnComplete path** (need session nodes: emit event to parent for nodes snapshot, or accept `getCanvasNodes` callback prop — prefer emit `requestCanvasSnapshot` / use existing turnComplete → parent passes nodes via new optional callback `onReconcileTasks`)
+
+Minimal wiring: `emit('turnComplete')` already reloads session in CanvasPage; add `emit('reconcileTasks')` or extend turnComplete to return nodes. Simplest: **CanvasPage** after each `loadSession` during agent busy calls `sideRailRef.reconcileFromNodes(nodes)`.
+
+Expose:
+
+```ts
+function reconcileFromNodes(nodes: CanvasNode[]) {
+  taskProgress.value = reconcileTaskProgress(taskProgress.value, nodes)
+  if (shouldFinishTaskCard(taskProgress.value, nodes) && !taskProgress.value.finished) {
+    taskProgress.value = {
+      ...taskProgress.value,
+      finished: true,
+      summary: taskProgress.value.summary ?? synthesizeSummary(taskProgress.value),
+    }
+  }
+}
+defineExpose({ reconcileFromNodes })
+```
+
+- [ ] **Step 4: PASS + commit**
+
+```bash
+git commit -m "feat(web): reconcile agent task card after SSE disconnect"
+```
+
+---
+
+### Task 8: Canvas server-merge + poll during agent run
+
+**Files:**
+- Create: `apps/web/src/pages/canvas/canvasNodeMerge.ts`
+- Create: `apps/web/src/pages/canvas/canvasNodeMerge.test.ts`
+- Modify: `apps/web/src/pages/CanvasPage.vue`
+
+**Interfaces:**
+- Produces: `mergeCanvasNodesFromServer(local, server): Node[]`
+  - For matching ids: if server has non-empty `url` and local missing/different → take server url/status/generationRecordId
+  - if server has non-empty `content` → take content/status
+  - never let local empty url overwrite server url on subsequent save
+- CanvasPage: while agent streaming OR task card not finished, `setInterval` 4s `loadSession` then merge into vue-flow nodes (do not full-replace user selection if possible)
+- On agent `canvas_action` path: do **not** `saveCanvas()` immediately after apply if it would persist nodes still missing urls that server may already have — prefer `loadSession` merge first; if save needed, merge before PUT
+
+- [ ] **Step 1: Unit test merge preferences**
+
+```ts
+it('prefers server url over local empty', () => {
+  const merged = mergeCanvasNodesFromServer(
+    [{ id: 'i1', data: { url: '', status: 'draft' } }],
+    [{ id: 'i1', data: { url: 'https://x/a.png', status: 'completed' } }],
+  )
+  expect(merged[0].data.url).toBe('https://x/a.png')
+  expect(merged[0].data.status).toBe('completed')
+})
+```
+
+- [ ] **Step 2: Implement + wire poll in handleAgent stream start/stop**
+
+- [ ] **Step 3: PASS + commit**
+
+```bash
+git commit -m "fix(web): merge server canvas urls during agent generation"
+```
+
+---
+
+### Task 9: Copy confirm chips in Agent UI
+
+**Files:**
+- Modify: `apps/web/src/components/agent/AgentSideRail.vue` (or confirm-chip helper)
+- Test: small unit test for chip detection / message templates if pure fn extracted
+
+**Interfaces:**
+- When last assistant text includes `【主文案草稿】` or `写入主文案`, show chips: `写入主文案` | `要修改`
+- Click sends that text as user message (same as 确认拆图 chips)
+- Do not show plan confirm chips (`确认拆图`) while `phase` hint is copy draft
+
+- [ ] **Step 1: Extract `detectAgentChipSet(assistantText) -> 'plan' | 'copy' | null`**
+
+- [ ] **Step 2: Wire UI**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat(web): chips for main-copy confirm HITL"
+```
+
+---
+
+### Task 10: Cross-spec note + local verification
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-07-25-agent-task-progress-card-design.md` (lifecycle: text as needs_user; no orchestrate task_list replace)
+- Modify: `docs/superpowers/specs/2026-07-23-agent-runtime-langgraph-design.md` (pointer to confirm-loop §7)
+
+- [ ] **Step 1: Patch those two docs with short revision notes linking the new spec**
+
+- [ ] **Step 2: Run full relevant suites**
+
+```bash
+cd services/agent-runtime && python -m pytest tests/ -q
+pnpm --filter @lnkpi/server exec vitest run src/agent
+pnpm --filter @lnkpi/web exec vitest run src/components/agent src/pages/canvas
+```
+
+Expected: all PASS
+
+- [ ] **Step 3: Commit docs + any fixes**
+
+```bash
+git commit -m "docs: link confirm-loop hardening into prior agent specs"
+```
+
+---
+
+### Task 11: Production checklist (manual, after deploy)
+
+- [ ] Rebuild Runtime with `enable_agent_runtime=true` (API-only deploy is insufficient)
+- [ ] Clean canvas: plan → 确认拆图 → card has 9 items including 主文案 `needs_user`
+- [ ] Draft appears; 写入主文案 → node content filled
+- [ ] Images continue without waiting; after ~120s card still closes with summary
+- [ ] Successful images visible on canvas nodes
+- [ ] Plan node has no「好的，我将…」preamble
+
+---
+
+## Spec coverage self-check
+
+| Spec section | Task(s) |
+| --- | --- |
+| §2 Copy HITL | 3, 4, 9 |
+| §3 task_list stable | 5 |
+| §4 disconnect close + summary | 7 |
+| §5 canvas sync | 8 |
+| §6 plan clean | 6 |
+| §7 graph phases/edges / done preserve | 1, 3, 4 |
+| Nest write API | 2 |
+| Runtime rebuild reminder | 11 |
+| scheme B summary persistence | explicitly out of scope |
+
+## Placeholder scan
+
+No TBD/TODO steps; open product default (persist draft vs Studio regen) locked to persist draft per spec §2.3 / §12.

--- a/docs/superpowers/specs/2026-07-23-agent-runtime-langgraph-design.md
+++ b/docs/superpowers/specs/2026-07-23-agent-runtime-langgraph-design.md
@@ -4,7 +4,7 @@
 > 日期：2026-07-23（修订 2026-07-24）  
 > 范围：Agent Runtime 技术选型、控制面/数据面边界、一期 Graph/State/Tools/Skills、**确认后按拓扑自动出图**；贯穿场景为**企业营销方案 → 画布资产拆解 → 出图**  
 > 前置：`2026-07-18-node-data-flow-refs-design.md`（RefChip/数据贯通）、现有 `@lnkpi/agent` SSE + `CanvasAction`、Nest `Session.canvasData` / Studio 文生图·图生图  
-> 非范围：一期不引入 Temporal；不把画布全量镜像进 LangGraph State；不做生产级 durable HITL（仅预留）；**不打通 Agent 侧栏底部 dock 的模型/技能/积分参数链路**（遗留，见 §1.2 / §10）。**一期纳入**账户级画布生成默认（全模态）与 Agent 出图回退（见 §0 / §1.1 / §12.8）。**自动出视频**与**对话任务进度卡**见增补规格 `2026-07-25-agent-task-progress-card-design.md`（待审阅；将修正下文原「视频二期」表述）。
+> 非范围：一期不引入 Temporal；不把画布全量镜像进 LangGraph State；不做生产级 durable HITL（仅预留）；**不打通 Agent 侧栏底部 dock 的模型/技能/积分参数链路**（遗留，见 §1.2 / §10）。**一期纳入**账户级画布生成默认（全模态）与 Agent 出图回退（见 §0 / §1.1 / §12.8）。**自动出视频**与**对话任务进度卡**见增补规格 `2026-07-25-agent-task-progress-card-design.md`。**确认后闭环加固 + 主文案 HITL / 节点与边演进**见 `2026-07-25-agent-confirm-loop-hardening-design.md` §7。
 
 ---
 

--- a/docs/superpowers/specs/2026-07-25-agent-confirm-loop-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-25-agent-confirm-loop-hardening-design.md
@@ -1,0 +1,346 @@
+# Agent 确认后闭环加固 + 主文案 HITL（设计）
+
+> 状态：**已确认**（2026-07-25）  
+> 日期：2026-07-25  
+> 前置：  
+> - `2026-07-23-agent-runtime-langgraph-design.md`（Runtime / 轻量 HITL / 画布 SoT）  
+> - `2026-07-24-agent-chat-ux-phase1-design.md`（对话 UX / Vercel SSE ~120s）  
+> - `2026-07-25-agent-task-progress-card-design.md`（任务卡 / `task_*` / 自动出视频）  
+> 依据：生产干净画布复测（PR #58 + Runtime rebuild）后问题清单 1–6；产品确认主文案 **先草稿交互确认再写入节点**，出图不等文案  
+> 范围：主文案 HITL 编排、任务卡断流关账、画布 url/content 同步、方案节点开场白清洗、**LangGraph 节点与边可持续演进专篇**  
+> 非范围：`task_summary` 落库（方案 B，复测仍丢再加）、卡内一键重试/确认平台、生产级 durable `interrupt()` 跨天恢复、改 Vercel SSE 硬超时本身、Agent dock 模型/技能计费
+
+---
+
+## 0. 决策摘要
+
+| 项 | 结论 |
+| --- | --- |
+| 总体策略 | **方案 A**：编排补齐 + 断流对账；摘要落库留作复测后加码 |
+| 主文案 | **不**在「确认拆图」后静默写入；`draft_copy` → 对话确认/修改 → `write_copy_node` |
+| 出图 vs 文案 | **并行**：`split` 后出图/出视频照常；文案 HITL **不阻塞**出图 |
+| 任务卡主文案行 | 草稿待确认期间 = `needs_user`；写入成功 = `done` |
+| 任务清单 | split **一次**发全量项；orchestrate **禁止整表替换**冲掉文案项 |
+| 断流关账 | SSE 优先；断流后用 Session 节点态（+ Record）reconcile，合成终局 `task_summary` 态 |
+| 画布有图 | 确认拆图→关账期间周期性 `loadSession`（服务端 url/content 优先）；禁过期全量 `saveCanvas` 抹结果 |
+| 方案节点 | 写入前剥开场白；**不**改为「先聊后写方案节点」（与既有确认拆图习惯对齐） |
+| Graph 演进 | **专篇 §7**：控制流边 vs 数据流边、门控相位、并行扇出、可插槽 `interrupt()` |
+
+---
+
+## 1. 问题与目标
+
+### 1.1 生产复测问题（1–6）
+
+| # | 现象 | 根因摘要 |
+| --- | --- | --- |
+| 1 | 主文案无正文、卡上无该项 | `auto_generate:false` + orchestrate 二次 `task_list` 整表覆盖 |
+| 2 | 左侧任务 vs Agent 卡不同步 | 左栏轮询 Record；卡只吃 SSE，断流后不对账 |
+| 3 | 详情有图、多数节点无预览 | 断流后不续拉 Session；本地 `saveCanvas` 可盖掉 Nest 已写 url |
+| 4 | 方案节点含「好的，我将…」 | `plan` 原样 upsert LLM 全文 |
+| 5 | 任务卡一直卡住 | 未收到 `task_summary`，`finished` 永不 true |
+| 6 | 无终局摘要与下一步建议 | `task_summary` 仅 SSE、断流丢失 |
+
+### 1.2 成功标准
+
+1. 确认拆图后任务卡含 **9 项**（含主文案）；出图并行推进。  
+2. 对话出现主文案**草稿** +「写入主文案 / 要修改」；用户确认后节点 `content` 才有正文。  
+3. SSE 断流后任务卡仍能关账，出现「本轮执行结果」+ 建议行（合成亦可）。  
+4. 左侧任务成功且详情有 url 时，对应 image 节点可见预览。  
+5. 「营销方案」节点正文从 Markdown `#` 标题起，无寒暄开场白。  
+6. Graph 节点/边约定见 §7，后续加审批门 / durable HITL 不推翻拓扑语义。
+
+---
+
+## 2. 主文案 HITL（修订后的产品流）
+
+### 2.1 用户旅程
+
+```text
+用户要方案
+  → plan：对话摘要 + 营销方案节点（已清洗）
+  → await_confirm：「确认拆图 / 要修改」
+用户确认拆图
+  → split：9 骨架（主文案仅 prompt，content 空）
+  → 并行：
+       A. orchestrate_gen（image/video）→ 任务卡更新 →（终局摘要，可断流后合成）
+       B. draft_copy：对话展示主文案草稿 → END 本 turn
+           phase=await_copy_confirm，主文案任务行=needs_user
+用户下一轮：确认写入 / 说明修改
+  → await_copy_confirm
+       confirm → write_copy_node → 主文案 done
+       revise  → draft_copy → 再 await
+       none    → 提示，保持 await
+```
+
+交互对标：与「确认后再写设计文档供审阅」相同——**成果落库前必须有一轮可调节的确认**。
+
+### 2.2 与旧「自动生成正文」的差异
+
+| 旧设想（已否决） | 本规格 |
+| --- | --- |
+| 确认拆图后 `run_text_generation` 静默写 `content` | 先草稿进对话，确认后再写 |
+| 文案与出图同一 `orchestrate_gen` 队列 | 文案走独立门控相位；出图队列不含强制写文案 |
+| 卡上主文案 `running→done` | 卡上主文案 `needs_user→done`（或 revise 循环） |
+
+### 2.3 Nest / Runtime 职责
+
+| 能力 | 负责方 | 说明 |
+| --- | --- | --- |
+| 草稿生成 | Runtime `draft_copy` | 用规划 LLM + plan/skill 上下文；结果进 State `copy_draft` + `text_delta` / 芯片 |
+| 写入节点 | Nest `run-text-generation` **或** 轻量 `set-node-content` | 仅在用户确认后调用；写 `data.content` + `status=completed` |
+| 修改轮 | Runtime `draft_copy` | 用户修改意见进 HumanMessage，覆盖 `copy_draft` |
+
+一期可用「确认后直接把 `copy_draft` 写入节点」的 internal API，不必强行走 Studio 计费文生若产品未要求；若需与左栏文本模型/积分一致，则走 `studio.generateText` 路径（实现计划阶段二选一，默认：**确认写入 = 落已审草稿**，避免二次计费）。
+
+**默认决策（本规格）：** `write_copy_node` = 将已确认的 `copy_draft` 持久化到节点；**不**在确认瞬间再调一次生成 API。用户点「要修改」才重新 `draft_copy`。
+
+### 2.4 任务卡与确认芯片
+
+- `task_list` 含 `copy_main`（kind=text）。  
+- `draft_copy` 结束：`task_update(copy_main, needs_user, errorHint=请确认主文案后写入)`。  
+- 芯片：「写入主文案」「要修改」（可复用现有 confirm/revise 芯片样式，文案区分于「确认拆图」）。  
+- `write_copy_node` 成功：`task_update(copy_main, done)`。
+
+---
+
+## 3. 任务清单稳定
+
+1. `split` 成功后 **emit 一次**全量 `task_list`（manifest 全项，含 text）。  
+2. `orchestrate_gen` **不得**再发整表 `task_list`；只用 `task_update`。  
+3. 若实现失误需重发：必须 **按 id merge**，禁止删除已有项、禁止无故重置 `done/needs_user`。
+
+修正既有任务卡规格中「text 可 skipped 或不入卡」：主文案 **入卡**，待确认 = `needs_user`，不是 `skipped`。
+
+---
+
+## 4. 断流关账 + 终局摘要（修 2/5/6）
+
+### 4.1 原则
+
+- 运行中仍以 SSE `task_*` 为准。  
+- Vercel ~120s 断流后 Runtime 可继续；前端必须 **对账关账**，不能永久「进行中」。  
+- 本轮 **不**要求 `task_summary` 落库；合成摘要可接受。落库列为复测加码（方案 B）。
+
+### 4.2 对账输入与映射
+
+| 节点观察 | 任务项状态 |
+| --- | --- |
+| image/video `completed` + url | `done` |
+| `generating` | `running` |
+| `fallback_pending` / 积分类错误 | `needs_user` + 既有 hint 表 |
+| `error` / failed | `failed` |
+| text：`content` 非空且已确认写入 | `done` |
+| text：仍有 `copy_draft` 待确认 / content 空且 phase 文案门 | `needs_user` |
+| 无结果且非 generating | `pending` 或保持上次 |
+
+### 4.3 关账条件（满足其一）
+
+1. 收到 SSE `task_summary`；或  
+2. Agent 流结束且卡内无 `running|pending|retrying`（`needs_user` **不阻塞**出图关账，见下）；或  
+3. 流结束后轮询（建议 4s，最多 ~15 次）无 `generating` 节点，则按 §4.2 合成 summary 并 `finished=true`。
+
+**关账与文案 HITL：** 出图/出视频子集可先关账展示「本轮执行结果（生成）」；若主文案仍 `needs_user`，底栏保留「主文案待你确认写入」一行，**不**把整卡打回「进行中」。标题策略：
+
+- 仍有 image/video `running` →「正在按方案拆解并出图」  
+- 生成侧已终局、文案仍待确认 →「本轮执行结果」+ 文案待处理提示  
+- 全部终局（含文案 done/failed）→ 完整合计
+
+### 4.4 与左侧任务栏
+
+左侧继续轮询 GenerationRecord；Agent 卡对账后语义对齐「成功/需处理」，允许短暂延迟（≤一轮 poll）。
+
+---
+
+## 5. 画布图 / 正文同步（修 3）
+
+1. 自确认拆图起至任务卡 `finished`（生成侧）：`CanvasPage` **周期性 `loadSession`**，合并规则：**服务端 `url` / `content` / `status` / `generationRecordId` 优先于本地空值或过期 generating**。  
+2. Agent `canvas_action` 应用路径避免用陈旧本地图 **全量 `saveCanvas`** 覆盖 Nest；必要保存时做字段级 merge（已有 url 不被空覆盖）。  
+3. 对已有 `generationRecordId` 且本地无 url 的节点：允许 generation poll 回填（放宽「draft 不应用 poll」门禁中的这一支）。
+
+---
+
+## 6. 方案节点清洗（修 4）
+
+`plan` → `upsert_prompt_node` 前：
+
+1. Prompt 约束：只输出方案 Markdown，禁止寒暄。  
+2. 后处理：去掉开场白；优先从第一个 `#` 标题截取正文。  
+3. 对话确认摘要仍用 `build_confirm_message`，**不**进节点。
+
+**不在本期**把「营销方案」改为先对话确认再写入节点（避免与确认拆图双重门叠床架屋）。若未来要做，走 §7.5 插槽「资产写入门」，与主文案门同型。
+
+---
+
+## 7. LangGraph 节点与边专篇（可持续迭代）
+
+> 本章是后续演进的契约：改实现可以，但**不要破坏**「控制流边 vs 数据流边」「门控必须 END 本 turn」「扇出不阻塞」三条。
+
+### 7.1 两条边，不要混
+
+| 种类 | 存在位置 | 含义 | 禁止 |
+| --- | --- | --- | --- |
+| **控制流边** | LangGraph `add_edge` / 条件路由 | 阶段迁移：规划 → 确认 → 拆解 → 生成 / 文案门 | 用控制流边表达「主图依赖白底」 |
+| **数据流边** | Nest `canvasData.edges` + RefChip | 资产依赖、出图拓扑、用户可见连线 | 把完整 nodes/edges 镜像进 Graph State |
+
+LangGraph State **只**持：phase、门控标志、plan 摘要、manifest 轻量项、`copy_draft`、gen 进度 id 列表等。画布真相源永远是 Nest。
+
+### 7.2 相位（phase）与入口路由
+
+现行与本期新增：
+
+| phase | 含义 | `route_entry` |
+| --- | --- | --- |
+| `intake` | 意图/技能门控 | 默认入口 |
+| `plan` | 写方案 | intake → plan |
+| `await_confirm` | 等确认拆图/修改方案 | `awaiting_user && phase==await_confirm` |
+| `split` | 拆骨架 | confirm → split |
+| `orchestrate_gen` | 自动出图/出视频 | split 后 |
+| `draft_copy` | 生成主文案草稿（可短时） | split 扇出 |
+| `await_copy_confirm` | 等确认写入/修改文案 | **新增**入口优先于 intake |
+| `write_copy_node` | 落库主文案 | copy confirm → |
+| `done` / `error` | 收尾 | → END |
+
+**入口路由优先级（建议）：**
+
+```text
+if awaiting_user and phase == await_copy_confirm → await_copy_confirm
+elif awaiting_user and phase == await_confirm → await_confirm
+else → intake
+```
+
+新增门控时：**只加 phase + route_entry 分支 + 对称节点**，不要把等待逻辑塞进 `orchestrate_gen` 长循环。
+
+### 7.3 目标拓扑（本期选定）
+
+**入口与门控：**
+
+```text
+START → route_entry
+          ├─ await_copy_confirm → confirm → write_copy_node → END
+          │                    → revise  → draft_copy → (重新置 await_copy_confirm) → END
+          │                    → none    → END（保持门）
+          ├─ await_confirm      → confirm → split → …
+          │                    → revise  → plan → await_confirm
+          │                    → none    → END
+          └─ intake → chat → END
+                   → plan → await_confirm → …
+```
+
+**确认拆图后主链（本期落地边，线性但语义并行）：**
+
+```text
+split → draft_copy → orchestrate_gen → done → END
+```
+
+| 节点 | 同 run 内必须完成 | 留给下一 turn |
+| --- | --- | --- |
+| `split` | 骨架 + 一次 `task_list` | — |
+| `draft_copy` | 出草稿、`text_delta`/芯片、`task_update(needs_user)`；置 `phase=await_copy_confirm` 且 `awaiting_user=true` | 用户确认/修改 |
+| `orchestrate_gen` | 出图/出视频 + `task_update` + 尽量发 `task_summary` | 断流后由前端对账 |
+| `done` | 收尾；**不得清除**文案门的 `awaiting_user` / `phase=await_copy_confirm` | 下一消息进 `await_copy_confirm` |
+
+**「并行」含义（产品）：** 用户在出图进行中或结束后，随时可用下一轮消息确认/修改主文案；出图不因文案未写入而暂停。  
+**「并行」含义（实现本期）：** 不要求 LangGraph Send 扇出；`draft_copy` 必须排在长时间 `orchestrate_gen` **之前**，保证草稿先达用户。真正的图级扇出列为 §7.5 性能插槽，不得改变 phase 契约。
+
+**硬约束：**
+
+1. **禁止**在 `orchestrate_gen` 内同步等待用户。  
+2. `done` / checkpoint 持久化后，文案门相位必须仍可被 `route_entry` 命中（单测必覆盖）。  
+3. 若发现 `done` 误清 `awaiting_user`：改为在 thread 元数据备份 `phase`，或 `draft_copy` 后先 END、出图改 Nest 后台作业——属实现修复，不改本章语义。
+### 7.4 门控节点模式（可复制）
+
+所有人机门遵循同一模式（已有 `await_confirm`，文案门照抄）：
+
+```text
+GateNode(state):
+  分类用户决策 → confirm | revise | none
+  confirm → 下游写副作用节点 / 下一阶段
+  revise  → 回到生产节点（plan 或 draft_copy）
+  none    → 提示 + 保持 awaiting + END
+```
+
+**硬约束：** Gate 不得假设 HTTP SSE 仍连接；副作用写 Nest 必须可在**新 turn**执行。
+
+### 7.5 演进插槽（二期+，本规格只占位）
+
+| 插槽 | 用法 | 与本期关系 |
+| --- | --- | --- |
+| `await_asset_write` 通用门 | 任意「草稿 → 确认 → 写入节点」 | 主文案是第一个实例 |
+| `interrupt()` + 持久 checkpointer | 跨进程/跨天恢复 | 不替换轻量 Gate 语义，只换持久层 |
+| 审批门 `await_approval` | 企业角色审批方案 | 插在 `plan` 与 `await_confirm` 之间 |
+| 并行 Send 扇出 | 多资产独立子图 | 不改变数据流在 Nest 的事实 |
+| `task_summary` 落库 | 断流必达摘要 | 方案 B，复测加码 |
+
+演进时优先 **加节点加 phase**，避免在 `orchestrate_gen` 增加隐藏状态机。
+
+### 7.6 反模式清单
+
+1. 在长耗时生成循环里同步等用户输入。  
+2. 用第二次 `task_list` 整表覆盖丢掉 HITL 项。  
+3. 把 canvas 全量 nodes 塞进 LangGraph State。  
+4. 用控制流边表达 Ref/依赖（依赖只在 Nest edges + manifest `depends_on`）。  
+5. 门控成功却不清理或错误清理 `awaiting_user`，导致下一轮误路由。  
+6. 本地 `saveCanvas` 用空 url 覆盖 Nest 已完成结果。
+
+---
+
+## 8. 事件与前端
+
+### 8.1 SSE（沿用 + 约定）
+
+| 事件 | 本期约定 |
+| --- | --- |
+| `task_list` | 仅 split 后一次全量 |
+| `task_update` | 出图进度 + 文案 needs_user/done |
+| `task_summary` | orchestrate 结束时发；前端断流则合成 |
+| `text_delta` | 草稿正文 + 进度短句；确认芯片不依赖 Markdown |
+
+### 8.2 前端
+
+- `applyTaskEvent`：禁止无 merge 的整表重置误用。  
+- `AgentSideRail`：流结束 / 定时 reconcile（§4）。  
+- `CanvasPage`：loadSession 合并（§5）。  
+- 文案芯片发送「确认写入主文案」/「要修改：…」类消息，供 `await_copy_confirm` 分类（可复用 classify，扩展关键词）。
+
+---
+
+## 9. 风险与缓解
+
+| 风险 | 缓解 |
+| --- | --- |
+| 同 run 出图导致 120s 内看不到终局 | §4 对账合成摘要 |
+| checkpoint 在 done 后丢失文案门 | 单测 + thread 元数据备份 phase |
+| 用户从未确认文案 | 卡上长期 needs_user；不阻塞出图关账 |
+| 草稿与节点 prompt 不一致 | 写入时同时可选刷新 prompt 摘要字段（实现计划定） |
+
+---
+
+## 10. 修订关系
+
+| 文档 | 修订点 |
+| --- | --- |
+| `2026-07-25-agent-task-progress-card-design.md` | 主文案入卡且待确认为 `needs_user`；生命周期含文案门；禁止 orchestrate 整表 task_list |
+| `2026-07-23-agent-runtime-langgraph-design.md` | 增补 phase / 文案 HITL 指针 → 本文 §7 |
+| 本文 | 确认后闭环加固的主规格 |
+
+---
+
+## 11. 验收清单（干净画布）
+
+- [ ] 确认拆图后卡上 9 项含主文案（needs_user）  
+- [ ] 对话有主文案草稿与写入/修改芯片  
+- [ ] 确认写入后节点 content 有正文；修改可重出草稿  
+- [ ] 出图不因文案未确认而停  
+- [ ] 断流后卡可关账并有摘要/建议（合成可）  
+- [ ] 成功出图节点可见预览（与详情一致）  
+- [ ] 营销方案节点无寒暄开场白  
+- [ ] 左栏任务与 Agent 卡终态大体一致  
+
+---
+
+## 12. 开放实现细节（计划阶段拍板，不阻塞本规格审阅）
+
+1. `write_copy_node`：纯落库草稿 vs 再走 Studio 文本生成（**规格默认：纯落库**）。  
+2. `draft_copy` 与 `orchestrate_gen` 同 run 顺序（**规格默认：draft_copy 先，再 orchestrate_gen**）。  
+3. 文案门 classify 关键词表与方案确认门是否共用函数（建议共用 + 场景参数）。

--- a/docs/superpowers/specs/2026-07-25-agent-task-progress-card-design.md
+++ b/docs/superpowers/specs/2026-07-25-agent-task-progress-card-design.md
@@ -7,7 +7,9 @@
 > - `2026-07-24-agent-chat-ux-phase1-design.md`（对话 UX / Skill 门控；已确认追加拆图与 Vercel SSE proxy 约束）  
 > 依据：脏画布复测（busy tip / 二轮节点不可见）+ 产品要求「类 Cursor 任务清单」+ **视频纳入一期自动编排**  
 > 范围：确认后侧栏**任务进度卡**、结构化进度事件、可恢复错误自动重试≤2、终局摘要与失败建议、点击定位节点、**自动出视频**（与出图同一编排）  
-> 非范围：卡片内一键确认平台兜底 API、卡片内一键重试出图/出片 API（二期）、`interrupt()` HITL、dock model/skillId 计费、按 brief 裁剪 manifest
+> 非范围：卡片内一键确认平台兜底 API、卡片内一键重试出图/出片 API（二期）、`interrupt()` HITL、dock model/skillId 计费、按 brief 裁剪 manifest  
+>
+> **修订（2026-07-25）：** 主文案入卡且待确认为 `needs_user`（非 `skipped`）；`orchestrate_gen` **禁止**整表替换 `task_list`。闭环与文案 HITL 见 `2026-07-25-agent-confirm-loop-hardening-design.md`。
 
 ---
 
@@ -50,9 +52,10 @@
 
 ```text
 用户确认 → split 成功
-  → emit task_list（含 image + video 可执行项；text 可列 skipped 或不入卡）
+  → emit task_list（全量 manifest，含 text；主文案随后 needs_user）
+  → draft_copy（主文案草稿 HITL，不阻塞出图）
   → 逐项 task_update（running / retrying / done / failed / needs_user / skipped）
-  → emit task_summary + 助手短文
+  → emit task_summary + 助手短文（断流后可由前端对账合成）
   → 卡标题改为「本轮执行结果」
 ```
 

--- a/services/agent-runtime/app/graph/builder.py
+++ b/services/agent-runtime/app/graph/builder.py
@@ -17,9 +17,16 @@ from app.graph.state import AgentRuntimeState
 
 
 def route_entry(state: AgentRuntimeState) -> str:
+    if state.get("awaiting_user") and state.get("phase") == "await_copy_confirm":
+        return "await_copy_confirm"
     if state.get("awaiting_user") and state.get("phase") == "await_confirm":
         return "await_confirm"
     return "intake"
+
+
+async def _stub_await_copy_confirm(state: AgentRuntimeState) -> dict:
+    """Placeholder until Task 4 implements the real copy HITL gate."""
+    return {}
 
 
 def route_after_intake(state: AgentRuntimeState) -> str:
@@ -55,11 +62,16 @@ def build_agent_graph(
     graph.add_node("split", make_split_node(nest=nest, skills_dir=skills_path))
     graph.add_node("orchestrate_gen", make_orchestrate_gen_node(nest=nest))
     graph.add_node("done", make_done_node())
+    graph.add_node("await_copy_confirm", _stub_await_copy_confirm)
 
     graph.add_conditional_edges(
         START,
         route_entry,
-        {"intake": "intake", "await_confirm": "await_confirm"},
+        {
+            "intake": "intake",
+            "await_confirm": "await_confirm",
+            "await_copy_confirm": "await_copy_confirm",
+        },
     )
     graph.add_conditional_edges(
         "intake",
@@ -76,6 +88,7 @@ def build_agent_graph(
     graph.add_edge("split", "orchestrate_gen")
     graph.add_edge("orchestrate_gen", "done")
     graph.add_edge("done", END)
+    graph.add_edge("await_copy_confirm", END)
 
     saver = checkpointer if checkpointer is not None else MemorySaver()
     return graph.compile(checkpointer=saver)

--- a/services/agent-runtime/app/graph/builder.py
+++ b/services/agent-runtime/app/graph/builder.py
@@ -9,6 +9,7 @@ from langgraph.graph import END, START, StateGraph
 from app.graph.nodes.await_confirm import make_await_confirm_node
 from app.graph.nodes.chat import make_chat_node
 from app.graph.nodes.done import make_done_node
+from app.graph.nodes.draft_copy import make_draft_copy_node
 from app.graph.nodes.intake import make_intake_node
 from app.graph.nodes.orchestrate_gen import make_orchestrate_gen_node
 from app.graph.nodes.plan import make_plan_node
@@ -27,6 +28,12 @@ def route_entry(state: AgentRuntimeState) -> str:
 async def _stub_await_copy_confirm(state: AgentRuntimeState) -> dict:
     """Placeholder until Task 4 implements the real copy HITL gate."""
     return {}
+
+
+def route_after_draft_copy(state: AgentRuntimeState) -> str:
+    if state.get("copy_revise_only"):
+        return "end"
+    return "orchestrate_gen"
 
 
 def route_after_intake(state: AgentRuntimeState) -> str:
@@ -60,6 +67,7 @@ def build_agent_graph(
     graph.add_node("plan", make_plan_node(nest=nest, llm=llm, skills_dir=skills_path))
     graph.add_node("await_confirm", make_await_confirm_node(llm=llm))
     graph.add_node("split", make_split_node(nest=nest, skills_dir=skills_path))
+    graph.add_node("draft_copy", make_draft_copy_node(nest=nest, llm=llm))
     graph.add_node("orchestrate_gen", make_orchestrate_gen_node(nest=nest))
     graph.add_node("done", make_done_node())
     graph.add_node("await_copy_confirm", _stub_await_copy_confirm)
@@ -85,7 +93,12 @@ def build_agent_graph(
         route_after_confirm,
         {"split": "split", "plan": "plan", "end": END},
     )
-    graph.add_edge("split", "orchestrate_gen")
+    graph.add_edge("split", "draft_copy")
+    graph.add_conditional_edges(
+        "draft_copy",
+        route_after_draft_copy,
+        {"orchestrate_gen": "orchestrate_gen", "end": END},
+    )
     graph.add_edge("orchestrate_gen", "done")
     graph.add_edge("done", END)
     graph.add_edge("await_copy_confirm", END)

--- a/services/agent-runtime/app/graph/builder.py
+++ b/services/agent-runtime/app/graph/builder.py
@@ -7,6 +7,7 @@ from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, START, StateGraph
 
 from app.graph.nodes.await_confirm import make_await_confirm_node
+from app.graph.nodes.await_copy_confirm import make_await_copy_confirm_node
 from app.graph.nodes.chat import make_chat_node
 from app.graph.nodes.done import make_done_node
 from app.graph.nodes.draft_copy import make_draft_copy_node
@@ -14,6 +15,7 @@ from app.graph.nodes.intake import make_intake_node
 from app.graph.nodes.orchestrate_gen import make_orchestrate_gen_node
 from app.graph.nodes.plan import make_plan_node
 from app.graph.nodes.split import make_split_node
+from app.graph.nodes.write_copy_node import make_write_copy_node
 from app.graph.state import AgentRuntimeState
 
 
@@ -25,15 +27,19 @@ def route_entry(state: AgentRuntimeState) -> str:
     return "intake"
 
 
-async def _stub_await_copy_confirm(state: AgentRuntimeState) -> dict:
-    """Placeholder until Task 4 implements the real copy HITL gate."""
-    return {}
-
-
 def route_after_draft_copy(state: AgentRuntimeState) -> str:
     if state.get("copy_revise_only"):
         return "end"
     return "orchestrate_gen"
+
+
+def route_after_copy_confirm(state: AgentRuntimeState) -> str:
+    decision = state.get("user_decision") or "none"
+    if decision == "confirm":
+        return "write_copy_node"
+    if decision == "revise":
+        return "draft_copy"
+    return "end"
 
 
 def route_after_intake(state: AgentRuntimeState) -> str:
@@ -70,7 +76,8 @@ def build_agent_graph(
     graph.add_node("draft_copy", make_draft_copy_node(nest=nest, llm=llm))
     graph.add_node("orchestrate_gen", make_orchestrate_gen_node(nest=nest))
     graph.add_node("done", make_done_node())
-    graph.add_node("await_copy_confirm", _stub_await_copy_confirm)
+    graph.add_node("await_copy_confirm", make_await_copy_confirm_node())
+    graph.add_node("write_copy_node", make_write_copy_node(nest=nest))
 
     graph.add_conditional_edges(
         START,
@@ -101,7 +108,16 @@ def build_agent_graph(
     )
     graph.add_edge("orchestrate_gen", "done")
     graph.add_edge("done", END)
-    graph.add_edge("await_copy_confirm", END)
+    graph.add_conditional_edges(
+        "await_copy_confirm",
+        route_after_copy_confirm,
+        {
+            "write_copy_node": "write_copy_node",
+            "draft_copy": "draft_copy",
+            "end": END,
+        },
+    )
+    graph.add_edge("write_copy_node", END)
 
     saver = checkpointer if checkpointer is not None else MemorySaver()
     return graph.compile(checkpointer=saver)

--- a/services/agent-runtime/app/graph/nodes/await_copy_confirm.py
+++ b/services/agent-runtime/app/graph/nodes/await_copy_confirm.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Literal
+
+from langchain_core.messages import AIMessage
+
+Decision = Literal["none", "confirm", "revise"]
+
+_NONE_TIP = "请确认主文案后回复「写入主文案」，或说明如何修改。"
+
+_CONFIRM_HINTS = (
+    "写入主文案",
+    "确认写入",
+    "可以写入",
+    "用这个",
+    "就这个",
+    "写入",
+)
+_REVISE_HINTS = (
+    "改成",
+    "修改",
+    "调整",
+    "换",
+    "不要",
+    "重新",
+    "revise",
+    "改一下",
+    "更偏",
+    "要修改",
+)
+
+
+def _latest_user_text(messages: list[Any]) -> str:
+    for msg in reversed(messages or []):
+        role = getattr(msg, "type", None) or (msg.get("role") if isinstance(msg, dict) else None)
+        content = getattr(msg, "content", None) or (msg.get("content") if isinstance(msg, dict) else "")
+        if role in ("human", "user") and content:
+            return str(content)
+    return ""
+
+
+def classify_copy_decision(text: str) -> Decision:
+    lowered = text.strip().lower()
+    if not lowered:
+        return "none"
+    if any(h in lowered for h in _REVISE_HINTS):
+        return "revise"
+    if any(h in lowered for h in _CONFIRM_HINTS):
+        return "confirm"
+    return "none"
+
+
+def make_await_copy_confirm_node() -> Callable:
+    async def await_copy_confirm(state: dict) -> dict:
+        text = _latest_user_text(state.get("messages") or [])
+        decision = classify_copy_decision(text)
+        if decision == "none":
+            return {
+                "user_decision": "none",
+                "awaiting_user": True,
+                "phase": "await_copy_confirm",
+                "copy_revise_only": False,
+                "messages": [AIMessage(content=_NONE_TIP)],
+            }
+        if decision == "revise":
+            return {
+                "user_decision": "revise",
+                "awaiting_user": True,
+                "phase": "await_copy_confirm",
+                "copy_revise_only": True,
+            }
+        return {
+            "user_decision": "confirm",
+            "awaiting_user": True,
+            "phase": "await_copy_confirm",
+            "copy_revise_only": False,
+        }
+
+    return await_copy_confirm

--- a/services/agent-runtime/app/graph/nodes/done.py
+++ b/services/agent-runtime/app/graph/nodes/done.py
@@ -33,6 +33,14 @@ def make_done_node() -> Callable:
             msg = f"流程结束。\n{msg}"
         else:
             msg = "流程结束。本次无可汇总的出图结果；你也可手动在画布上生成。"
+        if state.get("phase") == "await_copy_confirm" or (
+            state.get("awaiting_user") and state.get("copy_draft")
+        ):
+            return {
+                "phase": "await_copy_confirm",
+                "awaiting_user": True,
+                "messages": [AIMessage(content=msg)],
+            }
         return {
             "phase": "done",
             "awaiting_user": False,

--- a/services/agent-runtime/app/graph/nodes/draft_copy.py
+++ b/services/agent-runtime/app/graph/nodes/draft_copy.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+_COPY_SYSTEM = (
+    "你是电商主文案写手。只输出主文案 Markdown 正文，禁止寒暄、禁止解释过程。"
+    "根据营销方案摘要写出可直接用于详情页的主文案。"
+)
+
+_DRAFT_FOOTER = (
+    "\n\n请确认后回复「写入主文案」；如需修改请说明（例如「改成更强调节水」）。"
+)
+
+
+def _pick_copy_item(manifest: list[Any]) -> dict[str, Any] | None:
+    for raw in manifest or []:
+        if not isinstance(raw, dict):
+            continue
+        if str(raw.get("key") or "") == "copy_main":
+            return raw
+    for raw in manifest or []:
+        if not isinstance(raw, dict):
+            continue
+        if str(raw.get("target_type") or "") == "text":
+            return raw
+    return None
+
+
+def make_draft_copy_node(*, nest: Any, llm: Any) -> Callable:
+    async def draft_copy(state: dict) -> dict:
+        item = _pick_copy_item(list(state.get("split_manifest") or []))
+        if item is None:
+            return {}
+
+        key = str(item.get("key") or "copy_main")
+        title = str(item.get("title") or "主文案")
+        node_id = str(item.get("node_id") or "") or None
+        plan_summary = str(state.get("plan_summary") or "").strip()
+        hint = str(item.get("prompt_hint") or item.get("prompt") or "").strip()
+
+        user_bits = [
+            f"方案摘要：\n{plan_summary or '（无）'}",
+        ]
+        if hint:
+            user_bits.append(f"节点提示：\n{hint}")
+        if state.get("copy_revise_only") and state.get("messages"):
+            # Prefer latest human revise note
+            for msg in reversed(state.get("messages") or []):
+                role = getattr(msg, "type", None) or (
+                    msg.get("role") if isinstance(msg, dict) else None
+                )
+                content = getattr(msg, "content", None) or (
+                    msg.get("content") if isinstance(msg, dict) else ""
+                )
+                if role in ("human", "user") and content:
+                    user_bits.append(f"用户修改意见：\n{content}")
+                    break
+
+        result = await llm.ainvoke(
+            [
+                SystemMessage(content=_COPY_SYSTEM),
+                HumanMessage(content="\n\n".join(user_bits)),
+            ]
+        )
+        draft = str(getattr(result, "content", "") or "").strip()
+        if not draft:
+            draft = hint or title
+
+        body = f"【主文案草稿】\n{draft}{_DRAFT_FOOTER}"
+        emit = getattr(nest, "emit_text", None)
+        if emit is not None:
+            await emit(body)
+
+        emit_upd = getattr(nest, "emit_task_update", None)
+        if emit_upd is not None:
+            await emit_upd(
+                id=key,
+                status="needs_user",
+                errorHint="请确认主文案后写入",
+            )
+
+        out: dict[str, Any] = {
+            "phase": "await_copy_confirm",
+            "awaiting_user": True,
+            "copy_draft": draft,
+            "copy_node_id": node_id,
+            "copy_revise_only": False,
+            "messages": [AIMessage(content=body)],
+        }
+        return out
+
+    return draft_copy

--- a/services/agent-runtime/app/graph/nodes/orchestrate_gen.py
+++ b/services/agent-runtime/app/graph/nodes/orchestrate_gen.py
@@ -76,21 +76,6 @@ def make_orchestrate_gen_node(
             if by_key.get(k) and by_key[k].get("node_id")
         ]
 
-        emit_list = getattr(nest, "emit_task_list", None)
-        if emit_list is not None:
-            await emit_list(
-                [
-                    {
-                        "id": k,
-                        "title": str(by_key[k].get("title") or k),
-                        "nodeId": str(by_key[k].get("node_id") or ""),
-                        "kind": str(by_key[k].get("target_type") or "image"),
-                    }
-                    for k in ordered_keys
-                    if by_key.get(k)
-                ]
-            )
-
         key_set = set(ordered_keys)
         deps_of = {
             k: [str(d) for d in (by_key[k].get("depends_on") or []) if str(d) in key_set]

--- a/services/agent-runtime/app/graph/nodes/plan.py
+++ b/services/agent-runtime/app/graph/nodes/plan.py
@@ -6,6 +6,7 @@ from typing import Any, Callable
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
 from app.skills.loader import discover_skills, load_skill
+from app.graph.plan_clean import strip_plan_preamble
 
 
 def _latest_user_text(messages: list[Any]) -> str:
@@ -81,13 +82,14 @@ def make_plan_node(*, nest: Any, llm: Any, skills_dir: Path) -> Callable:
             SystemMessage(content=skill.body),
             HumanMessage(
                 content=(
-                    "请根据用户需求输出完整企业营销方案 Markdown（含定位、文案与视觉资产章节）。\n"
+                    "请根据用户需求输出完整企业营销方案 Markdown（含定位、文案与视觉资产章节）。"
+                    "只输出方案 Markdown 正文，从一级标题开始，禁止寒暄与过程说明。\n"
                     f"用户需求：{user_text}"
                 )
             ),
         ]
         ai = await llm.ainvoke(messages)
-        plan_md = str(getattr(ai, "content", ai) or "")
+        plan_md = strip_plan_preamble(str(getattr(ai, "content", ai) or ""))
 
         result = await nest.upsert_prompt_node(
             prompt="营销方案",

--- a/services/agent-runtime/app/graph/nodes/write_copy_node.py
+++ b/services/agent-runtime/app/graph/nodes/write_copy_node.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from langchain_core.messages import AIMessage
+
+
+def make_write_copy_node(*, nest: Any) -> Callable:
+    async def write_copy_node(state: dict) -> dict:
+        node_id = str(state.get("copy_node_id") or "").strip()
+        draft = str(state.get("copy_draft") or "").strip()
+        if not node_id or not draft:
+            return {
+                "phase": "done",
+                "awaiting_user": False,
+                "messages": [AIMessage(content="主文案草稿缺失，无法写入节点。")],
+            }
+
+        await nest.set_node_content(node_id, draft)
+
+        key = "copy_main"
+        for raw in state.get("split_manifest") or []:
+            if isinstance(raw, dict) and str(raw.get("node_id") or "") == node_id:
+                key = str(raw.get("key") or key)
+                break
+
+        emit_upd = getattr(nest, "emit_task_update", None)
+        if emit_upd is not None:
+            await emit_upd(id=key, status="done")
+
+        return {
+            "phase": "done",
+            "awaiting_user": False,
+            "copy_revise_only": False,
+            "messages": [AIMessage(content="已将确认的主文案写入画布节点。")],
+        }
+
+    return write_copy_node

--- a/services/agent-runtime/app/graph/plan_clean.py
+++ b/services/agent-runtime/app/graph/plan_clean.py
@@ -1,0 +1,27 @@
+"""Strip chitchat preamble before writing plan markdown to the canvas node."""
+
+from __future__ import annotations
+
+import re
+
+
+_CHITCHAT_START = re.compile(
+    r"^(好的|当然|我将|下面给|以下是|没问题|可以的)[，,。.\s]",
+)
+
+
+def strip_plan_preamble(md: str) -> str:
+    text = (md or "").strip()
+    if not text:
+        return ""
+    lines = text.splitlines()
+    for i, ln in enumerate(lines):
+        if re.match(r"^#\s+", ln.strip()):
+            return "\n".join(lines[i:]).strip()
+    # No heading: drop leading chitchat lines
+    start = 0
+    while start < len(lines) and (
+        not lines[start].strip() or _CHITCHAT_START.match(lines[start].strip())
+    ):
+        start += 1
+    return "\n".join(lines[start:]).strip() or text

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -27,6 +27,9 @@ class AgentRuntimeState(TypedDict, total=False):
         "plan",
         "await_confirm",
         "split",
+        "draft_copy",
+        "await_copy_confirm",
+        "write_copy_node",
         "orchestrate_gen",
         "done",
         "error",
@@ -45,6 +48,8 @@ class AgentRuntimeState(TypedDict, total=False):
     gen_completed: list[str]
     gen_failed: list[dict]
     last_error: str | None
+    copy_draft: str | None
+    copy_node_id: str | None
 
     # 一期轻量人机
     awaiting_user: bool

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -50,6 +50,7 @@ class AgentRuntimeState(TypedDict, total=False):
     last_error: str | None
     copy_draft: str | None
     copy_node_id: str | None
+    copy_revise_only: bool
 
     # 一期轻量人机
     awaiting_user: bool

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -84,6 +84,11 @@ class NestEventProxy:
             await self._inner.set_node_prompt(node_id, prompt)
         )
 
+    async def set_node_content(self, node_id: str, content: str) -> dict[str, Any]:
+        return await self._forward_actions(
+            await self._inner.set_node_content(node_id, content)
+        )
+
     async def attach_refs(self, node_id: str, ref_order: list[str]) -> dict[str, Any]:
         return await self._forward_actions(
             await self._inner.attach_refs(node_id, ref_order)

--- a/services/agent-runtime/app/tools/nest_client.py
+++ b/services/agent-runtime/app/tools/nest_client.py
@@ -109,6 +109,17 @@ class NestCanvasClient:
             {"sessionId": self._session_id, "nodeId": node_id, "prompt": prompt},
         )
 
+    async def set_node_content(self, node_id: str, content: str) -> dict[str, Any]:
+        return await self._post(
+            "/agent/internal/set-node-content",
+            {
+                "sessionId": self._session_id,
+                "userId": self._user_id,
+                "nodeId": node_id,
+                "content": content,
+            },
+        )
+
     async def attach_refs(self, node_id: str, ref_order: list[str]) -> dict[str, Any]:
         return await self._post(
             "/agent/internal/attach-refs",

--- a/services/agent-runtime/tests/test_await_copy_confirm.py
+++ b/services/agent-runtime/tests/test_await_copy_confirm.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.graph.nodes.await_copy_confirm import classify_copy_decision, make_await_copy_confirm_node
+from app.graph.nodes.write_copy_node import make_write_copy_node
+from langchain_core.messages import HumanMessage
+
+
+def test_classify_write_copy():
+    assert classify_copy_decision("写入主文案") == "confirm"
+    assert classify_copy_decision("改成更强调节水") == "revise"
+    assert classify_copy_decision("随便看看") == "none"
+
+
+@pytest.mark.asyncio
+async def test_await_copy_confirm_sets_revise_flag():
+    node = make_await_copy_confirm_node()
+    out = await node({"messages": [HumanMessage(content="改成更强调节水")]})
+    assert out["user_decision"] == "revise"
+    assert out["copy_revise_only"] is True
+
+
+@pytest.mark.asyncio
+async def test_write_copy_persists_draft():
+    class FakeNest:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, Any]] = []
+
+        async def set_node_content(self, node_id: str, content: str) -> dict:
+            self.calls.append(("set_node_content", (node_id, content)))
+            return {"actions": []}
+
+        async def emit_task_update(self, **payload: Any) -> None:
+            self.calls.append(("emit_task_update", payload))
+
+    nest = FakeNest()
+    node = make_write_copy_node(nest=nest)
+    out = await node(
+        {
+            "copy_node_id": "t1",
+            "copy_draft": "正文A",
+            "split_manifest": [{"key": "copy_main", "node_id": "t1", "title": "主文案"}],
+        }
+    )
+    assert any(c[0] == "set_node_content" and c[1] == ("t1", "正文A") for c in nest.calls)
+    assert out["awaiting_user"] is False
+    assert any(
+        c[0] == "emit_task_update" and c[1].get("status") == "done" for c in nest.calls
+    )

--- a/services/agent-runtime/tests/test_draft_copy.py
+++ b/services/agent-runtime/tests/test_draft_copy.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from app.graph.nodes.draft_copy import make_draft_copy_node
+
+
+class FakeLLM:
+    def __init__(self, responses: list[str]) -> None:
+        self.responses = list(responses)
+
+    async def ainvoke(self, messages: Any, **kwargs: Any) -> AIMessage:
+        if not self.responses:
+            raise RuntimeError("FakeLLM: no responses left")
+        return AIMessage(content=self.responses.pop(0))
+
+
+class FakeNest:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Any]] = []
+
+    async def emit_text(self, text: str) -> None:
+        self.calls.append(("emit_text", text))
+
+    async def emit_task_update(self, **payload: Any) -> None:
+        self.calls.append(("emit_task_update", payload))
+
+
+@pytest.mark.asyncio
+async def test_draft_copy_sets_gate_and_needs_user():
+    nest = FakeNest()
+    llm = FakeLLM(responses=["# 主文案\n静音·洁净·极简\n..."])
+    node = make_draft_copy_node(nest=nest, llm=llm)
+    out = await node(
+        {
+            "split_manifest": [
+                {
+                    "key": "copy_main",
+                    "title": "主文案",
+                    "target_type": "text",
+                    "node_id": "t1",
+                },
+                {
+                    "key": "white_bg",
+                    "title": "白底图",
+                    "target_type": "image",
+                    "node_id": "i1",
+                },
+            ],
+            "plan_summary": "卫生洁具方案",
+        }
+    )
+    assert out["phase"] == "await_copy_confirm"
+    assert out["awaiting_user"] is True
+    assert out["copy_node_id"] == "t1"
+    assert "静音" in (out["copy_draft"] or "")
+    assert any(
+        c[0] == "emit_task_update" and c[1].get("status") == "needs_user"
+        for c in nest.calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_draft_copy_skips_without_text_item():
+    nest = FakeNest()
+    llm = FakeLLM(responses=["should-not-run"])
+    node = make_draft_copy_node(nest=nest, llm=llm)
+    out = await node(
+        {
+            "split_manifest": [
+                {"key": "white_bg", "title": "白底图", "target_type": "image", "node_id": "i1"},
+            ],
+        }
+    )
+    assert out == {}
+    assert nest.calls == []

--- a/services/agent-runtime/tests/test_graph_plan_split.py
+++ b/services/agent-runtime/tests/test_graph_plan_split.py
@@ -138,8 +138,8 @@ def _batch_keys(nest: FakeNest) -> set[str]:
 @pytest.mark.asyncio
 async def test_confirm_then_split_creates_image_skeletons():
     nest = FakeNest()
-    # plan markdown, then classification reply "确认" if heuristic needs LLM fallback
-    llm = FakeLLM(responses=[PLAN_MARKDOWN, "确认"])
+    # plan markdown, confirm classify (unused if heuristic), draft_copy body
+    llm = FakeLLM(responses=[PLAN_MARKDOWN, "确认", "# 主文案\n静音洁净\n"])
     graph = build_agent_graph(
         nest=nest,
         llm=llm,
@@ -168,7 +168,10 @@ async def test_confirm_then_split_creates_image_skeletons():
     keys = _batch_keys(nest)
     assert "white_bg" in keys
     assert "hero_main" in keys
-    assert state2["phase"] == "done"
+    # draft_copy then orchestrate_gen; done preserves copy HITL gate
+    assert state2["phase"] == "await_copy_confirm"
+    assert state2["awaiting_user"] is True
+    assert state2.get("copy_draft")
     assert state2["user_decision"] == "confirm"
     assert state2["split_manifest"]
     assert all(item.get("node_id") for item in state2["split_manifest"])

--- a/services/agent-runtime/tests/test_orchestrate_gen.py
+++ b/services/agent-runtime/tests/test_orchestrate_gen.py
@@ -107,6 +107,7 @@ async def test_orchestrate_white_bg_success_then_hero_called():
 
     assert nest.calls == ["white_bg", "hero_main"]
     assert result["gen_completed"] == ["node-white_bg", "node-hero_main"]
+    assert getattr(nest, "task_list", None) is None  # must not replace split task_list
     assert result["gen_failed"] == []
     assert result["gen_queue"] == ["node-white_bg", "node-hero_main"]
     assert result["phase"] == "orchestrate_gen"

--- a/services/agent-runtime/tests/test_plan_clean.py
+++ b/services/agent-runtime/tests/test_plan_clean.py
@@ -1,0 +1,18 @@
+from app.graph.plan_clean import strip_plan_preamble
+
+
+def test_strip_from_first_heading():
+    raw = "好的，我将根据您的需求输出一份方案 Markdown。\n\n# 卫生洁具方案\n\n正文"
+    assert strip_plan_preamble(raw).startswith("# 卫生洁具方案")
+
+
+def test_strip_chitchat_without_heading():
+    raw = "好的，下面给出方案。\n定位：极简\n卖点：静音"
+    out = strip_plan_preamble(raw)
+    assert not out.startswith("好的")
+    assert "定位" in out
+
+
+def test_already_clean():
+    raw = "# 方案\n\n内容"
+    assert strip_plan_preamble(raw) == raw

--- a/services/agent-runtime/tests/test_route_entry_copy_gate.py
+++ b/services/agent-runtime/tests/test_route_entry_copy_gate.py
@@ -1,0 +1,45 @@
+import asyncio
+
+from app.graph.builder import route_entry
+from app.graph.nodes.done import make_done_node
+
+
+def test_route_entry_prefers_copy_gate():
+    assert (
+        route_entry(
+            {
+                "awaiting_user": True,
+                "phase": "await_copy_confirm",
+            }
+        )
+        == "await_copy_confirm"
+    )
+
+
+def test_route_entry_still_supports_plan_confirm():
+    assert (
+        route_entry(
+            {
+                "awaiting_user": True,
+                "phase": "await_confirm",
+            }
+        )
+        == "await_confirm"
+    )
+
+
+def test_done_preserves_copy_gate():
+    done = make_done_node()
+    out = asyncio.get_event_loop().run_until_complete(
+        done(
+            {
+                "awaiting_user": True,
+                "phase": "await_copy_confirm",
+                "copy_draft": "主文案草稿",
+                "gen_completed": ["n1"],
+                "gen_failed": [],
+            }
+        )
+    )
+    assert out["awaiting_user"] is True
+    assert out["phase"] == "await_copy_confirm"

--- a/services/agent-runtime/tests/test_route_entry_copy_gate.py
+++ b/services/agent-runtime/tests/test_route_entry_copy_gate.py
@@ -1,4 +1,4 @@
-import asyncio
+import pytest
 
 from app.graph.builder import route_entry
 from app.graph.nodes.done import make_done_node
@@ -28,18 +28,17 @@ def test_route_entry_still_supports_plan_confirm():
     )
 
 
-def test_done_preserves_copy_gate():
+@pytest.mark.asyncio
+async def test_done_preserves_copy_gate():
     done = make_done_node()
-    out = asyncio.get_event_loop().run_until_complete(
-        done(
-            {
-                "awaiting_user": True,
-                "phase": "await_copy_confirm",
-                "copy_draft": "主文案草稿",
-                "gen_completed": ["n1"],
-                "gen_failed": [],
-            }
-        )
+    out = await done(
+        {
+            "awaiting_user": True,
+            "phase": "await_copy_confirm",
+            "copy_draft": "主文案草稿",
+            "gen_completed": ["n1"],
+            "gen_failed": [],
+        }
     )
     assert out["awaiting_user"] is True
     assert out["phase"] == "await_copy_confirm"


### PR DESCRIPTION
## Summary
- Preserve copy HITL gate across `done`; add `draft_copy` → parallel image gen → `await_copy_confirm` / `write_copy_node` (confirm writes draft via Nest `set-node-content`, no Studio regen).
- Stop orchestrate from re-emitting full `task_list` (keeps 主文案 on card); strip plan LLM preamble; frontend reconciles task card after SSE disconnect and merges server canvas urls/content on load/poll.
- Copy confirm chips（写入主文案 / 要修改）in Agent side rail.

## Test plan
- [ ] Runtime: `pytest` (60) in `services/agent-runtime`
- [ ] Server: `pnpm --filter @lnkpi/server exec vitest run src/agent`
- [ ] Web: vitest for `agentChipSet`, `taskProgressReconcile`, `canvasNodeMerge`
- [ ] After merge: deploy with **`enable_agent_runtime=true`** (API-only rebuild will not ship Runtime graph changes)
- [ ] Prod clean-canvas: task card shows 主文案; chips appear; confirm writes node; card closes after disconnect reconcile; images appear without waiting on copy; plan node has no chitchat preamble


Made with [Cursor](https://cursor.com)