### PR TITLE
fix(agent): modify split → await_topo routing + W8 tests + W14 brief reducer

### DIFF
--- a/apps/server/src/agent/agent-canvas-tools.service.test.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.test.ts
@@ -573,4 +573,162 @@ describe('AgentCanvasToolsService', () => {
       expect(node!.data.generationStartedAt, `${nodeId} startedAt`).toBeTruthy()
     }
   })
+
+  describe('W8 stage/commit', () => {
+    const stagedAt = new Date()
+
+    beforeEach(() => {
+      sessionFindUnique.mockImplementation(async () => ({
+        id: 's1',
+        userId: 'u1',
+        canvasData: JSON.stringify(canvas),
+        stagedActions: null,
+        stagedAt: null,
+      }))
+      sessionUpdate.mockImplementation(
+        async ({
+          data,
+        }: {
+          data: {
+            canvasData?: string
+            stagedActions?: string | null
+            stagedAt?: Date | null
+          }
+        }) => {
+          if (data.canvasData) canvas = JSON.parse(data.canvasData) as CanvasData
+          return { id: 's1', ...data }
+        },
+      )
+    })
+
+    it('stageCanvasActions accumulates without changing canvasData', async () => {
+      sessionFindUnique.mockImplementation(async () => ({
+        id: 's1',
+        userId: 'u1',
+        canvasData: JSON.stringify(canvas),
+        stagedActions: null,
+        stagedAt: null,
+      }))
+      const action = {
+        type: 'add_node' as const,
+        payload: {
+          id: 'staged-1',
+          nodeType: 'image' as const,
+          position: { x: 0, y: 0 },
+          data: { title: 'staged' },
+        },
+      }
+      const result = await svc.stageCanvasActions({ sessionId: 's1', actions: [action] })
+      expect(result.stagedCount).toBe(1)
+      expect(canvas.nodes).toHaveLength(0)
+      expect(sessionUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            stagedActions: expect.stringContaining('staged-1'),
+            stagedAt: expect.any(Date),
+          }),
+        }),
+      )
+    })
+
+    it('commitStage applies staged actions to canvasData', async () => {
+      const action = {
+        type: 'add_node' as const,
+        payload: {
+          id: 'staged-1',
+          nodeType: 'image' as const,
+          position: { x: 0, y: 0 },
+          data: { title: 'staged' },
+        },
+      }
+      sessionFindUnique.mockImplementation(async () => ({
+        id: 's1',
+        userId: 'u1',
+        canvasData: JSON.stringify(canvas),
+        stagedActions: JSON.stringify([action]),
+        stagedAt,
+      }))
+      const result = await svc.commitStage({ sessionId: 's1' })
+      expect(result.actions).toHaveLength(1)
+      expect(canvas.nodes).toHaveLength(1)
+      expect(canvas.nodes[0].id).toBe('staged-1')
+    })
+
+    it('rollbackStage clears stagedActions without touching canvas', async () => {
+      sessionFindUnique.mockImplementation(async () => ({
+        id: 's1',
+        userId: 'u1',
+        canvasData: JSON.stringify(canvas),
+        stagedActions: '[]',
+        stagedAt,
+      }))
+      const result = await svc.rollbackStage({ sessionId: 's1' })
+      expect(result.cleared).toBe(true)
+      expect(canvas.nodes).toHaveLength(0)
+      expect(sessionUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { stagedActions: null, stagedAt: null },
+        }),
+      )
+    })
+
+    it('expireStaleStage auto-clears stage older than TTL on commit', async () => {
+      const stale = new Date(Date.now() - 31 * 60 * 1000)
+      const action = {
+        type: 'add_node' as const,
+        payload: {
+          id: 'old-staged',
+          nodeType: 'image' as const,
+          position: { x: 0, y: 0 },
+          data: {},
+        },
+      }
+      let stagedActions: string | null = JSON.stringify([action])
+      let stagedAtVal: Date | null = stale
+      sessionFindUnique.mockImplementation(async () => ({
+        id: 's1',
+        userId: 'u1',
+        canvasData: JSON.stringify(canvas),
+        stagedActions,
+        stagedAt: stagedAtVal,
+      }))
+      sessionUpdate.mockImplementation(
+        async ({
+          data,
+        }: {
+          data: {
+            canvasData?: string
+            stagedActions?: string | null
+            stagedAt?: Date | null
+          }
+        }) => {
+          if (data.canvasData) canvas = JSON.parse(data.canvasData) as CanvasData
+          if (data.stagedActions !== undefined) stagedActions = data.stagedActions
+          if (data.stagedAt !== undefined) stagedAtVal = data.stagedAt
+          return { id: 's1', ...data }
+        },
+      )
+      const result = await svc.commitStage({ sessionId: 's1' })
+      expect(result.actions).toHaveLength(0)
+      expect(canvas.nodes).toHaveLength(0)
+      expect(stagedActions).toBeNull()
+    })
+
+    it('persist rejects when stagedActions pending', async () => {
+      canvas = {
+        nodes: [{ id: 'img-1', type: 'image', position: { x: 0, y: 0 }, data: {} }],
+        edges: [],
+      }
+      sessionFindUnique.mockImplementation(async () => ({
+        id: 's1',
+        userId: 'u1',
+        canvasData: JSON.stringify(canvas),
+        stagedActions: '[]',
+        stagedAt,
+      }))
+      await expect(
+        svc.setNodePrompt({ sessionId: 's1', nodeId: 'img-1', prompt: 'p' }),
+      ).rejects.toThrow(/staged actions pending/i)
+    })
+  })
 })

