### PR TITLE
feat(agent): topology preview HITL (方案门 + await_topo + 出图门)

### DIFF
--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -55,6 +55,7 @@ const chipSet = computed(() => {
 })
 const awaitingConfirm = computed(() => chipSet.value === 'plan')
 const awaitingCopyConfirm = computed(() => chipSet.value === 'copy')
+const awaitingTopoConfirm = computed(() => chipSet.value === 'topo')
 
 /** 面板是否展开（收缩态只保留右下角 logo FAB） */
 const open = ref(false)
@@ -580,17 +581,51 @@ defineExpose({ openPanel, reconcileFromNodes })
                 type="button"
                 class="neo-ctl rounded-lg px-3 py-1.5 text-xs font-medium text-[var(--neo-accent-text)]"
                 :disabled="agent.isStreaming"
-                @click="sendPreset('确认')"
+                @click="sendPreset('1')"
               >
-                确认拆图
+                1 / A 确认方案
               </button>
               <button
                 type="button"
                 class="neo-ctl rounded-lg px-3 py-1.5 text-xs"
                 :disabled="agent.isStreaming"
-                @click="sendPreset('我要修改：')"
+                @click="sendPreset('2')"
               >
-                要修改
+                2 / B 换方向
+              </button>
+              <button
+                type="button"
+                class="neo-ctl rounded-lg px-3 py-1.5 text-xs"
+                :disabled="agent.isStreaming"
+                @click="sendPreset('3')"
+              >
+                3 / C 自己说明
+              </button>
+            </div>
+            <div v-else-if="awaitingTopoConfirm" class="mb-2 flex flex-wrap gap-2 px-0.5">
+              <button
+                type="button"
+                class="neo-ctl rounded-lg px-3 py-1.5 text-xs font-medium text-[var(--neo-accent-text)]"
+                :disabled="agent.isStreaming"
+                @click="sendPreset('确认出图')"
+              >
+                确认出图
+              </button>
+              <button
+                type="button"
+                class="neo-ctl rounded-lg px-3 py-1.5 text-xs"
+                :disabled="agent.isStreaming"
+                @click="sendPreset('写入主文案')"
+              >
+                写入主文案
+              </button>
+              <button
+                type="button"
+                class="neo-ctl rounded-lg px-3 py-1.5 text-xs"
+                :disabled="agent.isStreaming"
+                @click="sendPreset('要改拓扑：')"
+              >
+                要改拓扑
               </button>
             </div>
             <div v-else-if="awaitingCopyConfirm" class="mb-2 flex flex-wrap gap-2 px-0.5">
@@ -606,7 +641,7 @@ defineExpose({ openPanel, reconcileFromNodes })
                 type="button"
                 class="neo-ctl rounded-lg px-3 py-1.5 text-xs"
                 :disabled="agent.isStreaming"
-                @click="sendPreset('要修改：')"
+                @click="sendPreset('文案要修改：')"
               >
                 要修改
               </button>

