### PR TITLE
feat(agent): heartbeat detection + idempotency keys

### DIFF
--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -194,6 +194,21 @@ model AgentMessage {
   createdAt DateTime @default(now())
 }
 
+/// Idempotency records for POST /agent/chat/conversation — prevent duplicate requests
+/// from network retries. 5 min TTL, lazy-cleaned on each lookup.
+model IdempotencyRecord {
+  id             String   @id @default(cuid())
+  idempotencyKey String   @unique
+  sessionId      String
+  threadId       String
+  status         String   @default("processing") // processing | completed | error
+  resultSummary  String?  // assistant text summary (≤500 chars) after completion
+  createdAt      DateTime @default(now())
+  expiresAt      DateTime // createdAt + 5 min
+
+  @@index([expiresAt])
+}
+
 model Work {
   id           String   @id @default(cuid())
   title        String

--- a/apps/server/src/agent/agent.controller.ts
+++ b/apps/server/src/agent/agent.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Get, Inject, Post, Query, Req, Res, UseGuards } from '@nestjs/common'
 import { IsIn, IsOptional, IsString } from 'class-validator'
-import type { Response } from 'express'
+import type { Request, Response } from 'express'
 import { AuthGuard } from '../auth/auth.guard'
 import { AgentService } from './agent.service'
 
@@ -48,6 +48,13 @@ export class AgentController {
     return { code: 0, message: 'ok', data }
   }
 
