### PR TITLE
fix(provider): env-first platform baseUrl + Agnes default models

### DIFF
--- a/apps/server/src/canvas/material.fallback.test.ts
+++ b/apps/server/src/canvas/material.fallback.test.ts
@@ -263,7 +263,7 @@ describe('MaterialService BYOK fallback_pending', () => {
     expect(videoGenerate).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
-        model: 'seedance-2.0-min',
+        model: 'agnes-video-v2.0',
         image: 'https://cdn.example.com/frame.png',
       }),
     )

--- a/apps/server/src/provider/provider-resolver.service.test.ts
+++ b/apps/server/src/provider/provider-resolver.service.test.ts
@@ -111,10 +111,10 @@ describe('ProviderResolverService', () => {
   })
 
   it('resolves platform channel from env credentials', async () => {
-    const result = await resolver.resolveForGeneration('u1', 'platform::seedream-5.0-pro', 'image')
+    const result = await resolver.resolveForGeneration('u1', 'platform::agnes-image-2.1-flash', 'image')
     expect(result).toEqual({
       channelId: 'platform',
-      modelName: 'seedream-5.0-pro',
+      modelName: 'agnes-image-2.1-flash',
       apiFormat: 'openai',
       credentials: {
         apiKey: 'platform-env-key',
@@ -124,10 +124,19 @@ describe('ProviderResolverService', () => {
     })
   })
 
+  it('prefers OPENAI_BASE_URL over stale platform channel baseUrl', async () => {
+    const row = prisma._channels.get(PLATFORM_CHANNEL_ID)!
+    row.baseUrl = 'https://stale.example.com/v1'
+    process.env.OPENAI_BASE_URL = 'https://fresh.example.com/v1'
+
+    const result = await resolver.resolveForGeneration('u1', 'platform::agnes-2.0-flash', 'text')
+    expect(result.credentials.baseUrl).toBe('https://fresh.example.com/v1')
+  })
+
   it('treats legacy bare model keys as platform', async () => {
-    const result = await resolver.resolveForGeneration('u1', 'seedream-5.0-pro', 'image')
+    const result = await resolver.resolveForGeneration('u1', 'agnes-image-2.1-flash', 'image')
     expect(result.channelId).toBe('platform')
-    expect(result.modelName).toBe('seedream-5.0-pro')
+    expect(result.modelName).toBe('agnes-image-2.1-flash')
     expect(result.source).toBe('platform')
   })
 

--- a/apps/server/src/provider/provider-resolver.service.ts
+++ b/apps/server/src/provider/provider-resolver.service.ts
@@ -41,8 +41,9 @@ export class ProviderResolverService {
       const channel = await this.prisma.providerChannel.findUnique({
         where: { id: PLATFORM_CHANNEL_ID },
       })
+      // Runtime .env wins over DB snapshot so deploy can retarget .cn without manual SQL.
       const baseUrl =
-        channel?.baseUrl || process.env.OPENAI_BASE_URL || ''
+        process.env.OPENAI_BASE_URL?.trim() || channel?.baseUrl || ''
       const apiKey = process.env.OPENAI_API_KEY || undefined
       return {
         channelId: PLATFORM_CHANNEL_ID,

--- a/apps/server/src/provider/provider.service.test.ts
+++ b/apps/server/src/provider/provider.service.test.ts
@@ -269,7 +269,7 @@ describe('ProviderService', () => {
   it('bootstraps platform channel from catalog and default preferences', async () => {
     const result = await svc.bootstrap('u1')
     expect(result.platformChannel.id).toBe('platform')
-    expect(result.preferences.defaultImageModel).toBe('platform::seedream-5.0-pro')
+    expect(result.preferences.defaultImageModel).toBe('platform::agnes-image-2.1-flash')
     expect(result.platformChannel.hasApiKey).toBe(false)
   })
 

--- a/apps/server/src/provider/provider.service.ts
+++ b/apps/server/src/provider/provider.service.ts
@@ -593,10 +593,19 @@ export class ProviderService {
   }
 
   private async ensurePlatformChannel(): Promise<ChannelRow> {
+    const envBaseUrl = process.env.OPENAI_BASE_URL?.trim() || ''
     const existing = await this.prisma.providerChannel.findUnique({
       where: { id: PLATFORM_CHANNEL_ID },
     })
-    if (existing) return existing
+    if (existing) {
+      if (envBaseUrl && existing.baseUrl !== envBaseUrl) {
+        return this.prisma.providerChannel.update({
+          where: { id: PLATFORM_CHANNEL_ID },
+          data: { baseUrl: envBaseUrl },
+        })
+      }
+      return existing
+    }
 
     return this.prisma.providerChannel.create({
       data: {
@@ -604,7 +613,7 @@ export class ProviderService {
         userId: null,
         name: '平台服务',
         apiFormat: 'openai',
-        baseUrl: process.env.OPENAI_BASE_URL || '',
+        baseUrl: envBaseUrl,
         models: JSON.stringify(catalogModels()),
         encryptedApiKey: null,
         iv: null,

--- a/apps/server/src/studio/studio.fallback.test.ts
+++ b/apps/server/src/studio/studio.fallback.test.ts
@@ -274,7 +274,7 @@ describe('StudioService BYOK fallback_pending', () => {
     const result = await svc.confirmPlatformFallback('u1', 'g1')
     expect(result.status).toBe('completed')
     expect(createTextProvider).toHaveBeenCalledWith(undefined)
-    expect(textGenerate).toHaveBeenCalledWith('hello', 'gemini-3.1-flash')
+    expect(textGenerate).toHaveBeenCalledWith('hello', 'agnes-2.0-flash')
     const [[, modelArg]] = textGenerate.mock.calls
     expect(modelArg).not.toBe('custom-model')
   })

--- a/deploy/deploy-remote-build.sh
+++ b/deploy/deploy-remote-build.sh
@@ -83,6 +83,17 @@ for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
   if curl -fsS "http://127.0.0.1:5100/api/health" >/dev/null 2>&1; then
     curl -fsS "http://127.0.0.1:5100/api/health" | head -c 200
     echo ""
+    log "=== Sync platform channel baseUrl from container env ==="
+    docker exec lnkpi-api node -e "
+const { PrismaClient } = require('@prisma/client');
+const url = (process.env.OPENAI_BASE_URL || '').trim();
+if (!url) { console.log('skip platform baseUrl sync: OPENAI_BASE_URL unset'); process.exit(0); }
+const p = new PrismaClient();
+p.providerChannel.update({ where: { id: 'platform' }, data: { baseUrl: url } })
+  .then((row) => { console.log('platform.baseUrl synced to', row.baseUrl); return p.\$disconnect(); })
+  .catch((err) => { console.error(err); process.exit(1); });
+" >>"$LOG_FILE" 2>&1 || log "WARN: platform baseUrl sync failed (non-fatal)"
+
     set_status success
     log "部署完成 (IMAGE=${LNKPI_API_IMAGE})"
     exit 0

--- a/packages/shared/src/studioModelCatalog.test.ts
+++ b/packages/shared/src/studioModelCatalog.test.ts
@@ -9,12 +9,13 @@ import {
 describe('studioModelCatalog', () => {
   it('lists fixed product models per modality', () => {
     expect(listModels('text').map((m) => m.modelKey)).toEqual([
+      'agnes-2.0-flash',
       'gemini-3.1-flash',
       'deepseek-v4',
       'gpt-5.5',
     ])
-    expect(listModels('image')).toHaveLength(4)
-    expect(listModels('video')).toHaveLength(3)
+    expect(listModels('image')).toHaveLength(5)
+    expect(listModels('video')).toHaveLength(4)
     expect(listModels('audio').map((m) => m.modelKey)).toEqual([
       'seed-audio-1.0',
       'minimax-speech-2.8-hd',

--- a/packages/shared/src/studioModelCatalog.ts
+++ b/packages/shared/src/studioModelCatalog.ts
@@ -62,6 +62,14 @@ const MINIMAX_AUDIO_PARAMS: Record<string, ParamDisposition> = {
 export const STUDIO_MODEL_CATALOG: StudioModelEntry[] = [
   // Text (§3.1)
   {
+    modelKey: 'agnes-2.0-flash',
+    displayName: 'Agnes 2.0 Flash',
+    gatewayModelId: 'agnes-2.0-flash',
+    modality: 'text',
+    providerBinding: 'gateway-openai-compat',
+    params: TEXT_PARAMS,
+  },
+  {
     modelKey: 'gemini-3.1-flash',
     displayName: 'Gemini 3.1 Flash',
     gatewayModelId: 'gemini-3.1-flash',
@@ -87,6 +95,14 @@ export const STUDIO_MODEL_CATALOG: StudioModelEntry[] = [
   },
 
   // Image (§3.2)
+  {
+    modelKey: 'agnes-image-2.1-flash',
+    displayName: 'Agnes Image 2.1 Flash',
+    gatewayModelId: 'agnes-image-2.1-flash',
+    modality: 'image',
+    providerBinding: 'gateway-openai-compat',
+    params: IMAGE_PARAMS,
+  },
   {
     modelKey: 'image2',
     displayName: 'Image2',
@@ -121,6 +137,14 @@ export const STUDIO_MODEL_CATALOG: StudioModelEntry[] = [
   },
 
   // Video (§3.3)
+  {
+    modelKey: 'agnes-video-v2.0',
+    displayName: 'Agnes Video v2.0',
+    gatewayModelId: 'agnes-video-v2.0',
+    modality: 'video',
+    providerBinding: 'gateway-openai-compat',
+    params: VIDEO_PARAMS,
+  },
   {
     modelKey: 'seedance-2.0-min',
     displayName: 'Seedance 2.0 Min',
@@ -178,9 +202,9 @@ export const STUDIO_MODEL_CATALOG: StudioModelEntry[] = [
 ]
 
 const DEFAULT_MODEL_KEYS: Record<StudioModality, string> = {
-  text: 'gemini-3.1-flash',
-  image: 'seedream-5.0-pro',
-  video: 'seedance-2.0-min',
+  text: 'agnes-2.0-flash',
+  image: 'agnes-image-2.1-flash',
+  video: 'agnes-video-v2.0',
   audio: 'minimax-speech-2.8-hd',
 }
 


### PR DESCRIPTION
## Summary
- Resolve platform `baseUrl` from `OPENAI_BASE_URL` before the DB snapshot so deploy `.env` changes take effect immediately
- Sync `platform.baseUrl` on bootstrap and after CVM deploy health check
- Add Agnes catalog entries and set platform default modelKeys to Agnes models verified on production `.cn`

## Why
Production had `.env` on `apihub.agnes-ai.cn` while DB `platform` row still pointed at `.com`, causing stale routing. Platform defaults (`gemini-3.1-flash`, etc.) also 503 on the current Agnes account.

## Test plan
- [x] `pnpm build`
- [x] `pnpm --filter @lnkpi/shared test`
- [x] `pnpm --filter @lnkpi/server test -- provider-resolver provider.service`
- [ ] Merge + deploy; verify `platform.baseUrl` in DB matches `.env`
- [ ] Platform text/image/video generation with default models on CVM


Made with [Cursor](https://cursor.com)