### PR TITLE
feat(agent): W13 gen-order presort + W12 SSE heartbeat

### DIFF
--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -30,6 +30,7 @@ import {
   shouldPollRuntimeHealth,
   checkRuntimeHealthViaNest,
   RUNTIME_UNREACHABLE_SNIPPET,
+  isStreamStale,
 } from '@/components/agent/streamRecovery'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
@@ -327,6 +328,7 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
   const idempotencyKey = buildIdempotencyKey(agentThreadId.value)
   // Track whether SSE stream ended normally (received [DONE])
   let streamEndedNormally = false
+  let lastStreamActivityAt = Date.now()
 
   try {
     const token = localStorage.getItem('token')
@@ -364,7 +366,9 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
           continue
         }
         try {
-          handleEvent(JSON.parse(line.slice(6)))
+          const event = JSON.parse(line.slice(6)) as { type: string; data: unknown }
+          lastStreamActivityAt = Date.now()
+          handleEvent(event)
         } catch { /* skip */ }
       }
     }
@@ -376,6 +380,8 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
       const last = agent.messages[agent.messages.length - 1]
       if (last?.role === 'assistant' && !last.content.trim()) {
         agent.appendText('\n\n⚠️ 连接意外断开，请稍后重试。')
+      } else if (last?.role === 'assistant' && isStreamStale(lastStreamActivityAt)) {
+        last.content += `\n\n⚠️ ${RUNTIME_UNREACHABLE_SNIPPET}，已保存进度。请稍后重试。`
       }
     }
 
@@ -497,6 +503,8 @@ function handleEvent(event: { type: string; data: unknown }) {
         event as Parameters<typeof applyTaskEvent>[1],
       )
       scrollToBottom()
+      break
+    case 'ping':
       break
     case 'error':
       agent.appendText(`\n\n⚠️ ${(event.data as { message: string }).message}`)

