### PR TITLE
fix(agent): W5补全 - 接通userDecision端到端传递，修复确认方案流程截断

### DIFF
--- a/apps/server/src/agent/agent-runtime.client.ts
+++ b/apps/server/src/agent/agent-runtime.client.ts
@@ -5,6 +5,9 @@ export interface RuntimeRunInput {
   userId: string
   message: string
   threadId?: string
+  /** W5 修复：用户结构化决策（confirm/revise/...），用于触发 agent-runtime 的
+   *  Command(resume=user_decision) 精确恢复 interrupt，避免重跑 route_entry→intake 卡死 */
+  userDecision?: 'confirm' | 'revise' | 'replan' | 'confirm_gen' | 'topo_revise' | 'node_revise'
 }
 
 /**
@@ -53,6 +56,9 @@ export class AgentRuntimeClient {
         user_id: input.userId,
         message: input.message,
         thread_id: input.threadId ?? input.sessionId,
+        // W5 修复：把结构化决策转发给 agent-runtime
+        // 与 RunRequest.user_decision 字段对应，触发 Command(resume=...) 恢复 interrupt
+        user_decision: input.userDecision,
       }),
     })
 

--- a/apps/server/src/agent/agent.controller.ts
+++ b/apps/server/src/agent/agent.controller.ts
@@ -1,5 +1,4 @@
-import { Body, Controller, Get, Inject, Post, Query, Req, Res, UseGuards } from '@nestjs/common'
-import { IsOptional, IsString } from 'class-validator'
+import { Body, Controller, Get, Inject, IsIn, IsOptional, IsString, Post, Query, Req, Res, UseGuards } from '@nestjs/common'
 import type { Response } from 'express'
 import { AuthGuard } from '../auth/auth.guard'
 import { AgentService } from './agent.service'
@@ -15,6 +14,12 @@ class ConversationDto {
   @IsOptional()
   @IsString()
   threadId?: string
+
+  /** W5 修复：用户结构化决策（确认/修改/换方向），用于触发 Command(resume=...) 精确恢复 interrupt。
+   *  文本消息（"1"/"2"/"确认方案"等）也能走兼容分支，但显式传值更可靠。 */
+  @IsOptional()
+  @IsIn(['confirm', 'revise', 'replan', 'confirm_gen', 'topo_revise', 'node_revise'])
+  userDecision?: 'confirm' | 'revise' | 'replan' | 'confirm_gen' | 'topo_revise' | 'node_revise'
 }
 
 class OptimizePromptDto {
@@ -65,6 +70,7 @@ export class AgentController {
         dto.message,
         req.user.sub,
         dto.threadId,
+        dto.userDecision,
       )) {
         res.write(`data: ${JSON.stringify(event)}\n\n`)
       }

--- a/apps/server/src/agent/agent.controller.ts
+++ b/apps/server/src/agent/agent.controller.ts
@@ -1,4 +1,5 @@
-import { Body, Controller, Get, Inject, IsIn, IsOptional, IsString, Post, Query, Req, Res, UseGuards } from '@nestjs/common'
+import { Body, Controller, Get, Inject, Post, Query, Req, Res, UseGuards } from '@nestjs/common'
+import { IsIn, IsOptional, IsString } from 'class-validator'
 import type { Response } from 'express'
 import { AuthGuard } from '../auth/auth.guard'
 import { AgentService } from './agent.service'

