### PR TITLE
ci: include services/agent-runtime in deploy.yml paths

### DIFF
--- a/.github/workflows/deploy-agent-runtime.yml
+++ b/.github/workflows/deploy-agent-runtime.yml
@@ -14,6 +14,7 @@ on:
     branches: [main]
     paths:
       - "services/agent-runtime/**"
+      - "deploy/docker/**"  # 包含 Dockerfile.agent-runtime 等构建文件
       - "deploy/docker-compose.prod.yml"
       - "deploy/docker-compose.prod.images.yml"
       - "deploy/enable-agent-runtime.sh"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "apps/server/**"
+      - "services/agent-runtime/**"  # 确保 agent-runtime 代码变更能自动触发部署
       - "packages/**"
       - "deploy/**"
       - "package.json"


### PR DESCRIPTION
## Problem

- deploy.yml 的 paths 不包含 services/agent-runtime/**
- 导致 agent-runtime 代码变更不会自动触发部署
- 需要手动触发 deploy-agent-runtime.yml

## Solution

- 添加 services/agent-runtime/** 到 paths
- 确保代码变更能自动触发部署

## Related

- 根因：PR #67 合并后只构建了 apps/server，没构建 services/agent-runtime
- 导致 agent-runtime 容器缺少 langgraph-checkpoint-sqlite 依赖