### PR TITLE
fix(web): agent thread id fallback for HTTP deployments

### DIFF
--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -24,6 +24,7 @@ import {
 import { detectAgentChipSet } from '@/components/agent/agentChipSet'
 import {
   buildIdempotencyKey,
+  createAgentThreadId,
   shouldPollRuntimeHealth,
   checkRuntimeHealthViaNest,
   RUNTIME_UNREACHABLE_SNIPPET,
@@ -49,8 +50,9 @@ const agent = useAgentStore()
 const auth = useAuthStore()
 const input = ref('')
 const chatContainer = ref<HTMLElement>()
+
 /** Runtime LangGraph thread；与画布 sessionId 解耦，新建对话时重置 */
-const agentThreadId = ref(`${props.sessionId}:main`)
+const agentThreadId = ref(createAgentThreadId(props.sessionId))
 const taskProgress = ref<AgentTaskProgressState>(emptyTaskProgress())
 const showTaskCard = computed(() => taskProgress.value.items.length > 0)
 
@@ -138,7 +140,7 @@ onMounted(() => {
 watch(
   () => props.sessionId,
   (id) => {
-    agentThreadId.value = `${id}:main`
+    agentThreadId.value = createAgentThreadId(id)
     agent.clear()
     taskProgress.value = emptyTaskProgress()
     void loadHistory()
@@ -217,7 +219,7 @@ function newAgentSession() {
   agent.clear()
   input.value = ''
   taskProgress.value = emptyTaskProgress()
-  agentThreadId.value = `${props.sessionId}:${crypto.randomUUID()}`
+  agentThreadId.value = createAgentThreadId(props.sessionId)
 }
 
 async function loadHistory() {

--- a/apps/web/src/components/agent/streamRecovery.test.ts
+++ b/apps/web/src/components/agent/streamRecovery.test.ts
@@ -1,10 +1,45 @@
 /** @vitest-environment node */
 import { describe, expect, it, vi, afterEach } from 'vitest'
-import { buildIdempotencyKey, shouldPollRuntimeHealth, checkRuntimeHealthViaNest } from './streamRecovery'
+import {
+  buildIdempotencyKey,
+  createAgentThreadId,
+  randomThreadSuffix,
+  shouldPollRuntimeHealth,
+  checkRuntimeHealthViaNest,
+} from './streamRecovery'
 
 vi.mock('@/services/api-base', () => ({
   apiUrl: (path: string) => `http://localhost:5100${path.startsWith('/') ? path : `/${path}`}`,
 }))
+
+describe('randomThreadSuffix', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('uses crypto.randomUUID when available', () => {
+    vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid-1234' })
+    expect(randomThreadSuffix()).toBe('test-uuid-1234')
+  })
+
+  it('falls back when crypto.randomUUID is unavailable (HTTP)', () => {
+    vi.stubGlobal('crypto', {})
+    const suffix = randomThreadSuffix()
+    expect(suffix).toMatch(/^[a-z0-9]+-[a-z0-9]+$/)
+  })
+})
+
+describe('createAgentThreadId', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('never uses :main suffix', () => {
+    vi.stubGlobal('crypto', { randomUUID: () => 'abc-def' })
+    expect(createAgentThreadId('sess1')).toBe('sess1:abc-def')
+    expect(createAgentThreadId('sess1')).not.toContain(':main')
+  })
+})
 
 describe('buildIdempotencyKey', () => {
   it('generates key with thread ID, timestamp, and random suffix', () => {

--- a/apps/web/src/components/agent/streamRecovery.ts
+++ b/apps/web/src/components/agent/streamRecovery.ts
@@ -11,6 +11,22 @@ import { apiUrl } from '@/services/api-base'
 
 export const RUNTIME_UNREACHABLE_SNIPPET = '生成服务暂时不可达'
 
+/**
+ * Thread suffix for agent-runtime LangGraph threads.
+ * crypto.randomUUID requires a secure context (HTTPS/localhost); production CVM is HTTP.
+ */
+export function randomThreadSuffix(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 11)}`
+}
+
+/** Build a session-scoped agent thread id (never reuse `:main`). */
+export function createAgentThreadId(sessionId: string): string {
+  return `${sessionId}:${randomThreadSuffix()}`
+}
+
 /** Generate an idempotency key for POST /api/agent/chat/conversation. */
 export function buildIdempotencyKey(threadId: string): string {
   const ts = Date.now()


### PR DESCRIPTION
## Summary
- Add `randomThreadSuffix` / `createAgentThreadId` with fallback when `crypto.randomUUID` is unavailable (HTTP non-secure context on CVM)
- Stop defaulting agent threads to `:main`; init, session switch, and 新建对话 all use unique thread ids
- Fixes agent always returning「上一轮仍在处理中」after 新建对话 on production

## Root cause
Production runs at `http://119.29.173.89:8888` where `crypto.randomUUID` throws. `newAgentSession()` cleared UI but failed to rotate `threadId`, so requests kept hitting the locked `{sessionId}:main` thread.

## Test plan
- [x] `pnpm --filter @lnkpi/web exec vitest run src/components/agent/streamRecovery.test.ts`
- [x] `pnpm build`
- [ ] After deploy: 强刷 → 新建对话 → 发营销 brief → Network 中 `threadId` 应为 UUID（非 `:main`）→ 出现方案确认门


Made with [Cursor](https://cursor.com)