### PR TITLE
fix(agent): harden copy gate with strong anchors and draft retry

### DIFF
--- a/services/agent-runtime/app/graph/copy_alignment.py
+++ b/services/agent-runtime/app/graph/copy_alignment.py
@@ -39,7 +39,31 @@ _PLAN_NOISE = frozenset(
     }
 )
 
+# Channel / platform terms — must not satisfy alignment on their own
+_CHANNEL_NOISE = frozenset(
+    {
+        "天猫",
+        "京东",
+        "抖音",
+        "旗舰店",
+        "官方",
+        "自营",
+        "电商",
+        "官网",
+        "店铺",
+        "平台",
+        "渠道",
+        "销售",
+        "正品",
+        "联保",
+        "退换",
+        "物流",
+        "客服",
+    }
+)
+
 _PLAN_DRAFT_EXCERPT = 3200
+_MAX_COPY_ATTEMPTS = 3
 
 
 def _add_term(terms: list[str], seen: set[str], raw: str) -> None:
@@ -50,6 +74,59 @@ def _add_term(terms: list[str], seen: set[str], raw: str) -> None:
     terms.append(t)
 
 
+def _add_strong(terms: list[str], seen: set[str], raw: str) -> None:
+    t = raw.strip().strip("|").strip("（）()")
+    if len(t) < 2 or t in _BRIEF_STOPWORDS or t in _PLAN_NOISE or t in _CHANNEL_NOISE:
+        return
+    if t in seen:
+        return
+    seen.add(t)
+    terms.append(t)
+
+
+def extract_strong_anchors(user_brief: str, plan_draft: str) -> list[str]:
+    """Brand + product category anchors — at least one must appear in copy."""
+    terms: list[str] = []
+    seen: set[str] = set()
+    brief = (user_brief or "").strip()
+    plan = (plan_draft or "").strip()
+
+    for m in re.finditer(r"品牌\s*[:：]?\s*([A-Za-z0-9\u4e00-\u9fff]+)", brief):
+        _add_strong(terms, seen, m.group(1))
+
+    for m in re.finditer(r"\b[A-Za-z]{2,}\b", brief):
+        w = m.group(0)
+        if w.lower() not in {"ipod", "pro", "sku", "hero", "banner", "the", "and", "for"}:
+            _add_strong(terms, seen, w)
+
+    for pat in (
+        r"\|\s*产品品类\s*\|\s*([^|\n]+)",
+        r"\|\s*品牌名称\s*\|\s*([^|\n]+)",
+        r"\|\s*品牌\s*\|\s*([^|\n]+)",
+        r"产品类别\s*[:：]\s*([^\n|]+)",
+        r"产品品类\s*[:：]\s*([^\n|]+)",
+    ):
+        m = re.search(pat, plan)
+        if m:
+            val = m.group(1).strip()
+            for part in re.split(r"[/（(、,，]", val):
+                chunk = part.strip()
+                if chunk:
+                    _add_strong(terms, seen, chunk)
+
+    for m in re.finditer(r"[\u4e00-\u9fff]{3,8}", brief):
+        chunk = m.group(0)
+        if chunk not in _BRIEF_STOPWORDS and chunk not in _CHANNEL_NOISE:
+            _add_strong(terms, seen, chunk)
+
+    for m in re.finditer(r"\b[A-Za-z]{2,}\b", plan[:_PLAN_DRAFT_EXCERPT]):
+        w = m.group(0)
+        if w.lower() not in {"the", "and", "for", "pro", "sku", "hero", "banner", "ln"}:
+            _add_strong(terms, seen, w)
+
+    return terms[:12]
+
+
 def extract_anchor_terms(user_brief: str, plan_draft: str) -> list[str]:
     """Terms that copy should reflect — derived from brief + plan, not hardcoded SKUs."""
     terms: list[str] = []
@@ -57,8 +134,8 @@ def extract_anchor_terms(user_brief: str, plan_draft: str) -> list[str]:
     brief = (user_brief or "").strip()
     plan = (plan_draft or "").strip()
 
-    for m in re.finditer(r"品牌\s*[:：]?\s*([A-Za-z0-9\u4e00-\u9fff]+)", brief):
-        _add_term(terms, seen, m.group(1))
+    for t in extract_strong_anchors(brief, plan):
+        _add_term(terms, seen, t)
 
     for m in re.finditer(r"[\u4e00-\u9fff]{2,8}", brief):
         _add_term(terms, seen, m.group(0))
