### PR TITLE
fix(agent): prevent copy drift with full context and alignment gate

### DIFF
--- a/services/agent-runtime/app/graph/copy_alignment.py
+++ b/services/agent-runtime/app/graph/copy_alignment.py
@@ -1,0 +1,147 @@
+"""Copy draft context assembly and brief-alignment harness."""
+
+from __future__ import annotations
+
+import re
+
+# Generic stopwords — not product-specific hardcoding
+_BRIEF_STOPWORDS = frozenset(
+    {
+        "请",
+        "帮我",
+        "帮",
+        "我",
+        "做",
+        "一个",
+        "的",
+        "营销",
+        "方案",
+        "请帮",
+        "制作",
+        "生成",
+        "设计",
+        "写出",
+        "创建",
+    }
+)
+
+_PLAN_NOISE = frozenset(
+    {
+        "市场背景",
+        "目标人群",
+        "默认设定",
+        "项目参数",
+        "核心卖点",
+        "销售渠道",
+        "视觉资产",
+        "方案全文",
+        "确认方案",
+    }
+)
+
+_PLAN_DRAFT_EXCERPT = 3200
+
+
+def _add_term(terms: list[str], seen: set[str], raw: str) -> None:
+    t = raw.strip().strip("|").strip()
+    if len(t) < 2 or t in _BRIEF_STOPWORDS or t in _PLAN_NOISE or t in seen:
+        return
+    seen.add(t)
+    terms.append(t)
+
+
+def extract_anchor_terms(user_brief: str, plan_draft: str) -> list[str]:
+    """Terms that copy should reflect — derived from brief + plan, not hardcoded SKUs."""
+    terms: list[str] = []
+    seen: set[str] = set()
+    brief = (user_brief or "").strip()
+    plan = (plan_draft or "").strip()
+
+    for m in re.finditer(r"品牌\s*[:：]?\s*([A-Za-z0-9\u4e00-\u9fff]+)", brief):
+        _add_term(terms, seen, m.group(1))
+
+    for m in re.finditer(r"[\u4e00-\u9fff]{2,8}", brief):
+        _add_term(terms, seen, m.group(0))
+
+    for m in re.finditer(r"[A-Za-z0-9]{2,}", brief):
+        _add_term(terms, seen, m.group(0))
+
+    for pat in (
+        r"\|\s*产品品类\s*\|\s*([^|\n]+)",
+        r"\|\s*品牌名称\s*\|\s*([^|\n]+)",
+        r"\|\s*品牌\s*\|\s*([^|\n]+)",
+    ):
+        m = re.search(pat, plan)
+        if m:
+            val = m.group(1).strip()
+            for part in re.split(r"[/（(、]", val):
+                _add_term(terms, seen, part.strip())
+
+    excerpt = plan[:_PLAN_DRAFT_EXCERPT]
+    for m in re.finditer(r"[\u4e00-\u9fff]{2,8}", excerpt):
+        _add_term(terms, seen, m.group(0))
+
+    for m in re.finditer(r"\b[A-Za-z]{2,}\b", excerpt):
+        w = m.group(0)
+        if w.lower() not in {"the", "and", "for", "pro", "sku", "hero", "banner"}:
+            _add_term(terms, seen, w)
+
+    return terms[:18]
+
+
+def build_copy_writer_context(
+    *,
+    user_brief: str,
+    plan_draft: str,
+    plan_summary: str,
+    hint: str,
+    user_revision: str = "",
+) -> str:
+    """Assemble LLM human message — brief + plan SoT, summary is supplementary only."""
+    parts: list[str] = []
+    brief = (user_brief or "").strip()
+    if brief:
+        parts.append(
+            "【用户需求锚定 - 不可偏离】\n"
+            f"{brief}\n"
+            "主文案必须与上述产品/品牌一致，禁止换品类或写无关产品。"
+        )
+    plan = (plan_draft or "").strip()
+    if plan:
+        excerpt = plan if len(plan) <= _PLAN_DRAFT_EXCERPT else plan[:_PLAN_DRAFT_EXCERPT] + "\n…"
+        parts.append(f"【已确认营销方案（全文摘录）】\n{excerpt}")
+    summary = (plan_summary or "").strip()
+    if summary:
+        parts.append(f"【方案一句话摘要（仅供参考）】\n{summary}")
+    if hint:
+        parts.append(f"【主文案节点提示】\n{hint}")
+    if user_revision:
+        parts.append(f"【用户修改意见】\n{user_revision}")
+    return "\n\n".join(parts)
+
+
+def validate_copy_alignment(
+    user_brief: str,
+    plan_draft: str,
+    copy_draft: str,
+) -> tuple[bool, str | None]:
+    """Return (ok, user-facing reason). Skip when no anchors can be derived."""
+    body = (copy_draft or "").strip()
+    if not body:
+        return False, "主文案为空，无法写入。"
+
+    anchors = extract_anchor_terms(user_brief, plan_draft)
+    if not anchors:
+        return True, None
+
+    hay = body.lower()
+    hits = [t for t in anchors if t.lower() in hay]
+    required = min(2, len(anchors)) if len(anchors) >= 2 else 1
+    if len(hits) >= required:
+        return True, None
+
+    sample = "、".join(anchors[:6])
+    return False, (
+        f"主文案与当前方案/需求不一致（缺少关键信息：{sample}）。"
+        "请说明修改意见后重新生成，或点「换方向」重开方案。"
+    )

