### PR TITLE
feat(agent): W8 canvas stage/commit for modify-mode topology

### DIFF
--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -147,6 +147,8 @@ model Session {
   userId        String
   user          User           @relation(fields: [userId], references: [id])
   canvasData    String?
+  stagedActions String?
+  stagedAt      DateTime?
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
   works         Work[]

--- a/apps/server/src/agent/agent-canvas-tools.controller.ts
+++ b/apps/server/src/agent/agent-canvas-tools.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Inject, Post, UseGuards } from '@nestjs/common'
-import { IsArray, IsOptional, IsString, ValidateNested } from 'class-validator'
+import { IsArray, IsBoolean, IsOptional, IsString, ValidateNested } from 'class-validator'
 import { Type } from 'class-transformer'
 import { AgentCanvasToolsService } from './agent-canvas-tools.service'
 import { AgentInternalGuard } from './agent-internal.guard'
@@ -67,6 +67,10 @@ class AddNodesBatchDto {
   @ValidateNested({ each: true })
   @Type(() => BatchNodeItemDto)
   items!: BatchNodeItemDto[]
+
+  @IsOptional()
+  @IsBoolean()
+  stage?: boolean
 }
 
 class EdgeDto {
@@ -85,6 +89,10 @@ class ConnectNodesDto {
   @ValidateNested({ each: true })
   @Type(() => EdgeDto)
   edges!: EdgeDto[]
+
+  @IsOptional()
+  @IsBoolean()
+  stage?: boolean
 }
 
 // W31: Remove nodes DTO
@@ -121,6 +129,10 @@ class SetNodePromptDto {
   @IsOptional()
   @IsString()
   title?: string
+
+  @IsOptional()
+  @IsBoolean()
+  stage?: boolean
 }
 
 class SetNodeContentDto {
@@ -206,6 +218,24 @@ class ReleaseThreadLockDto {
 
   @IsString()
   holderId!: string
+}
+
+class StageCanvasActionsDto {
+  @IsString()
+  sessionId!: string
+
+  @IsArray()
+  actions!: unknown[]
+}
+
+class CommitStageDto {
+  @IsString()
+  sessionId!: string
+}
+
+class RollbackStageDto {
+  @IsString()
+  sessionId!: string
 }
 
 // W15: Generation progress DTOs
@@ -351,6 +381,27 @@ export class AgentCanvasToolsController {
   @Post('release-thread-lock')
   async releaseThreadLock(@Body() dto: ReleaseThreadLockDto) {
     const data = await this.tools.releaseThreadLock(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('stage-canvas-actions')
+  async stageCanvasActions(@Body() dto: StageCanvasActionsDto) {
+    const data = await this.tools.stageCanvasActions({
+      sessionId: dto.sessionId,
+      actions: dto.actions as any,
+    })
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('commit-stage')
+  async commitStage(@Body() dto: CommitStageDto) {
+    const data = await this.tools.commitStage(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('rollback-stage')
+  async rollbackStage(@Body() dto: RollbackStageDto) {
+    const data = await this.tools.rollbackStage(dto)
     return { code: 0, message: 'ok', data }
   }
 

--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common'
+import { ConflictException, ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common'
 import { applyCanvasActions } from '@lnkpi/agent'
 import {
   resolveNodeRefs,
@@ -15,6 +15,7 @@ const GRID_X = 280
 const GRID_Y = 220
 const DEFAULT_POLL_INTERVAL_MS = 1500
 const DEFAULT_POLL_TIMEOUT_MS = 180_000
+const STAGE_TTL_MS = 30 * 60 * 1000
 
 let nodeSeq = 0
 
@@ -37,6 +38,16 @@ function parseCanvas(raw: string | null | undefined): CanvasData {
     }
   } catch {
     return { nodes: [], edges: [] }
+  }
+}
+
+function parseStagedActions(raw: string | null | undefined): CanvasAction[] {
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? (parsed as CanvasAction[]) : []
+  } catch {
+    return []
   }
 }
 
@@ -269,6 +280,7 @@ export class AgentCanvasToolsService {
       prompt?: string
       position?: { x: number; y: number }
     }>
+    stage?: boolean
   }): Promise<{ nodes: Array<{ key: string; nodeId: string }>; actions: CanvasAction[] }> {
     const { canvas } = await this.loadOwnedSession(input.sessionId, input.userId)
     const prefs = await this.loadAccountGenPrefs(input.userId)
@@ -305,13 +317,14 @@ export class AgentCanvasToolsService {
       mapping.push({ key: item.key, nodeId })
     }
 
-    await this.persist(input.sessionId, actions)
+    await this.applyOrStage(input.sessionId, actions, input.stage)
     return { nodes: mapping, actions }
   }
 
   async connectNodes(input: {
     sessionId: string
     edges: Array<{ source: string; target: string }>
+    stage?: boolean
   }): Promise<{ actions: CanvasAction[] }> {
     const { canvas } = await this.loadSession(input.sessionId)
     const actions: CanvasAction[] = []
@@ -331,7 +344,7 @@ export class AgentCanvasToolsService {
       })
     }
 
-    await this.persist(input.sessionId, actions)
+    await this.applyOrStage(input.sessionId, actions, input.stage)
     return { actions }
   }
 
@@ -396,6 +409,7 @@ export class AgentCanvasToolsService {
     nodeId: string
     prompt: string
     title?: string
+    stage?: boolean
   }): Promise<{ actions: CanvasAction[] }> {
     const { canvas } = await this.loadSession(input.sessionId)
     if (!canvas.nodes.some((n) => n.id === input.nodeId)) {
@@ -412,7 +426,7 @@ export class AgentCanvasToolsService {
         payload: { id: input.nodeId, data },
       },
     ]
-    await this.persist(input.sessionId, actions)
+    await this.applyOrStage(input.sessionId, actions, input.stage)
     return { actions }
   }
 
@@ -950,6 +964,102 @@ export class AgentCanvasToolsService {
   }
 
   /**
+   * W8: Accumulate canvas actions in stagedActions without applying to canvasData.
+   */
+  async stageCanvasActions(input: {
+    sessionId: string
+    actions: CanvasAction[]
+  }): Promise<{ stagedCount: number }> {
+    if (input.actions.length === 0) {
+      const session = await this.prisma.session.findUnique({ where: { id: input.sessionId } })
+      if (!session) throw new NotFoundException('会话不存在')
+      const staged = parseStagedActions(session.stagedActions)
+      return { stagedCount: staged.length }
+    }
+    await this.expireStaleStage(input.sessionId)
+    const now = new Date()
+    await this.prisma.$transaction(async (tx) => {
+      const session = await tx.session.findUnique({
+        where: { id: input.sessionId },
+        select: { stagedActions: true },
+      })
+      if (!session) throw new NotFoundException('会话不存在')
+      const merged = [...parseStagedActions(session.stagedActions), ...input.actions]
+      await tx.session.update({
+        where: { id: input.sessionId },
+        data: { stagedActions: JSON.stringify(merged), stagedAt: now },
+      })
+    })
+    return { stagedCount: input.actions.length }
+  }
+
+  /** W8: Apply staged actions atomically and clear the stage. */
+  async commitStage(input: { sessionId: string }): Promise<{ actions: CanvasAction[] }> {
+    await this.expireStaleStage(input.sessionId)
+    return this.prisma.$transaction(async (tx) => {
+      const session = await tx.session.findUnique({
+        where: { id: input.sessionId },
+        select: { canvasData: true, stagedActions: true },
+      })
+      if (!session) throw new NotFoundException('会话不存在')
+      const staged = parseStagedActions(session.stagedActions)
+      if (staged.length === 0) return { actions: [] }
+      const current = parseCanvas(session.canvasData)
+      const updated = applyCanvasActions(current, staged)
+      await tx.session.update({
+        where: { id: input.sessionId },
+        data: {
+          canvasData: JSON.stringify(updated),
+          stagedActions: null,
+          stagedAt: null,
+        },
+      })
+      return { actions: staged }
+    })
+  }
+
+  /** W8: Discard staged actions without touching canvasData. */
+  async rollbackStage(input: { sessionId: string }): Promise<{ cleared: boolean }> {
+    const session = await this.prisma.session.findUnique({
+      where: { id: input.sessionId },
+      select: { stagedActions: true },
+    })
+    if (!session) throw new NotFoundException('会话不存在')
+    if (!session.stagedActions) return { cleared: false }
+    await this.prisma.session.update({
+      where: { id: input.sessionId },
+      data: { stagedActions: null, stagedAt: null },
+    })
+    return { cleared: true }
+  }
+
+  private async expireStaleStage(sessionId: string): Promise<void> {
+    const session = await this.prisma.session.findUnique({
+      where: { id: sessionId },
+      select: { stagedActions: true, stagedAt: true },
+    })
+    if (!session?.stagedActions || !session.stagedAt) return
+    if (Date.now() - session.stagedAt.getTime() <= STAGE_TTL_MS) return
+    await this.prisma.session.update({
+      where: { id: sessionId },
+      data: { stagedActions: null, stagedAt: null },
+    })
+  }
+
+  private async applyOrStage(
+    sessionId: string,
+    actions: CanvasAction[],
+    stage?: boolean,
+  ): Promise<void> {
+    if (actions.length === 0) return
+    if (stage) {
+      await this.stageCanvasActions({ sessionId, actions })
+      return
+    }
+    await this.persist(sessionId, actions)
+  }
+
+  /**
    * Atomic canvas patch — re-reads canvasData inside a Prisma transaction so
    * concurrent calls on the same session never lose each other's updates.
    *
@@ -966,6 +1076,7 @@ export class AgentCanvasToolsService {
     sessionId: string,
     actions: CanvasAction[],
   ): Promise<CanvasData> {
+    await this.expireStaleStage(sessionId)
     if (actions.length === 0) {
       // Dedup-to-empty fast path (e.g. connectNodes with all edges already
       // present). Skip the transaction and just return the current canvas.
@@ -974,13 +1085,16 @@ export class AgentCanvasToolsService {
       return parseCanvas(session.canvasData)
     }
     return this.prisma.$transaction(async (tx) => {
-      // Re-read inside the TX so concurrent persist() calls compose correctly
-      // rather than clobbering each other with stale in-memory snapshots.
       const session = await tx.session.findUnique({
         where: { id: sessionId },
-        select: { canvasData: true },
+        select: { canvasData: true, stagedActions: true },
       })
       if (!session) throw new NotFoundException('会话不存在')
+      if (session.stagedActions) {
+        throw new ConflictException(
+          'Canvas has staged actions pending commit; call commitStage or rollbackStage first',
+        )
+      }
       const current = parseCanvas(session.canvasData)
       const updated = applyCanvasActions(current, actions)
       await tx.session.update({

--- a/packages/shared/src/agentContract.ts
+++ b/packages/shared/src/agentContract.ts
@@ -96,6 +96,7 @@ export const AddNodesBatchRequestSchema = z.object({
   sessionId: z.string(),
   userId: z.string(),
   items: z.array(AddNodesBatchItemSchema),
+  stage: z.boolean().optional(),
 })
 
 export type AddNodesBatchRequest = z.infer<typeof AddNodesBatchRequestSchema>
@@ -126,6 +127,7 @@ export type ConnectNodesEdge = z.infer<typeof ConnectNodesEdgeSchema>
 export const ConnectNodesRequestSchema = z.object({
   sessionId: z.string(),
   edges: z.array(ConnectNodesEdgeSchema),
+  stage: z.boolean().optional(),
 })
 
 export type ConnectNodesRequest = z.infer<typeof ConnectNodesRequestSchema>
@@ -145,6 +147,7 @@ export const SetNodePromptRequestSchema = z.object({
   nodeId: z.string(),
   prompt: z.string(),
   title: z.string().optional(),
+  stage: z.boolean().optional(),
 })
 
 export type SetNodePromptRequest = z.infer<typeof SetNodePromptRequestSchema>
@@ -372,6 +375,47 @@ export const ReleaseThreadLockResponseSchema = z.object({
 })
 
 export type ReleaseThreadLockResponse = z.infer<typeof ReleaseThreadLockResponseSchema>
+
+// ============================================================
+// canvas_stage (W8)
+// ============================================================
+
+export const StageCanvasActionsRequestSchema = z.object({
+  sessionId: z.string(),
+  actions: z.array(CanvasActionSchema),
+})
+
+export type StageCanvasActionsRequest = z.infer<typeof StageCanvasActionsRequestSchema>
+
+export const StageCanvasActionsResponseSchema = z.object({
+  stagedCount: z.number(),
+})
+
+export type StageCanvasActionsResponse = z.infer<typeof StageCanvasActionsResponseSchema>
+
+export const CommitStageRequestSchema = z.object({
+  sessionId: z.string(),
+})
+
+export type CommitStageRequest = z.infer<typeof CommitStageRequestSchema>
+
+export const CommitStageResponseSchema = z.object({
+  actions: z.array(CanvasActionSchema),
+})
+
+export type CommitStageResponse = z.infer<typeof CommitStageResponseSchema>
+
+export const RollbackStageRequestSchema = z.object({
+  sessionId: z.string(),
+})
+
+export type RollbackStageRequest = z.infer<typeof RollbackStageRequestSchema>
+
+export const RollbackStageResponseSchema = z.object({
+  cleared: z.boolean(),
+})
+
+export type RollbackStageResponse = z.infer<typeof RollbackStageResponseSchema>
 
 // ============================================================
 // gen_progress (W15)

--- a/scripts/verify-contract.ts
+++ b/scripts/verify-contract.ts
@@ -57,6 +57,12 @@ import {
   GetGenProgressResponseSchema,
   SaveGenProgressRequestSchema,
   SaveGenProgressResponseSchema,
+  StageCanvasActionsRequestSchema,
+  StageCanvasActionsResponseSchema,
+  CommitStageRequestSchema,
+  CommitStageResponseSchema,
+  RollbackStageRequestSchema,
+  RollbackStageResponseSchema,
 } from '../packages/shared/src/agentContract'
 
 interface ContractMapping {
@@ -132,6 +138,18 @@ const CONTRACTS: Record<string, { request: ContractMapping; response: ContractMa
   release_thread_lock: {
     request: { tsSchema: ReleaseThreadLockRequestSchema, pyModel: 'ReleaseThreadLockRequest' },
     response: { tsSchema: ReleaseThreadLockResponseSchema, pyModel: 'ReleaseThreadLockResponse' },
+  },
+  stage_canvas_actions: {
+    request: { tsSchema: StageCanvasActionsRequestSchema, pyModel: 'StageCanvasActionsRequest' },
+    response: { tsSchema: StageCanvasActionsResponseSchema, pyModel: 'StageCanvasActionsResponse' },
+  },
+  commit_stage: {
+    request: { tsSchema: CommitStageRequestSchema, pyModel: 'CommitStageRequest' },
+    response: { tsSchema: CommitStageResponseSchema, pyModel: 'CommitStageResponse' },
+  },
+  rollback_stage: {
+    request: { tsSchema: RollbackStageRequestSchema, pyModel: 'RollbackStageRequest' },
+    response: { tsSchema: RollbackStageResponseSchema, pyModel: 'RollbackStageResponse' },
   },
   get_gen_progress: {
     request: { tsSchema: GetGenProgressRequestSchema, pyModel: 'GetGenProgressRequest' },

--- a/services/agent-runtime/app/contract.py
+++ b/services/agent-runtime/app/contract.py
@@ -111,6 +111,7 @@ class AddNodesBatchRequest(BaseModel):
     sessionId: str
     userId: str
     items: list[AddNodesBatchItem]
+    stage: Optional[bool] = None
 
 
 class AddNodesBatchResponseNode(BaseModel):
@@ -144,6 +145,7 @@ class ConnectNodesRequest(BaseModel):
 
     sessionId: str
     edges: list[ConnectNodesEdge]
+    stage: Optional[bool] = None
 
 
 class ConnectNodesResponse(BaseModel):
@@ -164,6 +166,7 @@ class SetNodePromptRequest(BaseModel):
     nodeId: str
     prompt: str
     title: Optional[str] = None
+    stage: Optional[bool] = None
 
 
 class SetNodePromptResponse(BaseModel):
@@ -397,6 +400,48 @@ class ReleaseThreadLockResponse(BaseModel):
     """Response for release_thread_lock endpoint."""
 
     released: bool
+
+
+# ============================================================
+# canvas_stage (W8)
+# ============================================================
+
+
+class StageCanvasActionsRequest(BaseModel):
+    """Request for stage_canvas_actions endpoint."""
+
+    sessionId: str
+    actions: list[CanvasAction]
+
+
+class StageCanvasActionsResponse(BaseModel):
+    """Response for stage_canvas_actions endpoint."""
+
+    stagedCount: int
+
+
+class CommitStageRequest(BaseModel):
+    """Request for commit_stage endpoint."""
+
+    sessionId: str
+
+
+class CommitStageResponse(BaseModel):
+    """Response for commit_stage endpoint."""
+
+    actions: list[CanvasAction]
+
+
+class RollbackStageRequest(BaseModel):
+    """Request for rollback_stage endpoint."""
+
+    sessionId: str
+
+
+class RollbackStageResponse(BaseModel):
+    """Response for rollback_stage endpoint."""
+
+    cleared: bool
 
 
 # ============================================================

--- a/services/agent-runtime/app/graph/nodes/split.py
+++ b/services/agent-runtime/app/graph/nodes/split.py
@@ -144,7 +144,7 @@ async def _apply_modify_split(nest: Any, state: dict, plan_node_id: str) -> dict
             title = str(op.get("title") or key)
             prompt_hint = str(op.get("prompt_hint") or "")
             try:
-                await nest.set_node_prompt(node_id, prompt_hint, title=title)
+                await nest.set_node_prompt(node_id, prompt_hint, title=title, stage=True)
             except Exception:  # noqa: BLE001
                 pass
             # 同步更新 split_manifest 内存副本
@@ -169,7 +169,7 @@ async def _apply_modify_split(nest: Any, state: dict, plan_node_id: str) -> dict
     # 批量新增节点
     if new_items_for_batch:
         try:
-            batch = await nest.add_nodes_batch(new_items_for_batch)
+            batch = await nest.add_nodes_batch(new_items_for_batch, stage=True)
             for n in batch.get("nodes") or []:
                 k = str(n.get("key") or "")
                 nid = str(n.get("nodeId") or "")
@@ -204,7 +204,7 @@ async def _apply_modify_split(nest: Any, state: dict, plan_node_id: str) -> dict
                 edges.append({"source": dep_id, "target": nid})
     if edges:
         try:
-            await nest.connect_nodes(edges)
+            await nest.connect_nodes(edges, stage=True)
         except Exception:  # noqa: BLE001
             pass
 

--- a/services/agent-runtime/app/graph/nodes/start_gen.py
+++ b/services/agent-runtime/app/graph/nodes/start_gen.py
@@ -15,10 +15,17 @@ from langchain_core.messages import AIMessage
 from app.graph.topo import topo_sort_gen_keys
 
 
-def make_start_gen_node(*, max_concurrency: int = 3) -> Callable:
+def make_start_gen_node(*, nest: Any = None, max_concurrency: int = 3) -> Callable:
     """Create start_gen node. ``max_concurrency`` caps parallel gen_node per superstep."""
 
     async def start_gen(state: dict) -> dict:
+        commit_fn = getattr(nest, "commit_stage", None) if nest is not None else None
+        if commit_fn is not None:
+            try:
+                await commit_fn()
+            except Exception:  # noqa: BLE001
+                pass
+
         manifest = list(state.get("split_manifest") or [])
         if not manifest:
             return {

--- a/services/agent-runtime/app/graph/subgraphs/topo_gate.py
+++ b/services/agent-runtime/app/graph/subgraphs/topo_gate.py
@@ -31,7 +31,7 @@ def route_after_topo(state: AgentRuntimeState) -> str:
 def register_topo_gate(graph: StateGraph, *, nest: Any) -> None:
     graph.add_node("await_topo", make_await_topo_node())
     graph.add_node("topo_revise", make_topo_revise_node(nest=nest))
-    graph.add_node("start_gen", make_start_gen_node())
+    graph.add_node("start_gen", make_start_gen_node(nest=nest))
     graph.add_node("gen_scheduler", make_gen_scheduler_node())
     graph.add_node("gen_node", make_gen_node(nest=nest))
     graph.add_node("collect_gen", make_collect_gen_node(nest=nest))

--- a/services/agent-runtime/app/tools/nest_client.py
+++ b/services/agent-runtime/app/tools/nest_client.py
@@ -91,17 +91,25 @@ class NestCanvasClient:
             {"sessionId": self._session_id, "nodeId": node_id},
         )
 
-    async def add_nodes_batch(self, items: list[dict[str, Any]]) -> dict[str, Any]:
-        return await self._post(
-            "/agent/internal/add-nodes-batch",
-            {"sessionId": self._session_id, "userId": self._user_id, "items": items},
-        )
+    async def add_nodes_batch(
+        self, items: list[dict[str, Any]], *, stage: bool = False
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "sessionId": self._session_id,
+            "userId": self._user_id,
+            "items": items,
+        }
+        if stage:
+            body["stage"] = True
+        return await self._post("/agent/internal/add-nodes-batch", body)
 
-    async def connect_nodes(self, edges: list[dict[str, Any]]) -> dict[str, Any]:
-        return await self._post(
-            "/agent/internal/connect-nodes",
-            {"sessionId": self._session_id, "edges": edges},
-        )
+    async def connect_nodes(
+        self, edges: list[dict[str, Any]], *, stage: bool = False
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {"sessionId": self._session_id, "edges": edges}
+        if stage:
+            body["stage"] = True
+        return await self._post("/agent/internal/connect-nodes", body)
 
     async def remove_nodes(self, node_ids: list[str]) -> dict[str, Any]:
         """W31: Remove nodes and their associated edges."""
@@ -118,7 +126,7 @@ class NestCanvasClient:
         )
 
     async def set_node_prompt(
-        self, node_id: str, prompt: str, *, title: str | None = None
+        self, node_id: str, prompt: str, *, title: str | None = None, stage: bool = False
     ) -> dict[str, Any]:
         body: dict[str, Any] = {
             "sessionId": self._session_id,
@@ -128,6 +136,8 @@ class NestCanvasClient:
         # P0 修复：modify 模式 upsert 节点时同时更新标题（Nest 端可选字段）
         if title:
             body["title"] = title
+        if stage:
+            body["stage"] = True
         return await self._post("/agent/internal/set-node-prompt", body)
 
     async def set_node_content(self, node_id: str, content: str) -> dict[str, Any]:
@@ -242,4 +252,22 @@ class NestCanvasClient:
                 "lines": lines,
                 "summary": summary,
             },
+        )
+
+    async def stage_canvas_actions(self, actions: list[dict[str, Any]]) -> dict[str, Any]:
+        return await self._post(
+            "/agent/internal/stage-canvas-actions",
+            {"sessionId": self._session_id, "actions": actions},
+        )
+
+    async def commit_stage(self) -> dict[str, Any]:
+        return await self._post(
+            "/agent/internal/commit-stage",
+            {"sessionId": self._session_id},
+        )
+
+    async def rollback_stage(self) -> dict[str, Any]:
+        return await self._post(
+            "/agent/internal/rollback-stage",
+            {"sessionId": self._session_id},
         )

--- a/services/agent-runtime/tests/test_await_topo.py
+++ b/services/agent-runtime/tests/test_await_topo.py
@@ -198,7 +198,7 @@ async def test_node_revise_full_flow_updates_canvas():
             self.calls.append(("set_node_prompt", {"node_id": node_id, "prompt": prompt, **kwargs}))
             return {"nodeId": node_id, "actions": []}
 
-        async def add_nodes_batch(self, items: list[dict[str, Any]]) -> dict[str, Any]:
+        async def add_nodes_batch(self, items: list[dict[str, Any]], **kwargs: Any) -> dict[str, Any]:
             self.calls.append(("add_nodes_batch", items))
             # 模拟新节点创建返回 nodeId
             return {"nodes": [{"key": it["key"], "nodeId": f"new-{it['key']}"} for it in items]}


### PR DESCRIPTION
## Summary
- 为 modify 模式拓扑变更引入 canvas stage/commit：Session 新增 `stagedActions` / `stagedAt`，Nest 提供 `stageCanvasActions`、`commitStage`、`rollbackStage`
- 画布工具 API（`setNodePrompt` / `addNodesBatch` / `connectNodes`）支持 `stage?: boolean`；`persist` 在 stage pending 时返回 Conflict
- Agent Runtime：`split.py` modify 模式以 `stage=True` 写入；`start_gen.py` 出图前自动 `commit_stage()`；契约 +23 端点

## Test plan
- [x] `pnpm build`
- [x] agent-runtime pytest (147 passed)
- [ ] CI 全绿
- [ ] 合并后生产复测 modify 拓扑（confirm 前 canvas 不变）

## Follow-ups (后续 PR)
- create 模式 split 也走 stage
- stage 30min 超时集成测试
- `agent-canvas-tools.service` stage/commit 单测


Made with [Cursor](https://cursor.com)