### PR TITLE
fix(deploy): speed up CVM API Docker build

### DIFF
--- a/deploy/deploy-remote-build.sh
+++ b/deploy/deploy-remote-build.sh
@@ -13,6 +13,7 @@ IMAGE_TAG="${IMAGE_TAG:?set IMAGE_TAG to git commit sha}"
 STATUS_FILE="${STATUS_FILE:-/tmp/lnkpi-deploy-${IMAGE_TAG}.status}"
 LOG_FILE="${LOG_FILE:-/tmp/lnkpi-deploy-${IMAGE_TAG}.log}"
 export LNKPI_API_IMAGE="lnkpi-api:${IMAGE_TAG}"
+export USE_TENCENT_APT_MIRROR=1
 export DOCKER_BUILDKIT=1
 export COMPOSE_DOCKER_CLI_BUILD=1
 

--- a/deploy/deploy-remote-build.sh
+++ b/deploy/deploy-remote-build.sh
@@ -40,8 +40,17 @@ df -h / /var/lib/docker 2>/dev/null || df -h /
 
 log "=== Prune unused Docker data ==="
 docker image prune -f >/dev/null 2>&1 || true
-# 保留一周内的构建缓存以复用 pnpm/编译层，磁盘充足时不要激进清理
-docker builder prune -f --filter 'until=168h' >/dev/null 2>&1 || true
+# 仅在 Docker 数据盘 >85% 时清理 builder cache，避免误删 apt/pnpm 层缓存导致冷构建 1h+
+docker_use_pct=$(df /var/lib/docker 2>/dev/null | awk 'NR==2 {gsub(/%/,"",$5); print $5}')
+if [[ -z "${docker_use_pct}" ]]; then
+  docker_use_pct=$(df / | awk 'NR==2 {gsub(/%/,"",$5); print $5}')
+fi
+if [[ "${docker_use_pct:-0}" -gt 85 ]]; then
+  log "Docker disk ${docker_use_pct}% — pruning builder cache older than 7d"
+  docker builder prune -f --filter 'until=168h' >/dev/null 2>&1 || true
+else
+  log "Docker disk ${docker_use_pct}% — keeping builder cache"
+fi
 docker images lnkpi-api --format '{{.Tag}}' 2>/dev/null | while read -r tag; do
   [[ -z "$tag" || "$tag" == "<none>" ]] && continue
   [[ "$tag" == "$IMAGE_TAG" || "$tag" == "latest" ]] && continue

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -20,6 +20,8 @@ services:
     build:
       context: ..
       dockerfile: deploy/docker/Dockerfile.api
+      args:
+        USE_TENCENT_APT_MIRROR: ${USE_TENCENT_APT_MIRROR:-0}
     container_name: lnkpi-api
     restart: unless-stopped
     env_file:

--- a/deploy/docker/Dockerfile.api
+++ b/deploy/docker/Dockerfile.api
@@ -1,7 +1,12 @@
 # lnkpi API（NestJS + Prisma SQLite）
 FROM node:22-bookworm-slim AS build
+# CVM 跨境访问 deb.debian.org 极慢；build 阶段仅需 openssl（Prisma），不必装 ffmpeg
+RUN sed -i 's|deb.debian.org|mirrors.cloud.tencent.com|g; s|security.debian.org|mirrors.cloud.tencent.com/debian-security|g' \
+      /etc/apt/sources.list.d/debian.sources 2>/dev/null \
+    || sed -i 's|deb.debian.org|mirrors.cloud.tencent.com|g; s|security.debian.org|mirrors.cloud.tencent.com/debian-security|g' \
+      /etc/apt/sources.list 2>/dev/null || true
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends openssl ca-certificates ffmpeg \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 WORKDIR /app
@@ -37,6 +42,10 @@ ENV NODE_ENV=production
 ENV PORT=3001
 ENV DATABASE_URL=file:/app/apps/server/data/lnkpi.db
 
