### PR TITLE
fix(agent): guard canvas ownership before agent writes

### DIFF
--- a/apps/server/src/agent/agent.controller.ts
+++ b/apps/server/src/agent/agent.controller.ts
@@ -1,8 +1,23 @@
-import { Body, Controller, Get, Inject, Post, Query, Req, Res, UseGuards } from '@nestjs/common'
+import {
+  Body,
+  Controller,
+  ForbiddenException,
+  Get,
+  Inject,
+  Post,
+  Query,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common'
 import { IsIn, IsOptional, IsString } from 'class-validator'
 import type { Request, Response } from 'express'
 import { AuthGuard } from '../auth/auth.guard'
+import { SessionsService } from '../sessions/sessions.service'
 import { AgentService } from './agent.service'
+
+const SESSION_FORBIDDEN_HINT =
+  '⚠️ 此画布不属于当前账号，无法写入。请返回工作台新建画布，或使用画布所有者账号登录。'
 
 class ConversationDto {
   @IsString()
@@ -34,7 +49,10 @@ class OptimizePromptDto {
 
 @Controller('agent')
 export class AgentController {
-  constructor(@Inject(AgentService) private readonly agentService: AgentService) {}
+  constructor(
+    @Inject(AgentService) private readonly agentService: AgentService,
+    @Inject(SessionsService) private readonly sessionsService: SessionsService,
+  ) {}
 
   @Get('capabilities/list')
   getCapabilities() {
@@ -86,6 +104,20 @@ export class AgentController {
         res.end()
         return
       }
+    }
+
+    try {
+      await this.sessionsService.findOne(dto.sessionId, req.user.sub)
+    } catch (err) {
+      if (err instanceof ForbiddenException) {
+        res.write(
+          `data: ${JSON.stringify({ type: 'text_delta', data: { text: SESSION_FORBIDDEN_HINT } })}\n\n`,
+        )
+        res.write('data: [DONE]\n\n')
+        res.end()
+        return
+      }
+      throw err
     }
 
     try {

--- a/apps/server/src/agent/agent.module.ts
+++ b/apps/server/src/agent/agent.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common'
 import { CanvasModule } from '../canvas/canvas.module'
+import { SessionsModule } from '../sessions/sessions.module'
 import { StudioModule } from '../studio/studio.module'
 import { AgentCanvasToolsController } from './agent-canvas-tools.controller'
 import { AgentCanvasToolsService } from './agent-canvas-tools.service'
@@ -8,7 +9,7 @@ import { AgentInternalGuard } from './agent-internal.guard'
 import { AgentService } from './agent.service'
 
 @Module({
-  imports: [CanvasModule, StudioModule],
+  imports: [CanvasModule, SessionsModule, StudioModule],
   controllers: [AgentController, AgentCanvasToolsController],
   providers: [AgentService, AgentCanvasToolsService, AgentInternalGuard],
   exports: [AgentService, AgentCanvasToolsService],

--- a/apps/server/src/sessions/sessions.service.ts
+++ b/apps/server/src/sessions/sessions.service.ts
@@ -42,7 +42,9 @@ export class SessionsService {
   async findOne(id: string, userId?: string) {
     const session = await this.prisma.session.findUnique({ where: { id } })
     if (!session) throw new NotFoundException('会话不存在')
-    if (userId && session.userId !== userId) throw new ForbiddenException()
+    if (userId && session.userId !== userId) {
+      throw new ForbiddenException('此画布不属于当前账号')
+    }
     return this.formatSession(session)
   }
 

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { computed, ref, onMounted, nextTick, watch } from 'vue'
+import { useRouter } from 'vue-router'
 import { useAgentStore } from '@/stores/agent'
 import { useAuthStore } from '@/stores/auth'
 import { apiUrl } from '@/services/api-base'
+import { sessionsApi } from '@/services/sessions-api'
 import NeoAgentLogo from '@/components/agent/NeoAgentLogo.vue'
 import AgentTaskProgressCard from '@/components/agent/AgentTaskProgressCard.vue'
 import {
@@ -36,6 +38,8 @@ import { useClickOutside } from '@/composables/useClickOutside'
 
 const props = defineProps<{
   sessionId: string
+  /** 当前登录用户非画布所有者时为 true，禁止 Agent 写入画布 */
+  readOnly?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -48,6 +52,7 @@ const emit = defineEmits<{
 
 const agent = useAgentStore()
 const auth = useAuthStore()
+const router = useRouter()
 const input = ref('')
 const chatContainer = ref<HTMLElement>()
 
@@ -283,7 +288,35 @@ function mapPresetToDecision(text: string): 'confirm' | 'revise' | undefined {
   return undefined
 }
 
+function goToWorkflowHome() {
+  void router.push('/workflow')
+}
+
+async function createOwnCanvas() {
+  if (!auth.isLoggedIn) {
+    auth.openLogin()
+    return
+  }
+  try {
+    const { data } = await sessionsApi.create({ title: '我的画布' })
+    void router.push(`/workflow/${data.data.id}`)
+  } catch {
+    goToWorkflowHome()
+  }
+}
+
 async function sendMessage(message: string, userDecision?: 'confirm' | 'revise') {
+  if (props.readOnly) {
+    agent.addUserMessage(message)
+    agent.startAssistantMessage()
+    agent.appendText(
+      '⚠️ 此画布不属于当前账号，无法写入。请返回工作台新建画布，或使用画布所有者账号登录。',
+    )
+    agent.finishStreaming()
+    await nextTick()
+    scrollToBottom()
+    return
+  }
   agent.addUserMessage(message)
   agent.isStreaming = true
   agent.startAssistantMessage()
@@ -625,6 +658,22 @@ defineExpose({ openPanel, reconcileFromNodes })
             </div>
           </div>
 
+          <div
+            v-if="readOnly"
+            class="agent-readonly-banner mx-3 mt-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2.5 text-[11px] leading-relaxed text-amber-100"
+          >
+            <p>此画布属于其他账号，Agent 无法写入节点。</p>
+            <p class="mt-1 opacity-80">请新建自己的画布，或使用画布所有者账号登录。</p>
+            <div class="mt-2.5 flex flex-wrap gap-2">
+              <button type="button" class="agent-readonly-btn" @click="goToWorkflowHome">
+                返回工作台
+              </button>
+              <button type="button" class="agent-readonly-btn agent-readonly-btn-primary" @click="createOwnCanvas">
+                新建画布
+              </button>
+            </div>
+          </div>
+
           <!-- 消息列表 -->
           <div ref="chatContainer" class="min-h-0 flex-1 overflow-y-auto space-y-3 px-3 py-3">
             <div v-if="!agent.messages.length" class="agent-empty py-10 text-center">
@@ -923,6 +972,32 @@ defineExpose({ openPanel, reconcileFromNodes })
 .agent-head-btn.is-active {
   background: var(--neo-accent-soft);
   color: var(--neo-accent-text);
+}
+
+.agent-readonly-btn {
+  border-radius: 8px;
+  border: 1px solid rgba(251, 191, 36, 0.35);
+  background: rgba(0, 0, 0, 0.15);
+  padding: 4px 10px;
+  font-size: 11px;
+  line-height: 1.4;
+  color: rgb(254, 243, 199);
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.agent-readonly-btn:hover {
+  background: rgba(251, 191, 36, 0.12);
+  border-color: rgba(251, 191, 36, 0.55);
+}
+
+.agent-readonly-btn-primary {
+  border-color: rgba(251, 191, 36, 0.55);
+  background: rgba(251, 191, 36, 0.18);
+  color: rgb(255, 251, 235);
+}
+
+.agent-readonly-btn-primary:hover {
+  background: rgba(251, 191, 36, 0.28);
 }
 
 /* ---- 消息气泡 ---- */

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -196,6 +196,10 @@ const {
   selectedNodeId,
 } = useSelectedNodeEditor(nodes)
 const sessionTitle = ref('未命名画布')
+const sessionOwnerId = ref<string | null>(null)
+const agentReadOnly = computed(
+  () => !!auth.user?.id && !!sessionOwnerId.value && auth.user.id !== sessionOwnerId.value,
+)
 const saving = ref(false)
 const canvasMode = ref<'vueflow' | 'playcanvas'>('vueflow')
 const showStoryboard = ref(false)
@@ -2309,10 +2313,14 @@ function hydrateCanvasEdges(
 
 async function loadSession() {
   try {
-    const { data } = await api.get<{ data: { title: string; canvasData?: { nodes: Node[]; edges: Edge[] } } }>(
+    const { data } = await api.get<{ data: { title: string; userId?: string; canvasData?: { nodes: Node[]; edges: Edge[] } } }>(
       `/sessions/${sessionId.value}`,
     )
     sessionTitle.value = data.data.title
+    sessionOwnerId.value = data.data.userId ?? null
+    if (agentReadOnly.value) {
+      ElMessage.warning('此画布属于其他账号，Agent 无法写入画布')
+    }
     if (data.data.canvasData?.nodes?.length) {
       const serverNodes = data.data.canvasData.nodes as EditableFlowNode[]
       nodes.value = (
@@ -2718,6 +2726,7 @@ onMounted(() => {
       <AgentSideRail
         ref="agentRailRef"
         :session-id="sessionId"
+        :read-only="agentReadOnly"
         @canvas-actions="handleAgentActions"
         @turn-complete="handleAgentTurnComplete"
         @focus-node="focusNodeById"


### PR DESCRIPTION
## Summary
- Agent 对话开始前校验画布归属，非 owner 返回中文提示（不再暴露内部 403 URL）
- 前端检测非 owner 时 Agent 侧栏只读，并提供「返回工作台」「新建画布」快捷按钮

## Test plan
- [x] pnpm build
- [x] vitest agent.service.test.ts (14 passed)
- [ ] 生产：用非 owner 账号打开他人画布链接，确认侧栏警告 + 按钮可用
- [ ] 生产：owner 账号确认方案正常写入


Made with [Cursor](https://cursor.com)