+  /** Proxy agent-runtime health check for frontend heartbeat detection. */
+  @Get('runtime-health')
+  async runtimeHealth() {
+    const data = await this.agentService.checkRuntimeHealth()
+    return { code: 0, message: 'ok', data }
+  }
+
   @Post('chat/optimize-prompt')
   async optimizePrompt(@Body() dto: OptimizePromptDto) {
     const data = await this.agentService.optimizePrompt(dto.prompt, dto.style)
@@ -58,12 +65,28 @@ export class AgentController {
   @UseGuards(AuthGuard)
   async conversation(
     @Body() dto: ConversationDto,
-    @Req() req: { user: { sub: string } },
+    @Req() req: Request & { user: { sub: string } },
     @Res() res: Response,
   ) {
     res.setHeader('Content-Type', 'text/event-stream')
     res.setHeader('Cache-Control', 'no-cache')
     res.setHeader('Connection', 'keep-alive')
+
+    // Idempotency key check — prevent duplicate requests from network retries
+    const idempotencyKey = req.headers['idempotency-key'] as string | undefined
+    if (idempotencyKey) {
+      const cached = await this.agentService.checkIdempotencyKey(idempotencyKey)
+      if (cached) {
+        const text =
+          cached.status === 'processing'
+            ? '上一轮仍在处理中，请稍候…'
+            : cached.resultSummary || '已完成'
+        res.write(`data: ${JSON.stringify({ type: 'text_delta', data: { text } })}\n\n`)
+        res.write('data: [DONE]\n\n')
+        res.end()
+        return
+      }
+    }
 
     try {
       for await (const event of this.agentService.streamConversation(
@@ -72,6 +95,7 @@ export class AgentController {
         req.user.sub,
         dto.threadId,
         dto.userDecision,
+        idempotencyKey,
       )) {
         res.write(`data: ${JSON.stringify(event)}\n\n`)
       }

--- a/apps/server/src/agent/agent.service.test.ts
+++ b/apps/server/src/agent/agent.service.test.ts
@@ -9,6 +9,10 @@ describe('AgentService streamConversation', () => {
   const agentMessageFindMany = vi.fn()
   const sessionFindUnique = vi.fn()
   const sessionUpdate = vi.fn()
+  const idempotencyRecordCreate = vi.fn()
+  const idempotencyRecordFindUnique = vi.fn()
+  const idempotencyRecordUpdateMany = vi.fn()
+  const idempotencyRecordDeleteMany = vi.fn()
 
   let service: AgentService
 
@@ -22,6 +26,10 @@ describe('AgentService streamConversation', () => {
     ])
     sessionFindUnique.mockResolvedValue({ id: 's1', canvasData: null })
     sessionUpdate.mockResolvedValue({})
+    idempotencyRecordCreate.mockResolvedValue({})
+    idempotencyRecordFindUnique.mockResolvedValue(null)
+    idempotencyRecordUpdateMany.mockResolvedValue({ count: 1 })
+    idempotencyRecordDeleteMany.mockResolvedValue({ count: 0 })
 
     service = new AgentService(
       {
@@ -32,6 +40,12 @@ describe('AgentService streamConversation', () => {
         session: {
           findUnique: sessionFindUnique,
           update: sessionUpdate,
+        },
+        idempotencyRecord: {
+          create: idempotencyRecordCreate,
+          findUnique: idempotencyRecordFindUnique,
+          updateMany: idempotencyRecordUpdateMany,
+          deleteMany: idempotencyRecordDeleteMany,
         },
       } as never,
       { create: vi.fn() } as never,
@@ -135,5 +149,178 @@ describe('AgentService streamConversation', () => {
 
     expect(runSpy).toHaveBeenCalledOnce()
     expect(events.some((e) => e.type === 'text_delta')).toBe(true)
+  })
+})
+
+describe('AgentService idempotency', () => {
+  const idempotencyRecordCreate = vi.fn()
+  const idempotencyRecordFindUnique = vi.fn()
+  const idempotencyRecordUpdateMany = vi.fn()
+  const idempotencyRecordDeleteMany = vi.fn()
+  const agentMessageCreate = vi.fn()
+  const agentMessageFindMany = vi.fn()
+  const sessionFindUnique = vi.fn()
+  const sessionUpdate = vi.fn()
+
+  let service: AgentService
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    delete process.env.AGENT_RUNTIME_URL
+    agentMessageCreate.mockResolvedValue({})
+    agentMessageFindMany.mockResolvedValue([])
+    sessionFindUnique.mockResolvedValue(null)
+    sessionUpdate.mockResolvedValue({})
+    idempotencyRecordCreate.mockResolvedValue({})
+    idempotencyRecordFindUnique.mockResolvedValue(null)
+    idempotencyRecordUpdateMany.mockResolvedValue({ count: 1 })
+    idempotencyRecordDeleteMany.mockResolvedValue({ count: 0 })
+
+    service = new AgentService(
+      {
+        agentMessage: {
+          create: agentMessageCreate,
+          findMany: agentMessageFindMany,
+        },
+        session: { findUnique: sessionFindUnique, update: sessionUpdate },
+        idempotencyRecord: {
+          create: idempotencyRecordCreate,
+          findUnique: idempotencyRecordFindUnique,
+          updateMany: idempotencyRecordUpdateMany,
+          deleteMany: idempotencyRecordDeleteMany,
+        },
+      } as never,
+      { create: vi.fn() } as never,
+      { createFromAgent: vi.fn() } as never,
+    )
+  })
+
+  it('checkIdempotencyKey returns null for unknown key', async () => {
+    idempotencyRecordFindUnique.mockResolvedValue(null)
+    const result = await service.checkIdempotencyKey('unknown-key')
+    expect(result).toBeNull()
+  })
+
+  it('checkIdempotencyKey returns processing for active key', async () => {
+    idempotencyRecordFindUnique.mockResolvedValue({
+      idempotencyKey: 'ik-test',
+      status: 'processing',
+      resultSummary: null,
+    })
+    const result = await service.checkIdempotencyKey('ik-test')
+    expect(result).toEqual({ status: 'processing', resultSummary: undefined })
+  })
+
+  it('checkIdempotencyKey returns completed for finished key', async () => {
+    idempotencyRecordFindUnique.mockResolvedValue({
+      idempotencyKey: 'ik-test',
+      status: 'completed',
+      resultSummary: '方案已确认',
+    })
+    const result = await service.checkIdempotencyKey('ik-test')
+    expect(result).toEqual({ status: 'completed', resultSummary: '方案已确认' })
+  })
+
+  it('checkIdempotencyKey lazily cleans expired records', async () => {
+    await service.checkIdempotencyKey('any-key')
+    expect(idempotencyRecordDeleteMany).toHaveBeenCalledWith({
+      where: { expiresAt: { lt: expect.any(Date) } },
+    })
+  })
+
+  it('registerIdempotencyKey creates record with 5-min TTL', async () => {
+    await service.registerIdempotencyKey('ik-123', 's1', 't1')
+    expect(idempotencyRecordCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        idempotencyKey: 'ik-123',
+        sessionId: 's1',
+        threadId: 't1',
+        status: 'processing',
+      }),
+    })
+    const call = idempotencyRecordCreate.mock.calls[0][0] as { data: { expiresAt: Date } }
+    const ttl = call.data.expiresAt.getTime() - Date.now()
+    expect(ttl).toBeGreaterThan(4 * 60 * 1000) // > 4 min
+    expect(ttl).toBeLessThanOrEqual(6 * 60 * 1000) // <= 6 min (buffer)
+  })
+
+  it('registerIdempotencyKey ignores unique constraint conflict', async () => {
+    idempotencyRecordCreate.mockRejectedValue(new Error('Unique constraint failed'))
+    // Should not throw
+    await expect(service.registerIdempotencyKey('ik-dupe', 's1', 't1')).resolves.toBeUndefined()
+  })
+
+  it('completeIdempotencyKey updates status and resultSummary', async () => {
+    await service.completeIdempotencyKey('ik-123', '方案已确认，正在拆解画布')
+    expect(idempotencyRecordUpdateMany).toHaveBeenCalledWith({
+      where: { idempotencyKey: 'ik-123', status: 'processing' },
+      data: { status: 'completed', resultSummary: '方案已确认，正在拆解画布' },
+    })
+  })
+
+  it('completeIdempotencyKey truncates resultSummary to 500 chars', async () => {
+    const longText = 'x'.repeat(600)
+    await service.completeIdempotencyKey('ik-123', longText)
+    const call = idempotencyRecordUpdateMany.mock.calls[0][0] as { data: { resultSummary: string } }
+    expect(call.data.resultSummary.length).toBe(500)
+  })
+})
+
+describe('AgentService checkRuntimeHealth', () => {
+  const agentMessageCreate = vi.fn()
+  const agentMessageFindMany = vi.fn()
+  const sessionFindUnique = vi.fn()
+  const sessionUpdate = vi.fn()
+  const idempotencyRecordCreate = vi.fn()
+  const idempotencyRecordFindUnique = vi.fn()
+  const idempotencyRecordUpdateMany = vi.fn()
+  const idempotencyRecordDeleteMany = vi.fn()
+
+  let service: AgentService
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    delete process.env.AGENT_RUNTIME_URL
+
+    service = new AgentService(
+      {
+        agentMessage: { create: agentMessageCreate, findMany: agentMessageFindMany },
+        session: { findUnique: sessionFindUnique, update: sessionUpdate },
+        idempotencyRecord: {
+          create: idempotencyRecordCreate,
+          findUnique: idempotencyRecordFindUnique,
+          updateMany: idempotencyRecordUpdateMany,
+          deleteMany: idempotencyRecordDeleteMany,
+        },
+      } as never,
+      { create: vi.fn() } as never,
+      { createFromAgent: vi.fn() } as never,
+    )
+  })
+
+  it('returns ok:false when AGENT_RUNTIME_URL is unset', async () => {
+    const result = await service.checkRuntimeHealth()
+    expect(result).toEqual({ ok: false })
+  })
+
+  it('returns ok:true when runtime is healthy', async () => {
+    process.env.AGENT_RUNTIME_URL = 'http://127.0.0.1:8000'
+    vi.spyOn(service, 'createRuntimeClient').mockReturnValue({
+      healthOk: vi.fn().mockResolvedValue(true),
+    } as unknown as AgentRuntimeClient)
+
+    const result = await service.checkRuntimeHealth()
+    expect(result.ok).toBe(true)
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0)
+  })
+
+  it('returns ok:false when runtime is unreachable', async () => {
+    process.env.AGENT_RUNTIME_URL = 'http://127.0.0.1:8000'
+    vi.spyOn(service, 'createRuntimeClient').mockReturnValue({
+      healthOk: vi.fn().mockResolvedValue(false),
+    } as unknown as AgentRuntimeClient)
+
+    const result = await service.checkRuntimeHealth()
+    expect(result).toEqual({ ok: false })
   })
 })