@@ -66,20 +143,11 @@ def extract_anchor_terms(user_brief: str, plan_draft: str) -> list[str]:
     for m in re.finditer(r"[A-Za-z0-9]{2,}", brief):
         _add_term(terms, seen, m.group(0))
 
-    for pat in (
-        r"\|\s*产品品类\s*\|\s*([^|\n]+)",
-        r"\|\s*品牌名称\s*\|\s*([^|\n]+)",
-        r"\|\s*品牌\s*\|\s*([^|\n]+)",
-    ):
-        m = re.search(pat, plan)
-        if m:
-            val = m.group(1).strip()
-            for part in re.split(r"[/（(、]", val):
-                _add_term(terms, seen, part.strip())
-
     excerpt = plan[:_PLAN_DRAFT_EXCERPT]
     for m in re.finditer(r"[\u4e00-\u9fff]{2,8}", excerpt):
-        _add_term(terms, seen, m.group(0))
+        chunk = m.group(0)
+        if chunk not in _CHANNEL_NOISE:
+            _add_term(terms, seen, chunk)
 
     for m in re.finditer(r"\b[A-Za-z]{2,}\b", excerpt):
         w = m.group(0)
@@ -96,6 +164,7 @@ def build_copy_writer_context(
     plan_summary: str,
     hint: str,
     user_revision: str = "",
+    alignment_feedback: str = "",
 ) -> str:
     """Assemble LLM human message — brief + plan SoT, summary is supplementary only."""
     parts: list[str] = []