+RUN sed -i 's|deb.debian.org|mirrors.cloud.tencent.com|g; s|security.debian.org|mirrors.cloud.tencent.com/debian-security|g' \
+      /etc/apt/sources.list.d/debian.sources 2>/dev/null \
+    || sed -i 's|deb.debian.org|mirrors.cloud.tencent.com|g; s|security.debian.org|mirrors.cloud.tencent.com/debian-security|g' \
+      /etc/apt/sources.list 2>/dev/null || true
 RUN apt-get update \
   && apt-get install -y --no-install-recommends openssl ca-certificates ffmpeg \
   && rm -rf /var/lib/apt/lists/* \

--- a/deploy/docker/Dockerfile.api
+++ b/deploy/docker/Dockerfile.api
@@ -1,10 +1,19 @@
 # lnkpi API（NestJS + Prisma SQLite）
 FROM node:22-bookworm-slim AS build
-# CVM 跨境访问 deb.debian.org 极慢；build 阶段仅需 openssl（Prisma），不必装 ffmpeg
-RUN sed -i 's|deb.debian.org|mirrors.cloud.tencent.com|g; s|security.debian.org|mirrors.cloud.tencent.com/debian-security|g' \
-      /etc/apt/sources.list.d/debian.sources 2>/dev/null \
-    || sed -i 's|deb.debian.org|mirrors.cloud.tencent.com|g; s|security.debian.org|mirrors.cloud.tencent.com/debian-security|g' \
-      /etc/apt/sources.list 2>/dev/null || true
+# CVM 跨境访问 deb.debian.org 极慢；仅在 deploy 脚本传 USE_TENCENT_APT_MIRROR=1 时换 http 腾讯源
+ARG USE_TENCENT_APT_MIRROR=0
+RUN if [ "$USE_TENCENT_APT_MIRROR" = "1" ]; then \
+      for f in /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list; do \
+        [ -f "$f" ] || continue; \
+        sed -i \
+          -e 's|https://deb.debian.org|http://mirrors.cloud.tencent.com|g' \
+          -e 's|http://deb.debian.org|http://mirrors.cloud.tencent.com|g' \
+          -e 's|https://security.debian.org|http://mirrors.cloud.tencent.com/debian-security|g' \
+          -e 's|http://security.debian.org|http://mirrors.cloud.tencent.com/debian-security|g' \
+          "$f"; \
+      done; \
+    fi
+# build 阶段仅需 openssl（Prisma），不必装 ffmpeg
 RUN apt-get update \
   && apt-get install -y --no-install-recommends openssl ca-certificates \
   && rm -rf /var/lib/apt/lists/*
@@ -37,15 +46,23 @@ RUN pnpm run build
 WORKDIR /app
 
 FROM node:22-bookworm-slim AS runner
+ARG USE_TENCENT_APT_MIRROR=0
 WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=3001
 ENV DATABASE_URL=file:/app/apps/server/data/lnkpi.db
 
-RUN sed -i 's|deb.debian.org|mirrors.cloud.tencent.com|g; s|security.debian.org|mirrors.cloud.tencent.com/debian-security|g' \
-      /etc/apt/sources.list.d/debian.sources 2>/dev/null \
-    || sed -i 's|deb.debian.org|mirrors.cloud.tencent.com|g; s|security.debian.org|mirrors.cloud.tencent.com/debian-security|g' \
-      /etc/apt/sources.list 2>/dev/null || true
+RUN if [ "$USE_TENCENT_APT_MIRROR" = "1" ]; then \
+      for f in /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list; do \
+        [ -f "$f" ] || continue; \
+        sed -i \
+          -e 's|https://deb.debian.org|http://mirrors.cloud.tencent.com|g' \
+          -e 's|http://deb.debian.org|http://mirrors.cloud.tencent.com|g' \
+          -e 's|https://security.debian.org|http://mirrors.cloud.tencent.com/debian-security|g' \
+          -e 's|http://security.debian.org|http://mirrors.cloud.tencent.com/debian-security|g' \
+          "$f"; \
+      done; \
+    fi
 RUN apt-get update \
   && apt-get install -y --no-install-recommends openssl ca-certificates ffmpeg \
   && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Summary
- Use Tencent Cloud apt mirror in API Dockerfile to avoid slow deb.debian.org downloads on CVM
- Remove ffmpeg from build stage (only runner needs it for video-composition export)
- Skip builder cache prune unless Docker disk usage exceeds 85%

## Why
Cold CVM builds were taking 1–1.5h because ffmpeg pulls ~200 Debian packages twice (build + runner) over a slow cross-border mirror. Cached builds normally finish in ~1–2 minutes.

## Test plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @lnkpi/server exec prisma generate`
- [x] `pnpm build`
- [ ] Merge and verify next `deploy.yml` run completes in minutes when builder cache is warm
- [ ] Verify `POST /agent/canvas/video-composition/export` still works (ffmpeg in runner)


Made with [Cursor](https://cursor.com)