### PR TITLE
feat(agent): W11 dual-channel signal — generation record poll authority

### DIFF
--- a/apps/server/src/agent/agent-canvas-tools.controller.ts
+++ b/apps/server/src/agent/agent-canvas-tools.controller.ts
@@ -172,6 +172,20 @@ class RunImageGenerationDto {
   nodeId!: string
 }
 
+class WaitImageGenerationDto {
+  @IsString()
+  sessionId!: string
+
+  @IsString()
+  userId!: string
+
+  @IsString()
+  nodeId!: string
+
+  @IsString()
+  generationRecordId!: string
+}
+
 class SaveAgentMessageDto {
   @IsString()
   sessionId!: string
@@ -331,6 +345,18 @@ export class AgentCanvasToolsController {
   @Post('run-image-generation')
   async runImageGeneration(@Body() dto: RunImageGenerationDto) {
     const data = await this.tools.runImageGeneration(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('start-image-generation')
+  async startImageGeneration(@Body() dto: RunImageGenerationDto) {
+    const data = await this.tools.startImageGeneration(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('wait-image-generation')
+  async waitImageGeneration(@Body() dto: WaitImageGenerationDto) {
+    const data = await this.tools.waitImageGeneration(dto)
     return { code: 0, message: 'ok', data }
   }
 

--- a/apps/server/src/agent/agent-canvas-tools.service.test.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.test.ts
@@ -545,6 +545,14 @@ describe('AgentCanvasToolsService', () => {
       .mockResolvedValueOnce({ id: 'rec-a', status: 'completed', url: 'https://cdn/a.png' })
       .mockResolvedValueOnce({ id: 'rec-b', status: 'completed', url: 'https://cdn/b.png' })
       .mockResolvedValueOnce({ id: 'rec-c', status: 'completed', url: 'https://cdn/c.png' })
+    getGeneration.mockImplementation(async (_uid: string, recordId: string) => {
+      const urls: Record<string, string> = {
+        'rec-a': 'https://cdn/a.png',
+        'rec-b': 'https://cdn/b.png',
+        'rec-c': 'https://cdn/c.png',
+      }
+      return { id: recordId, status: 'completed', url: urls[recordId] }
+    })
 
     const results = await Promise.all([
       svc.runImageGeneration({ sessionId: 's1', userId: 'u1', nodeId: 'img-a' }),

--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -488,11 +488,11 @@ export class AgentCanvasToolsService {
     return { actions }
   }
 
-  async runImageGeneration(input: {
+  async startImageGeneration(input: {
     sessionId: string
     userId: string
     nodeId: string
-  }): Promise<{ url?: string; status: string; actions: CanvasAction[] }> {
+  }): Promise<{ generationRecordId: string; status: string; actions: CanvasAction[] }> {
     const { canvas } = await this.loadOwnedSession(input.sessionId, input.userId)
     const node = canvas.nodes.find((n) => n.id === input.nodeId)
     if (!node) throw new NotFoundException('节点不存在')
@@ -515,44 +515,61 @@ export class AgentCanvasToolsService {
     let current = await this.persist(input.sessionId, started)
     const allActions = [...started]
 
-    try {
-      const prefs = await this.loadAccountGenPrefs(input.userId)
-      const refs = toStudioRefs(node, current)
-      const aspectRatio = pickString(node.data?.imageAspect, prefs.defaultImageAspect || '16:9')
-      const resolution = pickString(
-        node.data?.imageResolution,
-        prefs.defaultImageResolution || '1K',
-      )
-      const count = clampImageGenCount(
-        node.data?.imageCount ?? prefs.canvasImageCount ?? 1,
-      )
-      const model = pickString(node.data?.imageModel, prefs.defaultImageModel) || undefined
+    const prefs = await this.loadAccountGenPrefs(input.userId)
+    const refs = toStudioRefs(node, current)
+    const aspectRatio = pickString(node.data?.imageAspect, prefs.defaultImageAspect || '16:9')
+    const resolution = pickString(
+      node.data?.imageResolution,
+      prefs.defaultImageResolution || '1K',
+    )
+    const count = clampImageGenCount(
+      node.data?.imageCount ?? prefs.canvasImageCount ?? 1,
+    )
+    const model = pickString(node.data?.imageModel, prefs.defaultImageModel) || undefined
 
-      const record = await this.studio.generateImage(
-        input.userId,
-        prompt,
-        model,
-        aspectRatio,
-        refs,
-        undefined,
-        resolution,
-        count,
-        { sessionId: input.sessionId, nodeId: input.nodeId },
-      )
+    const record = await this.studio.generateImage(
+      input.userId,
+      prompt,
+      model,
+      aspectRatio,
+      refs,
+      undefined,
+      resolution,
+      count,
+      { sessionId: input.sessionId, nodeId: input.nodeId },
+    )
 
-      const recordId = record.id
-      allActions.push({
+    const recordId = record.id
+    allActions.push({
+      type: 'update_node',
+      payload: { id: input.nodeId, data: { generationRecordId: recordId } },
+    })
+    await this.persist(input.sessionId, [
+      {
         type: 'update_node',
         payload: { id: input.nodeId, data: { generationRecordId: recordId } },
-      })
-      await this.persist(input.sessionId, [
-        {
-          type: 'update_node',
-          payload: { id: input.nodeId, data: { generationRecordId: recordId } },
-        },
-      ])
+      },
+    ])
 
-      const terminal = await this.pollGeneration(input.userId, recordId, record)
+    return {
+      generationRecordId: recordId,
+      status: 'generating',
+      actions: allActions,
+    }
+  }
+
+  async waitImageGeneration(input: {
+    sessionId: string
+    userId: string
+    nodeId: string
+    generationRecordId: string
+  }): Promise<{ url?: string; status: string; generationRecordId: string; actions: CanvasAction[] }> {
+    const recordId = input.generationRecordId
+    const allActions: CanvasAction[] = []
+
+    try {
+      const initial = await this.studio.getGeneration(input.userId, recordId)
+      const terminal = await this.pollGeneration(input.userId, recordId, initial)
       const status = String(terminal.status)
       const url = typeof terminal.url === 'string' && terminal.url ? terminal.url : undefined
 
@@ -579,7 +596,40 @@ export class AgentCanvasToolsService {
       return {
         url,
         status: String(finishData.status),
+        generationRecordId: recordId,
         actions: allActions,
+      }
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : '图像生成失败'
+      const errorActions: CanvasAction[] = [
+        {
+          type: 'update_node',
+          payload: {
+            id: input.nodeId,
+            data: { status: 'error', errorMessage, generationRecordId: recordId },
+          },
+        },
+      ]
+      await this.persist(input.sessionId, errorActions)
+      allActions.push(...errorActions)
+      return { status: 'error', generationRecordId: recordId, actions: allActions }
+    }
+  }
+
+  async runImageGeneration(input: {
+    sessionId: string
+    userId: string
+    nodeId: string
+  }): Promise<{ url?: string; status: string; generationRecordId?: string; actions: CanvasAction[] }> {
+    try {
+      const started = await this.startImageGeneration(input)
+      const finished = await this.waitImageGeneration({
+        ...input,
+        generationRecordId: started.generationRecordId,
+      })
+      return {
+        ...finished,
+        actions: [...started.actions, ...finished.actions],
       }
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : '图像生成失败'
@@ -593,8 +643,7 @@ export class AgentCanvasToolsService {
         },
       ]
       await this.persist(input.sessionId, errorActions)
-      allActions.push(...errorActions)
-      return { status: 'error', actions: allActions }
+      return { status: 'error', actions: errorActions }
     }
   }
 

--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -632,6 +632,7 @@ export class AgentCanvasToolsService {
         actions: [...started.actions, ...finished.actions],
       }
     } catch (err) {
+      if (err instanceof ForbiddenException || err instanceof NotFoundException) throw err
       const errorMessage = err instanceof Error ? err.message : '图像生成失败'
       const errorActions: CanvasAction[] = [
         {

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -9,9 +9,11 @@ import NeoAgentLogo from '@/components/agent/NeoAgentLogo.vue'
 import AgentTaskProgressCard from '@/components/agent/AgentTaskProgressCard.vue'
 import {
   applyTaskEvent,
+  applyPollRecordToTask,
   emptyTaskProgress,
   type AgentTaskProgressState,
 } from '@/components/agent/agentTaskProgress'
+import { useGenerationPolling, type GenerationPollTask } from '@/composables/useGenerationPolling'
 import {
   reconcileTaskProgress,
   shouldFinishTaskCard,
@@ -61,6 +63,31 @@ const chatContainer = ref<HTMLElement>()
 const agentThreadId = ref(createAgentThreadId(props.sessionId))
 const taskProgress = ref<AgentTaskProgressState>(emptyTaskProgress())
 const showTaskCard = computed(() => taskProgress.value.items.length > 0)
+
+const taskRecordPolling = useGenerationPolling((results) => {
+  for (const { task, record } of results) {
+    taskProgress.value = applyPollRecordToTask(
+      taskProgress.value,
+      task.nodeId,
+      record.status,
+    )
+  }
+})
+
+function startTaskRecordPoll(tasks: GenerationPollTask[]) {
+  if (!tasks.length) return
+  taskRecordPolling.start(tasks)
+}
+
+function pollTasksFromProgress() {
+  const tasks: GenerationPollTask[] = []
+  for (const it of taskProgress.value.items) {
+    if (it.recordId && it.nodeId) {
+      tasks.push({ recordId: it.recordId, nodeId: it.nodeId })
+    }
+  }
+  startTaskRecordPoll(tasks)
+}
 
 /** 方案确认门 / 主文案确认门：侧栏快捷钮 */
 const chipSet = computed(() => {
@@ -497,13 +524,24 @@ function handleEvent(event: { type: string; data: unknown }) {
       break
     case 'task_list':
     case 'task_update':
-    case 'task_summary':
+    case 'task_summary': {
+      const prev = taskProgress.value
       taskProgress.value = applyTaskEvent(
         taskProgress.value,
         event as Parameters<typeof applyTaskEvent>[1],
       )
+      if (event.type === 'task_update') {
+        const data = event.data as { recordId?: string; id?: string }
+        const item = taskProgress.value.items.find((it) => it.id === data.id)
+        if (item?.recordId && item.nodeId) {
+          startTaskRecordPoll([{ recordId: item.recordId, nodeId: item.nodeId }])
+        }
+      } else if (event.type === 'task_list' && taskProgress.value.items.length !== prev.items.length) {
+        pollTasksFromProgress()
+      }
       scrollToBottom()
       break
+    }
     case 'ping':
       break
     case 'error':
@@ -530,6 +568,19 @@ function onKeydown(e: KeyboardEvent) {
 function reconcileFromNodes(rawNodes: CanvasNodeLike[]) {
   if (!taskProgress.value.items.length) return
   let next = reconcileTaskProgress(taskProgress.value, rawNodes)
+  // W11: canvas generationRecordId → start poll for matching task items
+  for (const n of rawNodes) {
+    const recordId = n.data?.generationRecordId
+    if (typeof recordId !== 'string' || !recordId) continue
+    const item = next.items.find((it) => it.nodeId === n.id)
+    if (item && !item.recordId) {
+      next = applyTaskEvent(next, {
+        type: 'task_update',
+        data: { id: item.id, status: item.status, recordId },
+      })
+    }
+  }
+  pollTasksFromProgress()
   if (shouldFinishTaskCard(next, rawNodes) && !next.finished) {
     next = {
       ...next,

--- a/apps/web/src/components/agent/agentTaskProgress.test.ts
+++ b/apps/web/src/components/agent/agentTaskProgress.test.ts
@@ -1,6 +1,11 @@
 /** @vitest-environment node */
 import { describe, expect, it } from 'vitest'
-import { applyTaskEvent, emptyTaskProgress } from './agentTaskProgress'
+import {
+  applyPollRecordToTask,
+  applyTaskEvent,
+  emptyTaskProgress,
+  mapRecordStatusToTaskStatus,
+} from './agentTaskProgress'
 
 describe('applyTaskEvent', () => {
   it('applies task_update retrying attempt', () => {
@@ -27,5 +32,44 @@ describe('applyTaskEvent', () => {
     })
     expect(s.finished).toBe(true)
     expect(s.summary?.success).toBe(1)
+  })
+
+  it('W11: defers terminal SSE status when recordId is present', () => {
+    let s = applyTaskEvent(emptyTaskProgress(), {
+      type: 'task_list',
+      data: { items: [{ id: 'a', title: '主图', nodeId: 'n1' }] },
+    })
+    s = applyTaskEvent(s, {
+      type: 'task_update',
+      data: { id: 'a', status: 'running', recordId: 'rec-1' },
+    })
+    s = applyTaskEvent(s, {
+      type: 'task_update',
+      data: { id: 'a', status: 'done', recordId: 'rec-1' },
+    })
+    expect(s.items[0].recordId).toBe('rec-1')
+    expect(s.items[0].status).toBe('running')
+  })
+
+  it('W11: applyPollRecordToTask uses record status as authority', () => {
+    let s = applyTaskEvent(emptyTaskProgress(), {
+      type: 'task_list',
+      data: { items: [{ id: 'a', title: '主图', nodeId: 'n1' }] },
+    })
+    s = applyTaskEvent(s, {
+      type: 'task_update',
+      data: { id: 'a', status: 'running', recordId: 'rec-1' },
+    })
+    s = applyPollRecordToTask(s, 'n1', 'completed')
+    expect(s.items[0].status).toBe('done')
+  })
+})
+
+describe('mapRecordStatusToTaskStatus', () => {
+  it('maps studio statuses', () => {
+    expect(mapRecordStatusToTaskStatus('completed')).toBe('done')
+    expect(mapRecordStatusToTaskStatus('failed')).toBe('failed')
+    expect(mapRecordStatusToTaskStatus('fallback_pending')).toBe('needs_user')
+    expect(mapRecordStatusToTaskStatus('generating')).toBe('running')
   })
 })

--- a/apps/web/src/components/agent/agentTaskProgress.ts
+++ b/apps/web/src/components/agent/agentTaskProgress.ts
@@ -13,6 +13,7 @@ export interface AgentTaskItem {
   nodeId?: string
   kind?: string
   status: TaskItemStatus
+  recordId?: string
   attempt?: number
   maxAttempts?: number
   errorHint?: string
@@ -35,6 +36,8 @@ export const emptyTaskProgress = (): AgentTaskProgressState => ({
   finished: false,
 })
 
+const TERMINAL_STATUSES: TaskItemStatus[] = ['done', 'failed', 'needs_user', 'skipped']
+
 type TaskEvent =
   | { type: 'task_list'; data: { items: Array<{ id: string; title: string; nodeId?: string; kind?: string }> } }
   | {
@@ -42,6 +45,7 @@ type TaskEvent =
       data: {
         id: string
         status: TaskItemStatus
+        recordId?: string
         attempt?: number
         maxAttempts?: number
         errorHint?: string
@@ -57,6 +61,16 @@ type TaskEvent =
         lines?: Array<{ id: string; status: string; title: string; hint?: string }>
       }
     }
+
+/** Map Studio generation record status → task card status (W11 authority channel). */
+export function mapRecordStatusToTaskStatus(recordStatus: string): TaskItemStatus {
+  const s = recordStatus.toLowerCase()
+  if (s === 'completed' || s === 'success') return 'done'
+  if (s === 'failed' || s === 'error' || s === 'timeout') return 'failed'
+  if (s === 'fallback_pending') return 'needs_user'
+  if (s === 'generating' || s === 'pending') return 'running'
+  return 'running'
+}
 
 export function applyTaskEvent(
   state: AgentTaskProgressState,
@@ -75,17 +89,22 @@ export function applyTaskEvent(
     }
   }
   if (event.type === 'task_update') {
-    const items = state.items.map((it) =>
-      it.id === event.data.id
-        ? {
-            ...it,
-            status: event.data.status,
-            attempt: event.data.attempt,
-            maxAttempts: event.data.maxAttempts,
-            errorHint: event.data.errorHint,
-          }
-        : it,
-    )
+    const { recordId, status, ...rest } = event.data
+    const items = state.items.map((it) => {
+      if (it.id !== event.data.id) return it
+      const next: AgentTaskItem = { ...it, ...rest }
+      if (recordId) next.recordId = recordId
+      // W11: SSE task_update is hint-only when recordId exists; terminal status from poll.
+      const deferTerminal = Boolean(recordId || it.recordId) && TERMINAL_STATUSES.includes(status)
+      if (!deferTerminal) {
+        next.status = status
+      } else if (status === 'running' || status === 'retrying' || status === 'pending') {
+        next.status = status
+      } else if (it.status === 'pending') {
+        next.status = 'running'
+      }
+      return next
+    })
     return { ...state, items }
   }
   if (event.type === 'task_summary') {
@@ -102,4 +121,17 @@ export function applyTaskEvent(
     }
   }
   return state
+}
+
+/** Apply polled generation record as authoritative task status (W11). */
+export function applyPollRecordToTask(
+  state: AgentTaskProgressState,
+  nodeId: string,
+  recordStatus: string,
+): AgentTaskProgressState {
+  const mapped = mapRecordStatusToTaskStatus(recordStatus)
+  const items = state.items.map((it) =>
+    it.nodeId === nodeId ? { ...it, status: mapped } : it,
+  )
+  return { ...state, items }
 }

--- a/apps/web/src/components/agent/taskProgressReconcile.ts
+++ b/apps/web/src/components/agent/taskProgressReconcile.ts
@@ -65,6 +65,8 @@ export function reconcileTaskProgress(
   const items = state.items.map((item) => {
     const node = findNodeForItem(item, nodes)
     if (!node) return item
+    // W11: when polling a generation record, canvas/SSE must not override task status.
+    if (item.recordId) return item
     return { ...item, status: mapNodeStatus(node, item) }
   })
   return { ...state, items }

--- a/packages/shared/src/agentContract.ts
+++ b/packages/shared/src/agentContract.ts
@@ -210,10 +210,40 @@ export type RunImageGenerationRequest = z.infer<typeof RunImageGenerationRequest
 export const RunImageGenerationResponseSchema = z.object({
   url: z.string().optional(),
   status: z.string(),
+  generationRecordId: z.string().optional(),
   actions: z.array(CanvasActionSchema),
 })
 
 export type RunImageGenerationResponse = z.infer<typeof RunImageGenerationResponseSchema>
+
+// ============================================================
+// start_image_generation / wait_image_generation (W11)
+// ============================================================
+
+export const StartImageGenerationRequestSchema = RunImageGenerationRequestSchema
+
+export type StartImageGenerationRequest = z.infer<typeof StartImageGenerationRequestSchema>
+
+export const StartImageGenerationResponseSchema = z.object({
+  status: z.string(),
+  generationRecordId: z.string(),
+  actions: z.array(CanvasActionSchema),
+})
+
+export type StartImageGenerationResponse = z.infer<typeof StartImageGenerationResponseSchema>
+
+export const WaitImageGenerationRequestSchema = z.object({
+  sessionId: z.string(),
+  userId: z.string(),
+  nodeId: z.string(),
+  generationRecordId: z.string(),
+})
+
+export type WaitImageGenerationRequest = z.infer<typeof WaitImageGenerationRequestSchema>
+
+export const WaitImageGenerationResponseSchema = RunImageGenerationResponseSchema
+
+export type WaitImageGenerationResponse = z.infer<typeof WaitImageGenerationResponseSchema>
 
 // ============================================================
 // run_video_generation

--- a/scripts/verify-contract.ts
+++ b/scripts/verify-contract.ts
@@ -35,6 +35,10 @@ import {
   AttachRefsResponseSchema,
   RunImageGenerationRequestSchema,
   RunImageGenerationResponseSchema,
+  StartImageGenerationRequestSchema,
+  StartImageGenerationResponseSchema,
+  WaitImageGenerationRequestSchema,
+  WaitImageGenerationResponseSchema,
   RunVideoGenerationRequestSchema,
   RunVideoGenerationResponseSchema,
   GetGenerationStatusRequestSchema,
@@ -102,6 +106,14 @@ const CONTRACTS: Record<string, { request: ContractMapping; response: ContractMa
   run_image_generation: {
     request: { tsSchema: RunImageGenerationRequestSchema, pyModel: 'RunImageGenerationRequest' },
     response: { tsSchema: RunImageGenerationResponseSchema, pyModel: 'RunImageGenerationResponse' },
+  },
+  start_image_generation: {
+    request: { tsSchema: StartImageGenerationRequestSchema, pyModel: 'StartImageGenerationRequest' },
+    response: { tsSchema: StartImageGenerationResponseSchema, pyModel: 'StartImageGenerationResponse' },
+  },
+  wait_image_generation: {
+    request: { tsSchema: WaitImageGenerationRequestSchema, pyModel: 'WaitImageGenerationRequest' },
+    response: { tsSchema: WaitImageGenerationResponseSchema, pyModel: 'WaitImageGenerationResponse' },
   },
   run_video_generation: {
     request: { tsSchema: RunVideoGenerationRequestSchema, pyModel: 'RunVideoGenerationRequest' },

--- a/services/agent-runtime/app/contract.py
+++ b/services/agent-runtime/app/contract.py
@@ -232,6 +232,46 @@ class RunImageGenerationResponse(BaseModel):
 
     url: Optional[str] = None
     status: str
+    generationRecordId: Optional[str] = None
+    actions: list[CanvasAction]
+
+
+# ============================================================
+# start_image_generation / wait_image_generation (W11)
+# ============================================================
+
+
+class StartImageGenerationRequest(BaseModel):
+    """Request for start_image_generation endpoint."""
+
+    sessionId: str
+    userId: str
+    nodeId: str
+
+
+class StartImageGenerationResponse(BaseModel):
+    """Response for start_image_generation endpoint."""
+
+    status: str
+    generationRecordId: str
+    actions: list[CanvasAction]
+
+
+class WaitImageGenerationRequest(BaseModel):
+    """Request for wait_image_generation endpoint."""
+
+    sessionId: str
+    userId: str
+    nodeId: str
+    generationRecordId: str
+
+
+class WaitImageGenerationResponse(BaseModel):
+    """Response for wait_image_generation endpoint."""
+
+    url: Optional[str] = None
+    status: str
+    generationRecordId: Optional[str] = None
     actions: list[CanvasAction]
 
 

--- a/services/agent-runtime/app/graph/nodes/gen_node.py
+++ b/services/agent-runtime/app/graph/nodes/gen_node.py
@@ -46,6 +46,13 @@ def _is_gen_success(result: Any) -> bool:
     return status in ("completed", "success") or has_url
 
 
+def _result_record_id(result: Any) -> str | None:
+    if not isinstance(result, dict):
+        return None
+    rid = result.get("generationRecordId")
+    return str(rid) if rid else None
+
+
 def _result_status(result: Any, exc: BaseException | None = None) -> str:
     if exc is not None:
         return str(exc)
@@ -81,6 +88,7 @@ def make_gen_node(*, nest: Any) -> Callable:
         plan_node_id = state.get("plan_node_id")
         retries = max_auto_retries()
         last_status = "error"
+        last_record_id: str | None = None
 
         await _emit_task_update(nest, id=key, status="running", attempt=0, maxAttempts=retries)
 
@@ -95,6 +103,7 @@ def make_gen_node(*, nest: Any) -> Callable:
                     errorHint=hint_for_error(last_status),
                 )
 
+            record_id = None
             try:
                 ref_order = build_chain_ref_order(
                     item=dict(item),
@@ -117,10 +126,38 @@ def make_gen_node(*, nest: Any) -> Callable:
                         }
                     result = await run(str(node_id))
                 else:
-                    result = await nest.run_image_generation(str(node_id))
+                    start_fn = getattr(nest, "start_image_generation", None)
+                    if start_fn is not None:
+                        started = await start_fn(str(node_id))
+                        record_id = _result_record_id(started)
+                        if record_id:
+                            last_record_id = record_id
+                            await _emit_task_update(
+                                nest,
+                                id=key,
+                                status="running",
+                                recordId=record_id,
+                                attempt=attempt,
+                                maxAttempts=retries,
+                            )
+                        wait_fn = getattr(nest, "wait_image_generation", None)
+                        if wait_fn is not None and record_id:
+                            result = await wait_fn(str(node_id), record_id)
+                            if not _result_record_id(result):
+                                result = {**result, "generationRecordId": record_id}
+                        else:
+                            result = started
+                    else:
+                        result = await nest.run_image_generation(str(node_id))
+                        record_id = _result_record_id(result)
+                        if record_id:
+                            last_record_id = record_id
 
                 if _is_gen_success(result):
-                    await _emit_task_update(nest, id=key, status="done")
+                    payload: dict[str, Any] = {"id": key, "status": "done"}
+                    if last_record_id:
+                        payload["recordId"] = last_record_id
+                    await _emit_task_update(nest, **payload)
                     await _emit_line(nest, format_gen_progress_line(title=title, status="completed"))
                     return {"gen_completed_keys": [key]}
 
@@ -131,13 +168,15 @@ def make_gen_node(*, nest: Any) -> Callable:
 
             if not is_recoverable(last_status):
                 hint = hint_for_error(last_status)
-                await _emit_task_update(
-                    nest,
-                    id=key,
-                    status="needs_user",
-                    errorCode=last_status,
-                    errorHint=hint,
-                )
+                upd: dict[str, Any] = {
+                    "id": key,
+                    "status": "needs_user",
+                    "errorCode": last_status,
+                    "errorHint": hint,
+                }
+                if last_record_id:
+                    upd["recordId"] = last_record_id
+                await _emit_task_update(nest, **upd)
                 # P1-5: fallback_pending 不向聊天流 emit 单行（走画布 ByokFallbackConfirmDialog）
                 if "fallback_pending" not in last_status.lower():
                     await _emit_line(nest, format_gen_progress_line(title=title, status=last_status))
@@ -150,13 +189,15 @@ def make_gen_node(*, nest: Any) -> Callable:
 
         # Exhausted retries
         hint = hint_for_error(last_status)
-        await _emit_task_update(
-            nest,
-            id=key,
-            status="failed",
-            errorCode=last_status,
-            errorHint=hint,
-        )
+        fail_upd: dict[str, Any] = {
+            "id": key,
+            "status": "failed",
+            "errorCode": last_status,
+            "errorHint": hint,
+        }
+        if last_record_id:
+            fail_upd["recordId"] = last_record_id
+        await _emit_task_update(nest, **fail_upd)
         await _emit_line(nest, format_gen_progress_line(title=title, status=last_status))
         return {
             "gen_failed_keys": [key],

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -234,6 +234,29 @@ class NestEventProxy:
         payload: dict[str, Any] = {"nodeId": node_id, "status": status}
         if result.get("url"):
             payload["url"] = result["url"]
+        if result.get("generationRecordId"):
+            payload["generationRecordId"] = result["generationRecordId"]
+        await self._emit({"type": "node_status", "data": payload})
+        return result
+
+    async def start_image_generation(self, node_id: str) -> dict[str, Any]:
+        await self._emit(
+            {"type": "node_status", "data": {"nodeId": node_id, "status": "generating"}}
+        )
+        return await self._forward_actions(await self._inner.start_image_generation(node_id))
+
+    async def wait_image_generation(
+        self, node_id: str, generation_record_id: str
+    ) -> dict[str, Any]:
+        result = await self._forward_actions(
+            await self._inner.wait_image_generation(node_id, generation_record_id)
+        )
+        status = str(result.get("status") or "completed")
+        payload: dict[str, Any] = {"nodeId": node_id, "status": status}
+        if result.get("url"):
+            payload["url"] = result["url"]
+        if result.get("generationRecordId"):
+            payload["generationRecordId"] = result["generationRecordId"]
         await self._emit({"type": "node_status", "data": payload})
         return result
 

--- a/services/agent-runtime/app/tools/nest_client.py
+++ b/services/agent-runtime/app/tools/nest_client.py
@@ -166,6 +166,25 @@ class NestCanvasClient:
             timeout=timeout_sec,
         )
 
+    async def start_image_generation(self, node_id: str) -> dict[str, Any]:
+        return await self._post(
+            "/agent/internal/start-image-generation",
+            {"sessionId": self._session_id, "userId": self._user_id, "nodeId": node_id},
+        )
+
+    async def wait_image_generation(self, node_id: str, generation_record_id: str) -> dict[str, Any]:
+        timeout_sec = float(settings.image_gen_timeout_sec) + IMAGE_GEN_TIMEOUT_BUFFER_SEC
+        return await self._post(
+            "/agent/internal/wait-image-generation",
+            {
+                "sessionId": self._session_id,
+                "userId": self._user_id,
+                "nodeId": node_id,
+                "generationRecordId": generation_record_id,
+            },
+            timeout=timeout_sec,
+        )
+
     async def run_video_generation(self, node_id: str) -> dict[str, Any]:
         timeout_sec = float(settings.image_gen_timeout_sec) + IMAGE_GEN_TIMEOUT_BUFFER_SEC
         return await self._post(

--- a/services/agent-runtime/tests/test_gen_node.py
+++ b/services/agent-runtime/tests/test_gen_node.py
@@ -56,6 +56,17 @@ class FakeNest:
         self.image_calls.append(key)
         return self._gen(key, node_id)
 
+    async def start_image_generation(self, node_id: str) -> dict[str, Any]:
+        key = self._key_for(node_id)
+        self.image_calls.append(key)
+        result = self._gen(key, node_id)
+        return {**result, "generationRecordId": f"rec-{key}", "status": "generating"}
+
+    async def wait_image_generation(self, node_id: str, generation_record_id: str) -> dict[str, Any]:
+        key = self._key_for(node_id)
+        result = self._gen(key, node_id)
+        return {**result, "generationRecordId": generation_record_id}
+
     async def run_video_generation(self, node_id: str) -> dict[str, Any]:
         key = self._key_for(node_id)
         self.video_calls.append(key)
@@ -186,6 +197,16 @@ async def test_gen_node_video_calls_run_video_generation():
     assert nest.video_calls == ["k"]
     assert nest.image_calls == []
     assert out == {"gen_completed_keys": ["k"]}
+
+
+@pytest.mark.asyncio
+async def test_gen_node_emits_record_id_on_start():
+    nest = FakeNest()
+    node = make_gen_node(nest=nest)
+    by_key = {"k": _item("k", node_id="node-k")}
+    await node(_state("k", by_key))
+    assert any(u.get("recordId") == "rec-k" for u in nest.task_updates)
+    assert any(u.get("status") == "done" and u.get("recordId") == "rec-k" for u in nest.task_updates)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- **W11**: Split Nest `startImageGeneration` / `waitImageGeneration`; runtime `gen_node` emits `task_update` with `recordId` immediately after start
- **Web**: `AgentSideRail` polls Studio generation records as authoritative status; SSE `task_update` terminal states deferred when `recordId` present
- **Contract**: New start/wait image-gen schemas; `generationRecordId` on run response

## Test plan
- [x] pytest gen_node 9 passed
- [x] vitest agentTaskProgress 5 passed
- [x] verify-contract all pass
- [x] pnpm build
- [ ] CI green
- [ ] Merge + deploy + production verify


Made with [Cursor](https://cursor.com)