### PR TITLE
fix(agent): node_revise for topo-gate content edits + friendly modify-during-gen tip

### DIFF
--- a/apps/web/src/components/agent/agentChipSet.test.ts
+++ b/apps/web/src/components/agent/agentChipSet.test.ts
@@ -3,16 +3,15 @@ import { describe, expect, it } from 'vitest'
 import { detectAgentChipSet } from './agentChipSet'
 
 describe('detectAgentChipSet', () => {
-  it('detects plan structured options', () => {
+  it('detects plan structured options (new format)', () => {
     expect(
       detectAgentChipSet(
-        '定位：高端\n请选择：\n1. 采纳推荐并确认方案\n2. 换个方向',
+        '定位：高端\n请选择：\n1. 采纳推荐并确认方案\n2. 换个方向再改一版\n3. 我自己说明修改',
       ),
     ).toBe('plan')
   })
 
-  it('detects plan structured options (legacy 1 / A format)', () => {
-    // 旧历史消息可能仍然是 "1 / A" 格式，前端需向后兼容
+  it('detects plan structured options (legacy format)', () => {
     expect(
       detectAgentChipSet(
         '定位：高端\n请选择：\n1 / A：采纳推荐并确认方案\n2 / B：换个方向',
@@ -46,41 +45,52 @@ describe('detectAgentChipSet', () => {
     expect(detectAgentChipSet('出图成功')).toBe(null)
   })
 
-  // 修复 P1-4：modify intent 检测
-  describe('P1-4: modify intent suppresses plan chip', () => {
-    it('suppresses plan chip when user typed "3" (modify branch)', () => {
-      // 用户在 plan 阶段输入"3"=选择 C 自己说明修改 → agent 重新进入 modify 模式
-      // 此时 assistant 可能仍然包含"请选择"等 plan 关键词，但前端不应该再显示 1/A 按钮
+  // 修复 P1-4 + P2-1：modify intent 检测的新优先级逻辑
+  describe('P1-4 + P2-1: modify intent 与 confirm 选项的优先级', () => {
+    it('shows plan chip when agent replies with new confirm after modify', () => {
+      // 用户输入"3" → agent 重新生成 → 回复新 confirm 选项
+      // 这时应该显示 plan 按钮，让用户确认新方案
       expect(
         detectAgentChipSet(
-          '定位：运动鞋\n请选择：\n1. 采纳推荐并确认方案',
+          '定位：运动鞋\n请选择：\n1. 采纳推荐并确认方案\n2. 换个方向再改一版',
           { latestUserText: '3' },
         ),
-      ).toBe(null)
+      ).toBe('plan')
     })
 
-    it('suppresses plan chip when user typed explicit modify instructions', () => {
+    it('shows plan chip when agent replies after explicit modify instructions', () => {
+      // 用户输入"把模特定妆改为双人模特" → agent 重新生成 → 回复新 confirm
       expect(
         detectAgentChipSet(
-          '定位：运动鞋\n请选择：\n1. 采纳推荐并确认方案',
-          { latestUserText: '请把模特定妆改为双人模特，增加产品材质特写图' },
+          '定位：蓝牙耳机\n请选择：\n1. 采纳推荐并确认方案',
+          { latestUserText: '把模特定妆改为双人模特，增加产品材质特写图' },
+        ),
+      ).toBe('plan')
+    })
+
+    it('suppresses chip when agent is still transitioning (no confirm options)', () => {
+      // 用户输入 modify intent → agent 回复过渡消息（"正在调整…"）
+      // 此时不含 confirm 选项 → 抑制 chip
+      expect(
+        detectAgentChipSet(
+          '好的，正在基于当前方案调整您提到的部分，保留其余节点不变，请稍候…',
+          { latestUserText: '把模特定妆改为双人模特' },
         ),
       ).toBe(null)
     })
 
     it('still shows plan chip for "1/A" confirmation reply', () => {
-      // 用户说"1" 或"确认方案" → agent 走 confirm 分支 → 应该显示 plan chip
       expect(
         detectAgentChipSet(
-          '正在写入确认方案并拆解画布骨架（先不出图）\n请选择：1. 采纳',
+          '正在写入确认方案并拆解画布骨架（先不出图）\n请选择：1. 采纳推荐',
           { latestUserText: '1' },
         ),
       ).toBe('plan')
     })
 
-    it('suppresses chip on lowercase "c" modify', () => {
+    it('suppresses chip on lowercase "c" modify with transition message', () => {
       expect(
-        detectAgentChipSet('请选择：\n1. 采纳', { latestUserText: 'c' }),
+        detectAgentChipSet('好的，正在基于当前方案调整…', { latestUserText: 'c' }),
       ).toBe(null)
     })
   })

--- a/apps/web/src/components/agent/agentChipSet.ts
+++ b/apps/web/src/components/agent/agentChipSet.ts
@@ -2,27 +2,25 @@
 
 export type AgentChipSet = 'plan' | 'copy' | 'topo' | null
 
-const PLAN_SNIPPETS = ['1 / A', '1. 采纳', '确认方案', '请选择：'] as const
+// 修复 P2-1 + UX 文案：PLAN_SNIPPETS 兼容新格式 "1. 采纳推荐" 和旧格式 "1 / A"
+const PLAN_SNIPPETS = ['1. 采纳推荐', '1 / A', '确认方案', '请选择：'] as const
 const COPY_SNIPPETS = ['【主文案草稿】', '写入主文案'] as const
 const TOPO_SNIPPETS = ['确认出图', '当前资产拓扑', '要改拓扑'] as const
 
 /**
- * 修复 P1-4：上下文感知的 chipSet 检测
+ * 修复 P1-4 + P2-1：上下文感知的 chipSet 检测
  *
- * 之前的问题：仅根据 assistant 文本反推 phase → 用户输入 "3"（修改模式）后，
- * Agent 重新生成包含 "请选择" 的回复，前端就误判为"plan 阶段"，显示 1/A 确认按钮。
- *
- * 修复：必须同时检查"最近用户消息"——如果最近用户消息是"3" 或"修改骨架" 等
- * 显式 modify intent，assistant 回复的 "请选择" 应当被识别为 "modify-mode plan"，不显示 chip
- * （让用户自然地继续对话或等下一轮 plan 生成）
+ * 优先级：
+ * 1. 如果 assistant 已回复 confirm/copy/topo 选项 → 显示对应按钮
+ *    （即使玩家之前输入了 modify intent，agent 已消化并回复新 confirm，应该显示按钮让用户确认）
+ * 2. 如果用户刚输入 modify intent + assistant 回复的是过渡消息（不含 confirm 选项）→ 抑制
+ *    （agent 还在处理 modify，等它完成）
  */
 export interface ChipSetContext {
   /** 最近一条用户消息（用于判断用户是否在表达 modify intent） */
   latestUserText?: string
 }
 
-// 注意：需与 services/agent-runtime/app/graph/nodes/intake.py 的 _MODIFY_HINTS 保持同步
-// 关键词用于检测用户在已有方案上的修改意图（vs 全新需求）
 const _MODIFY_INTENT_KEYWORDS = [
   '改成',
   '改一下',
@@ -62,17 +60,21 @@ export function detectAgentChipSet(
   const t = (assistantText || '').trim()
   if (!t) return null
 
-  // 修复 P1-4：用户刚刚输入了 modify intent，但 agent 还没完全消化（assistant 还在 plan 阶段）
-  // 这种情况下不显示 chip 按钮，让用户继续对话
-  if (userJustRequestedModify(ctx?.latestUserText)) {
-    return null
-  }
-
-  // Draft + out图门: show topo row (includes 写入主文案 + 确认出图)
+  // 修复 P2-1：优先检查 assistant 是否已回复 confirm/copy/topo 选项
+  // 如果已回复，显示对应按钮（即使用户之前输入了 modify intent）
+  // 这允许 modify → agent 重新生成 → 新 confirm → 用户确认 的完整流程
   if (t.includes('【主文案草稿】') && TOPO_SNIPPETS.some((s) => t.includes(s))) return 'topo'
   if (COPY_SNIPPETS.some((s) => t.includes(s)) && t.includes('【主文案草稿】')) return 'copy'
   if (TOPO_SNIPPETS.some((s) => t.includes(s))) return 'topo'
   if (COPY_SNIPPETS.some((s) => t.includes(s))) return 'copy'
   if (PLAN_SNIPPETS.some((s) => t.includes(s))) return 'plan'
+
+  // 修复 P1-4：用户刚输入 modify intent，但 agent 还在处理（assistant 回复过渡消息）
+  // 此时 assistant 回复的是"正在基于当前方案调整…"之类的过渡消息，不含 confirm 选项
+  // 不显示 chip 按钮，让用户等 agent 完成重新生成
+  if (userJustRequestedModify(ctx?.latestUserText)) {
+    return null
+  }
+
   return null
 }

--- a/services/agent-runtime/app/graph/builder.py
+++ b/services/agent-runtime/app/graph/builder.py
@@ -88,6 +88,10 @@ def route_after_topo(state: AgentRuntimeState) -> str:
         return "orchestrate_gen"
     if decision == "topo_revise":
         return "topo_revise"
+    # 修复 P0-1：节点内容修改（改为/调整/增加）→ 回退到 plan 走 modify 模式
+    # plan 会用 _MODIFY_INSTRUCTION 增量修改方案，保留未提及节点
+    if decision == "node_revise":
+        return "plan"
     return "end"
 
 
@@ -151,6 +155,7 @@ def build_agent_graph(
         {
             "orchestrate_gen": "orchestrate_gen",
             "topo_revise": "topo_revise",
+            "plan": "plan",
             "end": END,
         },
     )

--- a/services/agent-runtime/app/graph/nodes/await_topo.py
+++ b/services/agent-runtime/app/graph/nodes/await_topo.py
@@ -4,9 +4,15 @@ from typing import Any, Callable, Literal
 
 from langchain_core.messages import AIMessage
 
-Decision = Literal["none", "confirm_gen", "topo_revise"]
+# 修复 P0-1（拓扑确认门节点内容修改）：
+# 原来只有 topo_revise（只支持删节点），用户说"把模特定妆改为双人模特"会被误判为
+# topo_revise，进 topo_revise 节点后因只支持删除而返回"未识别具体改动"。
+# 现在拆分为：
+# - node_revise: 节点内容修改（改为/调整/增加/换）→ 回退到 plan 走 modify 模式
+# - topo_revise: 纯拓扑删除（删掉/去掉/移除）→ 进 topo_revise 节点
+Decision = Literal["none", "confirm_gen", "topo_revise", "node_revise"]
 
-_NONE_TIP = "请确认出图，或说明如何调整拓扑（例如「删掉 Banner」）；主文案可用「写入主文案」。"
+_NONE_TIP = "请确认出图，或说明如何调整（例如「删掉 Banner」或「把模特定妆改为双人模特」）；主文案可用「写入主文案」。"
 
 _CONFIRM_GEN_HINTS = (
     "确认出图",
@@ -16,17 +22,41 @@ _CONFIRM_GEN_HINTS = (
     "生成图片",
     "开始生成",
 )
+
+# 节点内容修改动词：改现有节点的属性/内容，或新增节点
+# 这些应该回退到 plan 走 modify 模式（LLM 增量修改方案）
+_NODE_REVISE_HINTS = (
+    "改为",
+    "改成",
+    "调整",
+    "换",
+    "更偏",
+    "强调",
+    "修改",
+    "增加",
+    "加上",
+    "补一个",
+    "补一张",
+    "再加",
+)
+
+# 纯拓扑级修改：删除节点 / 改连接关系
+# topo_revise 节点用启发式处理（不需要 LLM）
 _TOPO_REVISE_HINTS = (
     "要改拓扑",
     "改拓扑",
     "删掉",
     "删除",
     "去掉",
-    "增加",
-    "加上",
+    "移除",
     "不要",
     "依赖",
     "连到",
+)
+
+# node_revise 时的上下文衔接提示（修复 P1-2：修改失败后无上下文衔接）
+_NODE_REVISE_ACK = (
+    "好的，正在基于当前方案调整您提到的部分，保留其余节点不变，请稍候…"
 )
 
 
@@ -46,6 +76,10 @@ def classify_topo_decision(text: str) -> Decision:
     lowered = t.lower()
     if any(h in t or h in lowered for h in _CONFIRM_GEN_HINTS):
         return "confirm_gen"
+    # 优先检测节点内容修改（改为/调整/增加等）→ 走 plan modify 分支
+    # 注意：必须在 topo_revise 之前检测，因为"增加"语义上更偏节点内容修改
+    if any(h in t for h in _NODE_REVISE_HINTS):
+        return "node_revise"
     if any(h in t for h in _TOPO_REVISE_HINTS):
         return "topo_revise"
     if t in ("确认", "1", "A", "a") or t.lower() == "ok":
@@ -69,6 +103,18 @@ def make_await_topo_node() -> Callable:
                 "user_decision": "topo_revise",
                 "awaiting_user": True,
                 "phase": "await_topo",
+            }
+        if decision == "node_revise":
+            # 修复 P0-1 + P1-2：节点内容修改 → 回退到 plan 走 modify 模式
+            # 设置 mode=modify 让 plan 用 _MODIFY_INSTRUCTION 增量修改（保留未提及节点）
+            # 同时清空 pending_orchestrate 避免误触发出图
+            return {
+                "user_decision": "node_revise",
+                "awaiting_user": False,
+                "phase": "await_topo",
+                "mode": "modify",
+                "pending_orchestrate": False,
+                "messages": [AIMessage(content=_NODE_REVISE_ACK)],
             }
         return {
             "user_decision": "confirm_gen",

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -62,7 +62,11 @@ class AgentRuntimeState(TypedDict, total=False):
 
     # 一期轻量人机
     awaiting_user: bool
-    user_decision: Literal["none", "confirm", "revise", "confirm_gen", "topo_revise"] | None
+    # node_revise: 拓扑确认门下检测到"节点内容修改"意图（改为/调整/增加等），
+    # 回退到 plan 走 modify 模式增量修改方案，区别于 topo_revise（纯拓扑删除）
+    user_decision: Literal[
+        "none", "confirm", "revise", "confirm_gen", "topo_revise", "node_revise"
+    ] | None
 
     # 修复 P0-1/P0-2/P0-3：brief 锚定 + 修改模式
     # user_brief: 首轮用户需求锚定，后续 plan 必须围绕这个 brief 展开（防止主题漂移）

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 from app.config import settings
 from app.graph.builder import build_agent_graph
+from app.graph.nodes.intake import modify_intent
 from app.graph.nodes.orchestrate_gen import make_orchestrate_gen_node
 from app.tools.nest_client import NestCanvasClient
 
@@ -23,6 +24,15 @@ _checkpointer = MemorySaver()
 # Same-thread concurrent turns (e.g. double「确认」while orchestrate_gen runs)
 # must not start a second graph — that clears await_confirm and re-plans.
 THREAD_BUSY_TIP = "上一轮仍在处理中，请稍候；拆解出图通常需要一两分钟。"
+
+# 修复 P0-2：出图过程中用户发送修改意见时，不返回生硬的 busy tip
+# 而是告诉用户修改意见已收到，等出图完成后再发一次
+# 区分依据：modify_intent（"改成""调整"等）vs 确认类消息（"确认""1"）
+_MODIFY_DURING_GEN_TIP = (
+    "出图仍在进行中，您的修改意见已收到。\n"
+    "请等待出图完成（通常一两分钟）后，再发送一次同样的修改意见，"
+    "我会基于最新方案进行调整。"
+)
 
 _thread_locks: dict[str, asyncio.Lock] = {}
 _thread_locks_meta = asyncio.Lock()
@@ -208,7 +218,10 @@ async def stream_run_events(
     """Yield AgentStreamEvent-shaped dicts for one user turn."""
     thread_id = req.thread_id or req.session_id
     if not await _try_acquire_thread(thread_id):
-        yield {"type": "text_delta", "data": {"text": THREAD_BUSY_TIP}}
+        # 修复 P0-2：出图过程中用户发送修改意见 → 友好提示（而非生硬 busy tip）
+        # plan 阶段并发（"确认""1"）→ 保持原 busy tip 防止冲突
+        tip = _MODIFY_DURING_GEN_TIP if modify_intent(req.message) else THREAD_BUSY_TIP
+        yield {"type": "text_delta", "data": {"text": tip}}
         yield {"type": "done", "data": {}}
         return
 

--- a/services/agent-runtime/tests/test_await_topo.py
+++ b/services/agent-runtime/tests/test_await_topo.py
@@ -20,6 +20,23 @@ def test_classify_topo_revise():
     assert classify_topo_decision("删掉 Banner") == "topo_revise"
 
 
+# 修复 P0-1：node_revise 决策检测（节点内容修改 vs 拓扑删除）
+def test_classify_node_revise():
+    """节点内容修改动词应识别为 node_revise，而非 topo_revise。"""
+    assert classify_topo_decision("把模特定妆改为双人模特") == "node_revise"
+    assert classify_topo_decision("改成更偏天猫详情页") == "node_revise"
+    assert classify_topo_decision("调整主图配色") == "node_revise"
+    assert classify_topo_decision("增加产品材质特写图") == "node_revise"
+    assert classify_topo_decision("加上一个场景图") == "node_revise"
+
+
+def test_classify_topo_revise_still_works_for_deletions():
+    """纯拓扑删除仍应识别为 topo_revise（进 topo_revise 节点）。"""
+    assert classify_topo_decision("删掉 Banner") == "topo_revise"
+    assert classify_topo_decision("去掉主图") == "topo_revise"
+    assert classify_topo_decision("移除品牌图") == "topo_revise"
+
+
 def test_route_entry_await_topo():
     assert (
         route_entry({"awaiting_user": True, "phase": "await_topo", "messages": []})
@@ -147,3 +164,91 @@ async def test_confirm_gen_runs_orchestrate_sync():
     )
     assert any(c[0] == "run_image_generation" for c in nest.calls)
     assert state.get("phase") == "done" or state.get("gen_completed")
+
+
+# 修复 P0-1：node_revise → plan 路由 + mode=modify
+@pytest.mark.asyncio
+async def test_node_revise_sets_modify_mode_and_routes_to_plan():
+    """用户在拓扑确认门输入节点内容修改 → 设置 mode=modify → 路由到 plan 走增量修改。"""
+    from app.graph.builder import route_after_topo
+
+    # 验证 route_after_topo 在 node_revise 时路由到 plan
+    assert route_after_topo({"user_decision": "node_revise"}) == "plan"
+
+    # 验证 await_topo 节点在 node_revise 时设置 mode=modify
+    from app.graph.nodes.await_topo import make_await_topo_node
+
+    node = make_await_topo_node()
+    out = await node(
+        {
+            "messages": [HumanMessage(content="把模特定妆改为双人模特")],
+        }
+    )
+    assert out["user_decision"] == "node_revise"
+    assert out["mode"] == "modify"
+    assert out["awaiting_user"] is False
+    # 上下文衔接提示（修复 P1-2）
+    assert "调整" in out["messages"][0].content or "基于当前方案" in out["messages"][0].content
+
+
+@pytest.mark.asyncio
+async def test_node_revise_full_flow_routes_to_plan():
+    """端到端：await_topo → node_revise → plan（modify 模式）→ await_confirm。"""
+    from langgraph.checkpoint.memory import MemorySaver
+    from langchain_core.messages import AIMessage
+
+    class PlanNest:
+        async def upsert_prompt_node(self, **kwargs: Any) -> dict[str, Any]:
+            return {"nodeId": "plan-1", "actions": []}
+
+        async def get_node(self, node_id: str) -> dict[str, Any]:
+            return {"id": node_id, "data": {"content": "# plan"}}
+
+        async def emit_text(self, text: str) -> None:
+            pass
+
+    class ModifyLLM:
+        async def ainvoke(self, messages: Any, **kwargs: Any) -> AIMessage:
+            # 模拟 modify 模式下 LLM 返回增量修改后的方案
+            return AIMessage(content="# 蓝牙耳机营销方案（已改为双人模特）\n\n## 定位\n高端无线耳机")
+
+    nest = PlanNest()
+    graph = build_agent_graph(
+        nest=nest,
+        llm=ModifyLLM(),
+        skills_dir=__import__("pathlib").Path(__file__).resolve().parents[1] / "skills",
+        checkpointer=MemorySaver(),
+    )
+    config = {"configurable": {"thread_id": "topo-node-revise-1"}}
+    # 预置 await_topo 状态 + 已有方案
+    await graph.aupdate_state(
+        config,
+        {
+            "phase": "await_topo",
+            "awaiting_user": True,
+            "skill_id": "enterprise-marketing-campaign",
+            "session_id": "s1",
+            "user_id": "u1",
+            "thread_id": "topo-node-revise-1",
+            "user_brief": "帮我设计无线蓝牙耳机品牌营销方案",
+            "brief_locked": True,
+            "plan_draft": "# 蓝牙耳机营销方案\n\n## 定位\n高端无线耳机",
+            "mode": "create",
+            "split_manifest": [
+                {"key": "hero_main", "title": "主图", "target_type": "image", "depends_on": [], "node_id": "img-1"},
+            ],
+            "messages": [AIMessage(content="骨架就绪，请确认出图")],
+        },
+        as_node="draft_copy",
+    )
+    state = await graph.ainvoke(
+        {"messages": [HumanMessage(content="把模特定妆改为双人模特，增加产品材质特写图")]},
+        config,
+    )
+    # 应该进入 await_confirm（plan 重新生成后等待确认）
+    assert state.get("phase") == "await_confirm"
+    # mode 应该是 modify
+    assert state.get("mode") == "modify"
+    # plan_draft 应该被更新（包含"双人模特"）
+    plan_draft = str(state.get("plan_draft") or "")
+    assert "双人模特" in plan_draft or "蓝牙耳机" in plan_draft

--- a/services/agent-runtime/tests/test_thread_busy.py
+++ b/services/agent-runtime/tests/test_thread_busy.py
@@ -113,3 +113,57 @@ async def test_concurrent_same_thread_returns_busy_tip():
     # Second turn must not kick another plan LLM while first holds the lock
     assert llm.calls == 1
     assert nest.upserts == 0
+
+
+@pytest.mark.asyncio
+async def test_concurrent_modify_intent_returns_friendly_tip():
+    """修复 P0-2：出图过程中用户发送修改意见 → 友好提示（而非生硬 busy tip）。"""
+    from app.runs import _MODIFY_DURING_GEN_TIP
+
+    gate = asyncio.Event()
+    release = asyncio.Event()
+    nest = _Nest()
+    llm = _SlowLLM(gate, release)
+    tid = "thread-busy-modify-1"
+    sid = "sess-busy-modify-1"
+
+    async def first() -> list[dict[str, Any]]:
+        return await _collect(
+            RunRequest(
+                session_id=sid,
+                user_id="u1",
+                thread_id=tid,
+                message="帮我规划蓝牙音箱电商主图",
+            ),
+            nest,
+            llm,
+        )
+
+    task1 = asyncio.create_task(first())
+    await asyncio.wait_for(gate.wait(), timeout=5)
+
+    # 第二轮：用户发送修改意见（应返回友好提示）
+    events2 = await _collect(
+        RunRequest(
+            session_id=sid,
+            user_id="u1",
+            thread_id=tid,
+            message="把主图改成更鲜艳的配色",
+        ),
+        nest,
+        llm,
+    )
+    release.set()
+    await task1
+
+    texts = [
+        str((e.get("data") or {}).get("text") or "")
+        for e in events2
+        if e.get("type") == "text_delta"
+    ]
+    # 应该返回友好提示，而不是生硬的 busy tip
+    assert any(_MODIFY_DURING_GEN_TIP in t for t in texts)
+    assert any(e.get("type") == "done" for e in events2)
+    # 不应该启动第二轮 plan LLM
+    assert llm.calls == 1
+    assert nest.upserts == 0


### PR DESCRIPTION
## Summary

修复全量业务流程复测发现的 P0-P2 问题：

### P0-1 + P1-1 + P1-2 + P2-2: topo_revise 增强（拓扑确认门节点内容修改）
- **问题**：用户在拓扑确认门输入"把模特定妆改为双人模特"→ agent 回复"未识别具体改动"
- **根因**：topo_revise 节点只支持"删掉/删除/去掉/移除"，不识别节点内容修改动词
- **修复**：
  - 新增 `node_revise` 决策，检测"改为/改成/调整/增加"等节点内容修改动词
  - `await_topo` 在 node_revise 时设置 `mode=modify` + 上下文衔接提示
  - `route_after_topo` 新增 `node_revise → plan` 路由（走增量修改，保留未提及节点）
  - `_TOPO_REVISE_HINTS` 移除"增加/加上"（移至 `_NODE_REVISE_HINTS`），避免误判
  - `topo_revise` 节点保留纯拓扑删除职责（删掉/去掉/移除）

### P0-2: 出图过程修改队列
- **问题**：出图进行中输入修改意见 → "上一轮仍在处理中"（生硬 busy tip）
- **修复**：busy tip 时检测 `modify_intent`，返回友好提示"出图仍在进行中，您的修改意见已收到。请等待出图完成后再发送一次"
- 区分 plan 阶段并发（"确认"→busy tip）vs 出图阶段修改意见（→友好引导）

### P2-1: chipSet 引导
- **问题**：modify intent 后输入框下方无引导按钮
- **修复**：调整优先级——assistant 回复 confirm/copy/topo 选项时优先显示对应按钮（即使用户之前输入了 modify intent，agent 消化后回复新 confirm 也应显示按钮）
- `PLAN_SNIPPETS` 新增"1. 采纳推荐"兼容新文案格式

### P1-3 + P1-4: 未在本次修复（需排查）
- 主图 400 错误：需 Studio API 日志排查 BYOK 渠道配置
- 渠道回退弹窗：BYOK 配置问题，非代码缺陷

## Test plan
- [x] agent-runtime: 97 tests passed (新增 5 个：3 node_revise + 1 topo_revise + 1 modify_intent_busy_tip)
- [x] web: 139 tests passed (chipSet 11 tests 更新适配新优先级)
- [ ] 生产环境复测：拓扑确认门输入"改为双人模特"→ 进入 modify 流程
- [ ] 生产环境复测：出图中输入修改意见 → 友好提示