### PR TITLE
fix(web): agent reconcile stale busy tips and health URL

### DIFF
--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, onMounted, nextTick } from 'vue'
+import { computed, ref, onMounted, nextTick, watch } from 'vue'
 import { useAgentStore } from '@/stores/agent'
 import { useAuthStore } from '@/stores/auth'
 import { apiUrl } from '@/services/api-base'
@@ -18,10 +18,16 @@ import {
 } from '@/components/agent/taskProgressReconcile'
 import {
   looksLikeConfirmTurn,
+  pickAssistantForLatestUserTurn,
   shouldApplyReconciledAssistant,
 } from '@/components/agent/assistantReconcile'
 import { detectAgentChipSet } from '@/components/agent/agentChipSet'
-import { buildIdempotencyKey, shouldPollRuntimeHealth, checkRuntimeHealthViaNest } from '@/components/agent/streamRecovery'
+import {
+  buildIdempotencyKey,
+  shouldPollRuntimeHealth,
+  checkRuntimeHealthViaNest,
+  RUNTIME_UNREACHABLE_SNIPPET,
+} from '@/components/agent/streamRecovery'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
@@ -128,6 +134,16 @@ function applyHistoryPrompt(content: string) {
 onMounted(() => {
   void loadHistory()
 })
+
+watch(
+  () => props.sessionId,
+  (id) => {
+    agentThreadId.value = `${id}:main`
+    agent.clear()
+    taskProgress.value = emptyTaskProgress()
+    void loadHistory()
+  },
+)
 
 function openPanel() {
   open.value = true
@@ -349,11 +365,14 @@ const COPY_WRITTEN_SNIPPET = '已将确认的主文案'
 /** 流结束后用 DB 历史补齐（避免只看到 busy / 截断 / 被旧确认文案覆盖）。
  *  当检测到仍在生成中时，附加 runtime 健康轮询。 */
 async function reconcileLatestAssistant() {
+  const localAssistantContent = () =>
+    [...agent.messages].reverse().find((m) => m.role === 'assistant')?.content?.trim() ?? ''
+
   const pull = async () => {
     const res = await fetch(apiUrl(`/api/agent/chat/user/messages?sessionId=${props.sessionId}`))
     const json = await res.json()
     const rows = (json.data || []) as Array<{ role: string; content: string }>
-    const lastDb = [...rows].reverse().find((m) => m.role === 'assistant')
+    const lastDb = pickAssistantForLatestUserTurn(rows)
     if (!lastDb?.content?.trim()) return null
     const lastLocal = agent.messages[agent.messages.length - 1]
     if (
@@ -369,36 +388,38 @@ async function reconcileLatestAssistant() {
     let content = await pull()
     const lastUser = [...agent.messages].reverse().find((m) => m.role === 'user')
     const confirmTurn = lastUser ? looksLikeConfirmTurn(lastUser.content || '') : false
+    const effectiveContent = () => content ?? localAssistantContent()
     // busy tip：首轮仍在写 DB；确认拆图：Nest 可能在 Vercel 断流后继续跑完
     const shouldPoll =
-      content?.includes(BUSY_TIP_SNIPPET)
-      || (confirmTurn && !content?.includes(EXEC_PROGRESS_SNIPPET) && !content?.includes('自动出图'))
+      effectiveContent().includes(BUSY_TIP_SNIPPET)
+      || (confirmTurn && !effectiveContent().includes(EXEC_PROGRESS_SNIPPET) && !effectiveContent().includes('自动出图'))
     if (shouldPoll) {
       let runtimeFailCount = 0
       for (let i = 0; i < 36; i++) {
         await new Promise((r) => setTimeout(r, 5_000))
         content = await pull()
+        const active = effectiveContent()
         if (
-          content
-          && !content.includes(BUSY_TIP_SNIPPET)
+          active
+          && !active.includes(BUSY_TIP_SNIPPET)
           && (
-            content.includes(COPY_WRITTEN_SNIPPET)
-            || content.includes(EXEC_PROGRESS_SNIPPET)
-            || content.includes('自动出图')
-            || content.length > 80
+            active.includes(COPY_WRITTEN_SNIPPET)
+            || active.includes(EXEC_PROGRESS_SNIPPET)
+            || active.includes('自动出图')
+            || active.length > 80
           )
         ) {
           scrollToBottom()
           break
         }
         // Runtime health check (every 3rd poll, i.e. every 15s)
-        if (i > 0 && i % 3 === 0 && content && shouldPollRuntimeHealth(content)) {
-          const health = await checkRuntimeHealthViaNest(apiUrl(''))
+        if (i > 0 && i % 3 === 0 && active && shouldPollRuntimeHealth(active)) {
+          const health = await checkRuntimeHealthViaNest()
           if (!health || !health.ok) {
             runtimeFailCount++
             if (runtimeFailCount >= 2) {
               const last = agent.messages[agent.messages.length - 1]
-              if (last?.role === 'assistant') {
+              if (last?.role === 'assistant' && !last.content.includes(RUNTIME_UNREACHABLE_SNIPPET)) {
                 last.content += '\n\n⚠️ 生成服务暂时不可达，出图可能已中断。请稍后重试或新建对话。'
               }
               scrollToBottom()

--- a/apps/web/src/components/agent/assistantReconcile.test.ts
+++ b/apps/web/src/components/agent/assistantReconcile.test.ts
@@ -3,8 +3,30 @@ import { describe, expect, it } from 'vitest'
 import {
   looksLikeConfirmTurn,
   looksLikeCopyWriteTurn,
+  pickAssistantForLatestUserTurn,
   shouldApplyReconciledAssistant,
 } from './assistantReconcile'
+
+describe('pickAssistantForLatestUserTurn', () => {
+  it('returns assistant after the latest user message only', () => {
+    const rows = [
+      { role: 'user', content: 'old brief' },
+      { role: 'assistant', content: '上一轮仍在处理中，请稍候；拆解出图通常需要一两分钟。' },
+      { role: 'user', content: '请帮我做蓝牙耳机营销方案' },
+    ]
+    expect(pickAssistantForLatestUserTurn(rows)).toBeNull()
+  })
+
+  it('returns current-turn assistant when present', () => {
+    const rows = [
+      { role: 'user', content: 'old brief' },
+      { role: 'assistant', content: '上一轮仍在处理中' },
+      { role: 'user', content: '新方案' },
+      { role: 'assistant', content: '定位：蓝牙耳机\n请确认是否按此方案拆解画布并出图' },
+    ]
+    expect(pickAssistantForLatestUserTurn(rows)?.content).toContain('请确认是否按此方案拆解')
+  })
+})
 
 describe('shouldApplyReconciledAssistant', () => {
   it('rejects stale confirm-gate overwrite of in-progress exec tip', () => {

--- a/apps/web/src/components/agent/assistantReconcile.ts
+++ b/apps/web/src/components/agent/assistantReconcile.ts
@@ -45,6 +45,26 @@ export function looksLikeCopyWriteTurn(userText: string): boolean {
   return /写入主文案|确认写入|可以写入/.test(t)
 }
 
+/** Assistant reply for the latest user turn only — avoids resurrecting stale busy tips. */
+export function pickAssistantForLatestUserTurn(
+  rows: Array<{ role: string; content: string }>,
+): { role: string; content: string } | null {
+  let lastUserIdx = -1
+  for (let i = rows.length - 1; i >= 0; i--) {
+    if (rows[i].role === 'user') {
+      lastUserIdx = i
+      break
+    }
+  }
+  if (lastUserIdx < 0) {
+    return [...rows].reverse().find((m) => m.role === 'assistant') ?? null
+  }
+  for (let j = lastUserIdx + 1; j < rows.length; j++) {
+    if (rows[j].role === 'assistant') return rows[j]
+  }
+  return null
+}
+
 export function looksLikeConfirmTurn(userText: string): boolean {
   const t = userText.trim()
   if (!t) return false

--- a/apps/web/src/components/agent/streamRecovery.test.ts
+++ b/apps/web/src/components/agent/streamRecovery.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect, vi } from 'vitest'
+/** @vitest-environment node */
+import { describe, expect, it, vi, afterEach } from 'vitest'
 import { buildIdempotencyKey, shouldPollRuntimeHealth, checkRuntimeHealthViaNest } from './streamRecovery'
+
+vi.mock('@/services/api-base', () => ({
+  apiUrl: (path: string) => `http://localhost:5100${path.startsWith('/') ? path : `/${path}`}`,
+}))
 
 describe('buildIdempotencyKey', () => {
   it('generates key with thread ID, timestamp, and random suffix', () => {
@@ -37,6 +42,10 @@ describe('shouldPollRuntimeHealth', () => {
 })
 
 describe('checkRuntimeHealthViaNest', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('returns health data when API responds ok', async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -44,31 +53,25 @@ describe('checkRuntimeHealthViaNest', () => {
     })
     vi.stubGlobal('fetch', mockFetch)
 
-    const result = await checkRuntimeHealthViaNest('http://localhost:5100')
+    const result = await checkRuntimeHealthViaNest()
     expect(result).toEqual({ ok: true, latencyMs: 42 })
     expect(mockFetch).toHaveBeenCalledWith(
-      'http://localhost:5100/api/agent/runtime-health',
+      'http://localhost:5100/agent/runtime-health',
       expect.objectContaining({ method: 'GET' }),
     )
-
-    vi.restoreAllMocks()
   })
 
   it('returns null when API is unreachable', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')))
 
-    const result = await checkRuntimeHealthViaNest('http://localhost:5100')
+    const result = await checkRuntimeHealthViaNest()
     expect(result).toBeNull()
-
-    vi.restoreAllMocks()
   })
 
   it('returns null when API returns non-ok status', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }))
 
-    const result = await checkRuntimeHealthViaNest('http://localhost:5100')
+    const result = await checkRuntimeHealthViaNest()
     expect(result).toBeNull()
-
-    vi.restoreAllMocks()
   })
 })

--- a/apps/web/src/components/agent/streamRecovery.ts
+++ b/apps/web/src/components/agent/streamRecovery.ts
@@ -1,3 +1,5 @@
+import { apiUrl } from '@/services/api-base'
+
 /**
  * Stream recovery utilities for frontend agent-side-rail.
  *
@@ -6,6 +8,8 @@
  * - Runtime health polling decision logic
  * - Idempotency key generation
  */
+
+export const RUNTIME_UNREACHABLE_SNIPPET = '生成服务暂时不可达'
 
 /** Generate an idempotency key for POST /api/agent/chat/conversation. */
 export function buildIdempotencyKey(threadId: string): string {
@@ -34,11 +38,9 @@ export function shouldPollRuntimeHealth(assistantContent: string): boolean {
  * Check agent-runtime health via Nest proxy endpoint.
  * Returns { ok: boolean, latencyMs?: number } or null on network failure.
  */
-export async function checkRuntimeHealthViaNest(
-  apiBase: string,
-): Promise<{ ok: boolean; latencyMs?: number } | null> {
+export async function checkRuntimeHealthViaNest(): Promise<{ ok: boolean; latencyMs?: number } | null> {
   try {
-    const res = await fetch(`${apiBase}/api/agent/runtime-health`, {
+    const res = await fetch(apiUrl('/agent/runtime-health'), {
       method: 'GET',
       signal: AbortSignal.timeout(5000),
     })


### PR DESCRIPTION
## Summary
- Reconcile only the assistant message after the latest user turn, so「新建对话」不再把旧 session 的 busy 提示贴回来
- Fix runtime health poll URL (`/api//api/...` → `/api/agent/runtime-health`) to stop false「生成服务不可达」warnings
- Dedupe unreachable warning text; reset agent thread when canvas sessionId changes

## Test plan
- [x] `pnpm build`
- [x] `pnpm --filter @lnkpi/web exec vitest run src/components/agent/streamRecovery.test.ts src/components/agent/assistantReconcile.test.ts`
- [ ] After deploy: 新建对话 → 发送营销方案 brief → 应出现方案确认门，无 busy/不可达误报


Made with [Cursor](https://cursor.com)