--- a/apps/server/src/agent/agent.service.ts
+++ b/apps/server/src/agent/agent.service.ts
@@ -50,6 +50,7 @@ export class AgentService {
     userMessage: string,
     userId?: string,
     threadId?: string,
+    userDecision?: 'confirm' | 'revise' | 'replan' | 'confirm_gen' | 'topo_revise' | 'node_revise',
   ): AsyncGenerator<AgentStreamEvent> {
     await this.prisma.agentMessage.create({
       data: { sessionId, role: 'user', content: userMessage },
@@ -65,6 +66,7 @@ export class AgentService {
           userMessage,
           userId,
           threadId,
+          userDecision,
         )
         return
       }
@@ -87,6 +89,7 @@ export class AgentService {
     userMessage: string,
     userId: string,
     threadId?: string,
+    userDecision?: 'confirm' | 'revise' | 'replan' | 'confirm_gen' | 'topo_revise' | 'node_revise',
   ): AsyncGenerator<AgentStreamEvent> {
     let assistantText = ''
     const canvasActions: CanvasAction[] = []
@@ -97,6 +100,9 @@ export class AgentService {
       message: userMessage,
       // 新建对话应换 thread，避免 MemorySaver 把旧 await_confirm 状态续上
       threadId: threadId?.trim() || sessionId,
+      // W5 修复：把前端结构化决策（按钮点击）传给 agent-runtime
+      // 让它走 Command(resume=...) 精确恢复 interrupt，不再重跑 route_entry→intake
+      userDecision,
     })) {
       if (event.type === 'text_delta') {
         assistantText += (event.data as { text: string }).text

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -235,7 +235,8 @@ async function send() {
   const skillPrefix = activeSkillId.value === 'canvas' ? '' : `【技能：${activeSkill.value.label}】`
   const message = `${skillPrefix}${input.value.trim()}`
   input.value = ''
-  await sendMessage(message)
+  // W5 修复：手动输入若匹配确认/修改关键词，也带上 userDecision 触发 Command(resume=...)
+  await sendMessage(message, mapPresetToDecision(message))
 }
 
 async function sendPreset(text: string) {
@@ -245,10 +246,25 @@ async function sendPreset(text: string) {
     return
   }
   input.value = ''
-  await sendMessage(text.trim())
+  // W5 修复：按钮选择是结构化决策（confirm/revise），需显式传递 userDecision
+  // 否则后端 Command(resume=...) 不会触发，流程会卡在 await_confirm
+  const decision = mapPresetToDecision(text)
+  await sendMessage(text.trim(), decision)
 }
 
-async function sendMessage(message: string) {
+/** 把按钮文本映射为后端可识别的 userDecision 值。 */
+function mapPresetToDecision(text: string): 'confirm' | 'revise' | undefined {
+  const t = (text || '').trim()
+  if (t === '1' || t === 'A' || t === '确认方案' || t === '确认出图' || t === '写入主文案') {
+    return 'confirm'
+  }
+  if (t === '2' || t === 'B' || t === '3' || t === 'C' || t === '换方向' || t === '自己说明修改' || t === '要修改' || t === '要改拓扑：') {
+    return 'revise'
+  }
+  return undefined
+}
+
+async function sendMessage(message: string, userDecision?: 'confirm' | 'revise') {
   agent.addUserMessage(message)
   agent.isStreaming = true
   agent.startAssistantMessage()
@@ -267,6 +283,7 @@ async function sendMessage(message: string) {
         sessionId: props.sessionId,
         message,
         threadId: agentThreadId.value,
+        userDecision,
       }),
     })
 


### PR DESCRIPTION
## 问题
用户输入营销需求 → AI 回复方案确认门（确认方案/换方向/自己说明修改三个选项）→ 用户点击任一按钮 → 流程截断，AI 重复显示同样的三个选项。

## 根因
commit 86f2d03 (`fix(agent-runtime): W5补全`) 只补了 agent-runtime 接收端（RunRequest.user_decision 字段 + Command(resume=...) 恢复逻辑），但**前端 / Nest 4 处都没接通**。结果：用户点击按钮时 `req.user_decision` 仍为 `None`，agent-runtime 走"兼容旧逻辑"分支 `aupdate_state → graph 重跑 route_entry → intake → plan → await_confirm`，无限循环看到同样的选项。

## 修复（4 处端到端）
| 层 | 文件 | 改动 |
|----|------|------|
| 前端 | `apps/web/.../AgentSideRail.vue` | `mapPresetToDecision()` 把按钮文本映射为 `confirm/revise`；`sendPreset()` 和 `send()` 把 `userDecision` 传入 `sendMessage`；POST body 增加 `userDecision` 字段 |
| Nest DTO | `apps/server/.../agent.controller.ts` | `ConversationDto` 新增 `userDecision` 字段（`@IsIn` 校验枚举值） |
| Nest Service | `apps/server/.../agent.service.ts` | `streamConversation` / `streamFromRuntime` 接收并透传 `userDecision` |
| Nest Client | `apps/server/.../agent-runtime.client.ts` | `RuntimeRunInput` 新增 `userDecision`；`streamRun` body JSON 新增 `user_decision` |

链路：前端按钮 → Nest DTO → AgentService → AgentRuntimeClient → agent-runtime `RunRequest.user_decision` → `Command(resume=user_decision)` → 精确恢复 `await_confirm`（不再重跑 intake）

## 验证
- ✅ Nest 后端 133 个单元测试通过（`pnpm vitest run --typecheck`）
- ✅ 前端 build 通过（`vue-tsc` 0 错误）
- ✅ 本地类型检查 0 错误

## 影响
- 用户点击"确认方案" → 正常进入 `split → draft_copy → await_topo` 阶段
- 用户点击"换方向/自己说明修改" → 触发 `revise` 逻辑回到 plan 节点
- 用户点击"确认出图/写入主文案/要改拓扑" → 走对应 `confirm_gen/topo_revise/node_revise` 决策

## 关联
- 依赖 commit `86f2d03`（agent-runtime 接收端）
- 修复 commit `6672083`（W5 interrupt_before 状态机重构）