--- a/services/agent-runtime/app/graph/nodes/draft_copy.py
+++ b/services/agent-runtime/app/graph/nodes/draft_copy.py
@@ -4,9 +4,12 @@ from typing import Any, Callable
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
+from app.graph.copy_alignment import build_copy_writer_context
+
 _COPY_SYSTEM = (
     "你是电商主文案写手。只输出主文案 Markdown 正文，禁止寒暄、禁止解释过程。"
-    "根据营销方案摘要写出可直接用于详情页的主文案。"
+    "必须严格依据【用户需求锚定】与【已确认营销方案】中的产品品类与品牌撰写，"
+    "禁止替换为其他行业或产品（例如用户要耳机时不得写破壁机、马桶等）。"
 )
 
 _DRAFT_FOOTER = (
@@ -39,13 +42,11 @@ def make_draft_copy_node(*, nest: Any, llm: Any) -> Callable:
         title = str(item.get("title") or "主文案")
         node_id = str(item.get("node_id") or "") or None
         plan_summary = str(state.get("plan_summary") or "").strip()
+        plan_draft = str(state.get("plan_draft") or "").strip()
+        user_brief = str(state.get("user_brief") or "").strip()
         hint = str(item.get("prompt_hint") or item.get("prompt") or "").strip()
 
-        user_bits = [
-            f"方案摘要：\n{plan_summary or '（无）'}",
-        ]
-        if hint:
-            user_bits.append(f"节点提示：\n{hint}")
+        user_revision = ""
         if state.get("copy_revise_only") and state.get("messages"):
             for msg in reversed(state.get("messages") or []):
                 role = getattr(msg, "type", None) or (
@@ -55,13 +56,21 @@ def make_draft_copy_node(*, nest: Any, llm: Any) -> Callable:
                     msg.get("content") if isinstance(msg, dict) else ""
                 )
                 if role in ("human", "user") and content:
-                    user_bits.append(f"用户修改意见：\n{content}")
+                    user_revision = str(content)
                     break
+
+        human_content = build_copy_writer_context(
+            user_brief=user_brief,
+            plan_draft=plan_draft,
+            plan_summary=plan_summary,
+            hint=hint,
+            user_revision=user_revision,
+        )
 
         result = await llm.ainvoke(
             [
                 SystemMessage(content=_COPY_SYSTEM),
-                HumanMessage(content="\n\n".join(user_bits)),
+                HumanMessage(content=human_content),
             ]
         )
         draft = str(getattr(result, "content", "") or "").strip()

--- a/services/agent-runtime/app/graph/nodes/plan/_shared.py
+++ b/services/agent-runtime/app/graph/nodes/plan/_shared.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
@@ -54,18 +55,37 @@ def latest_user_text(messages: list[Any]) -> str:
     return ""
 
 
+_SECTION_HEADING = re.compile(r"^[\d\.]+\s+[\u4e00-\u9fffA-Za-z0-9\s]{0,24}$")
+
+
+def _is_low_signal_line(text: str) -> bool:
+    """Skip section labels like '2.1 市场背景' when building one-line summaries."""
+    cleaned = text.lstrip("#>*- ").strip()
+    if len(cleaned) < 10:
+        return True
+    if cleaned in ("市场背景", "目标人群", "核心卖点", "竞争定位"):
+        return True
+    if _SECTION_HEADING.match(cleaned) and len(cleaned) < 28:
+        return True
+    return False
+
+
 def positioning_line(plan_md: str) -> str:
-    """Extract the first non-heading content line that follows a line containing '定位'."""
+    """Extract substantive positioning text — not bare section numbers."""
     lines = [ln.strip() for ln in (plan_md or "").splitlines() if ln.strip()]
     for i, ln in enumerate(lines):
         if "定位" in ln.lstrip("# ").strip():
-            for nxt in lines[i + 1 : i + 4]:
+            for nxt in lines[i + 1 : i + 8]:
                 cleaned = nxt.lstrip("#>*- ").strip()
-                if cleaned and "定位" not in cleaned:
-                    return cleaned[:120]
+                if not cleaned or "定位" in cleaned or _is_low_signal_line(cleaned):
+                    continue
+                return cleaned[:120]
     for ln in lines:
-        if not ln.startswith("#"):
-            return ln.lstrip("#>*- ").strip()[:120]
+        if ln.startswith("#"):
+            continue
+        cleaned = ln.lstrip("#>*- ").strip()
+        if cleaned and not _is_low_signal_line(cleaned):
+            return cleaned[:120]
     if lines:
         return lines[0].lstrip("# ").strip()[:120]
     return "（见画布方案节点）"

--- a/services/agent-runtime/app/graph/nodes/write_copy_node.py
+++ b/services/agent-runtime/app/graph/nodes/write_copy_node.py
@@ -4,6 +4,8 @@ from typing import Any, Callable
 
 from langchain_core.messages import AIMessage
 
+from app.graph.copy_alignment import validate_copy_alignment
+
 
 def make_write_copy_node(*, nest: Any) -> Callable:
     async def write_copy_node(state: dict) -> dict:
@@ -14,6 +16,20 @@ def make_write_copy_node(*, nest: Any) -> Callable:
                 "phase": "done",
                 "awaiting_user": False,
                 "messages": [AIMessage(content="主文案草稿缺失，无法写入节点。")],
+            }
+
+        ok, reason = validate_copy_alignment(
+            str(state.get("user_brief") or ""),
+            str(state.get("plan_draft") or ""),
+            draft,
+        )
+        if not ok:
+            return {
+                "phase": "await_copy_confirm",
+                "awaiting_user": True,
+                "copy_revise_only": False,
+                "pending_orchestrate": False,
+                "messages": [AIMessage(content=f"⚠️ {reason}")],
             }
 
         await nest.set_node_content(node_id, draft)

