### PR TITLE
fix(docker): use pyproject.toml for dependency management

### DIFF
--- a/deploy/docker/Dockerfile.agent-runtime
+++ b/deploy/docker/Dockerfile.agent-runtime
@@ -8,17 +8,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 # 依赖层先装：app/skills 变更不重装 pip（CVM 访问 PyPI 易超时）
+# 使用 pyproject.toml 管理依赖，避免硬编码
 COPY services/agent-runtime/pyproject.toml ./
 RUN pip install --no-cache-dir --default-timeout=120 \
     -i https://pypi.tuna.tsinghua.edu.cn/simple \
     --trusted-host pypi.tuna.tsinghua.edu.cn \
-    "fastapi>=0.115" \
-    "uvicorn[standard]>=0.32" \
-    "langgraph>=0.2" \
-    "langchain-openai>=0.2" \
-    "httpx>=0.27" \
-    "pyyaml>=6.0" \
-    "pydantic-settings>=2.0"
+    .
 
 COPY services/agent-runtime/app ./app
 COPY services/agent-runtime/skills ./skills


### PR DESCRIPTION
## Summary

修复 Dockerfile 硬编码依赖导致部署失败的问题。

## Problem

- Dockerfile 硬编码了依赖列表，完全忽略 `pyproject.toml`
- W1 添加了 `langgraph-checkpoint-sqlite` 到 `pyproject.toml`，但 Dockerfile 未同步
- 导致容器健康检查失败，部署失败

## Solution

- 修改 Dockerfile 使用 `pip install .` 安装 `pyproject.toml` 定义的依赖
- 确保依赖管理单一来源（pyproject.toml）

## Changes

- `deploy/docker/Dockerfile.agent-runtime`: 改用 `pip install .` 替代硬编码依赖

## Test

- 本地测试：`docker build -f deploy/docker/Dockerfile.agent-runtime .` 成功
- 依赖安装：`pip install .` 成功安装所有依赖（包括 langgraph-checkpoint-sqlite）

## Related

- 工作项：W1（checkpoint persistence）
- 验收标准：部署成功、容器健康检查通过