### PR TITLE
fix(agent-runtime): recover orphan in-process thread locks

### DIFF
--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -70,6 +70,24 @@ LOCK_RENEWAL_INTERVAL = 60  # Renew every 60 seconds
 _active_lock_holders: dict[str, tuple[str, asyncio.Task[None]]] = {}
 
 
+async def _reset_orphan_local_lock(thread_id: str, nest: NestCanvasClient) -> bool:
+    """In-process lock held but DB lease free → prior task crashed without finally."""
+    lock = _thread_locks.get(thread_id)
+    if lock is None or not lock.locked():
+        return True
+    probe_holder = f"orphan-probe-{uuid.uuid4().hex}"
+    try:
+        result = await nest.acquire_thread_lock(thread_id, probe_holder, 5)
+        if not result.get("acquired"):
+            return False
+        await nest.release_thread_lock(thread_id, probe_holder)
+    except Exception:
+        return False
+    async with _thread_locks_meta:
+        _thread_locks[thread_id] = asyncio.Lock()
+    return True
+
+
 async def _try_acquire_thread(
     thread_id: str,
     nest: NestCanvasClient,
@@ -79,11 +97,18 @@ async def _try_acquire_thread(
     Returns (success, holder_id). holder_id is None if lock failed.
     Uses two-level locking: process-local (fast path) + DB-based (distributed).
     """
-    # Step 1: Try to acquire process-local lock (fast path)
+    # Step 1: Process-local lock — recover orphaned locks when DB lease expired
+    async with _thread_locks_meta:
+        lock = _thread_locks.setdefault(thread_id, asyncio.Lock())
+        local_locked = lock.locked()
+
+    if local_locked:
+        if not await _reset_orphan_local_lock(thread_id, nest):
+            return False, None
+
     async with _thread_locks_meta:
         lock = _thread_locks.setdefault(thread_id, asyncio.Lock())
         if lock.locked():
-            # Process-local lock already held
             return False, None
         await lock.acquire()
     

--- a/services/agent-runtime/tests/test_thread_busy.py
+++ b/services/agent-runtime/tests/test_thread_busy.py
@@ -14,9 +14,33 @@ from app.runs import RunRequest, stream_run_events
 class _Nest:
     def __init__(self) -> None:
         self.upserts = 0
+        self._db_locks: set[str] = set()
 
     async def close(self) -> None:
         return None
+
+    async def acquire_thread_lock(
+        self, thread_id: str, holder_id: str, ttl_seconds: float = 300
+    ) -> dict[str, bool]:
+        if thread_id in self._db_locks:
+            return {"acquired": False}
+        self._db_locks.add(thread_id)
+        return {"acquired": True}
+
+    async def release_thread_lock(self, thread_id: str, holder_id: str) -> dict[str, bool]:
+        self._db_locks.discard(thread_id)
+        return {"released": True}
+
+    async def renew_thread_lock(
+        self, thread_id: str, holder_id: str, ttl_seconds: float = 300
+    ) -> dict[str, bool]:
+        return {"renewed": True}
+
+    async def get_agent_messages(self) -> list[dict[str, str]]:
+        return []
+
+    async def save_agent_message(self, **kwargs: Any) -> dict[str, Any]:
+        return {}
 
     async def upsert_prompt_node(self, **kwargs: Any) -> dict[str, Any]:
         self.upserts += 1
@@ -167,3 +191,40 @@ async def test_concurrent_modify_intent_returns_friendly_tip():
     # 不应该启动第二轮 plan LLM
     assert llm.calls == 1
     assert nest.upserts == 0
+
+
+@pytest.mark.asyncio
+async def test_orphan_local_lock_recovered_when_db_free():
+    """Worker crash can leave asyncio.Lock held while DB lease is gone."""
+    import asyncio
+
+    from app.runs import _release_thread, _thread_locks, _try_acquire_thread
+
+    class LockNest:
+        def __init__(self) -> None:
+            self._db_locks: set[str] = set()
+
+        async def acquire_thread_lock(
+            self, thread_id: str, holder_id: str, ttl_seconds: float = 300
+        ) -> dict[str, bool]:
+            if thread_id in self._db_locks:
+                return {"acquired": False}
+            self._db_locks.add(thread_id)
+            return {"acquired": True}
+
+        async def release_thread_lock(self, thread_id: str, holder_id: str) -> dict[str, bool]:
+            self._db_locks.discard(thread_id)
+            return {"released": True}
+
+    tid = "orphan-thread-1"
+    nest = LockNest()
+    orphan = asyncio.Lock()
+    await orphan.acquire()
+    _thread_locks[tid] = orphan
+
+    acquired, holder = await _try_acquire_thread(tid, nest)  # type: ignore[arg-type]
+    assert acquired is True
+    assert holder is not None
+
+    await _release_thread(tid, holder, nest)  # type: ignore[arg-type]
+    _thread_locks.pop(tid, None)


### PR DESCRIPTION
## Summary
- Add `_reset_orphan_local_lock`: when process-local `asyncio.Lock` is held but the DB lease is free (worker crash), probe and reset the local lock
- Wire recovery into `_try_acquire_thread` before rejecting concurrent requests
- Extend thread-busy tests with lock mock + orphan recovery case

## Context
Frontend PR #80 stops new sessions from defaulting to `:main`, but existing `:main` threads can still be stuck if agent-runtime crashed mid-run. This clears stale in-process locks without requiring a container restart.

## Test plan
- [x] CI agent-runtime contract verification
- [ ] After deploy: restart not required — stuck `:main` thread should accept new runs once DB lease expired


Made with [Cursor](https://cursor.com)