### PR TITLE
fix: unblock 写入主文案 during background image gen

### DIFF
--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -305,6 +305,7 @@ async function sendMessage(message: string) {
 
 const BUSY_TIP_SNIPPET = '上一轮仍在处理中'
 const EXEC_PROGRESS_SNIPPET = '出图成功'
+const COPY_WRITTEN_SNIPPET = '已将确认的主文案'
 
 /** 流结束后用 DB 历史补齐（避免只看到 busy / 截断 / 被旧确认文案覆盖） */
 async function reconcileLatestAssistant() {
@@ -339,7 +340,12 @@ async function reconcileLatestAssistant() {
         if (
           content
           && !content.includes(BUSY_TIP_SNIPPET)
-          && (content.includes(EXEC_PROGRESS_SNIPPET) || content.includes('自动出图') || content.length > 80)
+          && (
+            content.includes(COPY_WRITTEN_SNIPPET)
+            || content.includes(EXEC_PROGRESS_SNIPPET)
+            || content.includes('自动出图')
+            || content.length > 80
+          )
         ) {
           scrollToBottom()
           break

--- a/apps/web/src/components/agent/assistantReconcile.test.ts
+++ b/apps/web/src/components/agent/assistantReconcile.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   looksLikeConfirmTurn,
+  looksLikeCopyWriteTurn,
   shouldApplyReconciledAssistant,
 } from './assistantReconcile'
 
@@ -23,11 +24,34 @@ describe('shouldApplyReconciledAssistant', () => {
   it('accepts db when local empty', () => {
     expect(shouldApplyReconciledAssistant('', 'hello')).toBe(true)
   })
+
+  it('does not replace busy tip with stale copy draft', () => {
+    const local = '上一轮仍在处理中，请稍候；拆解出图通常需要一两分钟。'
+    const db = '【主文案草稿】\n# 文案\n请确认后回复「写入主文案」'
+    expect(shouldApplyReconciledAssistant(local, db)).toBe(false)
+  })
+
+  it('does not replace write success with longer draft', () => {
+    const local = '已将确认的主文案写入画布节点。'
+    const db = '【主文案草稿】\n很长的旧草稿……请确认后回复「写入主文案」'
+    expect(shouldApplyReconciledAssistant(local, db)).toBe(false)
+  })
+
+  it('prefers write success from DB over local draft bubble', () => {
+    const local = '【主文案草稿】\n旧草稿'
+    const db = '已将确认的主文案写入画布节点。'
+    expect(shouldApplyReconciledAssistant(local, db)).toBe(true)
+  })
 })
 
 describe('looksLikeConfirmTurn', () => {
   it('matches chip confirm', () => {
     expect(looksLikeConfirmTurn('确认')).toBe(true)
+  })
+
+  it('matches copy write chip', () => {
+    expect(looksLikeCopyWriteTurn('写入主文案')).toBe(true)
+    expect(looksLikeConfirmTurn('写入主文案')).toBe(true)
   })
 
   it('rejects long brief', () => {

--- a/apps/web/src/components/agent/assistantReconcile.ts
+++ b/apps/web/src/components/agent/assistantReconcile.ts
@@ -2,6 +2,9 @@
 
 export const CONFIRM_GATE_SNIPPET = '请确认是否按此方案拆解画布并出图'
 export const EXEC_TIP_SNIPPET = '正在按方案拆解'
+export const BUSY_TIP_SNIPPET = '上一轮仍在处理中'
+export const COPY_DRAFT_SNIPPET = '【主文案草稿】'
+export const COPY_WRITTEN_SNIPPET = '已将确认的主文案'
 
 /**
  * Whether DB assistant text should replace the local streaming bubble.
@@ -14,6 +17,21 @@ export function shouldApplyReconciledAssistant(localContent: string, dbContent: 
   const db = dbContent.trim()
   if (!db) return false
   if (!local) return true
+
+  // Prefer a successful write from DB even if shorter than a stale draft bubble
+  if (db.includes(COPY_WRITTEN_SNIPPET) && !local.includes(COPY_WRITTEN_SNIPPET)) {
+    return true
+  }
+  // Never let a previous-turn draft/progress overwrite busy tip or write success
+  if (local.includes(BUSY_TIP_SNIPPET)) {
+    if (db.includes(COPY_DRAFT_SNIPPET) || db.includes(EXEC_TIP_SNIPPET) || db.includes(BUSY_TIP_SNIPPET)) {
+      return false
+    }
+  }
+  if (local.includes(COPY_WRITTEN_SNIPPET) && db.includes(COPY_DRAFT_SNIPPET)) {
+    return false
+  }
+
   if (db.length <= local.length) return false
   const localIsExec = local.includes(EXEC_TIP_SNIPPET) || local.includes('已按方案拆解')
   const dbIsStaleGate = db.includes(CONFIRM_GATE_SNIPPET) && !db.includes(EXEC_TIP_SNIPPET)
@@ -21,9 +39,16 @@ export function shouldApplyReconciledAssistant(localContent: string, dbContent: 
   return true
 }
 
+export function looksLikeCopyWriteTurn(userText: string): boolean {
+  const t = userText.trim()
+  if (!t) return false
+  return /写入主文案|确认写入|可以写入/.test(t)
+}
+
 export function looksLikeConfirmTurn(userText: string): boolean {
   const t = userText.trim()
   if (!t) return false
+  if (looksLikeCopyWriteTurn(t)) return true
   if (/^(确认|同意|可以|没问题|开始拆|出图|ok|okay|yes|confirm)\s*$/i.test(t)) return true
   // Long briefs that merely mention「确认」are planning turns, not confirm chips
   if (/请为|写一份|帮我设计|帮我做|帮我写/.test(t)) return false

--- a/services/agent-runtime/app/graph/builder.py
+++ b/services/agent-runtime/app/graph/builder.py
@@ -12,7 +12,6 @@ from app.graph.nodes.chat import make_chat_node
 from app.graph.nodes.done import make_done_node
 from app.graph.nodes.draft_copy import make_draft_copy_node
 from app.graph.nodes.intake import make_intake_node
-from app.graph.nodes.orchestrate_gen import make_orchestrate_gen_node
 from app.graph.nodes.plan import make_plan_node
 from app.graph.nodes.split import make_split_node
 from app.graph.nodes.write_copy_node import make_write_copy_node
@@ -28,9 +27,11 @@ def route_entry(state: AgentRuntimeState) -> str:
 
 
 def route_after_draft_copy(state: AgentRuntimeState) -> str:
-    if state.get("copy_revise_only"):
-        return "end"
-    return "orchestrate_gen"
+    # Always end the user turn after draft so「写入主文案」is not blocked by image gen.
+    # First draft sets pending_orchestrate; stream_run_events kicks orchestrate in background.
+    if state.get("pending_orchestrate"):
+        return "done"
+    return "end"
 
 
 def route_after_copy_confirm(state: AgentRuntimeState) -> str:
@@ -74,7 +75,6 @@ def build_agent_graph(
     graph.add_node("await_confirm", make_await_confirm_node(llm=llm))
     graph.add_node("split", make_split_node(nest=nest, skills_dir=skills_path))
     graph.add_node("draft_copy", make_draft_copy_node(nest=nest, llm=llm))
-    graph.add_node("orchestrate_gen", make_orchestrate_gen_node(nest=nest))
     graph.add_node("done", make_done_node())
     graph.add_node("await_copy_confirm", make_await_copy_confirm_node())
     graph.add_node("write_copy_node", make_write_copy_node(nest=nest))
@@ -104,9 +104,9 @@ def build_agent_graph(
     graph.add_conditional_edges(
         "draft_copy",
         route_after_draft_copy,
-        {"orchestrate_gen": "orchestrate_gen", "end": END},
+        {"done": "done", "end": END},
     )
-    graph.add_edge("orchestrate_gen", "done")
+    # orchestrate_gen runs in background via stream_run_events (not on sync path)
     graph.add_edge("done", END)
     graph.add_conditional_edges(
         "await_copy_confirm",

--- a/services/agent-runtime/app/graph/nodes/done.py
+++ b/services/agent-runtime/app/graph/nodes/done.py
@@ -11,7 +11,12 @@ def make_done_node() -> Callable:
     async def done(state: dict) -> dict:
         completed = state.get("gen_completed") or []
         failed = state.get("gen_failed") or []
-        if completed or failed:
+        if state.get("pending_orchestrate") and not completed and not failed:
+            msg = (
+                "主文案草稿已就绪；图片/视频正在后台生成。"
+                "可先确认「写入主文案」，无需等待出图结束。"
+            )
+        elif completed or failed:
             lines: list[str] = []
             fallback_n = 0
             for item in failed:
@@ -39,11 +44,13 @@ def make_done_node() -> Callable:
             return {
                 "phase": "await_copy_confirm",
                 "awaiting_user": True,
+                "pending_orchestrate": False,
                 "messages": [AIMessage(content=msg)],
             }
         return {
             "phase": "done",
             "awaiting_user": False,
+            "pending_orchestrate": False,
             "messages": [AIMessage(content=msg)],
         }
 

--- a/services/agent-runtime/app/graph/nodes/draft_copy.py
+++ b/services/agent-runtime/app/graph/nodes/draft_copy.py
@@ -81,12 +81,15 @@ def make_draft_copy_node(*, nest: Any, llm: Any) -> Callable:
                 errorHint="请确认主文案后写入",
             )
 
+        was_revise = bool(state.get("copy_revise_only"))
         out: dict[str, Any] = {
             "phase": "await_copy_confirm",
             "awaiting_user": True,
             "copy_draft": draft,
             "copy_node_id": node_id,
             "copy_revise_only": False,
+            # First draft: arm background orchestrate. Revise-only: do not re-kick gens.
+            "pending_orchestrate": not was_revise,
             "messages": [AIMessage(content=body)],
         }
         return out

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -51,6 +51,8 @@ class AgentRuntimeState(TypedDict, total=False):
     copy_draft: str | None
     copy_node_id: str | None
     copy_revise_only: bool
+    # After first draft_copy: orchestrate_gen runs in background so write HITL is not blocked
+    pending_orchestrate: bool
 
     # 一期轻量人机
     awaiting_user: bool

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 from app.config import settings
 from app.graph.builder import build_agent_graph
+from app.graph.nodes.orchestrate_gen import make_orchestrate_gen_node
 from app.tools.nest_client import NestCanvasClient
 
 EmitFn = Callable[[dict[str, Any]], Awaitable[None]]
@@ -41,6 +42,36 @@ def _release_thread(thread_id: str) -> None:
     lock = _thread_locks.get(thread_id)
     if lock is not None and lock.locked():
         lock.release()
+
+
+async def _run_orchestrate_background(
+    *,
+    session_id: str,
+    user_id: str,
+    split_manifest: list[Any],
+    gen_completed: list[Any] | None = None,
+    gen_failed: list[Any] | None = None,
+) -> None:
+    """Image/video topo gen after draft turn ends — must not hold the thread lock."""
+
+    async def _noop_emit(_event: dict[str, Any]) -> None:
+        return None
+
+    inner = default_nest(session_id=session_id, user_id=user_id)
+    proxy = NestEventProxy(inner, _noop_emit)
+    try:
+        node = make_orchestrate_gen_node(nest=proxy)
+        await node(
+            {
+                "split_manifest": split_manifest,
+                "gen_completed": list(gen_completed or []),
+                "gen_failed": list(gen_failed or []),
+            }
+        )
+    except Exception:  # noqa: BLE001 — background; canvas/records still reflect partial progress
+        pass
+    finally:
+        await proxy.close()
 
 
 class RunRequest(BaseModel):
@@ -207,7 +238,11 @@ async def stream_run_events(
         "thread_id": thread_id,
     }
 
+    bg_payload: dict[str, Any] | None = None
+
     async def run_graph() -> None:
+        nonlocal bg_payload
+        saw_pending_orchestrate = False
         try:
             async for update in graph.astream(input_state, config, stream_mode="updates"):
                 if not isinstance(update, dict):
@@ -215,6 +250,8 @@ async def stream_run_events(
                 for _node, delta in update.items():
                     if not isinstance(delta, dict):
                         continue
+                    if delta.get("pending_orchestrate"):
+                        saw_pending_orchestrate = True
                     messages = delta.get("messages")
                     if not messages:
                         continue
@@ -231,6 +268,21 @@ async def stream_run_events(
                         )
                         if msg_type in ("ai", "assistant") or isinstance(msg, AIMessage):
                             await emit({"type": "text_delta", "data": {"text": str(content)}})
+            if saw_pending_orchestrate:
+                try:
+                    snap = await graph.aget_state(config)
+                    vals = getattr(snap, "values", None) or {}
+                    manifest = list(vals.get("split_manifest") or [])
+                    if manifest:
+                        bg_payload = {
+                            "session_id": req.session_id,
+                            "user_id": req.user_id,
+                            "split_manifest": manifest,
+                            "gen_completed": list(vals.get("gen_completed") or []),
+                            "gen_failed": list(vals.get("gen_failed") or []),
+                        }
+                except Exception:  # noqa: BLE001
+                    bg_payload = None
             await emit({"type": "done", "data": {}})
         except Exception as exc:  # noqa: BLE001 — surface to Nest SSE
             await emit({"type": "error", "data": {"message": str(exc)}})
@@ -248,6 +300,8 @@ async def stream_run_events(
             yield item
     finally:
         _release_thread(thread_id)
+        if bg_payload is not None:
+            asyncio.create_task(_run_orchestrate_background(**bg_payload))
         if not task.done():
             task.cancel()
             try:

--- a/services/agent-runtime/tests/test_draft_copy.py
+++ b/services/agent-runtime/tests/test_draft_copy.py
@@ -56,11 +56,36 @@ async def test_draft_copy_sets_gate_and_needs_user():
     assert out["phase"] == "await_copy_confirm"
     assert out["awaiting_user"] is True
     assert out["copy_node_id"] == "t1"
+    assert out["pending_orchestrate"] is True
     assert "静音" in (out["copy_draft"] or "")
     assert any(
         c[0] == "emit_task_update" and c[1].get("status") == "needs_user"
         for c in nest.calls
     )
+
+
+@pytest.mark.asyncio
+async def test_draft_copy_revise_skips_pending_orchestrate():
+    nest = FakeNest()
+    llm = FakeLLM(responses=["# 修订主文案\n节水优先\n"])
+    node = make_draft_copy_node(nest=nest, llm=llm)
+    out = await node(
+        {
+            "copy_revise_only": True,
+            "messages": [],
+            "split_manifest": [
+                {
+                    "key": "copy_main",
+                    "title": "主文案",
+                    "target_type": "text",
+                    "node_id": "t1",
+                },
+            ],
+            "plan_summary": "卫生洁具方案",
+        }
+    )
+    assert out["pending_orchestrate"] is False
+    assert out["phase"] == "await_copy_confirm"
 
 
 @pytest.mark.asyncio

--- a/services/agent-runtime/tests/test_graph_plan_split.py
+++ b/services/agent-runtime/tests/test_graph_plan_split.py
@@ -168,24 +168,17 @@ async def test_confirm_then_split_creates_image_skeletons():
     keys = _batch_keys(nest)
     assert "white_bg" in keys
     assert "hero_main" in keys
-    # draft_copy then orchestrate_gen; done preserves copy HITL gate
+    # draft_copy then done (orchestrate runs in background outside graph.ainvoke)
     assert state2["phase"] == "await_copy_confirm"
     assert state2["awaiting_user"] is True
     assert state2.get("copy_draft")
     assert state2["user_decision"] == "confirm"
     assert state2["split_manifest"]
     assert all(item.get("node_id") for item in state2["split_manifest"])
+    # Sync graph path must NOT block on image gen
     gen_calls = [c for c in nest.calls if c[0] == "run_image_generation"]
-    video_calls = [c for c in nest.calls if c[0] == "run_video_generation"]
-    assert gen_calls  # orchestrate_gen ran for auto_generate images
-    assert state2.get("gen_completed")
-    video_ids = {
-        item["node_id"]
-        for item in state2["split_manifest"]
-        if item.get("key") == "show_video"
-    }
-    assert video_calls
-    assert any(c[1]["node_id"] in video_ids for c in video_calls)
+    assert gen_calls == []
+    assert not state2.get("gen_completed")
     # task card list must be pinned at end of split (before long gen)
     task_lists = [c for c in nest.calls if c[0] == "emit_task_list"]
     assert task_lists

--- a/services/agent-runtime/tests/test_route_entry_copy_gate.py
+++ b/services/agent-runtime/tests/test_route_entry_copy_gate.py
@@ -42,3 +42,21 @@ async def test_done_preserves_copy_gate():
     )
     assert out["awaiting_user"] is True
     assert out["phase"] == "await_copy_confirm"
+
+
+@pytest.mark.asyncio
+async def test_done_pending_orchestrate_copy_ready_tip():
+    done = make_done_node()
+    out = await done(
+        {
+            "awaiting_user": True,
+            "phase": "await_copy_confirm",
+            "copy_draft": "主文案草稿",
+            "pending_orchestrate": True,
+            "gen_completed": [],
+            "gen_failed": [],
+        }
+    )
+    assert out["phase"] == "await_copy_confirm"
+    assert out["pending_orchestrate"] is False
+    assert "后台生成" in out["messages"][0].content


### PR DESCRIPTION
## Summary
- Root cause: sync `draft_copy → orchestrate_gen` held the thread lock while chips invited「写入主文案」; busy tip was then reconciled into the previous long draft bubble.
- Fix: end the user turn after draft (preserve copy gate); kick `orchestrate_gen` in background after lock release; harden assistant reconcile so busy/write success is not overwritten by stale draft.

## Test plan
- [x] Runtime pytest (62)
- [x] Web `assistantReconcile` + `agentChipSet` vitest
- [ ] Deploy with `enable_agent_runtime=true`
- [ ] Prod: confirm split → see draft chips while images still generating →「写入主文案」persists node and clears needs_user


Made with [Cursor](https://cursor.com)