### PR TITLE
fix: resolve 413 on canvas image node upload

### DIFF
--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -9,6 +9,10 @@ import { isOriginAllowed, parseCorsOrigins } from './cors.util'
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule)
 
+  // 分片上传 JSON body 含 base64（~3MB/片），默认 100kb 会 413
+  app.useBodyParser('json', { limit: '10mb' })
+  app.useBodyParser('urlencoded', { limit: '10mb', extended: true })
+
   app.setGlobalPrefix('api')
   app.useStaticAssets(join(process.cwd(), 'uploads'), { prefix: '/api/uploads/' })
 

--- a/apps/web/src/services/upload-api.test.ts
+++ b/apps/web/src/services/upload-api.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { shouldPreferChunkedUpload } from './upload-api'
+
+describe('shouldPreferChunkedUpload', () => {
+  const originalHostname = window.location.hostname
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: { hostname: originalHostname },
+      writable: true,
+    })
+  })
+
+  it('uses chunked upload on Vercel hosts', () => {
+    Object.defineProperty(window, 'location', {
+      value: { hostname: 'lnkpi-web.vercel.app' },
+      writable: true,
+    })
+    const small = new File(['x'], 'a.png', { type: 'image/png' })
+    expect(shouldPreferChunkedUpload(small)).toBe(true)
+  })
+
+  it('uses multipart for small files on localhost', () => {
+    Object.defineProperty(window, 'location', {
+      value: { hostname: 'localhost' },
+      writable: true,
+    })
+    const small = new File(['x'], 'a.png', { type: 'image/png' })
+    expect(shouldPreferChunkedUpload(small)).toBe(false)
+  })
+
+  it('uses chunked upload for files larger than 40MB everywhere', () => {
+    Object.defineProperty(window, 'location', {
+      value: { hostname: 'localhost' },
+      writable: true,
+    })
+    const huge = new File([new Uint8Array(41 * 1024 * 1024)], 'big.mp4', { type: 'video/mp4' })
+    expect(shouldPreferChunkedUpload(huge)).toBe(true)
+  })
+})

--- a/apps/web/src/services/upload-api.ts
+++ b/apps/web/src/services/upload-api.ts
@@ -1,6 +1,5 @@
 import type { AxiosError } from 'axios'
 import { api } from './api'
-import { getApiBaseUrl } from './api-base'
 
 export interface UploadResult {
   url: string
@@ -98,17 +97,19 @@ async function uploadChunked(
   return done.data
 }
 
-function preferChunked(file: File): boolean {
-  const base = getApiBaseUrl()
-  // 生产走 Vercel `/api` 代理：一律分片，避开 multipart 破坏与 4.5MB 硬限
-  if (base === '/api') return true
+/** Vercel Serverless 代理约 4.5MB/请求且 multipart 易损坏，需分片；CVM/nginx 直连可 multipart */
+export function shouldPreferChunkedUpload(file: File): boolean {
+  if (typeof window !== 'undefined') {
+    const host = window.location.hostname
+    if (host.endsWith('.vercel.app') || host === 'vercel.app') return true
+  }
   return file.size > 40 * 1024 * 1024
 }
 
 export const uploadApi = {
   upload: async (file: File, opts?: { onProgress?: (pct: number) => void }) => {
     try {
-      if (preferChunked(file)) {
+      if (shouldPreferChunkedUpload(file)) {
         return await uploadChunked(file, opts)
       }
       try {

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -18,6 +18,7 @@ server {
     gzip_min_length 1000;
 
     location /api/ {
+        client_max_body_size 50m;
         proxy_pass http://127.0.0.1:__API_PORT__/api/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;


### PR DESCRIPTION
## Summary
- Raise NestJS JSON/urlencoded body parser limit to 10MB so chunked upload (`/upload/chunk`) no longer hits default 100KB cap (413)
- Add `client_max_body_size 50m` to nginx `/api/` proxy so multipart and chunked requests pass on CVM
- Prefer chunked upload only on Vercel or files >40MB; local/CVM uses faster multipart with 413 fallback

## Test plan
- [x] `pnpm build`
- [x] `pnpm --filter @lnkpi/web exec vitest run src/services/upload-api.test.ts src/composables/useMediaUpload.test.ts`
- [ ] After deploy: upload >1MB image to canvas image node (local + production)
- [ ] After deploy: upload on Vercel frontend still works via chunked path


Made with [Cursor](https://cursor.com)