### PR TITLE
fix(agent): recognize Agnes .cn base URLs

### DIFF
--- a/packages/agent/src/tools/audio-provider.ts
+++ b/packages/agent/src/tools/audio-provider.ts
@@ -74,7 +74,7 @@ export class FallbackAudioProvider implements AudioProvider {
 }
 
 function isAgnesBaseUrl(baseUrl?: string) {
-  return Boolean(baseUrl?.includes('agnes-ai.com'))
+  return Boolean(baseUrl?.includes('agnes-ai.com') || baseUrl?.includes('agnes-ai.cn'))
 }
 
 export type ProviderCredentialOpts = { apiKey?: string; baseUrl?: string; model?: string }

--- a/packages/agent/src/tools/video-provider.ts
+++ b/packages/agent/src/tools/video-provider.ts
@@ -170,7 +170,7 @@ function sleep(ms: number) {
 }
 
 function isAgnesBaseUrl(baseUrl?: string) {
-  return Boolean(baseUrl?.includes('agnes-ai.com'))
+  return Boolean(baseUrl?.includes('agnes-ai.com') || baseUrl?.includes('agnes-ai.cn'))
 }
 
 export type ProviderCredentialOpts = { apiKey?: string; baseUrl?: string; model?: string }


### PR DESCRIPTION
## Summary
- Treat `agnes-ai.cn` the same as `agnes-ai.com` in audio/video provider base URL detection
- Unblocks domestic Agnes endpoints that use the `.cn` domain

## Test plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @lnkpi/server exec prisma generate`
- [x] `pnpm build`
- [x] `pnpm --filter @lnkpi/agent test`
- [ ] Confirm provider with `baseUrl` containing `agnes-ai.cn` routes through Agnes path


Made with [Cursor](https://cursor.com)