--- a/services/agent-runtime/tests/test_await_copy_confirm.py
+++ b/services/agent-runtime/tests/test_await_copy_confirm.py
@@ -51,3 +51,29 @@ async def test_write_copy_persists_draft():
     assert any(
         c[0] == "emit_task_update" and c[1].get("status") == "done" for c in nest.calls
     )
+
+
+@pytest.mark.asyncio
+async def test_write_copy_blocks_misaligned_draft():
+    class FakeNest:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, Any]] = []
+
+        async def set_node_content(self, node_id: str, content: str) -> dict:
+            self.calls.append(("set_node_content", (node_id, content)))
+            return {"actions": []}
+
+    nest = FakeNest()
+    node = make_write_copy_node(nest=nest)
+    out = await node(
+        {
+            "copy_node_id": "t1",
+            "copy_draft": "# 破壁机营销\n真正的好破壁机。",
+            "user_brief": "请帮我做一个蓝牙耳机营销方案，品牌lnkpi",
+            "plan_draft": "| 产品品类 | TWS 真无线蓝牙耳机 |",
+            "split_manifest": [{"key": "copy_main", "node_id": "t1", "title": "主文案"}],
+        }
+    )
+    assert nest.calls == []
+    assert out["phase"] == "await_copy_confirm"
+    assert "不一致" in out["messages"][0].content