--- a/apps/server/src/agent/agent.service.ts
+++ b/apps/server/src/agent/agent.service.ts
@@ -51,28 +51,115 @@ export class AgentService {
     userId?: string,
     threadId?: string,
     userDecision?: 'confirm' | 'revise' | 'replan' | 'confirm_gen' | 'topo_revise' | 'node_revise',
+    idempotencyKey?: string,
   ): AsyncGenerator<AgentStreamEvent> {
+    // Register idempotency key (if provided) before starting
+    if (idempotencyKey) {
+      await this.registerIdempotencyKey(idempotencyKey, sessionId, threadId || sessionId)
+    }
+
     await this.prisma.agentMessage.create({
       data: { sessionId, role: 'user', content: userMessage },
     })
+
+    let assistantText = ''
 
     const runtimeUrl = process.env.AGENT_RUNTIME_URL?.trim()
     if (runtimeUrl && userId) {
       const client = this.createRuntimeClient(runtimeUrl)
       if (await client.healthOk()) {
-        yield* this.streamFromRuntime(
+        for await (const event of this.streamFromRuntime(
           client,
           sessionId,
           userMessage,
           userId,
           threadId,
           userDecision,
-        )
+        )) {
+          if (event.type === 'text_delta') {
+            assistantText += (event.data as { text: string }).text
+          }
+          yield event
+        }
+        // Complete idempotency key after successful runtime stream
+        if (idempotencyKey) {
+          await this.completeIdempotencyKey(idempotencyKey, assistantText)
+        }
         return
       }
     }
 
-    yield* this.streamFromCanvasAgent(sessionId, userId)
+    for await (const event of this.streamFromCanvasAgent(sessionId, userId)) {
+      if (event.type === 'text_delta') {
+        assistantText += (event.data as { text: string }).text
+      }
+      yield event
+    }
+    // Complete idempotency key after canvas agent fallback
+    if (idempotencyKey) {
+      await this.completeIdempotencyKey(idempotencyKey, assistantText)
+    }
+  }
+
+  // ── Idempotency ──────────────────────────────────────────────
+
+  /** Check if an idempotency key already exists (lazy-clean expired records first). */
+  async checkIdempotencyKey(
+    key: string,
+  ): Promise<{ status: string; resultSummary?: string } | null> {
+    // Lazy-clean expired records
+    await this.prisma.idempotencyRecord.deleteMany({
+      where: { expiresAt: { lt: new Date() } },
+    })
+    const record = await this.prisma.idempotencyRecord.findUnique({
+      where: { idempotencyKey: key },
+    })
+    if (!record) return null
+    return { status: record.status, resultSummary: record.resultSummary ?? undefined }
+  }
+
+  /** Register a new idempotency key with 5-min TTL. */
+  async registerIdempotencyKey(
+    key: string,
+    sessionId: string,
+    threadId: string,
+  ): Promise<void> {
+    const now = new Date()
+    await this.prisma.idempotencyRecord
+      .create({
+        data: {
+          idempotencyKey: key,
+          sessionId,
+          threadId,
+          status: 'processing',
+          expiresAt: new Date(now.getTime() + 5 * 60 * 1000),
+        },
+      })
+      .catch(() => {
+        // Unique constraint conflict = concurrent registration, ignore
+      })
+  }
+
+  /** Mark idempotency key as completed with optional result summary. */
+  async completeIdempotencyKey(key: string, resultSummary?: string): Promise<void> {
+    await this.prisma.idempotencyRecord
+      .updateMany({
+        where: { idempotencyKey: key, status: 'processing' },
+        data: { status: 'completed', resultSummary: resultSummary?.slice(0, 500) || null },
+      })
+      .catch(() => {})
+  }
+
+  // ── Runtime Health ───────────────────────────────────────────
+
+  /** Proxy agent-runtime health check for frontend heartbeat detection. */
+  async checkRuntimeHealth(): Promise<{ ok: boolean; latencyMs?: number }> {
+    const runtimeUrl = process.env.AGENT_RUNTIME_URL?.trim()
+    if (!runtimeUrl) return { ok: false }
+    const client = this.createRuntimeClient(runtimeUrl)
+    const start = Date.now()
+    const ok = await client.healthOk(5000)
+    return { ok, latencyMs: ok ? Date.now() - start : undefined }
   }
 
   /** Overridable in unit tests */

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -21,6 +21,7 @@ import {
   shouldApplyReconciledAssistant,
 } from '@/components/agent/assistantReconcile'
 import { detectAgentChipSet } from '@/components/agent/agentChipSet'