@@ -117,6 +186,16 @@ def build_copy_writer_context(
         parts.append(f"【主文案节点提示】\n{hint}")
     if user_revision:
         parts.append(f"【用户修改意见】\n{user_revision}")
+    if alignment_feedback:
+        parts.append(
+            "【上次生成不合格 - 必须重写】\n"
+            f"{alignment_feedback}\n"
+            "请严格按方案中的品牌与产品品类重写，禁止写其他行业产品。"
+        )
+    strong = extract_strong_anchors(brief, plan)
+    if strong:
+        must = "、".join(strong[:6])
+        parts.append(f"【必须出现的关键词】\n{must}")
     return "\n\n".join(parts)
 
 
@@ -125,23 +204,27 @@ def validate_copy_alignment(
     plan_draft: str,
     copy_draft: str,
 ) -> tuple[bool, str | None]:
-    """Return (ok, user-facing reason). Skip when no anchors can be derived."""
+    """Return (ok, user-facing reason). Fail-closed when context or strong anchors missing."""
     body = (copy_draft or "").strip()
     if not body:
         return False, "主文案为空，无法写入。"
 
-    anchors = extract_anchor_terms(user_brief, plan_draft)
-    if not anchors:
-        return True, None
+    brief = (user_brief or "").strip()
+    plan = (plan_draft or "").strip()
+    if not brief and not plan:
+        return False, "缺少方案上下文，无法校验主文案一致性。请重新确认方案后再写入。"
+
+    strong = extract_strong_anchors(brief, plan)
+    if not strong:
+        return False, "无法从需求/方案提取校验锚点，请重新确认方案后再写入。"
 
     hay = body.lower()
-    hits = [t for t in anchors if t.lower() in hay]
-    required = min(2, len(anchors)) if len(anchors) >= 2 else 1
-    if len(hits) >= required:
-        return True, None
+    strong_hits = [t for t in strong if t.lower() in hay]
+    if not strong_hits:
+        sample = "、".join(strong[:6])
+        return False, (
+            f"主文案与当前方案/需求不一致（缺少品牌或产品关键词：{sample}）。"
+            "请说明修改意见后重新生成，或点「换方向」重开方案。"
+        )
 
-    sample = "、".join(anchors[:6])
-    return False, (
-        f"主文案与当前方案/需求不一致（缺少关键信息：{sample}）。"
-        "请说明修改意见后重新生成，或点「换方向」重开方案。"
-    )
+    return True, None

--- a/services/agent-runtime/app/graph/nodes/draft_copy.py
+++ b/services/agent-runtime/app/graph/nodes/draft_copy.py
@@ -4,12 +4,13 @@ from typing import Any, Callable
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
-from app.graph.copy_alignment import build_copy_writer_context
+from app.graph.copy_alignment import build_copy_writer_context, validate_copy_alignment
 
 _COPY_SYSTEM = (
     "你是电商主文案写手。只输出主文案 Markdown 正文，禁止寒暄、禁止解释过程。"
     "必须严格依据【用户需求锚定】与【已确认营销方案】中的产品品类与品牌撰写，"
-    "禁止替换为其他行业或产品（例如用户要耳机时不得写破壁机、马桶等）。"
+    "禁止替换为其他行业或产品（例如用户要耳机时不得写破壁机、乳胶枕、马桶等）。"
+    "正文必须包含【必须出现的关键词】中的品牌与产品词。"
 )
 
 _DRAFT_FOOTER = (
@@ -59,23 +60,32 @@ def make_draft_copy_node(*, nest: Any, llm: Any) -> Callable:
                     user_revision = str(content)
                     break
 
-        human_content = build_copy_writer_context(
-            user_brief=user_brief,
-            plan_draft=plan_draft,
-            plan_summary=plan_summary,
-            hint=hint,
-            user_revision=user_revision,
-        )
-
-        result = await llm.ainvoke(
-            [
-                SystemMessage(content=_COPY_SYSTEM),
-                HumanMessage(content=human_content),
-            ]
-        )
-        draft = str(getattr(result, "content", "") or "").strip()
-        if not draft:
-            draft = hint or title
+        draft = ""
+        alignment_feedback = ""
+        for attempt in range(3):
+            content = build_copy_writer_context(
+                user_brief=user_brief,
+                plan_draft=plan_draft,
+                plan_summary=plan_summary,
+                hint=hint,
+                user_revision=user_revision,
+                alignment_feedback=alignment_feedback,
+            )
+            result = await llm.ainvoke(
+                [
+                    SystemMessage(content=_COPY_SYSTEM),
+                    HumanMessage(content=content),
+                ]
+            )
+            draft = str(getattr(result, "content", "") or "").strip()
+            if not draft:
+                draft = hint or title
+            ok, reason = validate_copy_alignment(user_brief, plan_draft, draft)
+            if ok or (not user_brief and not plan_draft):
+                break
+            alignment_feedback = reason or "与方案不一致"
+            if attempt >= 2:
+                break
 
         body = f"【主文案草稿】\n{draft}{_DRAFT_FOOTER}"
         emit = getattr(nest, "emit_text", None)

--- a/services/agent-runtime/tests/test_await_copy_confirm.py
+++ b/services/agent-runtime/tests/test_await_copy_confirm.py
@@ -41,11 +41,13 @@ async def test_write_copy_persists_draft():
     out = await node(
         {
             "copy_node_id": "t1",
-            "copy_draft": "正文A",
+            "copy_draft": "# lnkpi 耳机\nTWS 蓝牙耳机正文。",
+            "user_brief": "请帮我做一个lnkpi蓝牙耳机营销方案",
+            "plan_draft": "| 产品品类 | TWS 真无线蓝牙耳机 |",
             "split_manifest": [{"key": "copy_main", "node_id": "t1", "title": "主文案"}],
         }
     )
-    assert any(c[0] == "set_node_content" and c[1] == ("t1", "正文A") for c in nest.calls)
+    assert any(c[0] == "set_node_content" and c[1] == ("t1", "# lnkpi 耳机\nTWS 蓝牙耳机正文。") for c in nest.calls)
     assert out["awaiting_user"] is True
     assert out["phase"] == "await_topo"
     assert any(
@@ -77,3 +79,22 @@ async def test_write_copy_blocks_misaligned_draft():
     assert nest.calls == []
     assert out["phase"] == "await_copy_confirm"
     assert "不一致" in out["messages"][0].content
+
+
+@pytest.mark.asyncio
+async def test_write_copy_blocks_when_context_missing():
+    class FakeNest:
+        async def set_node_content(self, node_id: str, content: str) -> dict:
+            raise AssertionError("should not write")
+
+    nest = FakeNest()
+    node = make_write_copy_node(nest=nest)
+    out = await node(
+        {
+            "copy_node_id": "t1",
+            "copy_draft": "# 任意文案",
+            "split_manifest": [{"key": "copy_main", "node_id": "t1", "title": "主文案"}],
+        }
+    )
+    assert out["phase"] == "await_copy_confirm"
+    assert "上下文" in out["messages"][0].content

--- a/services/agent-runtime/tests/test_copy_alignment.py
+++ b/services/agent-runtime/tests/test_copy_alignment.py
@@ -79,3 +79,32 @@ def test_build_copy_writer_context_includes_brief_and_plan():
     assert "lnkpi" in ctx
     assert "TWS" in ctx or "蓝牙耳机" in ctx
     assert "2.1 市场背景" in ctx  # summary is supplementary
+
+
+LATEX_COPY = """# 天然乳胶枕，让每夜深睡如云
+
+## 产品类别：天然乳胶寝具
+本产品通过天猫官方旗舰店、京东自营等主流电商平台直接销售。
+"""
+
+
+def test_validate_rejects_latex_copy_for_earphone_brief():
+    brief = "请帮我做一个lnkpi蓝牙耳机营销方案"
+    ok, reason = validate_copy_alignment(brief, EARPHONE_PLAN, LATEX_COPY)
+    assert ok is False
+    assert reason is not None
+
+
+def test_validate_rejects_when_brief_and_plan_missing():
+    ok, reason = validate_copy_alignment("", "", "任意正文")
+    assert ok is False
+    assert reason is not None
+    assert "上下文" in reason or "方案" in reason
+
+
+def test_validate_rejects_misaligned_even_with_channel_keywords():
+    """Generic 天猫/京东 overlap must not pass without brand/product anchors."""
+    brief = "请帮我做一个lnkpi蓝牙耳机营销方案"
+    copy = "天猫旗舰店京东自营官方正品销售"
+    ok, _ = validate_copy_alignment(brief, EARPHONE_PLAN, copy)
+    assert ok is False

--- a/services/agent-runtime/tests/test_draft_copy.py
+++ b/services/agent-runtime/tests/test_draft_copy.py
@@ -95,6 +95,36 @@ async def test_draft_copy_llm_context_includes_brief_and_plan():
 
 
 @pytest.mark.asyncio
+async def test_draft_copy_retries_when_first_draft_misaligned():
+    nest = FakeNest()
+    llm = FakeLLM(
+        responses=[
+            "# 天然乳胶枕\n天猫官方旗舰店销售。",
+            "# lnkpi Buds Pro\nTWS 蓝牙耳机，主动降噪。",
+        ]
+    )
+    node = make_draft_copy_node(nest=nest, llm=llm)
+    plan = "| 产品品类 | TWS 真无线蓝牙耳机 |\n| 品牌名称 | lnkpi |"
+    out = await node(
+        {
+            "user_brief": "请帮我做一个lnkpi蓝牙耳机营销方案",
+            "plan_draft": plan,
+            "plan_summary": "耳机方案",
+            "split_manifest": [
+                {
+                    "key": "copy_main",
+                    "title": "主文案",
+                    "target_type": "text",
+                    "node_id": "t1",
+                },
+            ],
+        }
+    )
+    assert len(llm.responses) == 0  # both responses consumed
+    assert "lnkpi" in (out["copy_draft"] or "").lower() or "耳机" in (out["copy_draft"] or "")
+
+
+@pytest.mark.asyncio
 async def test_draft_copy_revise_skips_pending_orchestrate():
     nest = FakeNest()
     llm = FakeLLM(responses=["# 修订主文案\n节水优先\n"])


### PR DESCRIPTION
## Summary
- 写入门禁改为 fail-closed：brief/plan 缺失或无强锚点时拒绝写入
- 强锚点策略：必须命中品牌或产品品类词，「天猫/京东」等渠道词不再放行
- draft_copy 生成后自校验，不合格最多重试 3 次并注入纠错提示

## Test plan
- [x] pytest copy_alignment / draft_copy / await_copy_confirm (20 passed)
- [ ] CI 全绿后 squash merge
- [ ] 生产复测：乳胶枕/破壁机 copy 应被拦截；耳机 brief 应生成含 lnkpi/耳机 的文案

Made with [Cursor](https://cursor.com)