--- a/apps/web/src/components/agent/streamRecovery.test.ts
+++ b/apps/web/src/components/agent/streamRecovery.test.ts
@@ -6,6 +6,8 @@ import {
   randomThreadSuffix,
   shouldPollRuntimeHealth,
   checkRuntimeHealthViaNest,
+  isStreamStale,
+  STREAM_STALE_MS,
 } from './streamRecovery'
 
 vi.mock('@/services/api-base', () => ({
@@ -73,6 +75,18 @@ describe('shouldPollRuntimeHealth', () => {
 
   it('returns false when both busy and done indicators present', () => {
     expect(shouldPollRuntimeHealth('上一轮仍在处理中，但出图成功')).toBe(false)
+  })
+})
+
+describe('isStreamStale', () => {
+  it('returns true after STREAM_STALE_MS without activity', () => {
+    const now = 1_000_000
+    expect(isStreamStale(now - STREAM_STALE_MS - 1, now)).toBe(true)
+  })
+
+  it('returns false when activity is recent', () => {
+    const now = 1_000_000
+    expect(isStreamStale(now - 5_000, now)).toBe(false)
   })
 })
 

--- a/apps/web/src/components/agent/streamRecovery.ts
+++ b/apps/web/src/components/agent/streamRecovery.ts
@@ -10,6 +10,12 @@ import { apiUrl } from '@/services/api-base'
  */
 
 export const RUNTIME_UNREACHABLE_SNIPPET = '生成服务暂时不可达'
+export const STREAM_STALE_MS = 30_000
+
+/** W12: true when no SSE activity (incl. ping) for longer than STREAM_STALE_MS. */
+export function isStreamStale(lastActivityAt: number, now = Date.now()): boolean {
+  return now - lastActivityAt > STREAM_STALE_MS
+}
 
 /**
  * Thread suffix for agent-runtime LangGraph threads.

--- a/services/agent-runtime/app/graph/builder.py
+++ b/services/agent-runtime/app/graph/builder.py
@@ -25,6 +25,8 @@ def route_after_intake(state: AgentRuntimeState) -> str:
 
 
 def route_after_split(state: AgentRuntimeState) -> str:
+    if state.get("gen_order_error"):
+        return "done"
     # modify split (node_revise) must return to topo gate — END caused intake replan on「确认出图」
     if state.get("mode") == "modify":
         return "await_topo"
@@ -62,7 +64,7 @@ def build_agent_graph(
     graph.add_conditional_edges(
         "split",
         route_after_split,
-        {"draft_copy": "draft_copy", "await_topo": "await_topo"},
+        {"draft_copy": "draft_copy", "await_topo": "await_topo", "done": "done"},
     )
     graph.add_edge("done", END)
 

--- a/services/agent-runtime/app/graph/nodes/split.py
+++ b/services/agent-runtime/app/graph/nodes/split.py
@@ -9,8 +9,29 @@ from app.graph.state import SplitManifestItem
 from app.graph.chain_refs import build_chain_ref_order
 from app.graph.copy_sot import snapshot_copy_sot_fields
 from app.graph.mermaid_topo import manifest_to_mermaid
+from app.graph.topo import precompute_gen_order
 from app.graph.topo_trim import trim_manifest_items
 from app.skills.loader import discover_skills, load_skill
+
+
+def _gen_order_fields(manifest: list[dict[str, Any]]) -> dict[str, Any]:
+    """W13: pre-sort auto-generate keys at split; detect cycles before await_topo."""
+    ordered, err = precompute_gen_order(manifest)
+    if err:
+        return {
+            "gen_order_error": err,
+            "gen_ordered_keys": None,
+            "phase": "split",
+            "messages": [
+                AIMessage(
+                    content=(
+                        f"拓扑依赖有环，无法继续：{err}。"
+                        "请调整方案中的节点 depends_on 后重试。"
+                    )
+                )
+            ],
+        }
+    return {"gen_order_error": None, "gen_ordered_keys": ordered}
 
 
 def _manifest_items(canvas_manifest: dict | None, max_downstream: int) -> list[SplitManifestItem]:
@@ -110,7 +131,7 @@ async def _apply_modify_split(nest: Any, state: dict, plan_node_id: str) -> dict
 
     # node_operations 为 None（LLM 解析失败）：不改动节点，直接回拓扑确认门
     if not ops:
-        return {
+        base = {
             "phase": "await_topo",
             "mode": "modify",
             "split_manifest": old_manifest,
@@ -123,6 +144,8 @@ async def _apply_modify_split(nest: Any, state: dict, plan_node_id: str) -> dict
                 )
             ],
         }
+        base.update(_gen_order_fields(old_manifest))
+        return base
 
     renamed_keys: list[str] = []
     added_keys: list[str] = []
@@ -235,13 +258,15 @@ async def _apply_modify_split(nest: Any, state: dict, plan_node_id: str) -> dict
         except Exception:  # noqa: BLE001
             pass
 
-    return {
+    out = {
         "phase": "await_topo",
         "mode": "modify",
         "split_manifest": updated,
         "focus_node_ids": [str(it.get("node_id")) for it in updated if it.get("node_id")],
         "messages": [AIMessage(content=msg)],
     }
+    out.update(_gen_order_fields(updated))
+    return out
 
 
 def make_split_node(*, nest: Any, skills_dir: Path) -> Callable:
@@ -363,7 +388,7 @@ def make_split_node(*, nest: Any, skills_dir: Path) -> Callable:
                     if item.get("key")
                 ]
             )
-        return {
+        out = {
             "phase": "split",
             "split_manifest": manifest,
             "topology_mode": mode,
@@ -371,5 +396,7 @@ def make_split_node(*, nest: Any, skills_dir: Path) -> Callable:
             "messages": [AIMessage(content=split_msg)],
             **snapshot_copy_sot_fields(state),
         }
+        out.update(_gen_order_fields(list(manifest)))
+        return out
 
     return split

--- a/services/agent-runtime/app/graph/nodes/start_gen.py
+++ b/services/agent-runtime/app/graph/nodes/start_gen.py
@@ -35,16 +35,17 @@ def make_start_gen_node(*, nest: Any = None, max_concurrency: int = 3) -> Callab
 
         by_key = {str(it["key"]): it for it in manifest if it.get("key")}
 
-        try:
-            ordered_keys = topo_sort_gen_keys(manifest)
-        except ValueError as exc:
-            return {
-                "phase": "done",
-                # legacy field for done.py / intake.py
-                "gen_failed": [{"key": None, "reason": str(exc)}],
-                "last_error": str(exc),
-                "messages": [AIMessage(content=f"出图编排失败：{exc}")],
-            }
+        ordered_keys = list(state.get("gen_ordered_keys") or [])
+        if not ordered_keys:
+            try:
+                ordered_keys = topo_sort_gen_keys(manifest)
+            except ValueError as exc:
+                return {
+                    "phase": "done",
+                    "gen_failed": [{"key": None, "reason": str(exc)}],
+                    "last_error": str(exc),
+                    "messages": [AIMessage(content=f"出图编排失败：{exc}")],
+                }
 
         if not ordered_keys:
             return {

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -100,6 +100,8 @@ class AgentRuntimeState(TypedDict, total=False):
     plan_node_id: str | None
     focus_node_ids: list[str]
     split_manifest: list[SplitManifestItem]
+    # W13: cycle detection at split; blocks await_topo when set
+    gen_order_error: str | None
     # P0 修复：node_revise 走 plan(modify) 后，LLM 产出的节点操作列表（rename/add/delete）；
     # split 在 modify 模式下按操作列表 upsert 画布节点。None 表示首轮 create 或 LLM 解析失败回退。
     node_operations: list[dict] | None
@@ -135,13 +137,7 @@ class AgentRuntimeState(TypedDict, total=False):
     # W10: decide_plan_mode 计算，供 revise_manifest / compose_confirm / route_after_plan 使用
     is_node_revise: bool | None
 
-    # W3: Transient fields for Send API fan-out generation.
-    # gen_ordered_keys/gen_deps_of/gen_by_key are write-once (start_gen) /
-    # clear-once (collect_gen), so plain overwrite is fine.
-    # gen_*_keys/gen_fail_details are written by PARALLEL gen_node instances in
-    # the same superstep → must use reset_or_union/reset_or_merge reducers.
-    # Returning None (start_gen at run start, collect_gen at run end) resets
-    # them so a re-generation on the same thread doesn't leak the prior run.
+    # W3/W13: gen_ordered_keys precomputed at split (W13), deps/by_key filled at start_gen.
     gen_ordered_keys: list[str] | None  # Topological order of generation keys
     gen_deps_of: dict[str, list[str]] | None  # Dependency graph
     gen_by_key: dict[str, dict] | None  # Manifest items by key

--- a/services/agent-runtime/app/graph/topo.py
+++ b/services/agent-runtime/app/graph/topo.py
@@ -54,3 +54,11 @@ def topo_sort_gen_keys(
 def topo_sort_image_keys(manifest: Iterable[dict[str, Any]]) -> list[str]:
     """Backward-compatible: image-only auto_generate keys."""
     return topo_sort_gen_keys(manifest, types=("image",))
+
+
+def precompute_gen_order(manifest: Iterable[dict[str, Any]]) -> tuple[list[str] | None, str | None]:
+    """W13: topo-sort at split time. Returns (ordered_keys, error_message)."""
+    try:
+        return topo_sort_gen_keys(manifest), None
+    except ValueError as exc:
+        return None, str(exc)

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 import uuid
 from pathlib import Path
 from typing import Any, AsyncIterator, Callable, Awaitable
@@ -504,6 +505,16 @@ async def stream_run_events(
                 await proxy.close()
 
     task = asyncio.create_task(run_graph())
+
+    async def heartbeat() -> None:
+        """W12: SSE ping every 15s so frontend can detect stale connections."""
+        while not task.done():
+            await asyncio.sleep(15)
+            if task.done():
+                break
+            await emit({"type": "ping", "data": {"ts": int(time.time() * 1000)}})
+
+    hb_task = asyncio.create_task(heartbeat())
     try:
         while True:
             item = await queue.get()
@@ -511,6 +522,11 @@ async def stream_run_events(
                 break
             yield item
     finally:
+        hb_task.cancel()
+        try:
+            await hb_task
+        except asyncio.CancelledError:
+            pass
         await _release_thread(thread_id, holder_id, lock_nest)
         if owns_nest:
             await lock_nest.close()

--- a/services/agent-runtime/tests/test_graph_routes.py
+++ b/services/agent-runtime/tests/test_graph_routes.py
@@ -11,3 +11,7 @@ def test_route_after_split_modify_returns_await_topo():
 
 def test_route_after_split_create_returns_draft_copy():
     assert route_after_split({"mode": "create"}) == "draft_copy"
+
+
+def test_route_after_split_cycle_goes_to_done():
+    assert route_after_split({"gen_order_error": "cycle detected"}) == "done"

--- a/services/agent-runtime/tests/test_split_gen_order.py
+++ b/services/agent-runtime/tests/test_split_gen_order.py
@@ -1,0 +1,25 @@
+"""W13: gen order precomputed at split."""
+
+from __future__ import annotations
+
+from app.graph.topo import precompute_gen_order
+
+
+def test_precompute_gen_order_success():
+    manifest = [
+        {"key": "white_bg", "target_type": "image", "auto_generate": True, "depends_on": []},
+        {"key": "hero_main", "target_type": "image", "auto_generate": True, "depends_on": ["white_bg"]},
+    ]
+    ordered, err = precompute_gen_order(manifest)
+    assert err is None
+    assert ordered == ["white_bg", "hero_main"]
+
+
+def test_precompute_gen_order_cycle():
+    manifest = [
+        {"key": "a", "target_type": "image", "auto_generate": True, "depends_on": ["b"]},
+        {"key": "b", "target_type": "image", "auto_generate": True, "depends_on": ["a"]},
+    ]
+    ordered, err = precompute_gen_order(manifest)
+    assert ordered is None
+    assert err is not None


### PR DESCRIPTION
## Summary
- **W13**: split 阶段预计算 `gen_ordered_keys` + `depends_on` 环检测；有环设置 `gen_order_error` 并路由到 `done`（不进 `await_topo`）；`start_gen` 复用 presorted keys
- **W12**: Runtime SSE 每 15s 发 `ping`；前端 `isStreamStale` + 异常断开不可达提示

## Test plan
- [x] pytest 157 passed
- [x] pnpm build
- [x] streamRecovery vitest 14 passed
- [ ] CI 全绿
- [ ] 合并后部署复测

## Follow-ups
- W11 双通道信号统一（task_update → recordId 轮询权威）
- W12 剩余：useAgentStream composable + 重连按钮


Made with [Cursor](https://cursor.com)