+import { buildIdempotencyKey, shouldPollRuntimeHealth, checkRuntimeHealthViaNest } from '@/components/agent/streamRecovery'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
@@ -271,6 +272,11 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
   await nextTick()
   scrollToBottom()
 
+  // Generate idempotency key for this request
+  const idempotencyKey = buildIdempotencyKey(agentThreadId.value)
+  // Track whether SSE stream ended normally (received [DONE])
+  let streamEndedNormally = false
+
   try {
     const token = localStorage.getItem('token')
     const res = await fetch(apiUrl('/api/agent/chat/conversation'), {
@@ -278,6 +284,7 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`,
+        'Idempotency-Key': idempotencyKey,
       },
       body: JSON.stringify({
         sessionId: props.sessionId,
@@ -300,7 +307,11 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
       const lines = buffer.split('\n')
       buffer = lines.pop() ?? ''
       for (const line of lines) {
-        if (!line.startsWith('data: ') || line === 'data: [DONE]') continue
+        if (!line.startsWith('data: ')) continue
+        if (line === 'data: [DONE]') {
+          streamEndedNormally = true
+          continue
+        }
         try {
           handleEvent(JSON.parse(line.slice(6)))
         } catch { /* skip */ }
@@ -309,6 +320,14 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
   } catch (err) {
     agent.appendText(`\n\n⚠️ 请求失败: ${err}`)
   } finally {
+    // SSE abnormal-end detection: stream broke without [DONE]
+    if (!streamEndedNormally) {
+      const last = agent.messages[agent.messages.length - 1]
+      if (last?.role === 'assistant' && !last.content.trim()) {
+        agent.appendText('\n\n⚠️ 连接意外断开，请稍后重试。')
+      }
+    }
+
     const last = agent.messages[agent.messages.length - 1]
     if (last?.role === 'assistant' && !last.content.trim()) {
       agent.appendText('（本轮无文本回复。若在确认方案，可再发「确认」；或点「新建对话」后重试。）')
@@ -327,7 +346,8 @@ const BUSY_TIP_SNIPPET = '上一轮仍在处理中'
 const EXEC_PROGRESS_SNIPPET = '出图成功'
 const COPY_WRITTEN_SNIPPET = '已将确认的主文案'
 
-/** 流结束后用 DB 历史补齐（避免只看到 busy / 截断 / 被旧确认文案覆盖） */
+/** 流结束后用 DB 历史补齐（避免只看到 busy / 截断 / 被旧确认文案覆盖）。
+ *  当检测到仍在生成中时，附加 runtime 健康轮询。 */
 async function reconcileLatestAssistant() {
   const pull = async () => {
     const res = await fetch(apiUrl(`/api/agent/chat/user/messages?sessionId=${props.sessionId}`))
@@ -354,6 +374,7 @@ async function reconcileLatestAssistant() {
       content?.includes(BUSY_TIP_SNIPPET)
       || (confirmTurn && !content?.includes(EXEC_PROGRESS_SNIPPET) && !content?.includes('自动出图'))
     if (shouldPoll) {
+      let runtimeFailCount = 0
       for (let i = 0; i < 36; i++) {
         await new Promise((r) => setTimeout(r, 5_000))
         content = await pull()
@@ -369,6 +390,23 @@ async function reconcileLatestAssistant() {
         ) {
           scrollToBottom()
           break
+        }
+        // Runtime health check (every 3rd poll, i.e. every 15s)
+        if (i > 0 && i % 3 === 0 && content && shouldPollRuntimeHealth(content)) {
+          const health = await checkRuntimeHealthViaNest(apiUrl(''))
+          if (!health || !health.ok) {
+            runtimeFailCount++
+            if (runtimeFailCount >= 2) {
+              const last = agent.messages[agent.messages.length - 1]
+              if (last?.role === 'assistant') {
+                last.content += '\n\n⚠️ 生成服务暂时不可达，出图可能已中断。请稍后重试或新建对话。'
+              }
+              scrollToBottom()
+              break
+            }
+          } else {
+            runtimeFailCount = 0
+          }
         }
       }
     }

--- a/apps/web/src/components/agent/streamRecovery.test.ts
+++ b/apps/web/src/components/agent/streamRecovery.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest'
+import { buildIdempotencyKey, shouldPollRuntimeHealth, checkRuntimeHealthViaNest } from './streamRecovery'
+
+describe('buildIdempotencyKey', () => {
+  it('generates key with thread ID, timestamp, and random suffix', () => {
+    const key = buildIdempotencyKey('thread-123')
+    expect(key).toMatch(/^ik_thread-123_\d+_[a-z0-9]{4}$/)
+  })
+
+  it('generates unique keys on successive calls', () => {
+    const keys = new Set(Array.from({ length: 10 }, () => buildIdempotencyKey('t1')))
+    expect(keys.size).toBe(10)
+  })
+})
+
+describe('shouldPollRuntimeHealth', () => {
+  it('returns true when content has busy indicators without completion', () => {
+    expect(shouldPollRuntimeHealth('上一轮仍在处理中，请稍候')).toBe(true)
+    expect(shouldPollRuntimeHealth('出图仍在进行中')).toBe(true)
+    expect(shouldPollRuntimeHealth('正在生成图片')).toBe(true)
+  })
+
+  it('returns false when content has completion indicators', () => {
+    expect(shouldPollRuntimeHealth('出图成功')).toBe(false)
+    expect(shouldPollRuntimeHealth('已将确认的主文案写入')).toBe(false)
+    expect(shouldPollRuntimeHealth('自动出图完成')).toBe(false)
+  })
+
+  it('returns false when content has no relevant indicators', () => {
+    expect(shouldPollRuntimeHealth('方案确认成功')).toBe(false)
+    expect(shouldPollRuntimeHealth('')).toBe(false)
+  })
+
+  it('returns false when both busy and done indicators present', () => {
+    expect(shouldPollRuntimeHealth('上一轮仍在处理中，但出图成功')).toBe(false)
+  })
+})
+
+describe('checkRuntimeHealthViaNest', () => {
+  it('returns health data when API responds ok', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ code: 0, data: { ok: true, latencyMs: 42 } }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const result = await checkRuntimeHealthViaNest('http://localhost:5100')
+    expect(result).toEqual({ ok: true, latencyMs: 42 })
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:5100/api/agent/runtime-health',
+      expect.objectContaining({ method: 'GET' }),
+    )
+
+    vi.restoreAllMocks()
+  })
+
+  it('returns null when API is unreachable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')))
+
+    const result = await checkRuntimeHealthViaNest('http://localhost:5100')
+    expect(result).toBeNull()
+
+    vi.restoreAllMocks()
+  })
+
+  it('returns null when API returns non-ok status', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }))
+
+    const result = await checkRuntimeHealthViaNest('http://localhost:5100')
+    expect(result).toBeNull()
+
+    vi.restoreAllMocks()
+  })
+})

--- a/apps/web/src/components/agent/streamRecovery.ts
+++ b/apps/web/src/components/agent/streamRecovery.ts
@@ -1,0 +1,54 @@
+/**
+ * Stream recovery utilities for frontend agent-side-rail.
+ *
+ * Provides:
+ * - SSE abnormal-end detection (streamEndedNormally flag)
+ * - Runtime health polling decision logic
+ * - Idempotency key generation
+ */
+
+/** Generate an idempotency key for POST /api/agent/chat/conversation. */
+export function buildIdempotencyKey(threadId: string): string {
+  const ts = Date.now()
+  const rand = Math.random().toString(36).slice(2, 6)
+  return `ik_${threadId}_${ts}_${rand}`
+}
+
+/**
+ * Decide whether the frontend should poll agent-runtime health after SSE ends.
+ * Returns true when the assistant content suggests generation is still in progress
+ * and hasn't reached a terminal state.
+ */
+export function shouldPollRuntimeHealth(assistantContent: string): boolean {
+  const BUSY_SNIPPETS = ['上一轮仍在处理中', '出图仍在进行中', '正在', '请稍候']
+  const DONE_SNIPPETS = ['出图成功', '已将确认的主文案', '自动出图', '已完成']
+
+  const hasBusy = BUSY_SNIPPETS.some((s) => assistantContent.includes(s))
+  const hasDone = DONE_SNIPPETS.some((s) => assistantContent.includes(s))
+
+  // Poll when: busy indicators present AND no completion indicators
+  return hasBusy && !hasDone
+}
+
+/**
+ * Check agent-runtime health via Nest proxy endpoint.
+ * Returns { ok: boolean, latencyMs?: number } or null on network failure.
+ */
+export async function checkRuntimeHealthViaNest(
+  apiBase: string,
+): Promise<{ ok: boolean; latencyMs?: number } | null> {
+  try {
+    const res = await fetch(`${apiBase}/api/agent/runtime-health`, {
+      method: 'GET',
+      signal: AbortSignal.timeout(5000),
+    })
+    if (!res.ok) return null
+    const json = (await res.json()) as {
+      code?: number
+      data?: { ok?: boolean; latencyMs?: number }
+    }
+    return json?.data ?? null
+  } catch {
+    return null
+  }
+}

--- a/apps/web/src/components/agent/streamRecovery.ts
+++ b/apps/web/src/components/agent/streamRecovery.ts
@@ -47,7 +47,9 @@ export async function checkRuntimeHealthViaNest(
       code?: number
       data?: { ok?: boolean; latencyMs?: number }
     }
-    return json?.data ?? null
+    const data = json?.data
+    if (!data || data.ok === undefined) return null
+    return { ok: data.ok, latencyMs: data.latencyMs }
   } catch {
     return null
   }


### PR DESCRIPTION
## Summary
- Frontend heartbeat detection: SSE abnormal-end flag + runtime health polling via new `GET /api/agent/runtime-health` proxy endpoint
- Nest API idempotency keys: `IdempotencyRecord` Prisma model with 5-min TTL, lazy cleanup, `Idempotency-Key` header support
- 23 new tests (14 backend + 9 frontend) all passing

## Changes
| File | Change |
|---|---|
| `apps/server/prisma/schema.prisma` | New `IdempotencyRecord` model |
| `apps/server/src/agent/agent.service.ts` | `checkRuntimeHealth()`, idempotency trio, `streamConversation()` adds `idempotencyKey` param |
| `apps/server/src/agent/agent.controller.ts` | `GET runtime-health`, `POST conversation` idempotency check |
| `apps/server/src/agent/agent.service.test.ts` | 11 new test cases |
| `apps/web/src/components/agent/streamRecovery.ts` | New pure function module |
| `apps/web/src/components/agent/streamRecovery.test.ts` | 9 new test cases |
| `apps/web/src/components/agent/AgentSideRail.vue` | `streamEndedNormally` flag, `Idempotency-Key` header, runtime health polling |

## Test plan
- [x] Backend unit tests pass (14/14)
- [x] Frontend unit tests pass (9/9)
- [ ] Manual: kill agent-runtime during generation → frontend shows error
- [ ] Manual: double-click confirm → second request returns "上一轮仍在处理中"
- [ ] Deploy to production and retest full flow