--- a/apps/web/src/components/agent/agentChipSet.test.ts
+++ b/apps/web/src/components/agent/agentChipSet.test.ts
@@ -3,16 +3,34 @@ import { describe, expect, it } from 'vitest'
 import { detectAgentChipSet } from './agentChipSet'
 
 describe('detectAgentChipSet', () => {
-  it('detects plan confirm gate', () => {
+  it('detects plan structured options', () => {
     expect(
-      detectAgentChipSet('…请确认是否按此方案拆解画布并出图；如需修改请直接说明。'),
+      detectAgentChipSet(
+        '定位：高端\n请选择：\n1 / A：采纳推荐并确认方案\n2 / B：换个方向',
+      ),
     ).toBe('plan')
   })
 
-  it('detects copy draft gate and prefers copy over plan', () => {
+  it('detects copy draft gate', () => {
     expect(
       detectAgentChipSet('【主文案草稿】\n静音\n\n请确认后回复「写入主文案」…'),
     ).toBe('copy')
+  })
+
+  it('prefers topo when draft also mentions 确认出图', () => {
+    expect(
+      detectAgentChipSet(
+        '【主文案草稿】\n静音\n\n请确认后回复「写入主文案」。拓扑确认无误后回复「确认出图」。',
+      ),
+    ).toBe('topo')
+  })
+
+  it('detects topo gate and prefers topo over bare plan words', () => {
+    expect(
+      detectAgentChipSet(
+        '已拆解骨架\n当前资产拓扑：\n```mermaid\nflowchart LR\n```\n确认无误后回复「确认出图」。',
+      ),
+    ).toBe('topo')
   })
 
   it('returns null for ordinary replies', () => {

--- a/apps/web/src/components/agent/agentChipSet.ts
+++ b/apps/web/src/components/agent/agentChipSet.ts
@@ -1,15 +1,20 @@
 /** @vitest-environment node */
 
-export type AgentChipSet = 'plan' | 'copy' | null
+export type AgentChipSet = 'plan' | 'copy' | 'topo' | null
 
-const PLAN_SNIPPET = '请确认是否按此方案拆解画布并出图'
+const PLAN_SNIPPETS = ['1 / A', '确认方案', '请选择：'] as const
 const COPY_SNIPPETS = ['【主文案草稿】', '写入主文案'] as const
+const TOPO_SNIPPETS = ['确认出图', '当前资产拓扑', '要改拓扑'] as const
 
 /** Which confirm chip row to show under the agent input. */
 export function detectAgentChipSet(assistantText: string): AgentChipSet {
   const t = (assistantText || '').trim()
   if (!t) return null
+  // Draft + out图门: show topo row (includes 写入主文案 + 确认出图)
+  if (t.includes('【主文案草稿】') && TOPO_SNIPPETS.some((s) => t.includes(s))) return 'topo'
+  if (COPY_SNIPPETS.some((s) => t.includes(s)) && t.includes('【主文案草稿】')) return 'copy'
+  if (TOPO_SNIPPETS.some((s) => t.includes(s))) return 'topo'
   if (COPY_SNIPPETS.some((s) => t.includes(s))) return 'copy'
-  if (t.includes(PLAN_SNIPPET)) return 'plan'
+  if (PLAN_SNIPPETS.some((s) => t.includes(s))) return 'plan'
   return null
 }

--- a/docs/superpowers/plans/2026-07-25-agent-topology-preview-hitl.md
+++ b/docs/superpowers/plans/2026-07-25-agent-topology-preview-hitl.md
@@ -1,0 +1,169 @@
+# Agent Topology Preview HITL Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement方案门（确认前不写画布 + 结构化选项）、骨架预览（Mermaid + 画布）、`await_topo`、出图门、Skill `full|trimmed` 双模式。
+
+**Architecture:** LangGraph phases: `plan` (draft only) → `await_confirm` → `write_plan_node` → `split` (no gen) → `draft_copy` → `await_topo` → `orchestrate_gen`. Remove auto `pending_orchestrate` bg gen after draft. Frontend chips for numbered plan options + topo/copy.
+
+**Tech Stack:** Python LangGraph Runtime, Nest canvas tools, Vue AgentSideRail chips, vitest/pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-25-agent-topology-preview-hitl-design.md`（已确认）
+
+## Global Constraints
+
+- 方案节点仅在「确认方案」后写入；确认前禁止 `upsert_prompt_node`。
+- 出图仅在「确认出图」后；禁止 draft 后 `pending_orchestrate` 自动出图。
+- Mermaid 画资产拓扑（`depends_on`），非 LangGraph 控制流。
+- `trimmed` 只能选模板内 key + 依赖闭包。
+- 复测必须覆盖 `full` 与 `trimmed`。
+- B/C（三视图链、Dock 手工后执行）不在本计划。
+
+---
+
+## File map
+
+| File | Responsibility |
+| --- | --- |
+| `services/agent-runtime/app/graph/state.py` | `plan_draft`, `topology_mode`, `phase=await_topo` |
+| `services/agent-runtime/app/graph/builder.py` | Wire `write_plan_node`, `await_topo`; routes |
+| `services/agent-runtime/app/graph/nodes/plan.py` | Summary + structured options; no canvas write |
+| `services/agent-runtime/app/graph/nodes/write_plan_node.py` | **New** — upsert confirmed plan + confirmed summary |
+| `services/agent-runtime/app/graph/nodes/await_confirm.py` | Classify 1/A, 2/B, 3/C |
+| `services/agent-runtime/app/graph/nodes/split.py` | Mode full/trimmed; emit Mermaid; no gen |
+| `services/agent-runtime/app/graph/nodes/await_topo.py` | **New** — classify confirm_gen / topo_revise / none |
+| `services/agent-runtime/app/graph/nodes/topo_revise.py` | **New** — NL → Nest + manifest + Mermaid |
+| `services/agent-runtime/app/graph/mermaid_topo.py` | **New** — manifest → mermaid string |
+| `services/agent-runtime/app/graph/topo_trim.py` | **New** — trimmed key selection + closure |
+| `services/agent-runtime/app/runs.py` | Remove/gate auto bg orchestrate; only after confirm_gen |
+| `services/agent-runtime/skills/.../SKILL.md` + `canvas-manifest.yaml` | `topology_mode_default` |
+| `apps/web/.../agentChipSet.ts` | plan/topo/copy chip detection |
+| `apps/web/.../AgentSideRail.vue` | Render numbered option chips |
+
+---
+
+### Task 1: State + Skill config
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/state.py`
+- Modify: `services/agent-runtime/skills/enterprise-marketing-campaign/SKILL.md`
+- Modify: `services/agent-runtime/skills/enterprise-marketing-campaign/assets/canvas-manifest.yaml`
+
+- [ ] Add `plan_draft: str | None`, `topology_mode: Literal["full","trimmed"] | None`, phase `await_topo` / `write_plan_node`
+- [ ] Add `topology_mode_default: full` to skill metadata / manifest defaults
+- [ ] Commit: `chore(agent-runtime): state fields for topology preview HITL`
+
+---
+
+### Task 2: Mermaid + trim helpers (TDD)
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/mermaid_topo.py`
+- Create: `services/agent-runtime/app/graph/topo_trim.py`
+- Create: `services/agent-runtime/tests/test_mermaid_topo.py`
+- Create: `services/agent-runtime/tests/test_topo_trim.py`
+
+- [ ] Write failing tests: mermaid labels use titles; edge from depends_on; trim keeps closure
+- [ ] Implement helpers
+- [ ] Pytest pass
+- [ ] Commit: `feat(agent-runtime): mermaid topo + trimmed manifest helpers`
+
+---
+
+### Task 3: plan without canvas write + structured options
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/nodes/plan.py`
+- Modify: `services/agent-runtime/app/graph/nodes/await_confirm.py`
+- Modify: `services/agent-runtime/tests/test_graph_plan_split.py` (expect no upsert until confirm)
+
+- [ ] Failing test: after first `plan` invoke, nest has no `upsert_prompt_node`
+- [ ] `plan` stores `plan_draft`, emits summary + options text (1/A 推荐理由, 2/B, 3/C); no nest upsert
+- [ ] `await_confirm` classifies `1`/`A`/`确认方案` → confirm; `2`/`B`/`3`/`C`/修改 → revise
+- [ ] Pytest pass
+- [ ] Commit: `feat(agent-runtime): plan draft-only with structured confirm options`
+
+---
+
+### Task 4: write_plan_node
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/nodes/write_plan_node.py`
+- Modify: `services/agent-runtime/app/graph/builder.py`
+- Create: `services/agent-runtime/tests/test_write_plan_node.py`
+
+- [ ] Failing test: write_plan_node upserts cleaned draft and sets plan_node_id; emits 已确认摘要
+- [ ] Implement node (reuse `plan_clean.strip_plan_preamble`)
+- [ ] Wire: `await_confirm` confirm → `write_plan_node` → `split`
+- [ ] Commit: `feat(agent-runtime): write_plan_node after scheme confirm`
+
+---
+
+### Task 5: split emits Mermaid; apply topology_mode; no gen
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/nodes/split.py`
+- Modify: `services/agent-runtime/app/graph/nodes/draft_copy.py` (`pending_orchestrate` default false / remove auto-arm)
+- Modify: `services/agent-runtime/app/runs.py` (do not bg-orchestrate unless confirm_gen armed)
+
+- [ ] Failing test: split message includes mermaid; trimmed mode fewer items; no image gen in confirm turn until topo confirm
+- [ ] Resolve mode from state or skill default; trim when needed
+- [ ] Append Mermaid to split (or separate emit_text)
+- [ ] Ensure draft_copy does **not** set pending_orchestrate for auto bg; runs.py only arms after explicit confirm_gen path
+- [ ] Commit: `feat(agent-runtime): split skeleton preview without auto image gen`
+
+---
+
+### Task 6: await_topo + topo_revise + orchestrate on confirm_gen
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/nodes/await_topo.py`
+- Create: `services/agent-runtime/app/graph/nodes/topo_revise.py`
+- Modify: `services/agent-runtime/app/graph/builder.py`
+- Create: `services/agent-runtime/tests/test_await_topo.py`
+
+- [ ] Failing tests: confirm_gen → orchestrate; 「删掉 Banner」updates manifest; route_entry hits await_topo
+- [ ] `await_topo` decisions: confirm_gen | topo_revise | none (and defer copy to existing copy gate when message is copy-confirm — prefer copy gate in route_entry first)
+- [ ] `topo_revise`: LLM or heuristic parse → Nest mutations → remint Mermaid → stay await_topo
+- [ ] Graph: draft_copy → done/end with phase await_topo; route_entry await_topo → node; confirm_gen → orchestrate_gen → done
+- [ ] Commit: `feat(agent-runtime): await_topo gate and live topo revise`
+
+---
+
+### Task 7: Frontend chips
+
+**Files:**
+- Modify or create: `apps/web/src/components/agent/agentChipSet.ts`
+- Modify: `apps/web/src/components/agent/AgentSideRail.vue`
+- Modify/create tests: `agentChipSet.test.ts`
+
+- [ ] Detect plan options (snippet like `1`/`A` 确认方案 or dedicated marker)
+- [ ] Detect topo chips（确认出图 / 要改拓扑）
+- [ ] Keep copy chips
+- [ ] sendPreset for `1` / `A` / 确认出图 etc.
+- [ ] Vitest pass
+- [ ] Commit: `feat(web): structured plan and topo confirm chips`
+
+---
+
+### Task 8: Cross-doc pointer + verification
+
+**Files:**
+- Touch: specs already synced; optional one-line in task-progress-card if needed
+
+- [ ] Runtime pytest full suite
+- [ ] Web vitest agent chip/reconcile
+- [ ] Manual checklist in PR: full path + trimmed path; no plan node before confirm; no gen before 确认出图
+- [ ] Commit if doc nits: `docs: topology preview HITL impl notes`
+
+---
+
+## Execution handoff
+
+After this plan is approved for coding:
+
+1. Create worktree/branch `feature/agent-topology-preview-hitl` from main  
+2. Use subagent-driven-development or executing-plans  
+3. Deploy with `enable_agent_runtime=true` after merge  
+
+**Stop here for human gate:** reply「开始实现」to execute Tasks 1–8.

--- a/docs/superpowers/specs/2026-07-23-agent-runtime-langgraph-design.md
+++ b/docs/superpowers/specs/2026-07-23-agent-runtime-langgraph-design.md
@@ -1,10 +1,10 @@
 # Agent Runtime（LangGraph）技术选型与一期设计
 
-> 状态：**已确认**（2026-07-24）；实现计划见 `docs/superpowers/plans/2026-07-24-agent-runtime-langgraph.md`  
-> 日期：2026-07-23（修订 2026-07-24）  
-> 范围：Agent Runtime 技术选型、控制面/数据面边界、一期 Graph/State/Tools/Skills、**确认后按拓扑自动出图**；贯穿场景为**企业营销方案 → 画布资产拆解 → 出图**  
+> 状态：**已确认**（2026-07-24）；**修订 2026-07-25**：方案门确认后写节点、`await_topo`、出图门——见 `2026-07-25-agent-topology-preview-hitl-design.md`  
+> 日期：2026-07-23（修订 2026-07-24；拓扑预览 HITL 2026-07-25）  
+> 范围：Agent Runtime 技术选型、控制面/数据面边界、一期 Graph/State/Tools/Skills、**确认方案 → 骨架预览 → 确认出图**；贯穿场景为**企业营销方案 → 画布资产拆解 → 出图**  
 > 前置：`2026-07-18-node-data-flow-refs-design.md`（RefChip/数据贯通）、现有 `@lnkpi/agent` SSE + `CanvasAction`、Nest `Session.canvasData` / Studio 文生图·图生图  
-> 非范围：一期不引入 Temporal；不把画布全量镜像进 LangGraph State；不做生产级 durable HITL（仅预留）；**不打通 Agent 侧栏底部 dock 的模型/技能/积分参数链路**（遗留，见 §1.2 / §10）。**一期纳入**账户级画布生成默认（全模态）与 Agent 出图回退（见 §0 / §1.1 / §12.8）。**自动出视频**与**对话任务进度卡**见增补规格 `2026-07-25-agent-task-progress-card-design.md`。**确认后闭环加固 + 主文案 HITL / 节点与边演进**见 `2026-07-25-agent-confirm-loop-hardening-design.md` §7。
+> 非范围：一期不引入 Temporal；不把画布全量镜像进 LangGraph State；不做生产级 durable HITL（仅预留）；**不打通 Agent 侧栏底部 dock 的模型/技能/积分参数链路**（遗留，见 §1.2 / §10）。**一期纳入**账户级画布生成默认（全模态）与 Agent 出图回退（见 §0 / §1.1 / §12.8）。**自动出视频**与**对话任务进度卡**见 `2026-07-25-agent-task-progress-card-design.md`。**拓扑预览 / 方案结构化确认**见 `2026-07-25-agent-topology-preview-hitl-design.md`（A；B/C 另文）。
 
 ---
 
@@ -14,10 +14,11 @@
 | --- | --- |
 | Runtime 选型 | **方案一**：Python **LangGraph** + Nest 网关 + **自研 Markdown Skills** |
 | 画布真相源 | **Nest `Session.canvasData` + 前端 Vue Flow**；LangGraph **不**持有全量画布镜像 |
-| 控制流 vs 数据流 | LangGraph 边 = **阶段/逻辑**；画布边 + RefChip = **资产依赖** |
-| 一期 HITL | **轻量澄清**（多轮口头确认）；预留 `interrupt()` + checkpointer 演进到生产级 durable |
-| Skills | 一期即要：见 **§7**，目录与 `SKILL.md` **对齐 [Agent Skills](https://agentskills.io/specification) 开放标准**，可兼容 skills 市场生态；lnkpi 扩展仅放 `metadata` / `assets/` |
-| 一期验收 | Skill 规划 → 确认 → 拆骨架（边/prompt/refs）→ **按拓扑自动出图**（URI 回写节点） |
+| 控制流 vs 数据流 | LangGraph 边 = **阶段/逻辑**；画布边 + RefChip + manifest `depends_on` = **资产依赖**（对话 Mermaid 只画后者） |
+| 一期 HITL | **结构化选项 + 多轮澄清**（方案门 / 拓扑门 / 文案门）；预留 `interrupt()` 演进到 durable |
+| Skills | 一期即要：见 **§7**，目录与 `SKILL.md` **对齐 [Agent Skills](https://agentskills.io/specification) 开放标准**；lnkpi 扩展仅放 `metadata` / `assets/`；含 `topology_mode_default` |
+| 一期验收 | Skill 规划摘要 → **确认后写方案节点** → 拆骨架+拓扑预览 → **确认出图** → 按拓扑出图/出视频 |
+| 拓扑模式 | Skill `topology_mode_default: full\|trimmed` + 用户可覆盖；见拓扑预览规格 |
 | 自动生成编排 | **一期包含自动出图 + 自动出视频**（任务进度卡见 `2026-07-25-agent-task-progress-card-design.md`） |
 | 规划 LLM | **一期平台配置**：Runtime `LNKPI_OPENAI_*`（密钥/base_url/model）；**非**用户 UI 选择 / 对话 BYOK |
 | Agent 底栏 dock 参数 | **一期不打通**（见 §1.2 / §10）；**一期须去误导**：隐藏模型选择器与积分徽章（见 `2026-07-24-agent-chat-ux-phase1-design.md`） |
@@ -27,7 +28,7 @@
 | 与「不自动级联」关系 | 引用变更仍**不**静默重跑下游；仅在用户确认方案后由 Agent **显式**执行出图工作流 |
 | 现有 `@lnkpi/agent` | 保留为 Nest 侧兼容/工具适配层；新控制面迁到 Python Runtime，不一夜删除 |
 
-**贯穿场景（企业营销）**：用户：「帮我设计一套卫生洁具的营销方案。」→ Agent 规划并征询确认 → 画布落方案节点 → 确认后拆解下游文/图骨架并连线、注入提示词与芯片 → **按依赖自动文生图/图生图**，节点缩略图刷新。
+**贯穿场景（企业营销）**：用户要方案 → Agent **多轮摘要 + 结构化选项（1/A、2/B、3/C）** → 用户确认后**才**写入画布「营销方案」节点并给「已确认摘要」→ 拆骨架 + Mermaid 拓扑预览（可 NL 改）→ **确认出图** → 按依赖出图/出视频。详见 `2026-07-25-agent-topology-preview-hitl-design.md`。
 
 ---
 
@@ -174,37 +175,47 @@ class AgentRuntimeState(TypedDict):
 
 ## 5. 一期 Graph 拓扑
 
+> **修订（2026-07-25）：** 方案确认后写节点；`split` 与出图之间插入 `await_topo`。权威细节见 `2026-07-25-agent-topology-preview-hitl-design.md`。
+
 ```text
 START
+  ├─ (await_copy_confirm 续轮) → …
+  ├─ (await_topo 续轮) → await_topo → …
   ├─ (await_confirm 续轮) → await_confirm → …
   └─ intake
-        ├─ 强营销意图 → plan → await_confirm ─┬─ revise → plan
-        │                                      └─ confirm → split → orchestrate_gen → done
+        ├─ 强营销意图 → plan（摘要+选项，不写画布）→ await_confirm
+        │     ├─ revise → plan
+        │     └─ confirm → write_plan_node → split → draft_copy → await_topo
+        │           ├─ NL 改拓扑 / 文案 HITL → 保持 await_topo
+        │           └─ 确认出图 → orchestrate_gen → done
         └─ 否则 → chat → END
 ```
 
 | Graph 节点 | 职责 | 主要副作用 |
 | --- | --- | --- |
-| `intake` | **门控**：强营销意图才设 `skill_id`；否则进入日常对话。**禁止**唯一 Skill 兜底 | 更新 `skill_id`（可 null） |
-| `chat` | 非 Skill 短答（同规划 LLM）；可提示如何发起营销方案 | 仅对话 `messages` |
-| `plan` | 按 Skill 生成方案 Markdown；写**可读摘要**（定位 + 将拆资产列表 + N + 画布指引） | `upsert_prompt_node` → `plan_node_id` |
-| `await_confirm` | 征询确认/修改；`awaiting_user=True` | 无强制画布写 |
-| `split` | 读方案；写 `split_manifest`；批量建下游；独立进度话术 | 建节点/边/prompt/refs |
-| `orchestrate_gen` | 从 manifest + 边得到 `gen_queue`；逐个/有限并发出图；**按张进度** | `run_image_generation`；进度写入对话 |
-| `done` | **按节点**汇总成功/失败/平台兜底；提示画布操作 | `phase=done` |
+| `intake` | **门控**：强营销意图才设 `skill_id`；否则日常对话 | 更新 `skill_id`（可 null） |
+| `chat` | 非 Skill 短答 | 仅对话 `messages` |
+| `plan` | 方案摘要 + **结构化选项（1/A、2/B、3/C + 推荐理由）**；写入 `plan_draft` | **不写画布** |
+| `await_confirm` | 分类 confirm/revise/none | 无画布写 |
+| `write_plan_node` | 确认稿写入「营销方案」+「已确认摘要」话术 | `upsert_prompt_node` → `plan_node_id` |
+| `split` | 按 `topology_mode` 物化骨架；Mermaid；一次 `task_list` | 建节点/边/prompt/refs；**不出图** |
+| `draft_copy` | 主文案草稿；置文案门 | 对话草稿；`task_update(needs_user)` |
+| `await_topo` | 拓扑/出图门；可交错文案确认 | NL 改骨架时写 Nest |
+| `await_copy_confirm` / `write_copy_node` | 主文案 HITL | `set_node_content` |
+| `orchestrate_gen` | 仅出图门后：拓扑出图/出视频 | Studio gen；`task_*` |
+| `done` | 收尾；不得误清未完成的人机门 | `phase` 按门保留 |
 
-详情与验收见 `2026-07-24-agent-chat-ux-phase1-design.md`。
+**控制流边 vs 数据流边：**
 
-**出图规则（一期）：**
+| 种类 | 载体 | 用途 |
+| --- | --- | --- |
+| 控制流边 | LangGraph 节点转移 | 相位、HITL 门 |
+| 数据流边 | Nest `canvasData.edges` + manifest `depends_on` | 资产依赖、出图顺序、**对话 Mermaid** |
 
-1. 仅处理 `target_type=image` 且 `auto_generate=true` 的项。
-2. 拓扑：`depends_on` 映射为边；依赖未成功出图则跳过下游并记入 `gen_failed`（可配置），不无限等待。
-3. `t2i`：依赖文本/方案 refs；`i2i`：上游 image 节点须已有 `url`。
-4. 单节点超时/失败不阻断其它无依赖任务；对话中报告部分失败。
-5. 并发上限建议 ≤3（可配置），避免打爆 Provider/积分。
+**出图规则：** 仅在用户「确认出图」之后执行；依赖未完成则下游 `dependency_failed`（可配置）。并发上限建议 ≤3。
 
-**一期不做**独立 `HumanGate` 空节点。  
-**二期**可将 `await_confirm` 换成 `interrupt()`；并为 video 扩展同一 `orchestrate_gen`。
+**一期不做**独立空 `HumanGate` 节点（门控用 `await_*` 节点表达）。  
+**二期**可将门控换成 `interrupt()`；B/C 见拓扑预览规格 §8。
 
 ---
 
@@ -214,35 +225,34 @@ START
 
 | 步骤 | 用户 / Agent | Graph | State 要点 | Nest / 画布 |
 | --- | --- | --- | --- | --- |
-| 1 | 「帮我设计一套卫生洁具的营销方案。」 | `intake` → `plan` | `skill_id=enterprise-marketing-campaign` | — |
-| 2 | Agent 输出方案并请确认 | `plan` → `await_confirm` | `plan_summary`；`plan_node_id`；`awaiting_user=True` | 新建/更新 **prompt 节点**（T1） |
-| 3a | 「改成更偏天猫详情页」 | → `plan` | `user_decision=revise` | **更新同一** `plan_node_id` |
-| 3b | 「确认，按这个拆并出图」 | → `split` | `user_decision=confirm` | — |
-| 4 | 拆解资产骨架 | `split` | `split_manifest` 回填 `node_id` | 下游 text/image（+可选 video 骨架）+ edges + prompt + refs |
-| 5 | 按拓扑自动出图 | `orchestrate_gen` | `gen_queue` / `gen_completed` / `gen_failed` | Studio 文生图/图生图；节点 `url` + 状态 SSE/轮询 |
-| 6 | 汇报结果 | `done` | `phase=done` | 用户可手动重跑失败节点或改 prompt |
+| 1 | 「帮我设计一套卫生洁具的营销方案。」 | `intake` → `plan` | `skill_id`；`plan_draft`；结构化选项 | **无**方案节点 |
+| 2 | 多轮改方案 / 选 2·B / 3·C | → `plan` | 更新 `plan_draft` | 仍不写方案节点 |
+| 3 | 选 `1`/`A` 确认方案 | → `write_plan_node` | `plan_node_id`；已确认摘要 | **此时**创建/更新营销方案节点 |
+| 4 | 拆骨架 + Mermaid | `split` → `draft_copy` → `await_topo` | `split_manifest`；`topology_mode` | 下游骨架 + 边；不出图 |
+| 5 | NL 改拓扑 / 写主文案 | `await_topo` / copy 门 | 更新 manifest | 即时改节点/边 |
+| 6 | 「确认出图」 | → `orchestrate_gen` → `done` | `gen_*` | Studio 出图/出视频 |
 
-### 6.2 建议的一期 `split_manifest` 键（洁具企业营销示例）
+### 6.2 `split_manifest` 键（洁具示例；`full` 默认全量）
 
-| key | target_type | auto_generate | depends_on | gen_mode | 说明 |
+| key | target_type | auto_generate（出图门后） | depends_on | gen_mode | 说明 |
 | --- | --- | --- | --- | --- | --- |
-| `copy_main` | text | false | [] | — | 主文案（可选，不出图） |
-| `white_bg` | image | **true** | [] | t2i | 白底图 |
-| `hero_main` | image | **true** | [`white_bg`] | i2i | 主图 |
-| `scene` | image | **true** | [] | t2i | 场景图 |
-| `banner` | image | **true** | [] | t2i | Banner |
-| `brand` | image | **true** | [] | t2i | 品牌图（可提示上传 logo） |
-| `model` | image | **true** | [] | t2i | 模特/人景 |
-| `detail_cut` | image | **true** | [`white_bg`] | i2i | 细节/剖面 |
-| `show_video` | video | **false** | [`hero_main`] | v_ref | 一期只建骨架，不出片 |
+| `copy_main` | text | false | [] | — | 主文案（骨架期 HITL） |
+| `white_bg` | image | true | [] | t2i | 白底图 |
+| `hero_main` | image | true | [`white_bg`] | i2i | 主图 |
+| `scene` | image | true | [] | t2i | 场景图 |
+| `banner` | image | true | [] | t2i | Banner |
+| `brand` | image | true | [] | t2i | 品牌图 |
+| `model` | image | true | [] | t2i | 模特/人景（**B** 将拆为一致性链） |
+| `detail_cut` | image | true | [`white_bg`] | i2i | 细节/剖面 |
+| `show_video` | video | true | [`hero_main`] | v_ref | 产品展示视频 |
 
-键集与默认 `auto_generate` 由 Skill 的 `assets/canvas-manifest.yaml`（lnkpi 扩展资源）定义。
+`trimmed`：从上述 key 选子集并做依赖闭包。键集由 Skill `assets/canvas-manifest.yaml` 定义；`topology_mode_default` 见 SKILL metadata。
 
 ### 6.3 画布边与芯片
 
-- 边：`plan_node` → 各下游；`depends_on` → 数据边（如 `white_bg` → `hero_main`）。
-- 芯片：下游 `refOrder` 引用上游；出图时 Nest `resolveNodeRefs`。
-- Logo：对话提示上传到 `brand` 等节点的 `localRefs`；若缺失仍可 t2i 降级，并在话术中说明。
+- 边：`plan_node` → 各下游；`depends_on` → 数据边。  
+- 芯片：下游 `refOrder`；出图时 Nest `resolveNodeRefs`。  
+- 对话 Mermaid 与画布骨架标题对齐。
 
 ---
 

--- a/docs/superpowers/specs/2026-07-25-agent-confirm-loop-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-25-agent-confirm-loop-hardening-design.md
@@ -1,12 +1,13 @@
 # Agent 确认后闭环加固 + 主文案 HITL（设计）
 
-> 状态：**已确认**（2026-07-25）  
+> 状态：**已确认**（2026-07-25）；**修订 2026-07-25**：§7 对齐拓扑预览 HITL（`await_topo` / 方案确认后写节点）  
 > 日期：2026-07-25  
 > 前置：  
 > - `2026-07-23-agent-runtime-langgraph-design.md`（Runtime / 轻量 HITL / 画布 SoT）  
 > - `2026-07-24-agent-chat-ux-phase1-design.md`（对话 UX / Vercel SSE ~120s）  
 > - `2026-07-25-agent-task-progress-card-design.md`（任务卡 / `task_*` / 自动出视频）  
-> 依据：生产干净画布复测（PR #58 + Runtime rebuild）后问题清单 1–6；产品确认主文案 **先草稿交互确认再写入节点**，出图不等文案  
+> - **后续产品编排**：`2026-07-25-agent-topology-preview-hitl-design.md`（A；覆盖原「确认拆图即出图」）  
+> 依据：生产干净画布复测（PR #58 + Runtime rebuild）后问题清单 1–6；产品确认主文案 **先草稿交互确认再写入节点**；方案/拓扑门见拓扑预览规格  
 > 范围：主文案 HITL 编排、任务卡断流关账、画布 url/content 同步、方案节点开场白清洗、**LangGraph 节点与边可持续演进专篇**  
 > 非范围：`task_summary` 落库（方案 B，复测仍丢再加）、卡内一键重试/确认平台、生产级 durable `interrupt()` 跨天恢复、改 Vercel SSE 硬超时本身、Agent dock 模型/技能计费
 
@@ -18,13 +19,13 @@
 | --- | --- |
 | 总体策略 | **方案 A**：编排补齐 + 断流对账；摘要落库留作复测后加码 |
 | 主文案 | **不**在「确认拆图」后静默写入；`draft_copy` → 对话确认/修改 → `write_copy_node` |
-| 出图 vs 文案 | **并行**：`split` 后出图/出视频照常；文案 HITL **不阻塞**出图 |
+| 出图 vs 文案 | 骨架期可写文案；**出图须过出图门**（`await_topo`）；文案不阻塞出图门之后的 gen |
 | 任务卡主文案行 | 草稿待确认期间 = `needs_user`；写入成功 = `done` |
 | 任务清单 | split **一次**发全量项；orchestrate **禁止整表替换**冲掉文案项 |
 | 断流关账 | SSE 优先；断流后用 Session 节点态（+ Record）reconcile，合成终局 `task_summary` 态 |
 | 画布有图 | 确认拆图→关账期间周期性 `loadSession`（服务端 url/content 优先）；禁过期全量 `saveCanvas` 抹结果 |
-| 方案节点 | 写入前剥开场白；**不**改为「先聊后写方案节点」（与既有确认拆图习惯对齐） |
-| Graph 演进 | **专篇 §7**：控制流边 vs 数据流边、门控相位、并行扇出、可插槽 `interrupt()` |
+| 方案节点 | **确认前不写**；方案门确认后 `write_plan_node`（见拓扑预览规格）；写入前剥开场白 |
+| Graph 演进 | **§7**；权威后续演进见 `2026-07-25-agent-topology-preview-hitl-design.md`（`await_topo` / 出图门） |
 
 ---
 
@@ -168,7 +169,7 @@
 2. 后处理：去掉开场白；优先从第一个 `#` 标题截取正文。  
 3. 对话确认摘要仍用 `build_confirm_message`，**不**进节点。
 
-**不在本期**把「营销方案」改为先对话确认再写入节点（避免与确认拆图双重门叠床架屋）。若未来要做，走 §7.5 插槽「资产写入门」，与主文案门同型。
+**不在本期（confirm-loop 原文）**把「营销方案」改为先对话确认再写入——**已由拓扑预览规格推翻并取代**：确认前不写、确认后 `write_plan_node`。若仅清洗开场白，仍适用 `plan_clean`。
 
 ---
 
@@ -211,43 +212,48 @@ else → intake
 
 新增门控时：**只加 phase + route_entry 分支 + 对称节点**，不要把等待逻辑塞进 `orchestrate_gen` 长循环。
 
-### 7.3 目标拓扑（本期选定）
+### 7.3 目标拓扑（修订 2026-07-25：对齐拓扑预览 HITL）
+
+> 产品权威：`2026-07-25-agent-topology-preview-hitl-design.md`。下文替换原「确认拆图后立刻出图」主链。
 
 **入口与门控：**
 
 ```text
 START → route_entry
-          ├─ await_copy_confirm → confirm → write_copy_node → END
-          │                    → revise  → draft_copy → (重新置 await_copy_confirm) → END
-          │                    → none    → END（保持门）
-          ├─ await_confirm      → confirm → split → …
+          ├─ await_copy_confirm → confirm → write_copy_node →（回到 await_topo 语义）END
+          │                    → revise  → draft_copy → END
+          │                    → none    → END
+          ├─ await_topo         → confirm_gen → orchestrate_gen → done
+          │                    → topo_revise → await_topo
+          │                    → none → END
+          ├─ await_confirm      → confirm → write_plan_node → split → …
           │                    → revise  → plan → await_confirm
           │                    → none    → END
           └─ intake → chat → END
-                   → plan → await_confirm → …
+                   → plan（摘要+结构化选项，不写画布）→ await_confirm → …
 ```
 
-**确认拆图后主链（本期落地边，线性但语义并行）：**
+**确认方案后主链：**
 
 ```text
-split → draft_copy → orchestrate_gen → done → END
+write_plan_node → split → draft_copy → await_topo →（确认出图）orchestrate_gen → done → END
 ```
 
 | 节点 | 同 run 内必须完成 | 留给下一 turn |
 | --- | --- | --- |
-| `split` | 骨架 + 一次 `task_list` | — |
-| `draft_copy` | 出草稿、`text_delta`/芯片、`task_update(needs_user)`；置 `phase=await_copy_confirm` 且 `awaiting_user=true` | 用户确认/修改 |
-| `orchestrate_gen` | 出图/出视频 + `task_update` + 尽量发 `task_summary` | 断流后由前端对账 |
-| `done` | 收尾；**不得清除**文案门的 `awaiting_user` / `phase=await_copy_confirm` | 下一消息进 `await_copy_confirm` |
-
-**「并行」含义（产品）：** 用户在出图进行中或结束后，随时可用下一轮消息确认/修改主文案；出图不因文案未写入而暂停。  
-**「并行」含义（实现本期）：** 不要求 LangGraph Send 扇出；`draft_copy` 必须排在长时间 `orchestrate_gen` **之前**，保证草稿先达用户。真正的图级扇出列为 §7.5 性能插槽，不得改变 phase 契约。
+| `write_plan_node` | 确认稿写营销方案节点 + 已确认摘要 | — |
+| `split` | 骨架 + Mermaid + 一次 `task_list`；**不出图** | — |
+| `draft_copy` | 草稿、文案 needs_user；可臂 `await_topo` | 用户写文案 / 改拓扑 / 确认出图 |
+| `await_topo` | 分类出图确认 / 拓扑修订 | 多轮 |
+| `orchestrate_gen` | **仅出图门后**出图/视频 + `task_*` | 断流对账 |
+| `done` | 收尾；不得误清未完成人机门 | — |
 
 **硬约束：**
 
-1. **禁止**在 `orchestrate_gen` 内同步等待用户。  
-2. `done` / checkpoint 持久化后，文案门相位必须仍可被 `route_entry` 命中（单测必覆盖）。  
-3. 若发现 `done` 误清 `awaiting_user`：改为在 thread 元数据备份 `phase`，或 `draft_copy` 后先 END、出图改 Nest 后台作业——属实现修复，不改本章语义。
+1. **禁止** `draft_copy` / `pending_orchestrate` 在出图门前自动后台出图。  
+2. **禁止**在 `orchestrate_gen` 内同步等用户。  
+3. 方案节点仅在 `write_plan_node` 创建/更新。  
+4. 文案门可与 `await_topo` 交错；出图门只管 image/video。
 ### 7.4 门控节点模式（可复制）
 
 所有人机门遵循同一模式（已有 `await_confirm`，文案门照抄）：
@@ -269,6 +275,9 @@ GateNode(state):
 | `await_asset_write` 通用门 | 任意「草稿 → 确认 → 写入节点」 | 主文案是第一个实例 |
 | `interrupt()` + 持久 checkpointer | 跨进程/跨天恢复 | 不替换轻量 Gate 语义，只换持久层 |
 | 审批门 `await_approval` | 企业角色审批方案 | 插在 `plan` 与 `await_confirm` 之间 |
+| 拓扑预览 A | `await_topo` / 方案确认后写节点 / full\|trimmed | **规格已出**：`2026-07-25-agent-topology-preview-hitl-design.md` |
+| 一致性链 B | 人物/产品三视图 | A 完成后 |
+| 手工改后执行 C | 画布/Dock 改完再「生图」 | B 完成后 |
 | 并行 Send 扇出 | 多资产独立子图 | 不改变数据流在 Nest 的事实 |
 | `task_summary` 落库 | 断流必达摘要 | 方案 B，复测加码 |
 

--- a/docs/superpowers/specs/2026-07-25-agent-topology-preview-hitl-design.md
+++ b/docs/superpowers/specs/2026-07-25-agent-topology-preview-hitl-design.md
@@ -1,0 +1,197 @@
+# Agent 拓扑预览确认 + 方案门结构化 HITL（设计）
+
+> 状态：**已确认**（2026-07-25）  
+> 日期：2026-07-25  
+> 前置：  
+> - `2026-07-23-agent-runtime-langgraph-design.md`（Runtime / 控制流 vs 数据流）  
+> - `2026-07-25-agent-confirm-loop-hardening-design.md`（主文案 HITL / Graph §7）  
+> - `2026-07-25-agent-task-progress-card-design.md`（任务卡）  
+> 范围（本期 **A**）：方案门多轮摘要 + 结构化选项、确认后写方案节点、骨架预览（Mermaid + 画布）、`await_topo`、出图门、Skill `full|trimmed` 双模式  
+> 非范围：**B** 人物/产品三视图一致性链；**C** 画布/Dock 手工改完再「执行生图」完整闭环；durable `interrupt()`  
+
+路线图：A（本文）→ B → C。
+
+---
+
+## 0. 决策摘要
+
+| 项 | 结论 |
+| --- | --- |
+| 方案门 | 多轮 NL + **结构化选项（1/A、2/B、3/C）**；附推荐与理由 |
+| 方案节点写入 | **确认前不写**；「确认方案」时才 `upsert`「营销方案」节点 |
+| 确认后 | 对话输出「已确认方案摘要」→ 再 `split` |
+| 拓扑预览 | **对话 Mermaid（资产拓扑）+ 画布骨架**；确认出图前可改 |
+| 改拓扑 | NL → **即时**改画布骨架 + 重发 Mermaid |
+| 门控 | 方案门 → 骨架可改（`await_topo`，含文案 HITL）→ **出图门** |
+| 模板模式 | Skill `topology_mode_default: full\|trimmed` + 用户可覆盖 |
+| 主文案 | 骨架阶段草稿确认；出图门只管 image/video |
+| 出图时机 | **仅**「确认出图」后 `orchestrate_gen`；禁止 draft 后自动 bg 出图 |
+| 实现 | LangGraph 加 `await_topo` + `write_plan_node` |
+
+---
+
+## 1. 用户旅程与相位
+
+```text
+用户要方案
+  → plan：只生成方案摘要 + 结构化选项（不写画布）
+  → await_confirm
+       · 选 2/B 或 3/C / 自由 NL → 回到 plan（更新摘要与选项）
+       · 选 1/A 确认 → write_plan_node（确认稿写入营销方案节点）
+                    → 对话「已确认方案摘要」
+                    → 解析 topology_mode（Skill 默认 | 覆盖）
+                    → split：物化骨架 + 连线（本步不出图）
+                    → Mermaid 资产拓扑
+                    → draft_copy（主文案草稿 chips）
+                    → phase=await_topo
+
+await_topo（可多轮）
+  · NL 改拓扑 → 即时改骨架 + 重发 Mermaid
+  · 写入/修改主文案 → await_copy_confirm / write_copy_node → 回到 await_topo
+  · 「确认出图」→ orchestrate_gen → done
+```
+
+### 1.1 相对现状的关键变化
+
+| 现状 | 本期 |
+| --- | --- |
+| `plan` 当轮 `upsert_prompt_node` | 确认前不写；确认后 `write_plan_node` |
+| 「确认拆图」= 拆骨架并出图 | 拆成 **确认方案** 与 **确认出图** |
+| draft 后可 bg 出图 | 出图必须过出图门 |
+| 固定 9 项模板 | `full` 全量 + `trimmed` 裁剪；复测双路径 |
+
+---
+
+## 2. 方案门：结构化选项
+
+每轮 `plan` / 修订后的助手消息须包含：
+
+1. **方案摘要**（定位、卖点、将拆资产意向列表）  
+2. **推荐选项**（默认标在 1/A）+ **一句话理由**  
+3. **可选决策**（chips 与文案一致）：
+
+| 选项 | 含义 |
+| --- | --- |
+| `1` / `A` | 采纳推荐，确认方案（写画布并进入骨架） |
+| `2` / `B` | 按 Agent 给出的某一改法修改（选项文案动态，如「更偏天猫详情」） |
+| `3` / `C` | 我自己说明修改（下一轮自由 NL） |
+
+用户可点 chip 或回复编号/字母。`await_confirm` 分类：
+
+- confirm：`1`/`A`/「确认方案」等  
+- revise：`2`/`B`/`3`/`C`/「要修改」/自由修改说明  
+- none：提示并保持门  
+
+确认成功后必须：
+
+1. `write_plan_node`：确认稿 → 画布「营销方案」（剥开场白，沿用既有清洗）  
+2. `text_delta`：「已确认方案摘要」短结  
+3. 进入 `split`（不得在确认前创建该节点）
+
+---
+
+## 3. 拓扑预览、NL 改拓扑、出图门
+
+### 3.1 Mermaid（资产拓扑，非控制流）
+
+- 内容：`split_manifest` 的 `depends_on` / 画布数据边  
+- 节点 label = 画布节点 `title`（可附 `key`），与骨架一一对应  
+- 每次 split 成功或拓扑变更后重发完整 `flowchart`
+
+### 3.2 `await_topo`
+
+- 支持：增/删**模板内**节点、改 `depends_on`、改标题/`prompt_hint`  
+- 即时：Nest 增删节点/边/`set_node_prompt` + 更新 `split_manifest` + 重发 Mermaid  
+- 依赖闭包：选中下游须带上游；删上游时断开或提示下游边  
+- chips：「确认出图」/「要改拓扑」；若主文案未写入，保留「写入主文案」/「要修改」
+
+### 3.3 出图门
+
+- 「确认出图」→ `orchestrate_gen`（仅 image/video 且应自动生成的项）  
+- **禁止**在 `draft_copy` 后通过 `pending_orchestrate` 后台自动出图  
+- 骨架期节点可存在，但生成在出图门之后
+
+---
+
+## 4. Skill 双模式
+
+```yaml
+# SKILL.md metadata 或 canvas-manifest.yaml
+topology_mode_default: full   # full | trimmed
+```
+
+| 模式 | 行为 |
+| --- | --- |
+| `full` | 使用 manifest `items` 全量 |
+| `trimmed` | LLM 从模板 `key` 中选子集 + 依赖闭包；禁止模板外 key |
+
+用户覆盖（方案确认后或 `await_topo` 内）：「用全套模板」「按方案精简」→ 写入 state `topology_mode`，必要时重建/裁剪骨架。
+
+**复测：** 同一 Skill 各跑 `full` 与 `trimmed` 一条干净画布路径。
+
+---
+
+## 5. Graph / State（相对 confirm-loop §7 的修订）
+
+```text
+START → route_entry
+  ├─ await_copy_confirm → … →（写完）回到 await_topo 语义
+  ├─ await_topo → confirm_gen → orchestrate_gen → done
+  │            → topo_revise → await_topo
+  │            → copy_* → await_copy_confirm
+  ├─ await_confirm → confirm → write_plan_node → split → draft_copy → await_topo
+  │               → revise  → plan → await_confirm
+  └─ intake → plan → await_confirm
+            → chat → END
+```
+
+新增/调整字段：
+
+| 字段 | 含义 |
+| --- | --- |
+| `plan_draft` | 确认前方案正文（只存 state/对话） |
+| `topology_mode` | `full` \| `trimmed` |
+| `phase=await_topo` | 骨架可改 / 待出图 |
+| `pending_orchestrate` | **仅**出图门置位；或删除自动臂逻辑 |
+
+控制流边 = LangGraph 相位；数据流边 = Nest edges + manifest `depends_on`（Mermaid 画后者）。
+
+---
+
+## 6. 前端 chips
+
+| 相位 | Chips |
+| --- | --- |
+| `await_confirm` | `1/A 确认方案（推荐）`、`2/B …`、`3/C 自己说` |
+| `await_topo` | `确认出图`、`要改拓扑`；+ 文案 chips（若未写入） |
+| 文案已写入 | 文案 chips 消失 |
+
+检测：扩展 `agentChipSet`（plan 结构化选项 / topo / copy）。
+
+---
+
+## 7. 成功标准（A）
+
+1. 方案多轮修订期间画布**无**「营销方案」节点；确认后才有，且对话有「已确认摘要」。  
+2. 确认方案后出现骨架 + Mermaid；**无**自动出图。  
+3. NL 改拓扑即时反映到画布与 Mermaid。  
+4. 「确认出图」后才出现 `run_image_generation` / 视频生成。  
+5. `full` 与 `trimmed` 复测均通过。  
+6. 主文案骨架期可写入，不阻塞后续出图门。
+
+---
+
+## 8. 非范围（B / C）
+
+| 阶段 | 内容 |
+| --- | --- |
+| **B** | 模特：模特图 → 三视图 → 人景；产品：产品三视图链；写入 manifest 依赖 |
+| **C** | 用户在画布/Dock 手工增删改 / 改 prompt 后，对话告知「执行生图」 |
+
+---
+
+## 9. 文档同步
+
+- 本文为 A 的权威产品+编排规格。  
+- `2026-07-23-agent-runtime-langgraph-design.md` §5/§6 须与本文图对齐。  
+- `2026-07-25-agent-confirm-loop-hardening-design.md` §7 主链改为含 `await_topo`；方案节点改为确认后写入；废除「出图与文案并行且 draft 后即可 bg 出图」中与出图门冲突的部分（文案仍可在出图前完成）。

--- a/services/agent-runtime/app/graph/builder.py
+++ b/services/agent-runtime/app/graph/builder.py
@@ -7,30 +7,50 @@ from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, START, StateGraph
 
 from app.graph.nodes.await_confirm import make_await_confirm_node
-from app.graph.nodes.await_copy_confirm import make_await_copy_confirm_node
+from app.graph.nodes.await_copy_confirm import (
+    classify_copy_decision,
+    make_await_copy_confirm_node,
+)
+from app.graph.nodes.await_topo import make_await_topo_node
 from app.graph.nodes.chat import make_chat_node
 from app.graph.nodes.done import make_done_node
 from app.graph.nodes.draft_copy import make_draft_copy_node
 from app.graph.nodes.intake import make_intake_node
+from app.graph.nodes.orchestrate_gen import make_orchestrate_gen_node
 from app.graph.nodes.plan import make_plan_node
 from app.graph.nodes.split import make_split_node
+from app.graph.nodes.topo_revise import make_topo_revise_node
 from app.graph.nodes.write_copy_node import make_write_copy_node
+from app.graph.nodes.write_plan_node import make_write_plan_node
 from app.graph.state import AgentRuntimeState
+
+
+def _latest_user_text(state: AgentRuntimeState) -> str:
+    for msg in reversed(state.get("messages") or []):
+        role = getattr(msg, "type", None) or (msg.get("role") if isinstance(msg, dict) else None)
+        content = getattr(msg, "content", None) or (msg.get("content") if isinstance(msg, dict) else "")
+        if role in ("human", "user") and content:
+            return str(content)
+    return ""
 
 
 def route_entry(state: AgentRuntimeState) -> str:
     if state.get("awaiting_user") and state.get("phase") == "await_copy_confirm":
         return "await_copy_confirm"
+    if state.get("awaiting_user") and state.get("phase") == "await_topo":
+        text = _latest_user_text(state)
+        copy_dec = classify_copy_decision(text)
+        if copy_dec == "confirm" or (
+            copy_dec == "revise" and ("文案" in text or "主文案" in text)
+        ):
+            return "await_copy_confirm"
+        return "await_topo"
     if state.get("awaiting_user") and state.get("phase") == "await_confirm":
         return "await_confirm"
     return "intake"
 
 
 def route_after_draft_copy(state: AgentRuntimeState) -> str:
-    # Always end the user turn after draft so「写入主文案」is not blocked by image gen.
-    # First draft sets pending_orchestrate; stream_run_events kicks orchestrate in background.
-    if state.get("pending_orchestrate"):
-        return "done"
     return "end"
 
 
@@ -52,9 +72,18 @@ def route_after_intake(state: AgentRuntimeState) -> str:
 def route_after_confirm(state: AgentRuntimeState) -> str:
     decision = state.get("user_decision") or "none"
     if decision == "confirm":
-        return "split"
+        return "write_plan_node"
     if decision == "revise":
         return "plan"
+    return "end"
+
+
+def route_after_topo(state: AgentRuntimeState) -> str:
+    decision = state.get("user_decision") or "none"
+    if decision == "confirm_gen":
+        return "orchestrate_gen"
+    if decision == "topo_revise":
+        return "topo_revise"
     return "end"
 
 
@@ -65,7 +94,7 @@ def build_agent_graph(
     skills_dir: str | Path,
     checkpointer: Any | None = None,
 ):
-    """Compile intake → (chat | plan → await_confirm → …)."""
+    """Compile intake → plan → confirm → write_plan → split → draft → await_topo → gen."""
     skills_path = Path(skills_dir)
     graph = StateGraph(AgentRuntimeState)
 
@@ -73,11 +102,15 @@ def build_agent_graph(
     graph.add_node("chat", make_chat_node(llm=llm))
     graph.add_node("plan", make_plan_node(nest=nest, llm=llm, skills_dir=skills_path))
     graph.add_node("await_confirm", make_await_confirm_node(llm=llm))
+    graph.add_node("write_plan_node", make_write_plan_node(nest=nest))
     graph.add_node("split", make_split_node(nest=nest, skills_dir=skills_path))
     graph.add_node("draft_copy", make_draft_copy_node(nest=nest, llm=llm))
     graph.add_node("done", make_done_node())
     graph.add_node("await_copy_confirm", make_await_copy_confirm_node())
     graph.add_node("write_copy_node", make_write_copy_node(nest=nest))
+    graph.add_node("await_topo", make_await_topo_node())
+    graph.add_node("topo_revise", make_topo_revise_node(nest=nest))
+    graph.add_node("orchestrate_gen", make_orchestrate_gen_node(nest=nest))
 
     graph.add_conditional_edges(
         START,
@@ -86,6 +119,7 @@ def build_agent_graph(
             "intake": "intake",
             "await_confirm": "await_confirm",
             "await_copy_confirm": "await_copy_confirm",
+            "await_topo": "await_topo",
         },
     )
     graph.add_conditional_edges(
@@ -98,15 +132,26 @@ def build_agent_graph(
     graph.add_conditional_edges(
         "await_confirm",
         route_after_confirm,
-        {"split": "split", "plan": "plan", "end": END},
+        {"write_plan_node": "write_plan_node", "plan": "plan", "end": END},
     )
+    graph.add_edge("write_plan_node", "split")
     graph.add_edge("split", "draft_copy")
     graph.add_conditional_edges(
         "draft_copy",
         route_after_draft_copy,
-        {"done": "done", "end": END},
+        {"end": END},
     )
-    # orchestrate_gen runs in background via stream_run_events (not on sync path)
+    graph.add_conditional_edges(
+        "await_topo",
+        route_after_topo,
+        {
+            "orchestrate_gen": "orchestrate_gen",
+            "topo_revise": "topo_revise",
+            "end": END,
+        },
+    )
+    graph.add_edge("topo_revise", END)
+    graph.add_edge("orchestrate_gen", "done")
     graph.add_edge("done", END)
     graph.add_conditional_edges(
         "await_copy_confirm",

--- a/services/agent-runtime/app/graph/mermaid_topo.py
+++ b/services/agent-runtime/app/graph/mermaid_topo.py
@@ -1,0 +1,37 @@
+"""Build Mermaid flowchart from split_manifest asset topology (not LangGraph control flow)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _safe_id(key: str) -> str:
+    raw = "".join(ch if ch.isalnum() or ch == "_" else "_" for ch in (key or "n"))
+    if not raw or raw[0].isdigit():
+        raw = f"n_{raw}"
+    return raw
+
+
+def manifest_to_mermaid(manifest: list[Any]) -> str:
+    """Return a mermaid flowchart LR from depends_on edges; labels use title (+ key)."""
+    items = [x for x in (manifest or []) if isinstance(x, dict) and x.get("key")]
+    if not items:
+        return "```mermaid\nflowchart LR\n  empty[暂无节点]\n```"
+
+    lines = ["```mermaid", "flowchart LR"]
+    key_set = {str(it["key"]) for it in items}
+    for it in items:
+        key = str(it["key"])
+        title = str(it.get("title") or key).replace('"', "'")
+        nid = _safe_id(key)
+        lines.append(f'  {nid}["{title} ({key})"]')
+    for it in items:
+        key = str(it["key"])
+        nid = _safe_id(key)
+        for dep in it.get("depends_on") or []:
+            d = str(dep)
+            if d not in key_set:
+                continue
+            lines.append(f"  {_safe_id(d)} --> {nid}")
+    lines.append("```")
+    return "\n".join(lines)

--- a/services/agent-runtime/app/graph/nodes/await_confirm.py
+++ b/services/agent-runtime/app/graph/nodes/await_confirm.py
@@ -6,18 +6,16 @@ from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
 Decision = Literal["none", "confirm", "revise"]
 
-# When user reply is neither confirm nor revise, still surface a visible tip
-# (otherwise stream ends with only `done` and the UI looks empty).
-_NONE_DECISION_TIP = "请确认方案或说明修改；也可回复「确认」继续拆解画布并出图。"
+_NONE_DECISION_TIP = "请选择 1/A 确认方案，或 2/B、3/C / 说明修改后再确认。"
 
 _CONFIRM_HINTS = (
+    "确认方案",
     "确认",
     "同意",
     "可以",
     "没问题",
     "按这个",
     "开始拆",
-    "出图",
     "ok",
     "okay",
     "yes",
@@ -33,8 +31,9 @@ _REVISE_HINTS = (
     "revise",
     "改一下",
     "更偏",
+    "要修改",
+    "自己说",
 )
-# 「等我确认」出现在长需求里时，应视为新 brief，而非对本轮方案确认
 _FRESH_BRIEF_HINTS = (
     "请为",
     "写一份",
@@ -62,24 +61,28 @@ def _latest_user_text(messages: list[Any]) -> str:
 
 def classify_user_decision(text: str) -> Decision | None:
     """Heuristic classifier. Returns None when ambiguous (caller may use LLM)."""
-    lowered = text.strip().lower()
+    raw = text.strip()
+    lowered = raw.lower()
     if not lowered:
         return "none"
 
-    # 「无修改 / 不修改」是确认，不能因子串「修改」误判为 revise
+    token = raw.split()[0].strip().rstrip(".).、）") if raw else ""
+    token_u = token.upper()
+    if token in ("1",) or token_u in ("A", "Ａ"):
+        return "confirm"
+    if token in ("2", "3") or token_u in ("B", "C", "Ｂ", "Ｃ"):
+        return "revise"
+
     if any(n in lowered for n in _CONFIRM_NEGATIONS):
         return "confirm"
 
-    # Prefer revise when both signals appear (e.g. "确认前先改成…")
     if any(h in lowered for h in _REVISE_HINTS):
         return "revise"
     if any(h in lowered for h in _CONFIRM_HINTS):
-        # 长需求里的「先等我确认」是未来动作，不是对本轮方案的确认
         if len(lowered) > 24 and any(h in lowered for h in _FRESH_BRIEF_HINTS):
             return None
         return "confirm"
 
-    # Fresh planning requests are not confirmations
     if any(k in lowered for k in ("营销方案", "帮我设计", "帮我做")):
         return "none"
     return None
@@ -114,8 +117,6 @@ def _last_role(messages: list[Any]) -> str | None:
 
 def make_await_confirm_node(*, llm: Any) -> Callable:
     async def await_confirm(state: dict) -> dict:
-        # After plan in the same turn, the latest message is the AI confirm prompt —
-        # do not re-classify the prior user text (avoids revise→plan→revise loops).
         if _last_role(state.get("messages") or []) not in ("human", "user"):
             return {
                 "user_decision": "none",
@@ -137,9 +138,8 @@ def make_await_confirm_node(*, llm: Any) -> Callable:
         if decision == "none":
             out["messages"] = [AIMessage(content=_NONE_DECISION_TIP)]
         elif decision == "confirm":
-            # Immediate tip so SSE stays visibly busy while split/orchestrate_gen runs
             out["messages"] = [
-                AIMessage(content="正在按方案拆解画布并出图，请稍候…")
+                AIMessage(content="正在写入确认方案并拆解画布骨架（先不出图），请稍候…")
             ]
         return out
     return await_confirm

--- a/services/agent-runtime/app/graph/nodes/await_copy_confirm.py
+++ b/services/agent-runtime/app/graph/nodes/await_copy_confirm.py
@@ -71,7 +71,7 @@ def make_await_copy_confirm_node() -> Callable:
             }
         return {
             "user_decision": "confirm",
-            "awaiting_user": True,
+            "awaiting_user": False,
             "phase": "await_copy_confirm",
             "copy_revise_only": False,
         }

--- a/services/agent-runtime/app/graph/nodes/await_topo.py
+++ b/services/agent-runtime/app/graph/nodes/await_topo.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Literal
+
+from langchain_core.messages import AIMessage
+
+Decision = Literal["none", "confirm_gen", "topo_revise"]
+
+_NONE_TIP = "请确认出图，或说明如何调整拓扑（例如「删掉 Banner」）；主文案可用「写入主文案」。"
+
+_CONFIRM_GEN_HINTS = (
+    "确认出图",
+    "开始出图",
+    "出图吧",
+    "可以出图",
+    "生成图片",
+    "开始生成",
+)
+_TOPO_REVISE_HINTS = (
+    "要改拓扑",
+    "改拓扑",
+    "删掉",
+    "删除",
+    "去掉",
+    "增加",
+    "加上",
+    "不要",
+    "依赖",
+    "连到",
+)
+
+
+def _latest_user_text(messages: list[Any]) -> str:
+    for msg in reversed(messages or []):
+        role = getattr(msg, "type", None) or (msg.get("role") if isinstance(msg, dict) else None)
+        content = getattr(msg, "content", None) or (msg.get("content") if isinstance(msg, dict) else "")
+        if role in ("human", "user") and content:
+            return str(content)
+    return ""
+
+
+def classify_topo_decision(text: str) -> Decision:
+    t = text.strip()
+    if not t:
+        return "none"
+    lowered = t.lower()
+    if any(h in t or h in lowered for h in _CONFIRM_GEN_HINTS):
+        return "confirm_gen"
+    if any(h in t for h in _TOPO_REVISE_HINTS):
+        return "topo_revise"
+    if t in ("确认", "1", "A", "a") or t.lower() == "ok":
+        return "confirm_gen"
+    return "none"
+
+
+def make_await_topo_node() -> Callable:
+    async def await_topo(state: dict) -> dict:
+        text = _latest_user_text(state.get("messages") or [])
+        decision = classify_topo_decision(text)
+        if decision == "none":
+            return {
+                "user_decision": "none",
+                "awaiting_user": True,
+                "phase": "await_topo",
+                "messages": [AIMessage(content=_NONE_TIP)],
+            }
+        if decision == "topo_revise":
+            return {
+                "user_decision": "topo_revise",
+                "awaiting_user": True,
+                "phase": "await_topo",
+            }
+        return {
+            "user_decision": "confirm_gen",
+            "awaiting_user": False,
+            "phase": "await_topo",
+            "pending_orchestrate": False,
+            "messages": [AIMessage(content="开始按拓扑出图，请稍候…")],
+        }
+
+    return await_topo

--- a/services/agent-runtime/app/graph/nodes/done.py
+++ b/services/agent-runtime/app/graph/nodes/done.py
@@ -11,12 +11,7 @@ def make_done_node() -> Callable:
     async def done(state: dict) -> dict:
         completed = state.get("gen_completed") or []
         failed = state.get("gen_failed") or []
-        if state.get("pending_orchestrate") and not completed and not failed:
-            msg = (
-                "主文案草稿已就绪；图片/视频正在后台生成。"
-                "可先确认「写入主文案」，无需等待出图结束。"
-            )
-        elif completed or failed:
+        if completed or failed:
             lines: list[str] = []
             fallback_n = 0
             for item in failed:
@@ -28,7 +23,7 @@ def make_done_node() -> Callable:
                     fallback_n += 1
                 lines.append(format_gen_progress_line(title=title, status=reason))
             for _ in completed:
-                pass  # per-node success already streamed in orchestrate_gen
+                pass
             msg = format_gen_summary(
                 lines=lines or ["（详见上方出图进度）"],
                 success_n=len(completed),
@@ -38,9 +33,8 @@ def make_done_node() -> Callable:
             msg = f"流程结束。\n{msg}"
         else:
             msg = "流程结束。本次无可汇总的出图结果；你也可手动在画布上生成。"
-        if state.get("phase") == "await_copy_confirm" or (
-            state.get("awaiting_user") and state.get("copy_draft")
-        ):
+
+        if state.get("phase") == "await_copy_confirm" and state.get("awaiting_user"):
             return {
                 "phase": "await_copy_confirm",
                 "awaiting_user": True,

--- a/services/agent-runtime/app/graph/nodes/draft_copy.py
+++ b/services/agent-runtime/app/graph/nodes/draft_copy.py
@@ -10,7 +10,8 @@ _COPY_SYSTEM = (
 )
 
 _DRAFT_FOOTER = (
-    "\n\n请确认后回复「写入主文案」；如需修改请说明（例如「改成更强调节水」）。"
+    "\n\n请确认后回复「写入主文案」；如需修改请说明（例如「文案改成更强调节水」）。"
+    "拓扑确认无误后回复「确认出图」。"
 )
 
 
@@ -46,7 +47,6 @@ def make_draft_copy_node(*, nest: Any, llm: Any) -> Callable:
         if hint:
             user_bits.append(f"节点提示：\n{hint}")
         if state.get("copy_revise_only") and state.get("messages"):
-            # Prefer latest human revise note
             for msg in reversed(state.get("messages") or []):
                 role = getattr(msg, "type", None) or (
                     msg.get("role") if isinstance(msg, dict) else None
@@ -83,15 +83,16 @@ def make_draft_copy_node(*, nest: Any, llm: Any) -> Callable:
 
         was_revise = bool(state.get("copy_revise_only"))
         out: dict[str, Any] = {
-            "phase": "await_copy_confirm",
+            "phase": "await_topo",
             "awaiting_user": True,
             "copy_draft": draft,
             "copy_node_id": node_id,
             "copy_revise_only": False,
-            # First draft: arm background orchestrate. Revise-only: do not re-kick gens.
-            "pending_orchestrate": not was_revise,
+            "pending_orchestrate": False,
             "messages": [AIMessage(content=body)],
         }
+        if was_revise:
+            out["phase"] = "await_copy_confirm"
         return out
 
     return draft_copy

--- a/services/agent-runtime/app/graph/nodes/plan.py
+++ b/services/agent-runtime/app/graph/nodes/plan.py
@@ -48,17 +48,21 @@ def _manifest_titles(canvas_manifest: dict | None) -> list[str]:
 
 
 def build_confirm_message(*, plan_md: str, canvas_manifest: dict | None) -> str:
-    """Readable confirm gate: positioning + asset list + N + canvas pointer."""
+    """Readable confirm gate: summary + structured options (no canvas write yet)."""
     positioning = _positioning_line(plan_md)
     titles = _manifest_titles(canvas_manifest)
     n = len(titles)
     asset_lines = "\n".join(f"- {t}" for t in titles) if titles else "- （Skill 未声明资产清单）"
     return (
         f"定位：{positioning}\n"
-        f"确认后将拆解 {n} 个画布节点并自动出图：\n"
+        f"拟定拆解约 {n} 个画布节点（确认方案后写入画布，确认出图后再生成）：\n"
         f"{asset_lines}\n"
-        "完整方案已写入画布「营销方案」节点，可在画布查看全文。\n"
-        "请确认是否按此方案拆解画布并出图；如需修改请直接说明。"
+        "方案全文见上方摘要（确认前不会写入画布节点）。\n\n"
+        "请选择：\n"
+        "1 / A：采纳推荐并确认方案（推荐：按当前摘要落稿，进入骨架预览）\n"
+        "2 / B：换个方向再改一版（例如更偏天猫详情页 / 更强调卖点）\n"
+        "3 / C：我自己说明修改\n"
+        "也可直接回复编号或具体修改意见。"
     )
 
 
@@ -90,13 +94,6 @@ def make_plan_node(*, nest: Any, llm: Any, skills_dir: Path) -> Callable:
         ]
         ai = await llm.ainvoke(messages)
         plan_md = strip_plan_preamble(str(getattr(ai, "content", ai) or ""))
-
-        result = await nest.upsert_prompt_node(
-            prompt="营销方案",
-            content=plan_md,
-            node_id=state.get("plan_node_id"),
-        )
-        plan_node_id = result["nodeId"]
         summary = _summarize(plan_md)
         confirm_msg = build_confirm_message(
             plan_md=plan_md,
@@ -106,7 +103,8 @@ def make_plan_node(*, nest: Any, llm: Any, skills_dir: Path) -> Callable:
         return {
             "phase": "await_confirm",
             "plan_summary": summary,
-            "plan_node_id": plan_node_id,
+            "plan_draft": plan_md,
+            # Do not upsert canvas until write_plan_node after confirm
             "awaiting_user": True,
             "user_decision": "none",
             "messages": [AIMessage(content=confirm_msg)],

--- a/services/agent-runtime/app/graph/nodes/split.py
+++ b/services/agent-runtime/app/graph/nodes/split.py
@@ -6,6 +6,8 @@ from typing import Any, Callable
 from langchain_core.messages import AIMessage
 
 from app.graph.state import SplitManifestItem
+from app.graph.mermaid_topo import manifest_to_mermaid
+from app.graph.topo_trim import trim_manifest_items
 from app.skills.loader import discover_skills, load_skill
 
 
@@ -37,13 +39,40 @@ def _manifest_items(canvas_manifest: dict | None, max_downstream: int) -> list[S
     return items
 
 
+def _resolve_topology_mode(state: dict, skill: Any, canvas_manifest: dict | None) -> str:
+    mode = state.get("topology_mode")
+    if mode in ("full", "trimmed"):
+        return mode
+    meta = getattr(skill, "metadata", None) or {}
+    if isinstance(meta, dict):
+        m = str(meta.get("lnkpi.topology_mode_default") or "").strip().lower()
+        if m in ("full", "trimmed"):
+            return m
+    if isinstance(canvas_manifest, dict):
+        defaults = canvas_manifest.get("defaults") or {}
+        m = str(defaults.get("topology_mode_default") or "").strip().lower()
+        if m in ("full", "trimmed"):
+            return m
+    return "full"
+
+
+def _select_trimmed_keys(plan_summary: str, items: list[SplitManifestItem]) -> list[str]:
+    """Heuristic trim: always keep copy + white_bg + hero; drop brand/model/banner if summary short."""
+    keys = [str(i["key"]) for i in items]
+    must = [k for k in ("copy_main", "white_bg", "hero_main", "detail_cut", "show_video") if k in keys]
+    if len(plan_summary or "") > 80:
+        for k in ("scene", "banner"):
+            if k in keys and k not in must:
+                must.append(k)
+    return must or keys[: max(3, min(5, len(keys)))]
+
+
 def make_split_node(*, nest: Any, skills_dir: Path) -> Callable:
     async def split(state: dict) -> dict:
         plan_node_id = state.get("plan_node_id")
         if not plan_node_id:
             raise RuntimeError("plan_node_id required before split")
 
-        # Read plan from Nest (canonical store); do not keep full canvas in state
         await nest.get_node(plan_node_id)
 
         skill_id = state.get("skill_id")
@@ -51,11 +80,31 @@ def make_split_node(*, nest: Any, skills_dir: Path) -> Callable:
             raise RuntimeError("skill_id missing for split")
         entries = {e.skill_id: e for e in discover_skills(skills_dir)}
         skill = load_skill(entries[skill_id])
+        mode = _resolve_topology_mode(state, skill, skill.canvas_manifest)
         manifest = _manifest_items(skill.canvas_manifest, skill.max_downstream)
+        if mode == "trimmed" and manifest:
+            selected = _select_trimmed_keys(str(state.get("plan_summary") or ""), manifest)
+            trimmed = trim_manifest_items([dict(it) for it in manifest], selected)
+            manifest = [
+                SplitManifestItem(
+                    key=str(it["key"]),
+                    title=str(it.get("title") or it["key"]),
+                    target_type=it.get("target_type") or "image",  # type: ignore[arg-type]
+                    source_section=str(it.get("source_section") or ""),
+                    gen_mode=it.get("gen_mode"),
+                    auto_generate=bool(it.get("auto_generate", True)),
+                    depends_on=[str(d) for d in (it.get("depends_on") or [])],
+                    prompt_hint=str(it.get("prompt_hint") or ""),
+                    node_id=it.get("node_id"),
+                )
+                for it in trimmed
+                if it.get("key")
+            ]
         if not manifest:
             return {
                 "phase": "split",
                 "split_manifest": [],
+                "topology_mode": mode,
                 "awaiting_user": False,
                 "messages": [AIMessage(content="当前 Skill 无 canvas-manifest，跳过批量拆解。")],
             }
@@ -106,13 +155,15 @@ def make_split_node(*, nest: Any, skills_dir: Path) -> Callable:
         focus = [i["node_id"] for i in manifest if i.get("node_id")]
         titles = [str(i.get("title") or i.get("key") or "") for i in manifest]
         title_hint = "、".join(t for t in titles if t)[:80]
+        mermaid = manifest_to_mermaid(list(manifest))
+        mode_label = "全量模板" if mode == "full" else "按方案精简"
         split_msg = (
-            f"已按方案拆解 {len(manifest)} 个画布节点骨架"
-            + (f"（{title_hint}…）" if title_hint else "。")
-            + "\n开始按依赖自动出图，请稍候…"
+            f"已按方案拆解 {len(manifest)} 个画布节点骨架（{mode_label}）"
+            + (f"：{title_hint}" if title_hint else "。")
+            + "\n先预览拓扑，确认出图前不会自动生成。\n\n"
+            + f"当前资产拓扑：\n{mermaid}\n\n"
+            + "可自然语言改拓扑，或确认主文案；准备好后回复「确认出图」。"
         )
-        # Pin task card as soon as skeleton exists (before long orchestrate_gen),
-        # so Vercel 120s SSE cutoff still leaves the card visible.
         emit_list = getattr(nest, "emit_task_list", None)
         if emit_list is not None:
             await emit_list(
@@ -130,8 +181,10 @@ def make_split_node(*, nest: Any, skills_dir: Path) -> Callable:
         return {
             "phase": "split",
             "split_manifest": manifest,
+            "topology_mode": mode,
             "focus_node_ids": focus,
             "awaiting_user": False,
+            "pending_orchestrate": False,
             "messages": [AIMessage(content=split_msg)],
         }
 

--- a/services/agent-runtime/app/graph/nodes/topo_revise.py
+++ b/services/agent-runtime/app/graph/nodes/topo_revise.py
@@ -1,0 +1,92 @@
+"""Heuristic topology revise: add/remove template keys and refresh Mermaid."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from langchain_core.messages import AIMessage
+
+from app.graph.mermaid_topo import manifest_to_mermaid
+
+
+def _apply_heuristic(manifest: list[dict[str, Any]], text: str) -> tuple[list[dict[str, Any]], str]:
+    """Return (new_manifest, note). Supports 删掉/去掉 {title|key}."""
+    t = text.strip()
+    remove_prefixes = ("删掉", "删除", "去掉", "移除")
+    target = ""
+    for p in remove_prefixes:
+        if p in t:
+            target = t.split(p, 1)[-1].strip().strip("「」\"' 。.")
+            break
+    if not target:
+        return manifest, "未识别具体改动；请说明例如「删掉 Banner」。"
+
+    next_items: list[dict[str, Any]] = []
+    removed = False
+    for it in manifest:
+        title = str(it.get("title") or "")
+        key = str(it.get("key") or "")
+        if target in title or target == key or target.lower() == key.lower():
+            removed = True
+            continue
+        deps = [d for d in (it.get("depends_on") or []) if str(d) != key]
+        item = dict(it)
+        item["depends_on"] = deps
+        next_items.append(item)
+
+    if not removed:
+        return manifest, f"未找到名为「{target}」的节点。"
+
+    removed_keys = {str(it.get("key")) for it in manifest} - {str(it.get("key")) for it in next_items}
+    cleaned: list[dict[str, Any]] = []
+    for it in next_items:
+        deps = [d for d in (it.get("depends_on") or []) if str(d) not in removed_keys]
+        item = dict(it)
+        item["depends_on"] = deps
+        cleaned.append(item)
+    return cleaned, f"已从拓扑移除「{target}」。"
+
+
+def make_topo_revise_node(*, nest: Any) -> Callable:
+    async def topo_revise(state: dict) -> dict:
+        text = ""
+        for msg in reversed(state.get("messages") or []):
+            role = getattr(msg, "type", None) or (msg.get("role") if isinstance(msg, dict) else None)
+            content = getattr(msg, "content", None) or (msg.get("content") if isinstance(msg, dict) else "")
+            if role in ("human", "user") and content:
+                text = str(content)
+                break
+
+        manifest = [dict(x) for x in (state.get("split_manifest") or []) if isinstance(x, dict)]
+        new_manifest, note = _apply_heuristic(manifest, text)
+
+        emit_list = getattr(nest, "emit_task_list", None)
+        if emit_list is not None and new_manifest != manifest:
+            await emit_list(
+                [
+                    {
+                        "id": str(item["key"]),
+                        "title": str(item.get("title") or item["key"]),
+                        "nodeId": str(item.get("node_id") or ""),
+                        "kind": str(item.get("target_type") or "image"),
+                    }
+                    for item in new_manifest
+                    if item.get("key")
+                ]
+            )
+
+        mermaid = manifest_to_mermaid(new_manifest)
+        body = f"{note}\n\n当前资产拓扑：\n{mermaid}\n\n确认无误后回复「确认出图」。"
+        emit = getattr(nest, "emit_text", None)
+        if emit is not None:
+            await emit(body)
+
+        return {
+            "phase": "await_topo",
+            "awaiting_user": True,
+            "split_manifest": new_manifest,
+            "user_decision": "none",
+            "messages": [AIMessage(content=body)],
+        }
+
+    return topo_revise

--- a/services/agent-runtime/app/graph/nodes/write_copy_node.py
+++ b/services/agent-runtime/app/graph/nodes/write_copy_node.py
@@ -28,11 +28,13 @@ def make_write_copy_node(*, nest: Any) -> Callable:
         if emit_upd is not None:
             await emit_upd(id=key, status="done")
 
+        stay_topo = bool(state.get("split_manifest"))
         return {
-            "phase": "done",
-            "awaiting_user": False,
+            "phase": "await_topo" if stay_topo else "done",
+            "awaiting_user": stay_topo,
             "copy_revise_only": False,
-            "messages": [AIMessage(content="已将确认的主文案写入画布节点。")],
+            "pending_orchestrate": False,
+            "messages": [AIMessage(content="已将确认的主文案写入画布节点。可继续改拓扑或回复「确认出图」。")],
         }
 
     return write_copy_node

--- a/services/agent-runtime/app/graph/nodes/write_plan_node.py
+++ b/services/agent-runtime/app/graph/nodes/write_plan_node.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from langchain_core.messages import AIMessage
+
+from app.graph.plan_clean import strip_plan_preamble
+
+
+def make_write_plan_node(*, nest: Any) -> Callable:
+    async def write_plan_node(state: dict) -> dict:
+        draft = strip_plan_preamble(str(state.get("plan_draft") or state.get("plan_summary") or "").strip())
+        if not draft:
+            return {
+                "phase": "await_confirm",
+                "awaiting_user": True,
+                "user_decision": "none",
+                "messages": [AIMessage(content="方案草稿缺失，请说明需求后重试。")],
+            }
+
+        result = await nest.upsert_prompt_node(
+            prompt="营销方案",
+            content=draft,
+            node_id=state.get("plan_node_id"),
+        )
+        plan_node_id = result["nodeId"]
+        confirmed = (
+            "【已确认方案摘要】\n"
+            f"{(state.get('plan_summary') or draft[:200]).strip()}\n"
+            "已写入画布「营销方案」节点。接下来将拆解画布骨架（先不出图），请稍后确认拓扑与出图。"
+        )
+        return {
+            "phase": "write_plan_node",
+            "plan_node_id": plan_node_id,
+            "plan_draft": draft,
+            "awaiting_user": False,
+            "messages": [AIMessage(content=confirmed)],
+        }
+
+    return write_plan_node

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -26,10 +26,12 @@ class AgentRuntimeState(TypedDict, total=False):
         "intake",
         "plan",
         "await_confirm",
+        "write_plan_node",
         "split",
         "draft_copy",
         "await_copy_confirm",
         "write_copy_node",
+        "await_topo",
         "orchestrate_gen",
         "done",
         "error",
@@ -41,9 +43,11 @@ class AgentRuntimeState(TypedDict, total=False):
 
     # 工作记忆（轻量；禁止存完整 canvas nodes/edges）
     plan_summary: str
+    plan_draft: str | None
     plan_node_id: str | None
     focus_node_ids: list[str]
     split_manifest: list[SplitManifestItem]
+    topology_mode: Literal["full", "trimmed"] | None
     gen_queue: list[str]
     gen_completed: list[str]
     gen_failed: list[dict]
@@ -51,9 +55,9 @@ class AgentRuntimeState(TypedDict, total=False):
     copy_draft: str | None
     copy_node_id: str | None
     copy_revise_only: bool
-    # After first draft_copy: orchestrate_gen runs in background so write HITL is not blocked
+    # Only arm after「确认出图」(await_topo confirm_gen); not after draft_copy alone
     pending_orchestrate: bool
 
     # 一期轻量人机
     awaiting_user: bool
-    user_decision: Literal["none", "confirm", "revise"] | None
+    user_decision: Literal["none", "confirm", "revise", "confirm_gen", "topo_revise"] | None

--- a/services/agent-runtime/app/graph/topo_trim.py
+++ b/services/agent-runtime/app/graph/topo_trim.py
@@ -1,0 +1,30 @@
+"""Trim canvas-manifest items to a key subset with dependency closure."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def dependency_closure(items: list[dict[str, Any]], selected: set[str]) -> set[str]:
+    by_key = {str(it["key"]): it for it in items if it.get("key")}
+    out = set(selected) & set(by_key)
+    changed = True
+    while changed:
+        changed = False
+        for key in list(out):
+            deps = by_key.get(key, {}).get("depends_on") or []
+            for d in deps:
+                ds = str(d)
+                if ds in by_key and ds not in out:
+                    out.add(ds)
+                    changed = True
+    return out
+
+
+def trim_manifest_items(
+    items: list[dict[str, Any]],
+    selected_keys: list[str] | set[str],
+) -> list[dict[str, Any]]:
+    """Keep only selected keys plus depends_on closure; preserve original order."""
+    wanted = dependency_closure(list(items), {str(k) for k in selected_keys})
+    return [it for it in items if str(it.get("key") or "") in wanted]

--- a/services/agent-runtime/skills/enterprise-marketing-campaign/SKILL.md
+++ b/services/agent-runtime/skills/enterprise-marketing-campaign/SKILL.md
@@ -10,6 +10,7 @@ metadata:
   author: lnkpi
   lnkpi.canvas_manifest: assets/canvas-manifest.yaml
   lnkpi.max_downstream: "12"
+  lnkpi.topology_mode_default: full
 allowed-tools: upsert_prompt_node add_nodes_batch connect_nodes set_node_prompt attach_refs run_image_generation get_generation_status
 ---
 
@@ -24,8 +25,9 @@ allowed-tools: upsert_prompt_node add_nodes_batch connect_nodes set_node_prompt 
 ## Split and image generation
 
 - Follow `assets/canvas-manifest.yaml` when splitting the canvas.
-- Do not call `run_image_generation` during plan; only after user confirm → split → orchestrate_gen.
-- Phase-1: auto-generate image and video nodes after confirm (see task progress card spec).
+- Do not call `run_image_generation` during plan; only after user「确认出图」→ orchestrate_gen.
+- Scheme confirm writes the plan node; topology preview (Mermaid + skeleton) comes before image gen.
+- `topology_mode_default` (`full`|`trimmed`) may be overridden by the user.
 
 ## Progressive disclosure
 

--- a/services/agent-runtime/skills/enterprise-marketing-campaign/assets/canvas-manifest.yaml
+++ b/services/agent-runtime/skills/enterprise-marketing-campaign/assets/canvas-manifest.yaml
@@ -2,6 +2,7 @@ schema_version: 1
 defaults:
   auto_generate_image: true
   auto_generate_video: true
+  topology_mode_default: full
 items:
   - key: copy_main
     title: 主文案

--- a/services/agent-runtime/tests/test_await_copy_confirm.py
+++ b/services/agent-runtime/tests/test_await_copy_confirm.py
@@ -46,7 +46,8 @@ async def test_write_copy_persists_draft():
         }
     )
     assert any(c[0] == "set_node_content" and c[1] == ("t1", "正文A") for c in nest.calls)
-    assert out["awaiting_user"] is False
+    assert out["awaiting_user"] is True
+    assert out["phase"] == "await_topo"
     assert any(
         c[0] == "emit_task_update" and c[1].get("status") == "done" for c in nest.calls
     )

--- a/services/agent-runtime/tests/test_await_topo.py
+++ b/services/agent-runtime/tests/test_await_topo.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.checkpoint.memory import MemorySaver
+
+from app.graph.builder import build_agent_graph, route_entry
+from app.graph.nodes.await_topo import classify_topo_decision
+from app.graph.nodes.topo_revise import make_topo_revise_node
+
+
+def test_classify_confirm_gen():
+    assert classify_topo_decision("确认出图") == "confirm_gen"
+    assert classify_topo_decision("开始出图") == "confirm_gen"
+
+
+def test_classify_topo_revise():
+    assert classify_topo_decision("删掉 Banner") == "topo_revise"
+
+
+def test_route_entry_await_topo():
+    assert (
+        route_entry({"awaiting_user": True, "phase": "await_topo", "messages": []})
+        == "await_topo"
+    )
+
+
+def test_route_entry_await_topo_prefers_copy_confirm():
+    assert (
+        route_entry(
+            {
+                "awaiting_user": True,
+                "phase": "await_topo",
+                "messages": [HumanMessage(content="写入主文案")],
+            }
+        )
+        == "await_copy_confirm"
+    )
+
+
+class FakeNest:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Any]] = []
+
+    async def emit_task_list(self, items: list[dict[str, Any]]) -> None:
+        self.calls.append(("emit_task_list", items))
+
+    async def emit_text(self, text: str) -> None:
+        self.calls.append(("emit_text", text))
+
+
+@pytest.mark.asyncio
+async def test_topo_revise_removes_by_title():
+    nest = FakeNest()
+    node = make_topo_revise_node(nest=nest)
+    out = await node(
+        {
+            "messages": [HumanMessage(content="删掉 Banner")],
+            "split_manifest": [
+                {"key": "copy_main", "title": "主文案", "target_type": "text", "depends_on": []},
+                {"key": "banner", "title": "Banner", "target_type": "image", "depends_on": ["copy_main"]},
+                {
+                    "key": "hero_main",
+                    "title": "主图",
+                    "target_type": "image",
+                    "depends_on": ["banner"],
+                },
+            ],
+        }
+    )
+    keys = {str(i["key"]) for i in out["split_manifest"]}
+    assert "banner" not in keys
+    assert "copy_main" in keys
+    assert out["phase"] == "await_topo"
+    assert "flowchart" in out["messages"][0].content or "资产拓扑" in out["messages"][0].content
+
+
+@pytest.mark.asyncio
+async def test_confirm_gen_runs_orchestrate_sync():
+    class GenNest(FakeNest):
+        async def get_node(self, node_id: str) -> dict[str, Any]:
+            return {"id": node_id, "type": "image", "data": {}}
+
+        async def set_node_prompt(self, node_id: str, prompt: str) -> dict[str, Any]:
+            return {"nodeId": node_id, "actions": []}
+
+        async def attach_refs(self, node_id: str, ref_order: list[str]) -> dict[str, Any]:
+            return {"nodeId": node_id, "actions": []}
+
+        async def run_image_generation(self, node_id: str) -> dict[str, Any]:
+            self.calls.append(("run_image_generation", {"node_id": node_id}))
+            return {"nodeId": node_id, "status": "completed", "actions": []}
+
+        async def run_video_generation(self, node_id: str) -> dict[str, Any]:
+            self.calls.append(("run_video_generation", {"node_id": node_id}))
+            return {"nodeId": node_id, "status": "completed", "actions": []}
+
+        async def emit_task_update(self, **payload: Any) -> None:
+            self.calls.append(("emit_task_update", payload))
+
+        async def emit_task_summary(self, **payload: Any) -> None:
+            self.calls.append(("emit_task_summary", payload))
+
+    class StubLLM:
+        async def ainvoke(self, messages: Any, **kwargs: Any) -> AIMessage:
+            return AIMessage(content="ok")
+
+    nest = GenNest()
+    graph = build_agent_graph(
+        nest=nest,
+        llm=StubLLM(),
+        skills_dir=__import__("pathlib").Path(__file__).resolve().parents[1] / "skills",
+        checkpointer=MemorySaver(),
+    )
+    config = {"configurable": {"thread_id": "topo-gen-1"}}
+    await graph.aupdate_state(
+        config,
+        {
+            "phase": "await_topo",
+            "awaiting_user": True,
+            "skill_id": "enterprise-marketing-campaign",
+            "session_id": "s1",
+            "user_id": "u1",
+            "thread_id": "topo-gen-1",
+            "split_manifest": [
+                {
+                    "key": "white_bg",
+                    "title": "白底图",
+                    "target_type": "image",
+                    "auto_generate": True,
+                    "depends_on": [],
+                    "node_id": "img-1",
+                    "prompt_hint": "white",
+                }
+            ],
+            "gen_completed": [],
+            "gen_failed": [],
+            "messages": [AIMessage(content="骨架就绪")],
+        },
+        as_node="draft_copy",
+    )
+    state = await graph.ainvoke(
+        {"messages": [HumanMessage(content="确认出图")]},
+        config,
+    )
+    assert any(c[0] == "run_image_generation" for c in nest.calls)
+    assert state.get("phase") == "done" or state.get("gen_completed")

--- a/services/agent-runtime/tests/test_draft_copy.py
+++ b/services/agent-runtime/tests/test_draft_copy.py
@@ -53,10 +53,10 @@ async def test_draft_copy_sets_gate_and_needs_user():
             "plan_summary": "卫生洁具方案",
         }
     )
-    assert out["phase"] == "await_copy_confirm"
+    assert out["phase"] == "await_topo"
     assert out["awaiting_user"] is True
     assert out["copy_node_id"] == "t1"
-    assert out["pending_orchestrate"] is True
+    assert out["pending_orchestrate"] is False
     assert "静音" in (out["copy_draft"] or "")
     assert any(
         c[0] == "emit_task_update" and c[1].get("status") == "needs_user"

--- a/services/agent-runtime/tests/test_graph_plan_split.py
+++ b/services/agent-runtime/tests/test_graph_plan_split.py
@@ -157,33 +157,46 @@ async def test_confirm_then_split_creates_image_skeletons():
         config,
     )
     assert state1["awaiting_user"] is True
-    assert state1["plan_node_id"]
     assert state1["skill_id"] == "enterprise-marketing-campaign"
-    assert any(c[0] == "upsert_prompt_node" for c in nest.calls)
+    assert not state1.get("plan_node_id")
+    # 方案确认前不得写画布
+    assert not any(c[0] == "upsert_prompt_node" for c in nest.calls)
+    texts1 = [
+        str(getattr(m, "content", "") or "")
+        for m in (state1.get("messages") or [])
+        if getattr(m, "type", None) == "ai" or isinstance(m, AIMessage)
+    ]
+    assert any("1 / A" in t for t in texts1)
 
     state2 = await graph.ainvoke(
-        {"messages": [HumanMessage(content="确认，按这个拆并出图")]},
+        {"messages": [HumanMessage(content="1")]},
         config,
     )
     keys = _batch_keys(nest)
     assert "white_bg" in keys
     assert "hero_main" in keys
-    # draft_copy then done (orchestrate runs in background outside graph.ainvoke)
-    assert state2["phase"] == "await_copy_confirm"
+    assert any(c[0] == "upsert_prompt_node" for c in nest.calls)
+    assert state2["plan_node_id"]
+    # draft_copy ends turn on await_topo; no auto image gen
+    assert state2["phase"] == "await_topo"
     assert state2["awaiting_user"] is True
     assert state2.get("copy_draft")
     assert state2["user_decision"] == "confirm"
     assert state2["split_manifest"]
     assert all(item.get("node_id") for item in state2["split_manifest"])
-    # Sync graph path must NOT block on image gen
+    assert not state2.get("pending_orchestrate")
     gen_calls = [c for c in nest.calls if c[0] == "run_image_generation"]
     assert gen_calls == []
     assert not state2.get("gen_completed")
-    # task card list must be pinned at end of split (before long gen)
+    texts2 = [
+        str(getattr(m, "content", "") or "")
+        for m in (state2.get("messages") or [])
+        if getattr(m, "type", None) == "ai" or isinstance(m, AIMessage)
+    ]
+    assert any("flowchart" in t or "mermaid" in t.lower() or "资产拓扑" in t for t in texts2)
     task_lists = [c for c in nest.calls if c[0] == "emit_task_list"]
     assert task_lists
     assert any(item.get("id") == "white_bg" for item in task_lists[0][1])
-    # State must not hold full canvas nodes/edges
     assert "nodes" not in state2
     assert "edges" not in state2
 
@@ -209,14 +222,14 @@ async def test_revise_returns_to_plan():
         },
         config,
     )
-    plan_calls_before = sum(1 for c in nest.calls if c[0] == "upsert_prompt_node")
+    assert not any(c[0] == "upsert_prompt_node" for c in nest.calls)
 
     state2 = await graph.ainvoke(
         {"messages": [HumanMessage(content="改成更偏天猫详情页")]},
         config,
     )
-    plan_calls_after = sum(1 for c in nest.calls if c[0] == "upsert_prompt_node")
-    assert plan_calls_after > plan_calls_before
+    # revise 仍不写画布，直到确认方案
+    assert not any(c[0] == "upsert_prompt_node" for c in nest.calls)
     assert state2["awaiting_user"] is True
     assert state2["user_decision"] == "none"
     assert state2["phase"] == "await_confirm"

--- a/services/agent-runtime/tests/test_mermaid_topo.py
+++ b/services/agent-runtime/tests/test_mermaid_topo.py
@@ -1,0 +1,21 @@
+from app.graph.mermaid_topo import manifest_to_mermaid
+
+
+def test_mermaid_includes_titles_and_edges():
+    text = manifest_to_mermaid(
+        [
+            {"key": "white_bg", "title": "白底图", "depends_on": []},
+            {"key": "hero_main", "title": "主图", "depends_on": ["white_bg"]},
+            {"key": "copy_main", "title": "主文案", "depends_on": []},
+        ]
+    )
+    assert "白底图" in text
+    assert "主图" in text
+    assert "white_bg" in text
+    assert "-->" in text
+    assert "flowchart LR" in text
+
+
+def test_mermaid_empty():
+    text = manifest_to_mermaid([])
+    assert "暂无节点" in text

--- a/services/agent-runtime/tests/test_plan_summary.py
+++ b/services/agent-runtime/tests/test_plan_summary.py
@@ -20,6 +20,7 @@ def test_build_confirm_message_lists_assets_and_n():
     assert "白底图" in msg
     assert "主图" in msg
     assert "场景图" in msg
-    assert "将拆解 3" in msg or "拆解 3" in msg
-    assert "营销方案" in msg
-    assert "请确认是否按此方案拆解画布并出图" in msg
+    assert "拟定拆解约 3" in msg or "拆解约 3" in msg
+    assert "1 / A" in msg
+    assert "确认方案" in msg
+    assert "确认前不会写入画布" in msg

--- a/services/agent-runtime/tests/test_route_entry_copy_gate.py
+++ b/services/agent-runtime/tests/test_route_entry_copy_gate.py
@@ -28,6 +28,13 @@ def test_route_entry_still_supports_plan_confirm():
     )
 
 
+def test_route_entry_await_topo():
+    assert (
+        route_entry({"awaiting_user": True, "phase": "await_topo", "messages": []})
+        == "await_topo"
+    )
+
+
 @pytest.mark.asyncio
 async def test_done_preserves_copy_gate():
     done = make_done_node()
@@ -45,18 +52,17 @@ async def test_done_preserves_copy_gate():
 
 
 @pytest.mark.asyncio
-async def test_done_pending_orchestrate_copy_ready_tip():
+async def test_done_after_gen_is_done():
     done = make_done_node()
     out = await done(
         {
-            "awaiting_user": True,
-            "phase": "await_copy_confirm",
+            "awaiting_user": False,
+            "phase": "orchestrate_gen",
             "copy_draft": "主文案草稿",
-            "pending_orchestrate": True,
-            "gen_completed": [],
+            "pending_orchestrate": False,
+            "gen_completed": ["n1"],
             "gen_failed": [],
         }
     )
-    assert out["phase"] == "await_copy_confirm"
+    assert out["phase"] == "done"
     assert out["pending_orchestrate"] is False
-    assert "后台生成" in out["messages"][0].content

--- a/services/agent-runtime/tests/test_runs_stream.py
+++ b/services/agent-runtime/tests/test_runs_stream.py
@@ -121,17 +121,14 @@ def test_runs_stream_ndjson_smoke():
         events = [json.loads(line) for line in response.iter_lines() if line]
 
     types = [e["type"] for e in events]
-    assert "canvas_action" in types
+    # plan 确认前不写画布，首轮只有文本门
     assert "text_delta" in types
     assert "done" in types
     assert "error" not in types
-    assert "upsert_prompt_node" in nest.calls
-
-    canvas = next(e for e in events if e["type"] == "canvas_action")
-    assert canvas["data"]["type"] == "add_node"
-    assert canvas["data"]["payload"]["nodeType"] == "prompt"
+    assert "upsert_prompt_node" not in nest.calls
+    assert "canvas_action" not in types
 
     text = "".join(
         e["data"]["text"] for e in events if e["type"] == "text_delta"
     )
-    assert "确认" in text or "方案" in text
+    assert "1 / A" in text or "确认方案" in text or "方案" in text

--- a/services/agent-runtime/tests/test_thread_busy.py
+++ b/services/agent-runtime/tests/test_thread_busy.py
@@ -11,12 +11,8 @@ from langchain_core.messages import AIMessage
 from app.runs import RunRequest, stream_run_events
 
 
-class _SlowNest:
-    """Blocks inside upsert so a second concurrent turn can race."""
-
-    def __init__(self, gate: asyncio.Event, release: asyncio.Event) -> None:
-        self.gate = gate
-        self.release = release
+class _Nest:
+    def __init__(self) -> None:
         self.upserts = 0
 
     async def close(self) -> None:
@@ -24,8 +20,6 @@ class _SlowNest:
 
     async def upsert_prompt_node(self, **kwargs: Any) -> dict[str, Any]:
         self.upserts += 1
-        self.gate.set()
-        await self.release.wait()
         return {"nodeId": "plan-1", "actions": []}
 
     async def get_node(self, node_id: str) -> dict[str, Any]:
@@ -47,8 +41,18 @@ class _SlowNest:
         return {"nodeId": node_id, "status": "completed", "actions": []}
 
 
-class _FakeLLM:
+class _SlowLLM:
+    """Blocks inside plan LLM so a second concurrent turn can race."""
+
+    def __init__(self, gate: asyncio.Event, release: asyncio.Event) -> None:
+        self.gate = gate
+        self.release = release
+        self.calls = 0
+
     async def ainvoke(self, messages: Any, **kwargs: Any) -> AIMessage:
+        self.calls += 1
+        self.gate.set()
+        await self.release.wait()
         return AIMessage(content="# 方案\n蓝牙音箱\n")
 
 
@@ -66,8 +70,8 @@ async def test_concurrent_same_thread_returns_busy_tip():
 
     gate = asyncio.Event()
     release = asyncio.Event()
-    nest = _SlowNest(gate, release)
-    llm = _FakeLLM()
+    nest = _Nest()
+    llm = _SlowLLM(gate, release)
     tid = "thread-busy-1"
     sid = "sess-busy-1"
 
@@ -106,5 +110,6 @@ async def test_concurrent_same_thread_returns_busy_tip():
     ]
     assert any(THREAD_BUSY_TIP in t for t in texts)
     assert any(e.get("type") == "done" for e in events2)
-    # Second turn must not kick another upsert/plan while first holds the lock
-    assert nest.upserts == 1
+    # Second turn must not kick another plan LLM while first holds the lock
+    assert llm.calls == 1
+    assert nest.upserts == 0

--- a/services/agent-runtime/tests/test_topo_trim.py
+++ b/services/agent-runtime/tests/test_topo_trim.py
@@ -1,0 +1,25 @@
+from app.graph.topo_trim import dependency_closure, trim_manifest_items
+
+_ITEMS = [
+    {"key": "copy_main", "title": "主文案", "depends_on": []},
+    {"key": "white_bg", "title": "白底图", "depends_on": []},
+    {"key": "hero_main", "title": "主图", "depends_on": ["white_bg"]},
+    {"key": "banner", "title": "Banner", "depends_on": []},
+    {"key": "show_video", "title": "视频", "depends_on": ["hero_main"]},
+]
+
+
+def test_closure_pulls_upstream():
+    assert dependency_closure(_ITEMS, {"hero_main"}) == {"hero_main", "white_bg"}
+    assert dependency_closure(_ITEMS, {"show_video"}) == {
+        "show_video",
+        "hero_main",
+        "white_bg",
+    }
+
+
+def test_trim_preserves_order_and_drops_unused():
+    out = trim_manifest_items(_ITEMS, ["hero_main", "copy_main"])
+    keys = [x["key"] for x in out]
+    assert keys == ["copy_main", "white_bg", "hero_main"]
+    assert "banner" not in keys

--- a/services/agent-runtime/tests/test_write_plan_node.py
+++ b/services/agent-runtime/tests/test_write_plan_node.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from app.graph.nodes.write_plan_node import make_write_plan_node
+
+
+class FakeNest:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Any]] = []
+
+    async def upsert_prompt_node(
+        self,
+        *,
+        prompt: str,
+        content: str,
+        node_id: str | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            ("upsert_prompt_node", {"prompt": prompt, "content": content, "node_id": node_id})
+        )
+        return {"nodeId": node_id or "prompt-plan-1", "actions": []}
+
+
+@pytest.mark.asyncio
+async def test_write_plan_node_upserts_and_emits_confirmed_summary():
+    nest = FakeNest()
+    node = make_write_plan_node(nest=nest)
+    out = await node(
+        {
+            "plan_draft": "# 定位\n高端卫浴\n",
+            "plan_summary": "高端卫浴电商详情页",
+        }
+    )
+    assert out["plan_node_id"] == "prompt-plan-1"
+    assert out["phase"] == "write_plan_node"
+    assert any(c[0] == "upsert_prompt_node" for c in nest.calls)
+    assert "已确认方案摘要" in out["messages"][0].content
+    assert nest.calls[0][1]["prompt"] == "营销方案"
+    assert "高端卫浴" in nest.calls[0][1]["content"]


### PR DESCRIPTION
## Summary
- 方案确认前不写画布；`1/A` 确认后 `write_plan_node` 再落「营销方案」节点
- `split` 只物化骨架 + Mermaid 资产拓扑（full/trimmed），**确认出图前不出图**
- 新增 `await_topo` / `topo_revise`；主文案 HITL 可与拓扑预览并行；「确认出图」同步跑 `orchestrate_gen`
- Web chips：方案门 `1/A–3/C`，骨架门「确认出图 / 写入主文案 / 要改拓扑」

## Test plan
- [x] `pytest` agent-runtime：74 passed
- [x] vitest `agentChipSet.test.ts`：5 passed
- [ ] 手动：full 路径 — 方案 → `1` → 见 Mermaid/骨架 → 写入主文案 → 确认出图
- [ ] 手动：trimmed 路径（改 skill default 或 state）节点更少
- [ ] 确认：首轮 plan 无 canvas upsert；draft 后无自动 bg 出图
- [ ] 部署后 `enable_agent_runtime=true` 复测


Made with [Cursor](https://cursor.com)