### PR TITLE
refactor(agent-runtime): orchestrate_gen→Send API 重构，支持 per-node checkpoint 与独立重试

### DIFF
--- a/services/agent-runtime/app/graph/builder.py
+++ b/services/agent-runtime/app/graph/builder.py
@@ -17,8 +17,8 @@ from app.graph.nodes.collect_gen import make_collect_gen_node
 from app.graph.nodes.done import make_done_node
 from app.graph.nodes.draft_copy import make_draft_copy_node
 from app.graph.nodes.gen_node import make_gen_node
+from app.graph.nodes.gen_scheduler import make_gen_scheduler_node
 from app.graph.nodes.intake import make_intake_node
-from app.graph.nodes.orchestrate_gen import make_orchestrate_gen_node
 from app.graph.nodes.plan import make_plan_node
 from app.graph.nodes.split import make_split_node
 from app.graph.nodes.start_gen import make_start_gen_node
@@ -103,7 +103,7 @@ def route_after_confirm(state: AgentRuntimeState) -> str:
 def route_after_topo(state: AgentRuntimeState) -> str:
     decision = state.get("user_decision") or "none"
     if decision == "confirm_gen":
-        return "start_gen"  # W3: start_gen prepares gen_queue, then routes to orchestrate_gen
+        return "start_gen"  # W3: start_gen inits gen state, then gen_scheduler fans out gen_node via Send
     if decision == "topo_revise":
         return "topo_revise"
     # 修复 P0-1：节点内容修改（改为/调整/增加）→ 回退到 plan 走 modify 模式