--- a/services/agent-runtime/tests/test_copy_alignment.py
+++ b/services/agent-runtime/tests/test_copy_alignment.py
@@ -1,0 +1,81 @@
+"""Tests for copy alignment harness and plan summary extraction."""
+
+from __future__ import annotations
+
+from app.graph.copy_alignment import (
+    build_copy_writer_context,
+    extract_anchor_terms,
+    validate_copy_alignment,
+)
+from app.graph.nodes.plan._shared import positioning_line, summarize
+
+EARPHONE_PLAN = """# lnkpi 蓝牙耳机企业营销方案
+
+## 2. 市场与竞争定位
+
+### 2.1 市场背景
+
+TWS 耳机市场已从功能竞争转向体验竞争。
+
+| 参数 | 默认设定 |
+|---|---|
+| 产品品类 | TWS 真无线蓝牙耳机（含充电仓） |
+| 品牌名称 | lnkpi（视觉统一为 LNKPI） |
+"""
+
+BLENDER_COPY = """# 破壁时代，重新定义一杯营养的浓度
+
+## 市场背景：吃得饱 ≠ 吃得好
+
+真正的好破壁机，不是转速堆砌。
+"""
+
+EARPHONE_COPY = """# lnkpi Buds Pro — 口袋里的澎湃声场
+
+TWS 蓝牙耳机，主动降噪，长续航。
+"""
+
+
+def test_positioning_line_skips_section_number_heading():
+    pos = positioning_line(EARPHONE_PLAN)
+    assert pos != "2.1 市场背景"
+    assert "TWS" in pos or "耳机" in pos
+
+
+def test_summarize_uses_substantive_line_for_real_llm_plan():
+    summary = summarize(EARPHONE_PLAN)
+    assert "2.1 市场背景" not in summary or "TWS" in summary
+
+
+def test_extract_anchor_terms_from_brief_and_plan():
+    brief = "请帮我做一个蓝牙耳机ipod的营销方案，品牌lnkpi"
+    terms = extract_anchor_terms(brief, EARPHONE_PLAN)
+    assert any("lnkpi" in t.lower() for t in terms)
+    assert any("耳机" in t for t in terms)
+
+
+def test_validate_rejects_blender_copy_for_earphone_brief():
+    brief = "请帮我做一个蓝牙耳机ipod的营销方案，品牌lnkpi"
+    ok, reason = validate_copy_alignment(brief, EARPHONE_PLAN, BLENDER_COPY)
+    assert ok is False
+    assert reason is not None
+    assert "不一致" in reason
+
+
+def test_validate_accepts_aligned_copy():
+    brief = "请帮我做一个蓝牙耳机ipod的营销方案，品牌lnkpi"
+    ok, _ = validate_copy_alignment(brief, EARPHONE_PLAN, EARPHONE_COPY)
+    assert ok is True
+
+
+def test_build_copy_writer_context_includes_brief_and_plan():
+    ctx = build_copy_writer_context(
+        user_brief="请帮我做一个蓝牙耳机ipod的营销方案，品牌lnkpi",
+        plan_draft=EARPHONE_PLAN,
+        plan_summary="2.1 市场背景",
+        hint="主文案节点",
+    )
+    assert "用户需求锚定" in ctx
+    assert "lnkpi" in ctx
+    assert "TWS" in ctx or "蓝牙耳机" in ctx
+    assert "2.1 市场背景" in ctx  # summary is supplementary

--- a/services/agent-runtime/tests/test_draft_copy.py
+++ b/services/agent-runtime/tests/test_draft_copy.py
@@ -11,8 +11,10 @@ from app.graph.nodes.draft_copy import make_draft_copy_node
 class FakeLLM:
     def __init__(self, responses: list[str]) -> None:
         self.responses = list(responses)
+        self.last_messages: list[Any] | None = None
 
     async def ainvoke(self, messages: Any, **kwargs: Any) -> AIMessage:
+        self.last_messages = messages
         if not self.responses:
             raise RuntimeError("FakeLLM: no responses left")
         return AIMessage(content=self.responses.pop(0))
@@ -62,6 +64,34 @@ async def test_draft_copy_sets_gate_and_needs_user():
         c[0] == "emit_task_update" and c[1].get("status") == "needs_user"
         for c in nest.calls
     )
+
+
+@pytest.mark.asyncio
+async def test_draft_copy_llm_context_includes_brief_and_plan():
+    nest = FakeNest()
+    llm = FakeLLM(responses=["# 主文案\nlnkpi 耳机\n"])
+    node = make_draft_copy_node(nest=nest, llm=llm)
+    plan = "# lnkpi 蓝牙耳机方案\n\nTWS 真无线耳机。"
+    await node(
+        {
+            "user_brief": "请帮我做一个蓝牙耳机营销方案，品牌lnkpi",
+            "plan_draft": plan,
+            "plan_summary": "2.1 市场背景",
+            "split_manifest": [
+                {
+                    "key": "copy_main",
+                    "title": "主文案",
+                    "target_type": "text",
+                    "node_id": "t1",
+                },
+            ],
+        }
+    )
+    assert llm.last_messages is not None
+    human = llm.last_messages[1].content
+    assert "用户需求锚定" in human
+    assert "lnkpi" in human
+    assert "TWS" in human or "蓝牙耳机" in human
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- 主文案生成改为传入 user brief + 方案摘录，不再仅依赖弱化的 plan summary
- 写入画布前增加一致性门禁：锚点词校验失败则拦截并回到 await_copy_confirm
- 改进 positioning_line 跳过纯章节标题，避免摘要丢失实质定位信息

## Test plan
- [x] pytest copy_alignment / draft_copy / await_copy_confirm / plan_summary (15 passed)
- [x] pnpm --filter @lnkpi/agent test (50 passed)
- [ ] CI 全绿后 squash merge
- [ ] 生产复测：Brief → 主文案应含 lnkpi/耳机；破壁机 copy 应被拦截

Made with [Cursor](https://cursor.com)