### PR TITLE
fix(agent): full-chain copy SoT resolution, harness, and graph routes

### DIFF
--- a/apps/web/src/components/agent/agentChipSet.test.ts
+++ b/apps/web/src/components/agent/agentChipSet.test.ts
@@ -25,10 +25,18 @@ describe('detectAgentChipSet', () => {
     ).toBe('copy')
   })
 
-  it('prefers topo when draft also mentions 确认出图', () => {
+  it('prefers copy when draft not yet written even if footer mentions 确认出图', () => {
     expect(
       detectAgentChipSet(
         '【主文案草稿】\n静音\n\n请确认后回复「写入主文案」。拓扑确认无误后回复「确认出图」。',
+      ),
+    ).toBe('copy')
+  })
+
+  it('shows topo after copy written and footer mentions 确认出图', () => {
+    expect(
+      detectAgentChipSet(
+        '【主文案草稿】\n静音\n\n已将确认的主文案写入画布节点。拓扑确认无误后回复「确认出图」。',
       ),
     ).toBe('topo')
   })

--- a/apps/web/src/components/agent/agentChipSet.ts
+++ b/apps/web/src/components/agent/agentChipSet.ts
@@ -63,8 +63,8 @@ export function detectAgentChipSet(
   // 修复 P2-1：优先检查 assistant 是否已回复 confirm/copy/topo 选项
   // 如果已回复，显示对应按钮（即使用户之前输入了 modify intent）
   // 这允许 modify → agent 重新生成 → 新 confirm → 用户确认 的完整流程
+  if (t.includes('【主文案草稿】') && !t.includes('已将确认的主文案写入')) return 'copy'
   if (t.includes('【主文案草稿】') && TOPO_SNIPPETS.some((s) => t.includes(s))) return 'topo'
-  if (COPY_SNIPPETS.some((s) => t.includes(s)) && t.includes('【主文案草稿】')) return 'copy'
   if (TOPO_SNIPPETS.some((s) => t.includes(s))) return 'topo'
   if (COPY_SNIPPETS.some((s) => t.includes(s))) return 'copy'
   if (PLAN_SNIPPETS.some((s) => t.includes(s))) return 'plan'

--- a/services/agent-runtime/app/graph/builder.py
+++ b/services/agent-runtime/app/graph/builder.py
@@ -92,8 +92,16 @@ def route_after_confirm(state: AgentRuntimeState) -> str:
     return "end"
 
 
+def route_after_write_copy(state: AgentRuntimeState) -> str:
+    if state.get("copy_write_blocked"):
+        return "draft_copy"
+    return "await_topo"
+
+
 def route_after_topo(state: AgentRuntimeState) -> str:
     decision = state.get("user_decision") or "none"
+    if decision == "copy_write":
+        return "write_copy_node"
     if decision == "confirm_gen":
         return "start_gen"  # W3: start_gen inits gen state, then gen_scheduler fans out gen_node via Send
     if decision == "topo_revise":
@@ -184,6 +192,7 @@ def build_agent_graph(
             "start_gen": "start_gen",
             "topo_revise": "topo_revise",
             "decide_plan_mode": "decide_plan_mode",
+            "write_copy_node": "write_copy_node",
             "end": END,
         },
     )
@@ -211,7 +220,11 @@ def build_agent_graph(
     )
     # 修复：write_copy_node 后进入拓扑确认门（await_topo），而不是 END。
     # 这样用户确认主文案后，流程继续到拓扑确认门，再「确认出图」进入生图/生视频。
-    graph.add_edge("write_copy_node", "await_topo")
+    graph.add_conditional_edges(
+        "write_copy_node",
+        route_after_write_copy,
+        {"draft_copy": "draft_copy", "await_topo": "await_topo"},
+    )
 
     saver = checkpointer if checkpointer is not None else MemorySaver()
     # W5: 使用 LangGraph 原生 interrupt_before 机制替代 custom awaiting_user flags

--- a/services/agent-runtime/app/graph/copy_sot.py
+++ b/services/agent-runtime/app/graph/copy_sot.py
@@ -1,0 +1,96 @@
+"""Source-of-truth resolution for copy alignment — decoupled from checkpoint gaps."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from app.graph.intent import marketing_intent
+
+
+@dataclass(frozen=True)
+class CopySoT:
+    user_brief: str
+    plan_draft: str
+
+
+def _role(msg: Any) -> str | None:
+    return getattr(msg, "type", None) or (msg.get("role") if isinstance(msg, dict) else None)
+
+
+def _content(msg: Any) -> str:
+    raw = getattr(msg, "content", None) or (msg.get("content") if isinstance(msg, dict) else "")
+    return str(raw or "").strip()
+
+
+def brief_from_messages(messages: list[Any]) -> str:
+    """First substantive marketing user turn — fallback when checkpoint brief is empty."""
+    candidates: list[str] = []
+    for msg in messages or []:
+        if _role(msg) not in ("human", "user"):
+            continue
+        text = _content(msg)
+        if not text or text in ("1", "2", "3"):
+            continue
+        if any(
+            kw in text
+            for kw in ("写入主文案", "确认出图", "确认方案", "确认写入", "采纳推荐")
+        ):
+            continue
+        candidates.append(text)
+    for text in candidates:
+        if marketing_intent(text):
+            return text
+    return candidates[0] if candidates else ""
+
+
+def plan_content_from_node(node: dict[str, Any]) -> str:
+    data = node.get("data")
+    if isinstance(data, dict):
+        for key in ("content", "text", "prompt"):
+            val = str(data.get(key) or "").strip()
+            if len(val) > 15:
+                return val
+    for key in ("content", "text", "prompt"):
+        val = str(node.get(key) or "").strip()
+        if len(val) > 15:
+            return val
+    return ""
+
+
+async def resolve_copy_sot(state: dict, nest: Any | None = None) -> CopySoT:
+    """Resolve brief + plan from state, snapshot fields, messages, and canvas plan node."""
+    brief = str(
+        state.get("user_brief") or state.get("copy_sot_brief") or ""
+    ).strip()
+    plan = str(state.get("plan_draft") or state.get("copy_sot_plan") or "").strip()
+
+    if not brief:
+        brief = brief_from_messages(list(state.get("messages") or []))
+
+    if not plan and nest is not None:
+        plan_node_id = str(state.get("plan_node_id") or "").strip()
+        if plan_node_id:
+            get_node = getattr(nest, "get_node", None)
+            if get_node is not None:
+                try:
+                    node = await get_node(plan_node_id)
+                    plan = plan_content_from_node(node).strip()
+                except Exception:  # noqa: BLE001 — canvas read is best-effort fallback
+                    pass
+
+    return CopySoT(user_brief=brief, plan_draft=plan)
+
+
+def snapshot_copy_sot_fields(state: dict) -> dict[str, str | None]:
+    """Persist SoT snapshot at plan write / split for later copy nodes."""
+    brief = str(state.get("user_brief") or state.get("copy_sot_brief") or "").strip()
+    plan = str(state.get("plan_draft") or state.get("copy_sot_plan") or "").strip()
+    if not brief and not plan:
+        brief = brief_from_messages(list(state.get("messages") or []))
+    out: dict[str, str | None] = {}
+    if brief:
+        out["copy_sot_brief"] = brief
+    if plan:
+        out["copy_sot_plan"] = plan
+    return out

--- a/services/agent-runtime/app/graph/nodes/await_topo.py
+++ b/services/agent-runtime/app/graph/nodes/await_topo.py
@@ -4,6 +4,7 @@ from typing import Any, Callable
 
 from langchain_core.messages import AIMessage
 
+from app.graph.nodes.await_copy_confirm import classify_copy_decision
 from app.graph.intent import classify_topo_decision
 
 # 修复 P0-1（拓扑确认门节点内容修改）：
@@ -35,6 +36,11 @@ def make_await_topo_node() -> Callable:
         # W5: interrupt_before 替代 awaiting_user flag
         # 从 checkpoint 恢复时，state 已包含用户新消息
         text = _latest_user_text(state.get("messages") or [])
+        if classify_copy_decision(text) == "confirm" and state.get("copy_draft"):
+            return {
+                "user_decision": "copy_write",
+                "phase": "await_topo",
+            }
         decision = classify_topo_decision(text)
         if decision == "none":
             return {

--- a/services/agent-runtime/app/graph/nodes/draft_copy.py
+++ b/services/agent-runtime/app/graph/nodes/draft_copy.py
@@ -4,18 +4,28 @@ from typing import Any, Callable
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
-from app.graph.copy_alignment import build_copy_writer_context, validate_copy_alignment
+from app.graph.copy_alignment import (
+    _MAX_COPY_ATTEMPTS,
+    build_copy_writer_context,
+    validate_copy_alignment,
+)
+from app.graph.copy_sot import resolve_copy_sot, snapshot_copy_sot_fields
 
 _COPY_SYSTEM = (
     "你是电商主文案写手。只输出主文案 Markdown 正文，禁止寒暄、禁止解释过程。"
     "必须严格依据【用户需求锚定】与【已确认营销方案】中的产品品类与品牌撰写，"
-    "禁止替换为其他行业或产品（例如用户要耳机时不得写破壁机、乳胶枕、马桶等）。"
+    "禁止替换为其他行业或产品（例如用户要耳机时不得写破壁机、乳胶枕、空气净化器等）。"
     "正文必须包含【必须出现的关键词】中的品牌与产品词。"
 )
 
-_DRAFT_FOOTER = (
-    "\n\n请确认后回复「写入主文案」；如需修改请说明（例如「文案改成更强调节水」）。"
+_DRAFT_FOOTER_OK = (
+    "\n\n请确认后回复「写入主文案」；如需修改请说明（例如「文案改成更强调降噪」）。"
     "拓扑确认无误后回复「确认出图」。"
+)
+
+_DRAFT_FOOTER_BLOCKED = (
+    "\n\n⚠️ 主文案与方案/需求可能不一致，写入画布前会被系统拦截。"
+    "请说明修改意见后我会重新生成，或点「换方向」重开方案。"
 )
 
 
@@ -43,9 +53,11 @@ def make_draft_copy_node(*, nest: Any, llm: Any) -> Callable:
         title = str(item.get("title") or "主文案")
         node_id = str(item.get("node_id") or "") or None
         plan_summary = str(state.get("plan_summary") or "").strip()
-        plan_draft = str(state.get("plan_draft") or "").strip()
-        user_brief = str(state.get("user_brief") or "").strip()
         hint = str(item.get("prompt_hint") or item.get("prompt") or "").strip()
+
+        sot = await resolve_copy_sot(state, nest)
+        user_brief = sot.user_brief
+        plan_draft = sot.plan_draft
 
         user_revision = ""
         if state.get("copy_revise_only") and state.get("messages"):
@@ -60,9 +72,14 @@ def make_draft_copy_node(*, nest: Any, llm: Any) -> Callable:
                     user_revision = str(content)
                     break
 
+        if state.get("copy_write_blocked") and state.get("copy_revise_only") and not user_revision:
+            user_revision = "请严格按方案中的品牌与产品品类重写主文案，禁止换品类。"
+
         draft = ""
         alignment_feedback = ""
-        for attempt in range(3):
+        aligned = False
+        has_sot = bool(user_brief or plan_draft)
+        for attempt in range(_MAX_COPY_ATTEMPTS):
             content = build_copy_writer_context(
                 user_brief=user_brief,
                 plan_draft=plan_draft,
@@ -80,14 +97,19 @@ def make_draft_copy_node(*, nest: Any, llm: Any) -> Callable:
             draft = str(getattr(result, "content", "") or "").strip()
             if not draft:
                 draft = hint or title
+            if not has_sot:
+                aligned = False
+                break
             ok, reason = validate_copy_alignment(user_brief, plan_draft, draft)
-            if ok or (not user_brief and not plan_draft):
+            if ok:
+                aligned = True
                 break
             alignment_feedback = reason or "与方案不一致"
-            if attempt >= 2:
+            if attempt >= _MAX_COPY_ATTEMPTS - 1:
                 break
 
-        body = f"【主文案草稿】\n{draft}{_DRAFT_FOOTER}"
+        footer = _DRAFT_FOOTER_OK if aligned else _DRAFT_FOOTER_BLOCKED
+        body = f"【主文案草稿】\n{draft}{footer}"
         emit = getattr(nest, "emit_text", None)
         if emit is not None:
             await emit(body)
@@ -97,21 +119,22 @@ def make_draft_copy_node(*, nest: Any, llm: Any) -> Callable:
             await emit_upd(
                 id=key,
                 status="needs_user",
-                errorHint="请确认主文案后写入",
+                errorHint="请确认主文案后写入" if aligned else "主文案需修改后再写入",
             )
 
-        was_revise = bool(state.get("copy_revise_only"))
-        out: dict[str, Any] = {
-            "phase": "await_topo",
+        return {
+            "phase": "await_copy_confirm",
             "awaiting_user": True,
             "copy_draft": draft,
             "copy_node_id": node_id,
             "copy_revise_only": False,
+            "copy_write_blocked": False,
+            "copy_alignment_ok": aligned,
             "pending_orchestrate": False,
             "messages": [AIMessage(content=body)],
+            **snapshot_copy_sot_fields(
+                {**state, "user_brief": user_brief, "plan_draft": plan_draft}
+            ),
         }
-        if was_revise:
-            out["phase"] = "await_copy_confirm"
-        return out
 
     return draft_copy

--- a/services/agent-runtime/app/graph/nodes/plan/_shared.py
+++ b/services/agent-runtime/app/graph/nodes/plan/_shared.py
@@ -104,8 +104,43 @@ def manifest_titles(canvas_manifest: dict | None) -> list[str]:
     return titles
 
 
+def plan_product_line(plan_md: str) -> str:
+    """Structured product/brand line from plan tables — preferred over section headings."""
+    text = plan_md or ""
+    for pat in (
+        r"\|\s*产品品类\s*\|\s*([^|\n]+)",
+        r"\|\s*产品类别\s*\|\s*([^|\n]+)",
+        r"\|\s*品牌名称\s*\|\s*([^|\n]+)",
+        r"产品类别\s*[:：]\s*([^\n|]+)",
+        r"产品品类\s*[:：]\s*([^\n|]+)",
+        r"\|\s*目标\s*SKU\s*\|\s*([^|\n]+)",
+    ):
+        m = re.search(pat, text)
+        if m:
+            val = m.group(1).strip()
+            if val and not _is_low_signal_line(val):
+                return val[:120]
+    return ""
+
+
 def summarize(plan_md: str, limit: int = 280) -> str:
-    return positioning_line(plan_md)[:limit]
+    product = plan_product_line(plan_md)
+    brand_m = re.search(
+        r"\|\s*品牌(?:名称)?\s*\|\s*([^|\n]+)|品牌\s*[:：]\s*([A-Za-z0-9\u4e00-\u9fff]+)",
+        plan_md or "",
+    )
+    brand = ""
+    if brand_m:
+        brand = (brand_m.group(1) or brand_m.group(2) or "").strip()
+    if product and brand:
+        line = f"{brand} · {product}"
+    elif product:
+        line = product
+    elif brand:
+        line = brand
+    else:
+        line = positioning_line(plan_md)
+    return line[:limit]
 
 
 def canvas_has_nodes(state: dict) -> bool:

--- a/services/agent-runtime/app/graph/nodes/split.py
+++ b/services/agent-runtime/app/graph/nodes/split.py
@@ -7,6 +7,7 @@ from langchain_core.messages import AIMessage
 
 from app.graph.state import SplitManifestItem
 from app.graph.chain_refs import build_chain_ref_order
+from app.graph.copy_sot import snapshot_copy_sot_fields
 from app.graph.mermaid_topo import manifest_to_mermaid
 from app.graph.topo_trim import trim_manifest_items
 from app.skills.loader import discover_skills, load_skill
@@ -375,6 +376,7 @@ def make_split_node(*, nest: Any, skills_dir: Path) -> Callable:
             "awaiting_user": False,
             "pending_orchestrate": False,
             "messages": [AIMessage(content=split_msg)],
+            **snapshot_copy_sot_fields(state),
         }
 
     return split

--- a/services/agent-runtime/app/graph/nodes/write_copy_node.py
+++ b/services/agent-runtime/app/graph/nodes/write_copy_node.py
@@ -5,6 +5,7 @@ from typing import Any, Callable
 from langchain_core.messages import AIMessage
 
 from app.graph.copy_alignment import validate_copy_alignment
+from app.graph.copy_sot import resolve_copy_sot, snapshot_copy_sot_fields
 
 
 def make_write_copy_node(*, nest: Any) -> Callable:
@@ -18,18 +19,24 @@ def make_write_copy_node(*, nest: Any) -> Callable:
                 "messages": [AIMessage(content="主文案草稿缺失，无法写入节点。")],
             }
 
-        ok, reason = validate_copy_alignment(
-            str(state.get("user_brief") or ""),
-            str(state.get("plan_draft") or ""),
-            draft,
-        )
+        sot = await resolve_copy_sot(state, nest)
+        ok, reason = validate_copy_alignment(sot.user_brief, sot.plan_draft, draft)
         if not ok:
             return {
                 "phase": "await_copy_confirm",
                 "awaiting_user": True,
-                "copy_revise_only": False,
+                "copy_revise_only": True,
+                "copy_write_blocked": True,
+                "copy_alignment_ok": False,
                 "pending_orchestrate": False,
-                "messages": [AIMessage(content=f"⚠️ {reason}")],
+                "messages": [
+                    AIMessage(
+                        content=f"⚠️ {reason}\n正在重新生成主文案，请稍候…"
+                    )
+                ],
+                **snapshot_copy_sot_fields(
+                    {**state, "user_brief": sot.user_brief, "plan_draft": sot.plan_draft}
+                ),
             }
 
         await nest.set_node_content(node_id, draft)
@@ -49,8 +56,15 @@ def make_write_copy_node(*, nest: Any) -> Callable:
             "phase": "await_topo" if stay_topo else "done",
             "awaiting_user": stay_topo,
             "copy_revise_only": False,
+            "copy_write_blocked": False,
+            "copy_alignment_ok": True,
             "pending_orchestrate": False,
-            "messages": [AIMessage(content="已将确认的主文案写入画布节点。可继续改拓扑或回复「确认出图」。")],
+            "messages": [
+                AIMessage(content="已将确认的主文案写入画布节点。可继续改拓扑或回复「确认出图」。")
+            ],
+            **snapshot_copy_sot_fields(
+                {**state, "user_brief": sot.user_brief, "plan_draft": sot.plan_draft}
+            ),
         }
 
     return write_copy_node

--- a/services/agent-runtime/app/graph/nodes/write_plan_node.py
+++ b/services/agent-runtime/app/graph/nodes/write_plan_node.py
@@ -4,6 +4,7 @@ from typing import Any, Callable
 
 from langchain_core.messages import AIMessage
 
+from app.graph.copy_sot import snapshot_copy_sot_fields
 from app.graph.plan_clean import strip_plan_preamble
 
 
@@ -35,6 +36,7 @@ def make_write_plan_node(*, nest: Any) -> Callable:
             "plan_draft": draft,
             "awaiting_user": False,
             "messages": [AIMessage(content=confirmed)],
+            **snapshot_copy_sot_fields({**state, "plan_draft": draft}),
         }
 
     return write_plan_node

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -106,8 +106,14 @@ class AgentRuntimeState(TypedDict, total=False):
     # node_revise: 拓扑确认门下检测到"节点内容修改"意图（改为/调整/增加等），
     # 回退到 plan 走 modify 模式增量修改方案，区别于 topo_revise（纯拓扑删除）
     user_decision: Literal[
-        "none", "confirm", "revise", "confirm_gen", "topo_revise", "node_revise"
+        "none", "confirm", "revise", "confirm_gen", "topo_revise", "node_revise", "copy_write"
     ] | None
+
+    # SoT snapshots — persisted at write_plan / split for copy harness fallbacks
+    copy_sot_brief: str | None
+    copy_sot_plan: str | None
+    copy_alignment_ok: bool | None
+    copy_write_blocked: bool | None
 
     # 修复 P0-1/P0-2/P0-3：brief 锚定 + 修改模式
     # user_brief: 首轮用户需求锚定，后续 plan 必须围绕这个 brief 展开（防止主题漂移）

--- a/services/agent-runtime/tests/test_await_copy_confirm.py
+++ b/services/agent-runtime/tests/test_await_copy_confirm.py
@@ -78,7 +78,8 @@ async def test_write_copy_blocks_misaligned_draft():
     )
     assert nest.calls == []
     assert out["phase"] == "await_copy_confirm"
-    assert "不一致" in out["messages"][0].content
+    assert out.get("copy_write_blocked") is True
+    assert "不一致" in out["messages"][0].content or "重新生成" in out["messages"][0].content
 
 
 @pytest.mark.asyncio

--- a/services/agent-runtime/tests/test_copy_alignment.py
+++ b/services/agent-runtime/tests/test_copy_alignment.py
@@ -7,7 +7,7 @@ from app.graph.copy_alignment import (
     extract_anchor_terms,
     validate_copy_alignment,
 )
-from app.graph.nodes.plan._shared import positioning_line, summarize
+from app.graph.nodes.plan._shared import plan_product_line, positioning_line, summarize
 
 EARPHONE_PLAN = """# lnkpi 蓝牙耳机企业营销方案
 
@@ -44,7 +44,12 @@ def test_positioning_line_skips_section_number_heading():
 
 def test_summarize_uses_substantive_line_for_real_llm_plan():
     summary = summarize(EARPHONE_PLAN)
-    assert "2.1 市场背景" not in summary or "TWS" in summary
+    assert "2.1 市场背景" not in summary or "TWS" in summary or "耳机" in summary
+
+
+def test_plan_product_line_from_table():
+    line = plan_product_line(EARPHONE_PLAN)
+    assert "耳机" in line or "TWS" in line
 
 
 def test_extract_anchor_terms_from_brief_and_plan():

--- a/services/agent-runtime/tests/test_copy_graph_routes.py
+++ b/services/agent-runtime/tests/test_copy_graph_routes.py
@@ -1,0 +1,13 @@
+"""Graph routing tests for copy write loop."""
+
+from app.graph.builder import route_after_topo, route_after_write_copy
+
+
+def test_route_after_write_copy_regens_when_blocked():
+    assert route_after_write_copy({"copy_write_blocked": True}) == "draft_copy"
+    assert route_after_write_copy({"copy_write_blocked": False}) == "await_topo"
+
+
+def test_route_after_topo_copy_write_goes_to_write_node():
+    assert route_after_topo({"user_decision": "copy_write"}) == "write_copy_node"
+    assert route_after_topo({"user_decision": "confirm_gen"}) == "start_gen"

--- a/services/agent-runtime/tests/test_copy_sot.py
+++ b/services/agent-runtime/tests/test_copy_sot.py
@@ -1,0 +1,57 @@
+"""Tests for copy SoT resolution fallbacks."""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from app.graph.copy_sot import (
+    brief_from_messages,
+    plan_content_from_node,
+    resolve_copy_sot,
+    snapshot_copy_sot_fields,
+)
+
+
+def test_brief_from_messages_skips_confirm_tokens():
+    msgs = [
+        HumanMessage(content="请帮我做一个lnkpi蓝牙耳机营销方案"),
+        HumanMessage(content="1"),
+        HumanMessage(content="写入主文案"),
+    ]
+    assert "lnkpi" in brief_from_messages(msgs)
+    assert brief_from_messages(msgs) == "请帮我做一个lnkpi蓝牙耳机营销方案"
+
+
+def test_plan_content_from_node_reads_data_content():
+    node = {"id": "p1", "data": {"content": "# lnkpi 蓝牙耳机方案\nTWS 真无线"}}
+    text = plan_content_from_node(node)
+    assert "蓝牙耳机" in text
+
+
+@pytest.mark.asyncio
+async def test_resolve_copy_sot_falls_back_to_plan_node():
+    class FakeNest:
+        async def get_node(self, node_id: str) -> dict:
+            return {
+                "id": node_id,
+                "data": {"content": "# lnkpi 蓝牙耳机企业营销方案\n| 产品类别 | TWS 耳机 |"},
+            }
+
+    sot = await resolve_copy_sot(
+        {"plan_node_id": "plan-1", "messages": [HumanMessage(content="请帮我做lnkpi耳机方案")]},
+        FakeNest(),
+    )
+    assert "lnkpi" in sot.user_brief.lower() or "耳机" in sot.user_brief
+    assert "蓝牙耳机" in sot.plan_draft or "TWS" in sot.plan_draft
+
+
+def test_snapshot_copy_sot_fields():
+    snap = snapshot_copy_sot_fields(
+        {
+            "user_brief": "请帮我做lnkpi耳机",
+            "plan_draft": "# 方案",
+        }
+    )
+    assert snap["copy_sot_brief"] == "请帮我做lnkpi耳机"
+    assert snap["copy_sot_plan"] == "# 方案"

--- a/services/agent-runtime/tests/test_draft_copy.py
+++ b/services/agent-runtime/tests/test_draft_copy.py
@@ -30,6 +30,9 @@ class FakeNest:
     async def emit_task_update(self, **payload: Any) -> None:
         self.calls.append(("emit_task_update", payload))
 
+    async def get_node(self, node_id: str) -> dict:
+        return {"data": {"content": ""}}
+
 
 @pytest.mark.asyncio
 async def test_draft_copy_sets_gate_and_needs_user():
@@ -55,7 +58,7 @@ async def test_draft_copy_sets_gate_and_needs_user():
             "plan_summary": "卫生洁具方案",
         }
     )
-    assert out["phase"] == "await_topo"
+    assert out["phase"] == "await_copy_confirm"
     assert out["awaiting_user"] is True
     assert out["copy_node_id"] == "t1"
     assert out["pending_orchestrate"] is False


### PR DESCRIPTION
## Summary
- **Graph**: 新增 `copy_sot` 解析层（state → snapshot → messages → canvas plan 节点）；`write_copy` 失败自动 regen；`await_topo` 支持「写入主文案」路由
- **Context**: `plan_product_line` 结构化摘要；`draft_copy` phase 固定为 `await_copy_confirm`
- **Harness**: draft/write 双节点均用 resolved SoT 校验；写入 blocked 触发 loop
- **Frontend**: chip 优先 copy（未写入前），避免 topo 按钮误路由

## Test plan
- [x] pytest copy_sot / copy_alignment / copy_graph_routes / draft_copy / await_copy_confirm (27 passed)
- [x] vitest agentChipSet (12 passed)
- [ ] CI 全绿后 squash merge
- [ ] 生产复测

Made with [Cursor](https://cursor.com)