--- a/services/agent-runtime/app/graph/builder.py
+++ b/services/agent-runtime/app/graph/builder.py
@@ -25,8 +25,9 @@ def route_after_intake(state: AgentRuntimeState) -> str:
 
 
 def route_after_split(state: AgentRuntimeState) -> str:
+    # modify split (node_revise) must return to topo gate — END caused intake replan on「确认出图」
     if state.get("mode") == "modify":
-        return "end"
+        return "await_topo"
     return "draft_copy"
 
 
@@ -61,7 +62,7 @@ def build_agent_graph(
     graph.add_conditional_edges(
         "split",
         route_after_split,
-        {"draft_copy": "draft_copy", "end": END},
+        {"draft_copy": "draft_copy", "await_topo": "await_topo"},
     )
     graph.add_edge("done", END)
 

--- a/services/agent-runtime/app/graph/nodes/intake.py
+++ b/services/agent-runtime/app/graph/nodes/intake.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable
 
-from app.graph.intent import marketing_intent, modify_intent
+from app.graph.intent import marketing_intent, modify_intent  # re-export for tests
+from app.graph.state import BRIEF_RESET_PREFIX
 from app.skills.loader import discover_skills
 
 
@@ -27,40 +28,26 @@ def make_intake_node(skills_dir: Path) -> Callable:
             if preferred in by_id:
                 skill_id = preferred
             elif entries:
-                # Only when intent matched: pick first available skill package
                 skill_id = entries[0].skill_id
-        # No unique-skill fallback when intent is weak — skill_id stays None → chat
 
-        # 修复 P0-1/P0-2：检测修改模式
-        # 如果 state 中已有 user_brief（说明不是首轮）且用户输入带修改意图 → 进入 modify 模式
         existing_brief = state.get("user_brief")
         existing_plan = state.get("plan_draft")
         is_modify = bool(existing_brief and existing_plan and modify_intent(text))
 
-        # 锁定 brief：首轮写入后即锁定，避免后续轮次的主题漂移
-        # 但用户明确要全新方案（mode=create + marketing_intent）时解锁并重置 brief
-        if is_modify:
-            # modify 模式：保留旧 brief 作为锚定
-            new_brief = existing_brief
-            new_locked = state.get("brief_locked", False)
-        elif marketing_intent(text):
-            # 用户新需求（含明确营销意图）→ 写入/覆盖 brief 并锁定
-            new_brief = text
-            new_locked = True
-        else:
-            # 非营销意图（闲聊/确认词）→ 保留现有 brief 状态
-            new_brief = existing_brief
-            new_locked = state.get("brief_locked", False)
-
-        # 决定 mode：modify 模式必须有 brief + plan + 显式 modify 意图
-        # 注意：existing_brief+plan 存在但用户无 modify 意图时，走 create 模式
-        # （例如用户在 done 后说"帮我做运动鞋详情页"应生成全新方案，而非锚定到旧主题）
         if is_modify:
             mode = "modify"
+            proposed_brief = None  # reducer keeps existing brief
+        elif marketing_intent(text):
+            mode = "create"
+            if existing_brief and not modify_intent(text):
+                proposed_brief = BRIEF_RESET_PREFIX + text
+            else:
+                proposed_brief = text
         else:
             mode = "create"
+            proposed_brief = None
 
-        return {
+        out: dict[str, Any] = {
             "phase": "intake",
             "skill_id": skill_id,
             "user_decision": "none",
@@ -69,10 +56,10 @@ def make_intake_node(skills_dir: Path) -> Callable:
             "gen_completed": state.get("gen_completed") or [],
             "gen_failed": state.get("gen_failed") or [],
             "last_error": state.get("last_error"),
-            # 修复 P0-1/P0-2/P0-3：传递 brief + mode 到后续节点
-            "user_brief": new_brief,
-            "brief_locked": new_locked,
             "mode": mode,
         }
+        if proposed_brief is not None:
+            out["user_brief"] = proposed_brief
+        return out
 
     return intake

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -1,8 +1,30 @@
 from __future__ import annotations
 
+import logging
 from typing import Annotated, Literal, TypedDict
 
 from langgraph.graph.message import add_messages
+
+logger = logging.getLogger(__name__)
+
+# W14: prefix signals brief_reducer to replace (fresh campaign) instead of rejecting overwrite
+BRIEF_RESET_PREFIX = "\0reset\0"
+
+
+def brief_reducer(left: str | None, right: str | None) -> str | None:
+    """W14: first non-empty write wins; fresh campaign uses BRIEF_RESET_PREFIX + text."""
+    if right is None:
+        return left
+    if str(right).startswith(BRIEF_RESET_PREFIX):
+        new = str(right)[len(BRIEF_RESET_PREFIX) :].strip()
+        return new or None
+    new = str(right).strip()
+    if not new:
+        return left
+    if left and str(left).strip():
+        logger.warning("brief_reducer: rejected overwrite of user_brief")
+        return left
+    return new
 
 
 def reset_or_union(left: list[str] | None, right: list[str] | None) -> list[str] | None:
@@ -107,11 +129,8 @@ class AgentRuntimeState(TypedDict, total=False):
     copy_alignment_ok: bool | None
     copy_write_blocked: bool | None
 
-    # 修复 P0-1/P0-2/P0-3：brief 锚定 + 修改模式
-    # user_brief: 首轮用户需求锚定，后续 plan 必须围绕这个 brief 展开（防止主题漂移）
-    # mode: "create"（首轮生成新方案）vs "modify"（在已有方案上修改）
-    user_brief: str | None
-    brief_locked: bool  # True 后 user_brief 不再被覆盖
+    # W14: user_brief uses brief_reducer — immutable after first write unless BRIEF_RESET_PREFIX
+    user_brief: Annotated[str | None, brief_reducer]
     mode: Literal["create", "modify"] | None
     # W10: decide_plan_mode 计算，供 revise_manifest / compose_confirm / route_after_plan 使用
     is_node_revise: bool | None

--- a/services/agent-runtime/tests/test_await_topo.py
+++ b/services/agent-runtime/tests/test_await_topo.py
@@ -249,7 +249,6 @@ async def test_node_revise_full_flow_updates_canvas():
             "user_id": "u1",
             "thread_id": "topo-node-revise-1",
             "user_brief": "帮我设计无线蓝牙耳机品牌营销方案",
-            "brief_locked": True,
             "plan_node_id": "plan-1",
             "plan_draft": "# 蓝牙耳机营销方案\n\n## 定位\n高端无线耳机",
             "mode": "create",
@@ -286,3 +285,77 @@ async def test_node_revise_full_flow_updates_canvas():
     final_keys = {str(it.get("key")) for it in (state.get("split_manifest") or [])}
     assert "product_material_detail" in final_keys
     assert "model_portrait" in final_keys
+
+
+@pytest.mark.asyncio
+async def test_modify_split_pauses_at_await_topo_interrupt():
+    """modify split 后应 interrupt 在 await_topo（非 END），以便「确认出图」能路由 start_gen。"""
+    from langgraph.checkpoint.memory import MemorySaver
+    from langchain_core.messages import AIMessage, HumanMessage
+
+    from app.graph.builder import build_agent_graph
+
+    class MinimalNest:
+        async def upsert_prompt_node(self, **kwargs: Any) -> dict[str, Any]:
+            return {"nodeId": "plan-1", "actions": []}
+
+        async def get_node(self, node_id: str) -> dict[str, Any]:
+            return {"id": node_id, "data": {}}
+
+        async def set_node_prompt(self, node_id: str, prompt: str, **kwargs: Any) -> dict[str, Any]:
+            return {"nodeId": node_id, "actions": []}
+
+        async def add_nodes_batch(self, items: list[dict[str, Any]], **kwargs: Any) -> dict[str, Any]:
+            return {"nodes": [{"key": it["key"], "nodeId": f"n-{it['key']}"} for it in items]}
+
+        async def connect_nodes(self, edges: list[dict[str, str]], **kwargs: Any) -> dict[str, Any]:
+            return {"actions": []}
+
+        async def emit_task_list(self, items: list[dict[str, Any]]) -> None:
+            pass
+
+        async def emit_text(self, text: str) -> None:
+            pass
+
+        async def commit_stage(self) -> dict[str, Any]:
+            return {"actions": []}
+
+    class MinimalLLM:
+        async def ainvoke(self, messages: Any, **kwargs: Any) -> AIMessage:
+            return AIMessage(content='[{"op":"add","key":"extra_scene","title":"场景图","target_type":"image","prompt_hint":"运动场景"}]')
+
+    graph = build_agent_graph(
+        nest=MinimalNest(),
+        llm=MinimalLLM(),
+        skills_dir=__import__("pathlib").Path(__file__).resolve().parents[1] / "skills",
+        checkpointer=MemorySaver(),
+    )
+    config = {"configurable": {"thread_id": "modify-confirm-gen-1"}}
+    await graph.aupdate_state(
+        config,
+        {
+            "phase": "await_topo",
+            "skill_id": "enterprise-marketing-campaign",
+            "session_id": "s1",
+            "user_id": "u1",
+            "thread_id": "modify-confirm-gen-1",
+            "user_brief": "蓝牙耳机方案",
+            "plan_node_id": "plan-1",
+            "plan_draft": "# plan",
+            "mode": "modify",
+            "split_manifest": [{"key": "hero_main", "title": "主图", "node_id": "img-1"}],
+            "messages": [
+                AIMessage(content="请确认拓扑"),
+                HumanMessage(content="增加运动场景图节点"),
+            ],
+            "user_decision": "node_revise",
+        },
+        as_node="await_topo",
+    )
+    await graph.ainvoke(None, config)
+    snap = graph.get_state(config)
+    assert snap.next == ("await_topo",), f"expected interrupt at await_topo, got {snap.next}"
+
+    await graph.ainvoke(None, config)
+    snap = graph.get_state(config)
+    assert snap.next == ("await_topo",), f"expected interrupt at await_topo, got {snap.next}"

--- a/services/agent-runtime/tests/test_brief_reducer.py
+++ b/services/agent-runtime/tests/test_brief_reducer.py
@@ -1,0 +1,22 @@
+"""W14 brief_reducer unit tests."""
+
+from __future__ import annotations
+
+from app.graph.state import BRIEF_RESET_PREFIX, brief_reducer
+
+
+def test_brief_reducer_first_write():
+    assert brief_reducer(None, "帮我做洁具详情页") == "帮我做洁具详情页"
+
+
+def test_brief_reducer_rejects_second_write():
+    left = "帮我做洁具详情页"
+    assert brief_reducer(left, "帮我做运动鞋详情页") == left
+
+
+def test_brief_reducer_reset_prefix_allows_fresh_campaign():
+    assert brief_reducer("洁具 brief", BRIEF_RESET_PREFIX + "运动鞋 brief") == "运动鞋 brief"
+
+
+def test_brief_reducer_none_right_keeps_left():
+    assert brief_reducer("existing", None) == "existing"

--- a/services/agent-runtime/tests/test_graph_routes.py
+++ b/services/agent-runtime/tests/test_graph_routes.py
@@ -1,0 +1,13 @@
+"""Graph builder routing unit tests."""
+
+from __future__ import annotations
+
+from app.graph.builder import route_after_split
+
+
+def test_route_after_split_modify_returns_await_topo():
+    assert route_after_split({"mode": "modify"}) == "await_topo"
+
+
+def test_route_after_split_create_returns_draft_copy():
+    assert route_after_split({"mode": "create"}) == "draft_copy"

--- a/services/agent-runtime/tests/test_intake_gate.py
+++ b/services/agent-runtime/tests/test_intake_gate.py
@@ -53,7 +53,6 @@ async def test_intake_first_turn_create_mode_locks_brief():
         }
     )
     assert out["mode"] == "create"