@@ -137,13 +137,15 @@ def build_agent_graph(
     graph.add_node("await_topo", make_await_topo_node())
     graph.add_node("topo_revise", make_topo_revise_node(nest=nest))
 
-    # W3: New generation nodes using Send API for per-node checkpointing
+    # W3: New generation nodes using Send API for per-node checkpointing.
+    # gen_scheduler is the central arbiter: fans out gen_node via Send and
+    # re-runs after each superstep to dispatch the next wave (diamond-safe).
+    # orchestrate_gen.py is intentionally NOT registered (deprecated, kept on
+    # disk only because runs.py still imports it — cleanup in a follow-up PR).
     graph.add_node("start_gen", make_start_gen_node())
+    graph.add_node("gen_scheduler", make_gen_scheduler_node())
     graph.add_node("gen_node", make_gen_node(nest=nest))
     graph.add_node("collect_gen", make_collect_gen_node(nest=nest))
-
-    # Keep old orchestrate_gen for backward compatibility (can be removed later)
-    graph.add_node("orchestrate_gen", make_orchestrate_gen_node(nest=nest))
 
     graph.add_conditional_edges(
         START,
@@ -194,15 +196,16 @@ def build_agent_graph(
     )
     graph.add_edge("topo_revise", END)
 
-    # W3: Generation DAG edges
-    # start_gen -> orchestrate_gen (prepares gen_queue, existing orchestrate_gen handles execution)
-    # orchestrate_gen -> done
-    graph.add_edge("start_gen", "orchestrate_gen")
+    # W3: Generation DAG edges (Send API fan-out via gen_scheduler).
+    # start_gen -> gen_scheduler : kick off the first dispatch wave
+    # gen_node   -> gen_scheduler : re-run scheduler after each superstep to dispatch next wave
+    # gen_scheduler -> gen_node   : DYNAMIC via Command(goto=[Send("gen_node", ...)]), no static edge
+    # gen_scheduler -> collect_gen: DYNAMIC via Command(goto=["collect_gen"]) when nothing to dispatch
+    # collect_gen -> done
+    graph.add_edge("start_gen", "gen_scheduler")
+    graph.add_edge("gen_node", "gen_scheduler")
     graph.add_edge("collect_gen", "done")
     graph.add_edge("done", END)
-
-    # Old orchestrate_gen edge (keep for backward compatibility)
-    graph.add_edge("orchestrate_gen", "done")
 
     graph.add_conditional_edges(
         "await_copy_confirm",

--- a/services/agent-runtime/app/graph/nodes/collect_gen.py
+++ b/services/agent-runtime/app/graph/nodes/collect_gen.py
@@ -1,8 +1,18 @@
-"""Collect generation results and emit final summary."""
+"""Collect generation results: aggregate, emit summary, bridge to legacy state.
+
+Reads the W3 Send-API accumulators (``gen_completed_keys`` / ``gen_failed_keys``
+/ ``gen_needs_user_keys`` / ``gen_fail_details``) and:
+  - emits a task_summary + per-line progress to the chat/canvas stream,
+  - persists progress to the GenProgress table (W15),
+  - bridges to the LEGACY ``gen_completed`` (node_id list) / ``gen_failed``
+    (list[dict]) fields that ``done.py`` still reads,
+  - clears all W3 transient fields so the next generation run starts clean.
+"""
 
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any, Callable
 
 from langchain_core.messages import AIMessage
@@ -24,21 +34,13 @@ async def _emit_text(nest: Any, text: str) -> None:
 
 
 def make_collect_gen_node(*, nest: Any) -> Callable:
-    """Create collect_gen node that aggregates results and emits summary.
-
-    Args:
-        nest: Nest client for emitting events
-
-    Returns:
-        Callable that returns final state update
-    """
-
     async def collect_gen(state: dict) -> dict:
-        completed_keys = set(state.get("gen_completed_keys") or [])
-        failed_keys = set(state.get("gen_failed_keys") or [])
-        needs_user_keys = set(state.get("gen_needs_user_keys") or [])
-        by_key = state.get("gen_by_key", {})
-        ordered_keys = state.get("gen_ordered_keys", [])
+        completed_keys: set[str] = set(state.get("gen_completed_keys") or [])
+        failed_keys: set[str] = set(state.get("gen_failed_keys") or [])
+        needs_user_keys: set[str] = set(state.get("gen_needs_user_keys") or [])
+        details: dict[str, dict] = state.get("gen_fail_details") or {}
+        by_key: dict[str, dict] = state.get("gen_by_key") or {}
+        ordered_keys: list[str] = list(state.get("gen_ordered_keys") or [])
 
         thread_id = state.get("thread_id", "")
         session_id = state.get("session_id", "")
@@ -46,88 +48,82 @@ def make_collect_gen_node(*, nest: Any) -> Callable:
         progress_lines: list[str] = []
         summary_lines: list[dict[str, str]] = []
         fallback_n = 0
-        needs_user_n = 0
-        skipped_n = 0
+        needs_user_n = 0  # self-needs-user (fallback_pending / non-recoverable), excludes skipped
+        skipped_n = 0  # dependency_skipped (upstream needs_user → downstream recoverable)
         success_n = 0
 
-        # Process results
+        # Legacy fields consumed by done.py
+        gen_completed_legacy: list[str] = []
+        gen_failed_legacy: list[dict] = []
+
         for key in ordered_keys:
             item = by_key.get(key, {})
             node_id = str(item.get("node_id") or key)
             title = str(item.get("title") or key)
+            reason = str((details.get(key) or {}).get("reason") or "")
+            reason_lower = reason.lower()
 
             if key in completed_keys:
                 success_n += 1
+                gen_completed_legacy.append(node_id)
                 line = format_gen_progress_line(title=title, status="completed")
                 progress_lines.append(line)
                 await _emit_text(nest, line)
             elif key in needs_user_keys:
-                reason = "needs_user"
-                needs_user_n += 1
-                reason_lower = str(reason).lower()
-                if reason_lower == "fallback_pending":
-                    fallback_n += 1
-                summary_lines.append(
-                    {
-                        "id": key,
-                        "status": "needs_user",
-                        "title": title,
-                        "hint": hint_for_error(reason),
-                    }
+                gen_failed_legacy.append(
+                    {"key": key, "node_id": node_id, "title": title, "reason": reason or "needs_user"}
                 )
-                line = format_gen_progress_line(title=title, status=str(reason))
+                if reason == "dependency_skipped":
+                    skipped_n += 1
+                else:
+                    needs_user_n += 1
+                    if reason_lower == "fallback_pending":
+                        fallback_n += 1
+                summary_lines.append(
+                    {"id": key, "status": "needs_user", "title": title, "hint": hint_for_error(reason)}
+                )
+                line = format_gen_progress_line(title=title, status=reason)
                 progress_lines.append(line)
+                # P1-5: fallback_pending 不向聊天流 emit 单行（走画布确认弹窗）
                 if reason_lower != "fallback_pending":
                     await _emit_text(nest, line)
             elif key in failed_keys:
-                # Check if it was dependency_skipped or dependency_failed
-                reason = "dependency_failed"  # Default, could be refined
-                summary_lines.append(
-                    {
-                        "id": key,
-                        "status": "failed",
-                        "title": title,
-                        "hint": hint_for_error(reason),
-                    }
+                gen_failed_legacy.append(
+                    {"key": key, "node_id": node_id, "title": title, "reason": reason or "failed"}
                 )
-                line = format_gen_progress_line(title=title, status=str(reason))
+                summary_lines.append(
+                    {"id": key, "status": "failed", "title": title, "hint": hint_for_error(reason)}
+                )
+                line = format_gen_progress_line(title=title, status=reason or "failed")
                 progress_lines.append(line)
                 await _emit_text(nest, line)
 
-        # Calculate fail_only (exclude needs_user and dependency_skipped)
-        fail_only = max(0, len(failed_keys) - needs_user_n - skipped_n)
-
-        # Emit task summary
+        # Real failures = all in failed_keys (dependency_failed + node-exhausted)
+        fail_n = len(failed_keys)
         await _emit_task_summary(
             nest,
             success=success_n,
-            failed=fail_only,
+            failed=fail_n,
             needsUser=needs_user_n,
             skipped=skipped_n,
             lines=summary_lines,
         )
 
-        # W15: Save progress to GenProgress table
+        # W15: persist progress to GenProgress table
         gen_progress_id = None
         if thread_id and session_id:
             try:
-                lines_json = json.dumps(progress_lines)
-                summary_json = json.dumps(summary_lines) if summary_lines else None
                 result = await nest.save_gen_progress(
                     thread_id=thread_id,
                     session_id=session_id,
-                    lines=lines_json,
-                    summary=summary_json,
+                    lines=json.dumps(progress_lines),
+                    summary=json.dumps(summary_lines) if summary_lines else None,
                 )
                 gen_progress_id = result.get("id")
-            except Exception as e:
-                # Log but don't fail the node
-                import logging
+            except Exception as e:  # noqa: BLE001
                 logging.getLogger(__name__).warning(f"Failed to save gen progress: {e}")
 
-        # Format final message
-        fail_n = len(failed_keys)
-        if success_n or fail_n:
+        if success_n or fail_n or needs_user_n or skipped_n:
             msg = format_gen_summary(
                 lines=progress_lines,
                 success_n=success_n,
@@ -140,14 +136,19 @@ def make_collect_gen_node(*, nest: Any) -> Callable:
         return {
             "phase": "orchestrate_gen",
             "gen_progress_id": gen_progress_id,
+            # Legacy bridges for done.py
+            "gen_completed": gen_completed_legacy,
+            "gen_failed": gen_failed_legacy,
             "messages": [AIMessage(content=msg)],
-            # Clean up transient state
+            # Clean up all W3 transient fields (None resets the reducer-backed ones)
             "gen_ordered_keys": None,
             "gen_deps_of": None,
             "gen_by_key": None,
             "gen_completed_keys": None,
             "gen_failed_keys": None,
             "gen_needs_user_keys": None,
+            "gen_fail_details": None,
+            "gen_max_concurrency": None,
         }
 
     return collect_gen

--- a/services/agent-runtime/app/graph/nodes/gen_node.py
+++ b/services/agent-runtime/app/graph/nodes/gen_node.py
@@ -1,16 +1,25 @@
-"""Single generation task node with retry and dependency tracking."""
+"""Single generation task node (Send API fan-out worker).
+
+Each ``gen_node`` invocation executes ONE manifest item's image/video generation
+with retry, then returns a pure state-dict update. Dispatching of the next wave
+(upstream-done → downstream-ready) is the responsibility of ``gen_scheduler``,
+NOT this node — that centralised scheduling avoids the diamond-dependency
+deadlock that per-node fan-out would cause (C depends on A,B; A and B run in
+parallel; neither sees the other's completion, so C is never dispatched).
+
+A node returns one of:
+  - ``{"gen_completed_keys": [key]}``                      # success
+  - ``{"gen_failed_keys": [key], "gen_fail_details": {key: {...}}}``   # hard fail
+  - ``{"gen_needs_user_keys": [key], "gen_fail_details": {key: {...}}}`` # needs user
+"""
 
 from __future__ import annotations
 
 from typing import Any, Callable
 
-from langchain_core.messages import AIMessage
-from langgraph.types import Send
-
 from app.graph.chain_refs import build_chain_ref_order
 from app.graph.gen_copy import format_gen_progress_line
 from app.graph.task_events import hint_for_error, is_recoverable, max_auto_retries
-from app.graph.state import AgentRuntimeState
 
 
 async def _emit_task_update(nest: Any, **payload: Any) -> None:
@@ -19,10 +28,11 @@ async def _emit_task_update(nest: Any, **payload: Any) -> None:
         await fn(**payload)
 
 
-async def _emit_task_summary(nest: Any, **payload: Any) -> None:
-    fn = getattr(nest, "emit_task_summary", None)
-    if fn is not None:
-        await fn(**payload)
+async def _emit_line(nest: Any, text: str) -> None:
+    """Push a user-visible progress line mid-node (mirrors orchestrate_gen)."""
+    emit = getattr(nest, "emit_text", None)
+    if emit is not None:
+        await emit(text if text.endswith("\n") else text + "\n")
 
 
 def _is_gen_success(result: Any) -> bool:
@@ -44,32 +54,15 @@ def _result_status(result: Any, exc: BaseException | None = None) -> str:
     return "error"
 
 
-def make_gen_node(
-    *,
-    nest: Any,
-) -> Callable:
-    """Create gen_node that executes a single generation task.
+def make_gen_node(*, nest: Any) -> Callable:
+    """Create the single-task generation worker node."""
 
-    Args:
-        nest: Nest client for canvas operations
-
-    Returns:
-        Callable that returns dict or list[Send]
-    """
-
-    async def gen_node(state: dict) -> dict | list[Send]:
+    async def gen_node(state: dict) -> dict:
         key = state.get("key")
         if not key:
             return {}
 
-        # Get generation context from state
-        by_key = state.get("gen_by_key", {})
-        deps_of = state.get("gen_deps_of", {})
-        ordered_keys = state.get("gen_ordered_keys", [])
-        completed_keys = set(state.get("gen_completed_keys") or [])
-        failed_keys = set(state.get("gen_failed_keys") or [])
-        needs_user_keys = set(state.get("gen_needs_user_keys") or [])
-
+        by_key = state.get("gen_by_key") or {}
         item = by_key.get(key)
         if not item:
             return {}
@@ -79,36 +72,17 @@ def make_gen_node(
         kind = str(item.get("target_type") or "image")
 
         if not node_id:
-            # Missing node_id, mark as failed
+            await _emit_task_update(nest, id=key, status="failed", errorCode="missing_node_id")
             return {
-                "gen_failed_keys": list(failed_keys | {key}),
+                "gen_failed_keys": [key],
+                "gen_fail_details": {key: {"node_id": None, "title": title, "reason": "missing_node_id"}},
             }
 
-        # Check if dependencies are met
-        deps = deps_of.get(key, [])
-        upstream_failed = [d for d in deps if d in failed_keys]
-        upstream_pending = [d for d in deps if d in needs_user_keys]
-
-        if upstream_failed or upstream_pending:
-            # Dependency failed or pending, skip this node
-            reason = "dependency_failed" if upstream_failed else "dependency_skipped"
-            return {
-                "gen_failed_keys": list(failed_keys | {key}),
-                "gen_needs_user_keys": list(needs_user_keys | {key}) if upstream_pending else list(needs_user_keys),
-            }
-
-        if not all(d in completed_keys for d in deps):
-            # Dependencies not ready yet, this shouldn't happen if start_gen works correctly
-            # But handle it gracefully
-            return {}
-
-        # Execute generation with retry
+        plan_node_id = state.get("plan_node_id")
         retries = max_auto_retries()
         last_status = "error"
 
-        await _emit_task_update(
-            nest, id=key, status="running", attempt=0, maxAttempts=retries
-        )
+        await _emit_task_update(nest, id=key, status="running", attempt=0, maxAttempts=retries)
 
         for attempt in range(retries + 1):
             if attempt > 0:
@@ -122,8 +96,6 @@ def make_gen_node(
                 )
 
             try:
-                # Attach refs if needed
-                plan_node_id = state.get("plan_node_id")
                 ref_order = build_chain_ref_order(
                     item=dict(item),
                     by_key=by_key,
@@ -133,7 +105,6 @@ def make_gen_node(
                 if attach is not None and ref_order:
                     await attach(str(node_id), ref_order)
 
-                # Run generation
                 if kind == "video":
                     run = getattr(nest, "run_video_generation", None)
                     if run is None:
@@ -141,7 +112,8 @@ def make_gen_node(
                             nest, id=key, status="failed", errorCode="video_not_supported"
                         )
                         return {
-                            "gen_failed_keys": list(failed_keys | {key}),
+                            "gen_failed_keys": [key],
+                            "gen_fail_details": {key: {"node_id": node_id, "title": title, "reason": "video_not_supported"}},
                         }
                     result = await run(str(node_id))
                 else:
@@ -149,67 +121,15 @@ def make_gen_node(
 
                 if _is_gen_success(result):
                     await _emit_task_update(nest, id=key, status="done")
-
-                    # Update completed keys
-                    new_completed = completed_keys | {key}
-
-                    # Find downstream nodes that are now ready
-                    ready_downstream = []
-                    for k in ordered_keys:
-                        if k in new_completed or k in failed_keys or k in needs_user_keys:
-                            continue
-                        k_deps = deps_of.get(k, [])
-                        if all(d in new_completed for d in k_deps):
-                            ready_downstream.append(k)
-
-                    if ready_downstream:
-                        # Fan out to downstream nodes
-                        sends: list[Send] = []
-                        for k in ready_downstream:
-                            sends.append(
-                                Send(
-                                    "gen_node",
-                                    {
-                                        "key": k,
-                                        "gen_ordered_keys": ordered_keys,
-                                        "gen_deps_of": deps_of,
-                                        "gen_by_key": by_key,
-                                        "gen_completed_keys": list(new_completed),
-                                        "gen_failed_keys": list(failed_keys),
-                                        "gen_needs_user_keys": list(needs_user_keys),
-                                    },
-                                )
-                            )
-                        return sends
-                    else:
-                        # No more downstream nodes, check if all done
-                        all_done = len(new_completed) + len(failed_keys) + len(needs_user_keys)
-                        if all_done >= len(ordered_keys):
-                            # All nodes processed, collect results
-                            return [
-                                Send(
-                                    "collect_gen",
-                                    {
-                                        "gen_completed_keys": list(new_completed),
-                                        "gen_failed_keys": list(failed_keys),
-                                        "gen_needs_user_keys": list(needs_user_keys),
-                                        "gen_by_key": by_key,
-                                        "gen_ordered_keys": ordered_keys,
-                                    },
-                                )
-                            ]
-                        return {
-                            "gen_completed_keys": list(new_completed),
-                        }
+                    await _emit_line(nest, format_gen_progress_line(title=title, status="completed"))
+                    return {"gen_completed_keys": [key]}
 
                 last_status = _result_status(result)
-
             except Exception as exc:  # noqa: BLE001
                 last_status = str(exc)
                 result = None
 
             if not is_recoverable(last_status):
-                # Non-recoverable error, mark as needs_user
                 hint = hint_for_error(last_status)
                 await _emit_task_update(
                     nest,
@@ -218,12 +138,15 @@ def make_gen_node(
                     errorCode=last_status,
                     errorHint=hint,
                 )
-                new_needs_user = needs_user_keys | {key}
+                # P1-5: fallback_pending 不向聊天流 emit 单行（走画布 ByokFallbackConfirmDialog）
+                if "fallback_pending" not in last_status.lower():
+                    await _emit_line(nest, format_gen_progress_line(title=title, status=last_status))
                 return {
-                    "gen_needs_user_keys": list(new_needs_user),
+                    "gen_needs_user_keys": [key],
+                    "gen_fail_details": {key: {"node_id": node_id, "title": title, "reason": last_status}},
                 }
 
-            # Continue retry loop
+            # recoverable → retry loop continues
 
         # Exhausted retries
         hint = hint_for_error(last_status)
@@ -234,8 +157,10 @@ def make_gen_node(
             errorCode=last_status,
             errorHint=hint,
         )
+        await _emit_line(nest, format_gen_progress_line(title=title, status=last_status))
         return {
-            "gen_failed_keys": list(failed_keys | {key}),
+            "gen_failed_keys": [key],
+            "gen_fail_details": {key: {"node_id": node_id, "title": title, "reason": last_status}},
         }
 
     return gen_node

--- a/services/agent-runtime/app/graph/nodes/gen_scheduler.py
+++ b/services/agent-runtime/app/graph/nodes/gen_scheduler.py
@@ -1,0 +1,111 @@
+"""Generation scheduler: the single arbiter that fans out gen_node via Send.
+
+Why a central scheduler (not per-node fan-out):
+  - Diamond dependencies (C depends on A,B; A,B run in parallel) deadlock under
+    per-node fan-out: A completes, sees B not done, doesn't dispatch C; B
+    completes, doesn't know A finished, doesn't dispatch C either. A central
+    scheduler reads the FULL accumulated state (merged by reducers after all
+    parallel gen_node of a superstep finish) and is the only thing that decides
+    what to dispatch next — so it always sees both A and B done.
+
+Why no in-flight / dispatched tracking:
+  - LangGraph Pregel batches all ``Send`` targets in one ``Command(goto=[...])``
+    into a single superstep; they ALL complete (results merged via reducer)
+    before the ``gen_node → gen_scheduler`` edge re-triggers the scheduler. So
+    "in-flight" is always 0 when the scheduler runs — concurrency is simply
+    ``ready[:max_concurrency]`` per superstep. ``completed/failed/needs_user``
+    already prevent re-dispatch, so no separate dispatched-set is needed.
+
+Termination: when nothing is ready to dispatch, every remaining unprocessed key
+has been cascade-marked failed/needs_user by the forward topo pass, so all keys
+are processed → ``goto collect_gen``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from langgraph.types import Command, Send
+
+
+def _detail(by_key: dict[str, dict], key: str, reason: str) -> dict[str, dict]:
+    item = by_key.get(key, {})
+    return {key: {"node_id": item.get("node_id"), "title": str(item.get("title") or key), "reason": reason}}
+
+
+def make_gen_scheduler_node() -> Callable:
+    """Create the generation scheduler node (pure state computation, no nest)."""
+
+    async def gen_scheduler(state: dict) -> Command:
+        ordered_keys = list(state.get("gen_ordered_keys") or [])
+        deps_of = state.get("gen_deps_of") or {}
+        by_key = state.get("gen_by_key") or {}
+        max_c = max(1, int(state.get("gen_max_concurrency") or 3))
+
+        completed: set[str] = set(state.get("gen_completed_keys") or [])
+        failed: set[str] = set(state.get("gen_failed_keys") or [])
+        needs_user: set[str] = set(state.get("gen_needs_user_keys") or [])
+
+        # 1. Forward topo cascade: mark dependency_failed / dependency_skipped.
+        # ordered_keys is topo-sorted, so a key's deps are classified before it.
+        new_failed: list[str] = []
+        new_needs_user: list[str] = []
+        new_details: dict[str, dict] = {}
+        for k in ordered_keys:
+            if k in completed or k in failed or k in needs_user:
+                continue
+            deps = deps_of.get(k, [])
+            dead = [d for d in deps if d in failed]
+            pending = [d for d in deps if d in needs_user]
+            if dead:
+                failed.add(k)
+                new_failed.append(k)
+                new_details.update(_detail(by_key, k, "dependency_failed"))
+            elif pending:
+                needs_user.add(k)
+                new_needs_user.append(k)
+                new_details.update(_detail(by_key, k, "dependency_skipped"))
+
+        # 2. Ready = unprocessed with all deps completed.
+        processed = completed | failed | needs_user
+        ready = [
+            k
+            for k in ordered_keys
+            if k not in processed and all(d in completed for d in deps_of.get(k, []))
+        ]
+        to_dispatch = ready[:max_c]
+
+        # 3. Build update (cascade results only — gen_node owns its own results).
+        update: dict[str, Any] = {}
+        if new_failed:
+            update["gen_failed_keys"] = new_failed
+        if new_needs_user:
+            update["gen_needs_user_keys"] = new_needs_user
+        if new_details:
+            update["gen_fail_details"] = new_details
+
+        # 4. Dispatch or finish.
+        if to_dispatch:
+            plan_node_id = state.get("plan_node_id")
+            return Command(
+                update=update,
+                goto=[
+                    # Send payload is the ONLY input gen_node sees (LangGraph Send
+                    # does not merge channel state into the worker's input), so we
+                    # must pass the shared context it needs alongside the key.
+                    Send(
+                        "gen_node",
+                        {
+                            "key": k,
+                            "gen_by_key": by_key,
+                            "plan_node_id": plan_node_id,
+                        },
+                    )
+                    for k in to_dispatch
+                ],
+            )
+        # Nothing ready → cascade has marked everything unprocessed as
+        # failed/needs_user → all keys processed → collect.
+        return Command(update=update, goto=["collect_gen"])
+
+    return gen_scheduler

--- a/services/agent-runtime/app/graph/nodes/orchestrate_gen.py
+++ b/services/agent-runtime/app/graph/nodes/orchestrate_gen.py
@@ -1,4 +1,12 @@
-"""Orchestrate topological image/video generation with retry and task events."""
+"""Orchestrate topological image/video generation with retry and task events.
+
+DEPRECATED: This node is superseded by the Send-API generation subgraph
+(``start_gen → gen_scheduler ⇄ gen_node → collect_gen``) which provides
+per-node checkpointing and independent retries. This file is kept ONLY
+because ``app/runs.py`` still imports ``make_orchestrate_gen_node`` for
+its legacy background-task path; it is no longer registered in the graph
+(see ``app/graph/builder.py``). Removal is tracked as a follow-up cleanup PR.
+"""
 
 from __future__ import annotations
 

--- a/services/agent-runtime/app/graph/nodes/start_gen.py
+++ b/services/agent-runtime/app/graph/nodes/start_gen.py
@@ -1,4 +1,10 @@
-"""Start generation DAG: compute topological order and prepare generation state."""
+"""Start generation: compute topological order + dependency graph, init W3 state.
+
+Writes the Send-API generation fields consumed by ``gen_scheduler`` /
+``gen_node`` / ``collect_gen``. The reducer-backed accumulators
+(``gen_*_keys`` / ``gen_fail_details``) are reset to ``None`` here so a
+re-generation on the same thread does not leak the previous run's keys.
+"""
 
 from __future__ import annotations
 
@@ -9,12 +15,8 @@ from langchain_core.messages import AIMessage
 from app.graph.topo import topo_sort_gen_keys
 
 
-def make_start_gen_node() -> Callable:
-    """Create start_gen node that initializes generation state.
-
-    This node computes topological order and sets up the generation queue.
-    The actual generation is handled by orchestrate_gen node (existing implementation).
-    """
+def make_start_gen_node(*, max_concurrency: int = 3) -> Callable:
+    """Create start_gen node. ``max_concurrency`` caps parallel gen_node per superstep."""
 
     async def start_gen(state: dict) -> dict:
         manifest = list(state.get("split_manifest") or [])
@@ -24,13 +26,14 @@ def make_start_gen_node() -> Callable:
                 "messages": [AIMessage(content="无可自动生成的图片/视频节点。")],
             }
 
-        by_key = {str(item["key"]): item for item in manifest if item.get("key")}
+        by_key = {str(it["key"]): it for it in manifest if it.get("key")}
 
         try:
             ordered_keys = topo_sort_gen_keys(manifest)
         except ValueError as exc:
             return {
                 "phase": "done",
+                # legacy field for done.py / intake.py
                 "gen_failed": [{"key": None, "reason": str(exc)}],
                 "last_error": str(exc),
                 "messages": [AIMessage(content=f"出图编排失败：{exc}")],
@@ -42,12 +45,23 @@ def make_start_gen_node() -> Callable:
                 "messages": [AIMessage(content="无可自动生成的图片/视频节点。")],
             }
 
-        # Initialize gen_queue with all keys
-        # orchestrate_gen will handle the actual generation
+        key_set = set(ordered_keys)
+        deps_of = {
+            k: [str(d) for d in (by_key[k].get("depends_on") or []) if str(d) in key_set]
+            for k in ordered_keys
+        }
+
         return {
-            "gen_queue": ordered_keys,
-            "gen_completed": [],
-            "gen_failed": [],
+            # write-once shared context (plain overwrite, no reducer)
+            "gen_ordered_keys": ordered_keys,
+            "gen_deps_of": deps_of,
+            "gen_by_key": by_key,
+            "gen_max_concurrency": max_concurrency,
+            # reducer-backed accumulators: reset to None for a clean run
+            "gen_completed_keys": None,
+            "gen_failed_keys": None,
+            "gen_needs_user_keys": None,
+            "gen_fail_details": None,
             "messages": [AIMessage(content=f"开始按拓扑出图，共 {len(ordered_keys)} 个节点…")],
         }
 

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -5,6 +5,35 @@ from typing import Annotated, Literal, TypedDict
 from langgraph.graph.message import add_messages
 
 
+def reset_or_union(left: list[str] | None, right: list[str] | None) -> list[str] | None:
+    """Reducer for parallel Send fan-out: union-dedupe within a run, None resets.
+
+    LangGraph runs multiple gen_node instances in one superstep; without a
+    reducer they'd raise ``InvalidUpdateError: Can receive only one value per
+    step``. This reducer merges those parallel writes (union, dedupe, order-
+    preserving). Returning ``None`` (from start_gen at run start, or collect_gen
+    at run end) resets the channel so a re-generation on the same thread does
+    not leak the previous run's keys (which would make the scheduler wrongly
+    treat nodes as already-completed and skip them).
+    """
+    if right is None:
+        return None
+    out: list[str] = []
+    seen: set[str] = set()
+    for k in [*(left or []), *(right or [])]:
+        if k not in seen:
+            seen.add(k)
+            out.append(k)
+    return out
+
+
+def reset_or_merge(left: dict | None, right: dict | None) -> dict | None:
+    """Reducer for gen_fail_details: shallow-merge within a run, None resets."""
+    if right is None:
+        return None
+    return {**(left or {}), **(right or {})}
+
+
 class SplitManifestItem(TypedDict, total=False):
     key: str
     title: str
@@ -87,11 +116,18 @@ class AgentRuntimeState(TypedDict, total=False):
     brief_locked: bool  # True 后 user_brief 不再被覆盖
     mode: Literal["create", "modify"] | None
 
-    # W3: Transient fields for Send API fan-out generation
-    # These are only used during orchestrate_gen and cleaned up by collect_gen
+    # W3: Transient fields for Send API fan-out generation.
+    # gen_ordered_keys/gen_deps_of/gen_by_key are write-once (start_gen) /
+    # clear-once (collect_gen), so plain overwrite is fine.
+    # gen_*_keys/gen_fail_details are written by PARALLEL gen_node instances in
+    # the same superstep → must use reset_or_union/reset_or_merge reducers.
+    # Returning None (start_gen at run start, collect_gen at run end) resets
+    # them so a re-generation on the same thread doesn't leak the prior run.
     gen_ordered_keys: list[str] | None  # Topological order of generation keys
     gen_deps_of: dict[str, list[str]] | None  # Dependency graph
     gen_by_key: dict[str, dict] | None  # Manifest items by key
-    gen_completed_keys: list[str] | None  # Completed generation keys
-    gen_failed_keys: list[str] | None  # Failed generation keys
-    gen_needs_user_keys: list[str] | None  # Keys needing user intervention
+    gen_completed_keys: Annotated[list[str] | None, reset_or_union]  # Completed keys
+    gen_failed_keys: Annotated[list[str] | None, reset_or_union]  # Failed keys
+    gen_needs_user_keys: Annotated[list[str] | None, reset_or_union]  # Keys needing user
+    gen_fail_details: Annotated[dict[str, dict] | None, reset_or_merge]  # key→{node_id,title,reason}
+    gen_max_concurrency: int | None  # Concurrency cap for gen_scheduler

--- a/services/agent-runtime/tests/test_await_topo.py
+++ b/services/agent-runtime/tests/test_await_topo.py
@@ -86,18 +86,22 @@ async def test_topo_revise_removes_by_title():
 
 
 @pytest.mark.asyncio
-async def test_confirm_gen_runs_orchestrate_sync():
-    """Test that start_gen + orchestrate_gen execute generation correctly."""
+async def test_confirm_gen_runs_send_api_subgraph():
+    """W3: start_gen → gen_scheduler ⇄ gen_node → collect_gen executes generation.
+
+    Replaces the old test that called orchestrate_gen directly. Now exercises the
+    full Send-API subgraph via ainvoke and asserts on the legacy bridge fields
+    that collect_gen produces for done.py.
+    """
+    from langgraph.graph import StateGraph, START, END
+
+    from app.graph.nodes.collect_gen import make_collect_gen_node
+    from app.graph.nodes.gen_node import make_gen_node
+    from app.graph.nodes.gen_scheduler import make_gen_scheduler_node
     from app.graph.nodes.start_gen import make_start_gen_node
-    from app.graph.nodes.orchestrate_gen import make_orchestrate_gen_node
+    from app.graph.state import AgentRuntimeState
 
     class GenNest(FakeNest):
-        async def get_node(self, node_id: str) -> dict[str, Any]:
-            return {"id": node_id, "type": "image", "data": {}}
-
-        async def set_node_prompt(self, node_id: str, prompt: str) -> dict[str, Any]:
-            return {"nodeId": node_id, "actions": []}
-
         async def attach_refs(self, node_id: str, ref_order: list[str]) -> dict[str, Any]:
             return {"nodeId": node_id, "actions": []}
 
@@ -115,44 +119,47 @@ async def test_confirm_gen_runs_orchestrate_sync():
         async def emit_task_summary(self, **payload: Any) -> None:
             self.calls.append(("emit_task_summary", payload))
 
+        async def save_gen_progress(self, **kwargs: Any) -> dict[str, Any]:
+            return {"id": "gp-1"}
+
     nest = GenNest()
 
-    # Test start_gen
-    start_gen = make_start_gen_node()
-    result1 = await start_gen({
-        "split_manifest": [
-            {
-                "key": "white_bg",
-                "title": "白底图",
-                "target_type": "image",
-                "auto_generate": True,
-                "depends_on": [],
-                "node_id": "img-1",
-                "prompt_hint": "white",
-            }
-        ],
-    })
-    assert result1.get("gen_queue") == ["white_bg"]
+    # Build the W3 generation subgraph in isolation
+    g = StateGraph(AgentRuntimeState)
+    g.add_node("start_gen", make_start_gen_node())
+    g.add_node("gen_scheduler", make_gen_scheduler_node())
+    g.add_node("gen_node", make_gen_node(nest=nest))
+    g.add_node("collect_gen", make_collect_gen_node(nest=nest))
+    g.add_edge(START, "start_gen")
+    g.add_edge("start_gen", "gen_scheduler")
+    g.add_edge("gen_node", "gen_scheduler")
+    g.add_edge("collect_gen", END)
+    graph = g.compile(checkpointer=MemorySaver())
 
-    # Test orchestrate_gen
-    orchestrate_gen = make_orchestrate_gen_node(nest=nest)
-    state = {
-        "split_manifest": [
-            {
-                "key": "white_bg",
-                "title": "白底图",
-                "target_type": "image",
-                "auto_generate": True,
-                "depends_on": [],
-                "node_id": "img-1",
-                "prompt_hint": "white",
-            }
-        ],
-    }
-    result2 = await orchestrate_gen(state)
+    manifest = [
+        {
+            "key": "white_bg",
+            "title": "白底图",
+            "target_type": "image",
+            "auto_generate": True,
+            "depends_on": [],
+            "node_id": "img-1",
+            "prompt_hint": "white",
+        }
+    ]
+    result = await graph.ainvoke(
+        {"split_manifest": manifest},
+        {"configurable": {"thread_id": "send-api-smoke"}, "recursion_limit": 100},
+    )
 
+    # gen_node ran the image generation
     assert any(c[0] == "run_image_generation" for c in nest.calls)
-    assert result2.get("gen_completed") == ["img-1"]
+    # collect_gen bridged to the legacy fields done.py reads
+    assert result.get("gen_completed") == ["img-1"]
+    assert result.get("gen_failed") == []
+    # W3 transient fields are cleared after collect
+    assert result.get("gen_ordered_keys") is None
+    assert result.get("gen_completed_keys") is None
 
 
 # 修复 P0-1：node_revise → plan 路由 + mode=modify

--- a/services/agent-runtime/tests/test_gen_node.py
+++ b/services/agent-runtime/tests/test_gen_node.py
@@ -1,0 +1,206 @@
+"""Unit tests for gen_node (Send-API single-task generation worker).
+
+gen_node is invoked via ``Send("gen_node", {"key": k, "gen_by_key": ..., "plan_node_id": ...})``
+so each test calls the node directly with that payload dict and asserts on the
+returned state update (never on graph wiring — that's test_gen_scheduler).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.graph.nodes.gen_node import make_gen_node
+
+
+class FakeNest:
+    """Records calls; configurable per-key failure modes."""
+
+    def __init__(
+        self,
+        *,
+        fail_keys: set[str] | None = None,
+        soft_error_keys: set[str] | None = None,
+        fallback_keys: set[str] | None = None,
+        fail_times: dict[str, int] | None = None,
+        video_keys: set[str] | None = None,
+    ) -> None:
+        self.fail_keys = fail_keys or set()
+        self.soft_error_keys = soft_error_keys or set()
+        self.fallback_keys = fallback_keys or set()
+        self.fail_times = fail_times or {}
+        self.video_keys = video_keys or set()
+        self._fail_counts: dict[str, int] = {}
+        self.image_calls: list[str] = []
+        self.video_calls: list[str] = []
+        self.task_updates: list[dict[str, Any]] = []
+        self.text_chunks: list[str] = []
+        self.ref_calls: list[tuple[str, list[str]]] = []
+
+    async def emit_task_update(self, **payload: Any) -> None:
+        self.task_updates.append(payload)
+
+    async def emit_task_summary(self, **payload: Any) -> None:
+        pass
+
+    async def emit_text(self, text: str) -> None:
+        self.text_chunks.append(text)
+
+    async def attach_refs(self, node_id: str, ref_order: list[str]) -> dict[str, Any]:
+        self.ref_calls.append((node_id, list(ref_order)))
+        return {"nodeId": node_id, "actions": []}
+
+    async def run_image_generation(self, node_id: str) -> dict[str, Any]:
+        key = self._key_for(node_id)
+        self.image_calls.append(key)
+        return self._gen(key, node_id)
+
+    async def run_video_generation(self, node_id: str) -> dict[str, Any]:
+        key = self._key_for(node_id)
+        self.video_calls.append(key)
+        return self._gen(key, node_id)
+
+    def _key_for(self, node_id: str) -> str:
+        # node_id pattern: node-{key}
+        return node_id.replace("node-", "") if node_id.startswith("node-") else node_id
+
+    def _gen(self, key: str, node_id: str) -> dict[str, Any]:
+        self._fail_counts[key] = self._fail_counts.get(key, 0) + 1
+        if key in self.fallback_keys:
+            return {"nodeId": node_id, "status": "fallback_pending", "actions": []}
+        need = self.fail_times.get(key, 0)
+        if need and self._fail_counts[key] <= need:
+            raise RuntimeError(f"timeout: {key}")
+        if key in self.fail_keys:
+            raise RuntimeError(f"gen failed: {key}")
+        if key in self.soft_error_keys:
+            return {"nodeId": node_id, "status": "error", "actions": []}
+        return {"nodeId": node_id, "status": "completed"}
+
+
+def _item(
+    key: str,
+    *,
+    node_id: str | None = "node-" + "k",
+    title: str = "t",
+    target_type: str = "image",
+    depends_on: list[str] | None = None,
+    chain: str | None = None,
+    role: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "key": key,
+        "node_id": node_id,
+        "title": title,
+        "target_type": target_type,
+        "depends_on": depends_on or [],
+        "chain": chain,
+        "role": role,
+    }
+
+
+def _state(key: str, by_key: dict[str, dict], plan_node_id: str | None = None) -> dict[str, Any]:
+    return {"key": key, "gen_by_key": by_key, "plan_node_id": plan_node_id}
+
+
+@pytest.mark.asyncio
+async def test_gen_node_success_returns_completed():
+    nest = FakeNest()
+    node = make_gen_node(nest=nest)
+    by_key = {"k": _item("k", node_id="node-k")}
+    out = await node(_state("k", by_key))
+    assert out == {"gen_completed_keys": ["k"]}
+    assert nest.image_calls == ["k"]
+    assert any(u.get("status") == "done" for u in nest.task_updates)
+
+
+@pytest.mark.asyncio
+async def test_gen_node_missing_node_id_fails_without_calling_nest():
+    nest = FakeNest()
+    node = make_gen_node(nest=nest)
+    by_key = {"k": _item("k", node_id=None, title="无节点")}
+    out = await node(_state("k", by_key))
+    assert out["gen_failed_keys"] == ["k"]
+    assert out["gen_fail_details"]["k"]["reason"] == "missing_node_id"
+    assert nest.image_calls == []  # never called run_image_generation
+    assert any(u.get("status") == "failed" for u in nest.task_updates)
+
+
+@pytest.mark.asyncio
+async def test_gen_node_hard_fail_after_retries():
+    nest = FakeNest(fail_keys={"k"})
+    node = make_gen_node(nest=nest)
+    by_key = {"k": _item("k", node_id="node-k")}
+    out = await node(_state("k", by_key))
+    # max_auto_retries=2 → 3 total attempts
+    assert nest.image_calls == ["k", "k", "k"]
+    assert out["gen_failed_keys"] == ["k"]
+    assert "gen failed" in out["gen_fail_details"]["k"]["reason"]
+    assert any(u.get("status") == "failed" for u in nest.task_updates)
+
+
+@pytest.mark.asyncio
+async def test_gen_node_soft_error_retries_then_fails():
+    nest = FakeNest(soft_error_keys={"k"})
+    node = make_gen_node(nest=nest)
+    by_key = {"k": _item("k", node_id="node-k")}
+    out = await node(_state("k", by_key))
+    assert nest.image_calls == ["k", "k", "k"]
+    assert out["gen_failed_keys"] == ["k"]
+    # soft_error (status="error") is recoverable → exhausted retries → failed
+
+
+@pytest.mark.asyncio
+async def test_gen_node_fallback_pending_needs_user_no_chat_line():
+    nest = FakeNest(fallback_keys={"k"})
+    node = make_gen_node(nest=nest)
+    by_key = {"k": _item("k", node_id="node-k", title="Banner")}
+    out = await node(_state("k", by_key))
+    assert nest.image_calls == ["k"]  # fallback_pending is non-recoverable → no retry
+    assert out["gen_needs_user_keys"] == ["k"]
+    assert out["gen_fail_details"]["k"]["reason"] == "fallback_pending"
+    assert any(u.get("status") == "needs_user" for u in nest.task_updates)
+    # P1-5: fallback_pending must NOT emit a chat line (canvas dialog handles it)
+    for chunk in nest.text_chunks:
+        assert "Banner" not in chunk
+
+
+@pytest.mark.asyncio
+async def test_gen_node_recoverable_then_success():
+    nest = FakeNest(fail_times={"k": 2})  # fail twice, succeed on 3rd
+    node = make_gen_node(nest=nest)
+    by_key = {"k": _item("k", node_id="node-k")}
+    out = await node(_state("k", by_key))
+    assert nest.image_calls == ["k", "k", "k"]
+    assert out == {"gen_completed_keys": ["k"]}
+    assert any(u.get("status") == "retrying" for u in nest.task_updates)
+
+
+@pytest.mark.asyncio
+async def test_gen_node_video_calls_run_video_generation():
+    nest = FakeNest()
+    node = make_gen_node(nest=nest)
+    by_key = {"k": _item("k", node_id="node-k", target_type="video")}
+    out = await node(_state("k", by_key))
+    assert nest.video_calls == ["k"]
+    assert nest.image_calls == []
+    assert out == {"gen_completed_keys": ["k"]}
+
+
+@pytest.mark.asyncio
+async def test_gen_node_attaches_chain_refs_in_correct_order():
+    """downstream product node: refs = [plan, seed, turnaround, ...deps]."""
+    nest = FakeNest()
+    node = make_gen_node(nest=nest)
+    by_key = {
+        "plan": _item("plan", node_id="n-plan", chain=None, role=None),
+        "white_bg": _item("white_bg", node_id="n-w", chain="product", role="seed"),
+        "turnaround": _item("turnaround", node_id="n-ta", chain="product", role="turnaround", depends_on=["white_bg"]),
+        "hero": _item("hero", node_id="n-hero", chain="product", role="downstream", depends_on=["turnaround", "white_bg"]),
+    }
+    await node(_state("hero", by_key, plan_node_id="n-plan"))
+    assert nest.ref_calls
+    hero_ref = [r for r in nest.ref_calls if r[0] == "n-hero"][-1]
+    # order: plan → seed → turnaround (deps already covered by turnaround)
+    assert hero_ref[1] == ["n-plan", "n-w", "n-ta"]

--- a/services/agent-runtime/tests/test_gen_scheduler.py
+++ b/services/agent-runtime/tests/test_gen_scheduler.py
@@ -1,0 +1,167 @@
+"""Unit tests for gen_scheduler (Send-API central generation arbiter).
+
+gen_scheduler is called with the FULL accumulated state (merged by reducers
+after a superstep) and returns a Command. Tests call it directly and assert on
+Command.goto (Send targets / collect_gen) and Command.update (cascade marks).
+No graph compilation needed — this is pure state→Command logic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from langgraph.types import Send
+
+from app.graph.nodes.gen_scheduler import make_gen_scheduler_node
+
+
+def _scheduler():
+    return make_gen_scheduler_node()
+
+
+def _item(key: str, *, node_id: str = "n-" + "k", deps: list[str] | None = None, title: str = "t") -> dict[str, Any]:
+    return {"key": key, "node_id": node_id, "title": title, "depends_on": deps or []}
+
+
+def _state(
+    ordered: list[str],
+    by_key: dict[str, dict],
+    *,
+    deps_of: dict[str, list[str]] | None = None,
+    completed: list[str] | None = None,
+    failed: list[str] | None = None,
+    needs_user: list[str] | None = None,
+    max_c: int = 3,
+    fail_details: dict[str, dict] | None = None,
+) -> dict[str, Any]:
+    return {
+        "gen_ordered_keys": ordered,
+        "gen_deps_of": deps_of or {k: by_key[k].get("depends_on", []) for k in ordered},
+        "gen_by_key": by_key,
+        "gen_completed_keys": completed,
+        "gen_failed_keys": failed,
+        "gen_needs_user_keys": needs_user,
+        "gen_fail_details": fail_details,
+        "gen_max_concurrency": max_c,
+    }
+
+
+def _dispatched_keys(cmd) -> list[str]:
+    """Extract keys from Command.goto Send targets (ignores non-Send like 'collect_gen')."""
+    return [s.arg["key"] for s in cmd.goto if isinstance(s, Send)]
+
+
+def _goto_node(cmd) -> str | None:
+    """If goto is a plain node name (not Send), return it."""
+    for g in cmd.goto:
+        if isinstance(g, str):
+            return g
+    return None
+
+
+# 1. dispatch_ready ----------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_dispatches_all_ready_when_no_deps():
+    sched = _scheduler()
+    by_key = {"a": _item("a", deps=[]), "b": _item("b", deps=[])}
+    cmd = await sched(_state(["a", "b"], by_key))
+    assert sorted(_dispatched_keys(cmd)) == ["a", "b"]
+    # update should be empty (no cascade marks needed)
+    assert cmd.update == {}
+
+
+# 2. concurrency -------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_respects_max_concurrency_cap():
+    sched = _scheduler()
+    by_key = {k: _item(k, deps=[]) for k in ["a", "b", "c", "d"]}
+    cmd = await sched(_state(["a", "b", "c", "d"], by_key, max_c=2))
+    dispatched = _dispatched_keys(cmd)
+    assert len(dispatched) == 2
+    # only the first 2 in topo order
+    assert dispatched == ["a", "b"]
+
+
+# 3. goto_collect ------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_goes_to_collect_when_all_processed():
+    sched = _scheduler()
+    by_key = {"a": _item("a", deps=[]), "b": _item("b", deps=["a"])}
+    cmd = await sched(_state(["a", "b"], by_key, completed=["a", "b"]))
+    assert _goto_node(cmd) == "collect_gen"
+    assert _dispatched_keys(cmd) == []
+
+
+# 4. cascade_failed ----------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_cascade_marks_dependent_as_dependency_failed():
+    sched = _scheduler()
+    by_key = {
+        "white_bg": _item("white_bg", deps=[]),
+        "hero": _item("hero", deps=["white_bg"]),
+    }
+    cmd = await sched(_state(["white_bg", "hero"], by_key, failed=["white_bg"]))
+    # hero should be marked dependency_failed, not dispatched
+    assert _dispatched_keys(cmd) == []
+    assert cmd.update["gen_failed_keys"] == ["hero"]
+    assert cmd.update["gen_fail_details"]["hero"]["reason"] == "dependency_failed"
+
+
+# 5. cascade_skipped ----------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_cascade_marks_dependent_as_dependency_skipped():
+    sched = _scheduler()
+    by_key = {
+        "white_bg": _item("white_bg", deps=[]),
+        "hero": _item("hero", deps=["white_bg"]),
+    }
+    cmd = await sched(
+        _state(["white_bg", "hero"], by_key, needs_user=["white_bg"])
+    )
+    assert _dispatched_keys(cmd) == []
+    assert cmd.update["gen_needs_user_keys"] == ["hero"]
+    assert cmd.update["gen_fail_details"]["hero"]["reason"] == "dependency_skipped"
+
+
+# 6. diamond_no_deadlock -----------------------------------------------------------
+@pytest.mark.asyncio
+async def test_diamond_dependency_dispatches_C_after_both_A_B_done():
+    """C depends on A and B; A and B both complete → C is dispatched (not deadlocked)."""
+    sched = _scheduler()
+    by_key = {
+        "a": _item("a", deps=[]),
+        "b": _item("b", deps=[]),
+        "c": _item("c", deps=["a", "b"]),
+    }
+    # A and B done in a prior superstep → scheduler should dispatch C
+    cmd = await sched(_state(["a", "b", "c"], by_key, completed=["a", "b"]))
+    assert _dispatched_keys(cmd) == ["c"]
+
+
+# 7. transitive_cascade -------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_transitive_cascade_through_chain():
+    """A failed → B (deps A) dependency_failed → C (deps B) dependency_failed."""
+    sched = _scheduler()
+    by_key = {
+        "a": _item("a", deps=[]),
+        "b": _item("b", deps=["a"]),
+        "c": _item("c", deps=["b"]),
+    }
+    cmd = await sched(_state(["a", "b", "c"], by_key, failed=["a"]))
+    # Both B and C should be cascade-marked failed (topo order ensures B before C)
+    assert sorted(cmd.update["gen_failed_keys"]) == ["b", "c"]
+    assert cmd.update["gen_fail_details"]["b"]["reason"] == "dependency_failed"
+    assert cmd.update["gen_fail_details"]["c"]["reason"] == "dependency_failed"
+    assert _dispatched_keys(cmd) == []
+
+
+# 8. no_redispatch -----------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_does_not_redispatch_completed_keys():
+    sched = _scheduler()
+    by_key = {"a": _item("a", deps=[]), "b": _item("b", deps=[])}
+    cmd = await sched(_state(["a", "b"], by_key, completed=["a"]))
+    # Only b should be dispatched (a already completed)
+    assert _dispatched_keys(cmd) == ["b"]

--- a/services/agent-runtime/tests/test_gen_subgraph.py
+++ b/services/agent-runtime/tests/test_gen_subgraph.py
@@ -1,0 +1,162 @@
+"""Integration tests for the W3 Send-API generation subgraph.
+
+These exercise the full ``start_gen → gen_scheduler ⇄ gen_node → collect_gen``
+subgraph via ``ainvoke`` (with a real MemorySaver checkpointer), covering the
+cross-node scenarios that unit tests can't: diamond dependencies across waves,
+concurrency caps across supersteps, and checkpoint recovery (completed nodes are
+not re-run after a simulated crash/resume).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import END, START, StateGraph
+
+from app.graph.nodes.collect_gen import make_collect_gen_node
+from app.graph.nodes.gen_node import make_gen_node
+from app.graph.nodes.gen_scheduler import make_gen_scheduler_node
+from app.graph.nodes.start_gen import make_start_gen_node
+from app.graph.state import AgentRuntimeState
+
+
+class _Nest:
+    """Records every run_image_generation call by node_id."""
+
+    def __init__(self, *, fail_keys: set[str] | None = None) -> None:
+        self.calls: list[str] = []
+        self.fail_keys = fail_keys or set()
+
+    async def emit_task_update(self, **payload: Any) -> None:
+        pass
+
+    async def emit_task_summary(self, **payload: Any) -> None:
+        pass
+
+    async def emit_text(self, text: str) -> None:
+        pass
+
+    async def attach_refs(self, node_id: str, ref_order: list[str]) -> dict[str, Any]:
+        return {"nodeId": node_id, "actions": []}
+
+    async def run_image_generation(self, node_id: str) -> dict[str, Any]:
+        self.calls.append(node_id)
+        if node_id in self.fail_keys:
+            raise RuntimeError(f"gen failed: {node_id}")
+        return {"nodeId": node_id, "status": "completed"}
+
+    async def save_gen_progress(self, **kwargs: Any) -> dict[str, Any]:
+        return {"id": "gp-1"}
+
+
+def _build_subgraph(nest: _Nest, *, max_concurrency: int = 3):
+    g = StateGraph(AgentRuntimeState)
+    g.add_node("start_gen", make_start_gen_node(max_concurrency=max_concurrency))
+    g.add_node("gen_scheduler", make_gen_scheduler_node())
+    g.add_node("gen_node", make_gen_node(nest=nest))
+    g.add_node("collect_gen", make_collect_gen_node(nest=nest))
+    g.add_edge(START, "start_gen")
+    g.add_edge("start_gen", "gen_scheduler")
+    g.add_edge("gen_node", "gen_scheduler")
+    g.add_edge("collect_gen", END)
+    return g.compile(checkpointer=MemorySaver())
+
+
+def _img(key: str, deps: list[str], node_id: str) -> dict[str, Any]:
+    return {
+        "key": key,
+        "target_type": "image",
+        "auto_generate": True,
+        "depends_on": deps,
+        "node_id": node_id,
+        "title": key,
+    }
+
+
+@pytest.mark.asyncio
+async def test_diamond_dependency_completes_without_deadlock():
+    """C depends on A and B (both independent); A and B run in parallel, then C.
+
+    Per-node fan-out deadlocks here (A sees B not done, skips C; B sees A not
+    done, skips C). The central scheduler sees both done after the first wave
+    and dispatches C. Verifies all 3 complete and each is called exactly once.
+    """
+    nest = _Nest()
+    graph = _build_subgraph(nest)
+    manifest = [
+        _img("a", [], "n-a"),
+        _img("b", [], "n-b"),
+        _img("c", ["a", "b"], "n-c"),
+    ]
+    result = await graph.ainvoke(
+        {"split_manifest": manifest},
+        {"configurable": {"thread_id": "diamond"}, "recursion_limit": 100},
+    )
+    assert sorted(result["gen_completed"]) == ["n-a", "n-b", "n-c"]
+    assert result["gen_failed"] == []
+    # Each node called exactly once (no re-runs)
+    assert sorted(nest.calls) == ["n-a", "n-b", "n-c"]
+    assert len(nest.calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_concurrency_cap_runs_in_waves():
+    """4 independent nodes with max_concurrency=2 → 2 waves of 2.
+
+    All 4 still complete (the cap only limits parallelism, not throughput).
+    """
+    nest = _Nest()
+    graph = _build_subgraph(nest, max_concurrency=2)
+    manifest = [_img(k, [], f"n-{k}") for k in ["a", "b", "c", "d"]]
+    result = await graph.ainvoke(
+        {"split_manifest": manifest},
+        {"configurable": {"thread_id": "conc"}, "recursion_limit": 100},
+    )
+    assert sorted(result["gen_completed"]) == ["n-a", "n-b", "n-c", "n-d"]
+    assert len(nest.calls) == 4
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_recovery_does_not_rerun_completed():
+    """Simulate a crash after white_bg completes: resume should NOT re-run it.
+
+    Uses interrupt_before on gen_node to halt after the first dispatch wave
+    (white_bg), then resumes — gen_scheduler should see white_bg already
+    completed (from checkpoint) and only dispatch hero_main.
+    """
+    nest = _Nest()
+    g = StateGraph(AgentRuntimeState)
+    g.add_node("start_gen", make_start_gen_node())
+    g.add_node("gen_scheduler", make_gen_scheduler_node())
+    g.add_node("gen_node", make_gen_node(nest=nest))
+    g.add_node("collect_gen", make_collect_gen_node(nest=nest))
+    g.add_edge(START, "start_gen")
+    g.add_edge("start_gen", "gen_scheduler")
+    g.add_edge("gen_node", "gen_scheduler")
+    g.add_edge("collect_gen", END)
+    # interrupt BEFORE gen_node → halts right before dispatching white_bg
+    graph = g.compile(
+        checkpointer=MemorySaver(),
+        interrupt_before=["gen_node"],
+    )
+    config = {"configurable": {"thread_id": "ckpt"}, "recursion_limit": 100}
+    manifest = [
+        _img("white_bg", [], "n-w"),
+        _img("hero_main", ["white_bg"], "n-h"),
+    ]
+
+    # First ainvoke: start_gen → gen_scheduler → halts before gen_node(white_bg)
+    await graph.ainvoke({"split_manifest": manifest}, config)
+    assert nest.calls == []  # gen_node hasn't run yet (interrupted before it)
+
+    # Resume: gen_node(white_bg) runs → gen_scheduler → halts before gen_node(hero_main)
+    await graph.ainvoke(None, config)
+    assert nest.calls == ["n-w"]  # only white_bg ran
+
+    # Resume again: gen_node(hero_main) runs → gen_scheduler → collect_gen → END
+    result = await graph.ainvoke(None, config)
+    assert sorted(result["gen_completed"]) == ["n-h", "n-w"]
+    # white_bg was NOT re-run during the resume (checkpoint recovery)
+    assert nest.calls == ["n-w", "n-h"]

--- a/services/agent-runtime/tests/test_route_entry_copy_gate.py
+++ b/services/agent-runtime/tests/test_route_entry_copy_gate.py
@@ -11,9 +11,9 @@ def test_route_entry_returns_intake_by_default():
     assert route_entry({"phase": "await_topo", "messages": []}) == "intake"
 
 
-def test_route_entry_returns_orchestrate_gen_when_pending():
-    # pending_orchestrate=True 时直接进入 orchestrate_gen
-    assert route_entry({"phase": "await_topo", "pending_orchestrate": True}) == "orchestrate_gen"
+def test_route_entry_returns_start_gen_when_pending():
+    # W3: pending_orchestrate=True 时进入 start_gen（Send-API 生成入口，gen_scheduler 接力）
+    assert route_entry({"phase": "await_topo", "pending_orchestrate": True}) == "start_gen"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

将生图编排从 `asyncio.Semaphore` 手动编排重构为 **LangGraph Send API fan-out**，落实项目 Hard Constraint：

> Generation DAG must use LangGraph Send API for fan-out parallel tasks instead of manual asyncio.gather to enable per-node checkpointing and independent retries

### 核心架构

```
start_gen → gen_scheduler ⇄ gen_node → collect_gen → done
                ↑______↓  (Command goto=[Send("gen_node",...)] 派发；gen_node 完成后回 gen_scheduler)
```

- **gen_scheduler**（新节点）：中央调度器，读累积 state 计算就绪任务，通过 `Command(goto=[Send(...)])` fan-out。解决**菱形依赖死锁**（C 依赖 A+B，A/B 并行完成后 C 不会被派发）。
- **gen_node**（简化）：纯 dict 返回的单任务 worker，移除 `list[Send]` 返回与下游 fan-out。
- **state.py**：新增 `reset_or_union`/`reset_or_merge` reducer，支持并行 Send 更新合并与重新生成时状态重置。

### 关键修复

**Send payload 必须携带 gen_by_key/plan_node_id**：LangGraph Send 不合并 channel state 到 worker input，只传 `{"key": k}` 会导致 gen_node 读不到 manifest 而空转递归溢出。gen_scheduler 现在在 Send payload 里带上完整上下文。

### 验证测试

| 测试文件 | 用例数 | 覆盖场景 |
|---------|-------|---------|
| test_gen_node.py | 8 | success/missing_node_id/hard_fail/soft_error/fallback_no_chat/retry/video/chain_refs |
| test_gen_scheduler.py | 8 | dispatch_ready/concurrency_cap/goto_collect/cascade_failed/cascade_skipped/diamond_no_deadlock/transitive_cascade/no_redispatch |
| test_gen_subgraph.py | 3 | 菱形依赖不死锁/并发上限分波/**checkpoint 恢复不重跑** |
| test_await_topo.py（迁移） | 1 | start_gen→gen_scheduler→gen_node→collect_gen 子图 ainvoke |
| test_route_entry_copy_gate.py（修断言） | 1 | route_entry pending→start_gen |

### 测试结果

- **117 passed, 6 failed**（6 项全为预存失败：需 Nest 服务器 3 项 + 既有 bug 3 项，经 `git stash` 在干净树上验证非本重构引起）
- 新增 19 个测试全绿，0 个新失败引入

### 回滚

重构隔离在 builder 边切换 + 5 节点文件 + state reducer + 新 gen_scheduler。回滚 = 还原 builder.py 边（`start_gen→orchestrate_gen→done`）+ 还原文件。orchestrate_gen.py 保留不删（runs.py 仍 import），仅取消注册并加弃用注释。

### 部署与复测

合并后需 `docker compose build --no-cache agent-runtime` + recreate，生产用测试账户新开干净画布复测生图走拓扑序、依赖失败正确跳过、崩溃恢复不重跑。

## Test plan
- [x] 本地 `.venv/bin/python -m pytest tests/` 全量通过（排除预存失败）
- [x] gen_node 8 单测全绿
- [x] gen_scheduler 8 单测全绿
- [x] gen_subgraph 3 集成测试全绿（含 checkpoint 恢复验证）
- [x] 图编译 + 冒烟测试（成功/级联失败）通过
- [ ] CI 绿
- [ ] 生产部署后端到端复测