-    assert out["brief_locked"] is True
     assert "洁具" in out["user_brief"]
 
 
@@ -65,14 +64,12 @@ async def test_intake_modify_intent_sets_modify_mode_and_keeps_brief():
         {
             "messages": [HumanMessage(content="把模特定妆改为双人模特")],
             "user_brief": "帮我做一套洁具详情页营销方案",
-            "brief_locked": True,
             "plan_draft": "# 洁具详情页方案\n## 定位...",
         }
     )
     assert out["mode"] == "modify"
-    # brief 保持首轮锚定，不被本轮修改意见覆盖
-    assert out["user_brief"] == "帮我做一套洁具详情页营销方案"
-    assert out["brief_locked"] is True
+    # W14: modify 模式不写入 user_brief，由 reducer 保留 checkpoint 中的锚定 brief
+    assert "user_brief" not in out
 
 
 @pytest.mark.asyncio
@@ -87,7 +84,6 @@ async def test_intake_new_product_request_resets_brief_to_create_mode():
                 HumanMessage(content="帮我做一套运动鞋详情页营销方案并出图")
             ],
             "user_brief": "帮我做一套洁具详情页营销方案",
-            "brief_locked": True,
             "plan_draft": "# 洁具详情页方案\n## 定位...",
         }
     )


### PR DESCRIPTION
Closes #90

## Summary
- **路由修复**：`route_after_split` 在 `mode=modify` 时改走 `await_topo`（不再 `END`），修复 modify split 后「确认出图」无法进入 `start_gen` 的问题
- **W8 follow-ups**：`agent-canvas-tools.service` stage/commit/rollback/TTL/persist-conflict 单测（5 cases）
- **W14 brief 不可变 channel**：`brief_reducer` + 移除 `brief_locked`；fresh campaign 用 `BRIEF_RESET_PREFIX` 重置

## Test plan
- [x] pytest 154 passed
- [x] vitest agent-canvas-tools 24 passed
- [x] pnpm build
- [ ] CI 全绿
- [ ] 合并后生产复测 modify → 确认出图 路径

## W8 未做（后续）
- create 模式 split staging（规格允许保持 immediate）


Made with [Cursor](https://cursor.com)