### PR TITLE
feat(agent): W12 SSE stream recovery — thread state + reconnect

### DIFF
--- a/apps/server/src/agent/agent-runtime.client.ts
+++ b/apps/server/src/agent/agent-runtime.client.ts
@@ -10,6 +10,14 @@ export interface RuntimeRunInput {
   userDecision?: 'confirm' | 'revise' | 'replan' | 'confirm_gen' | 'topo_revise' | 'node_revise'
 }
 
+export interface RuntimeThreadState {
+  threadId: string
+  phase: string | null
+  nextNodes: string[]
+  interrupted: boolean
+  finished: boolean
+}
+
 /**
  * HTTP client for Python agent-runtime (`GET /health`, `POST /v1/runs` NDJSON).
  * Nest sends `x-lnkpi-service-token` (AGENT_RUNTIME_SERVICE_TOKEN) on /v1/runs;
@@ -33,6 +41,27 @@ export class AgentRuntimeClient {
       return body?.ok === true
     } catch {
       return false
+    }
+  }
+
+  async getThreadState(threadId: string): Promise<RuntimeThreadState | null> {
+    const url = `${this.baseUrl.replace(/\/$/, '')}/v1/threads/${encodeURIComponent(threadId)}/state`
+    const headers: Record<string, string> = {}
+    const token =
+      this.serviceToken?.trim() || process.env.AGENT_RUNTIME_SERVICE_TOKEN?.trim()
+    if (token) {
+      headers['x-lnkpi-service-token'] = token
+    }
+    try {
+      const res = await fetch(url, {
+        method: 'GET',
+        headers,
+        signal: AbortSignal.timeout(8000),
+      })
+      if (!res.ok) return null
+      return (await res.json()) as RuntimeThreadState
+    } catch {
+      return null
     }
   }
 

--- a/apps/server/src/agent/agent.controller.ts
+++ b/apps/server/src/agent/agent.controller.ts
@@ -73,6 +73,16 @@ export class AgentController {
     return { code: 0, message: 'ok', data }
   }
 
+  /** W12: LangGraph checkpoint phase for agent reconnect. */
+  @Get('thread-state')
+  @UseGuards(AuthGuard)
+  async threadState(
+    @Query('threadId') threadId: string,
+  ) {
+    const data = await this.agentService.getThreadState(threadId)
+    return { code: 0, message: 'ok', data }
+  }
+
   @Post('chat/optimize-prompt')
   async optimizePrompt(@Body() dto: OptimizePromptDto) {
     const data = await this.agentService.optimizePrompt(dto.prompt, dto.style)

--- a/apps/server/src/agent/agent.service.ts
+++ b/apps/server/src/agent/agent.service.ts
@@ -162,6 +162,20 @@ export class AgentService {
     return { ok, latencyMs: ok ? Date.now() - start : undefined }
   }
 
+  /** W12: Read LangGraph checkpoint phase for reconnect UI. */
+  async getThreadState(threadId: string): Promise<{
+    threadId: string
+    phase: string | null
+    nextNodes: string[]
+    interrupted: boolean
+    finished: boolean
+  } | null> {
+    const runtimeUrl = process.env.AGENT_RUNTIME_URL?.trim()
+    if (!runtimeUrl || !threadId.trim()) return null
+    const client = this.createRuntimeClient(runtimeUrl)
+    return client.getThreadState(threadId.trim())
+  }
+
   /** Overridable in unit tests */
   createRuntimeClient(baseUrl: string): AgentRuntimeClient {
     return new AgentRuntimeClient(

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -14,6 +14,7 @@ import {
   type AgentTaskProgressState,
 } from '@/components/agent/agentTaskProgress'
 import { useGenerationPolling, type GenerationPollTask } from '@/composables/useGenerationPolling'
+import { useAgentStream, formatPhaseLabel } from '@/composables/useAgentStream'
 import {
   reconcileTaskProgress,
   shouldFinishTaskCard,
@@ -32,7 +33,6 @@ import {
   shouldPollRuntimeHealth,
   checkRuntimeHealthViaNest,
   RUNTIME_UNREACHABLE_SNIPPET,
-  isStreamStale,
 } from '@/components/agent/streamRecovery'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
@@ -88,6 +88,16 @@ function pollTasksFromProgress() {
   }
   startTaskRecordPoll(tasks)
 }
+
+let streamAbortController: AbortController | null = null
+const reconnecting = ref(false)
+const recoveredPhaseHint = ref<string | null>(null)
+
+const agentStream = useAgentStream({
+  onStale: () => {
+    streamAbortController?.abort()
+  },
+})
 
 /** 方案确认门 / 主文案确认门：侧栏快捷钮 */
 const chipSet = computed(() => {
@@ -355,12 +365,15 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
   const idempotencyKey = buildIdempotencyKey(agentThreadId.value)
   // Track whether SSE stream ended normally (received [DONE])
   let streamEndedNormally = false
-  let lastStreamActivityAt = Date.now()
+  recoveredPhaseHint.value = null
+  streamAbortController = new AbortController()
+  agentStream.start()
 
   try {
     const token = localStorage.getItem('token')
     const res = await fetch(apiUrl('/api/agent/chat/conversation'), {
       method: 'POST',
+      signal: streamAbortController.signal,
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`,
@@ -394,21 +407,27 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
         }
         try {
           const event = JSON.parse(line.slice(6)) as { type: string; data: unknown }
-          lastStreamActivityAt = Date.now()
+          agentStream.touch()
           handleEvent(event)
         } catch { /* skip */ }
       }
     }
   } catch (err) {
-    agent.appendText(`\n\n⚠️ 请求失败: ${err}`)
+    if ((err as Error)?.name !== 'AbortError') {
+      agent.appendText(`\n\n⚠️ 请求失败: ${err}`)
+    }
   } finally {
+    agentStream.stop()
+    streamAbortController = null
     // SSE abnormal-end detection: stream broke without [DONE]
     if (!streamEndedNormally) {
       const last = agent.messages[agent.messages.length - 1]
       if (last?.role === 'assistant' && !last.content.trim()) {
         agent.appendText('\n\n⚠️ 连接意外断开，请稍后重试。')
-      } else if (last?.role === 'assistant' && isStreamStale(lastStreamActivityAt)) {
-        last.content += `\n\n⚠️ ${RUNTIME_UNREACHABLE_SNIPPET}，已保存进度。请稍后重试。`
+      } else if (last?.role === 'assistant' && agentStream.unreachable.value) {
+        if (!last.content.includes(RUNTIME_UNREACHABLE_SNIPPET)) {
+          last.content += `\n\n⚠️ ${RUNTIME_UNREACHABLE_SNIPPET}，已保存进度。请点击下方「重连」继续。`
+        }
       }
     }
 
@@ -422,6 +441,50 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
     if (actions.length) emit('canvasActions', actions)
     // 始终回拉：Runtime 已写 Session.canvasData；本地 save 不得用旧节点覆盖
     emit('turnComplete')
+    scrollToBottom()
+  }
+}
+
+async function reconnectStream() {
+  if (reconnecting.value) return
+  reconnecting.value = true
+  try {
+    streamAbortController?.abort()
+    agentStream.stop()
+
+    const health = await checkRuntimeHealthViaNest()
+    if (!health?.ok) {
+      recoveredPhaseHint.value = '生成服务仍不可达，请稍后再试'
+      return
+    }
+
+    const token = localStorage.getItem('token')
+    const res = await fetch(
+      apiUrl(`/api/agent/thread-state?threadId=${encodeURIComponent(agentThreadId.value)}`),
+      { headers: { Authorization: `Bearer ${token}` } },
+    )
+    const json = (await res.json()) as {
+      data?: { phase?: string | null; interrupted?: boolean; finished?: boolean } | null
+    }
+    const phase = json.data?.phase ?? null
+
+    if (agent.isStreaming) {
+      agent.finishStreaming()
+    }
+    agentStream.reset()
+    await reconcileLatestAssistant()
+    emit('turnComplete')
+
+    const label = formatPhaseLabel(phase)
+    recoveredPhaseHint.value =
+      json.data?.finished
+        ? '服务已恢复。上一轮已完成，可继续新的指令。'
+        : `服务已恢复。当前阶段：${label}。请继续操作。`
+    pollTasksFromProgress()
+  } catch {
+    recoveredPhaseHint.value = '重连失败，请稍后再试'
+  } finally {
+    reconnecting.value = false
     scrollToBottom()
   }
 }
@@ -729,6 +792,26 @@ defineExpose({ openPanel, reconcileFromNodes })
               </button>
               <button type="button" class="agent-readonly-btn agent-readonly-btn-primary" @click="createOwnCanvas">
                 新建画布
+              </button>
+            </div>
+          </div>
+
+          <div
+            v-if="agentStream.unreachable.value || recoveredPhaseHint"
+            class="agent-stream-banner mx-3 mt-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2.5 text-[11px] leading-relaxed text-amber-100"
+          >
+            <p v-if="agentStream.unreachable.value && agent.isStreaming">
+              {{ RUNTIME_UNREACHABLE_SNIPPET }}，已保存进度。出图状态仍可通过轮询更新。
+            </p>
+            <p v-else-if="recoveredPhaseHint">{{ recoveredPhaseHint }}</p>
+            <div class="mt-2 flex flex-wrap gap-2">
+              <button
+                type="button"
+                class="agent-readonly-btn agent-readonly-btn-primary"
+                :disabled="reconnecting"
+                @click="reconnectStream"
+              >
+                {{ reconnecting ? '重连中…' : '重连' }}
               </button>
             </div>
           </div>

--- a/apps/web/src/composables/useAgentStream.test.ts
+++ b/apps/web/src/composables/useAgentStream.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { formatPhaseLabel, useAgentStream } from '@/composables/useAgentStream'
+import { STREAM_STALE_MS } from '@/components/agent/streamRecovery'
+
+describe('useAgentStream', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('marks unreachable after STREAM_STALE_MS without touch', () => {
+    const onStale = vi.fn()
+    const stream = useAgentStream({ pollMs: 1000, onStale })
+    stream.start()
+    vi.advanceTimersByTime(STREAM_STALE_MS + 1500)
+    expect(stream.unreachable.value).toBe(true)
+    expect(onStale).toHaveBeenCalledTimes(1)
+    stream.stop()
+  })
+
+  it('touch resets staleness', () => {
+    const stream = useAgentStream({ pollMs: 1000 })
+    stream.start()
+    vi.advanceTimersByTime(STREAM_STALE_MS - 1000)
+    stream.touch()
+    vi.advanceTimersByTime(STREAM_STALE_MS - 1000)
+    expect(stream.unreachable.value).toBe(false)
+    stream.stop()
+  })
+
+  it('stop clears monitoring', () => {
+    const onStale = vi.fn()
+    const stream = useAgentStream({ pollMs: 1000, onStale })
+    stream.start()
+    stream.stop()
+    vi.advanceTimersByTime(STREAM_STALE_MS + 5000)
+    expect(onStale).not.toHaveBeenCalled()
+  })
+})
+
+describe('formatPhaseLabel', () => {
+  it('maps known phases', () => {
+    expect(formatPhaseLabel('await_topo')).toBe('等待拓扑确认')
+    expect(formatPhaseLabel('unknown_phase')).toBe('unknown_phase')
+  })
+})

--- a/apps/web/src/composables/useAgentStream.ts
+++ b/apps/web/src/composables/useAgentStream.ts
@@ -1,0 +1,80 @@
+import { onUnmounted, ref } from 'vue'
+import { isStreamStale } from '@/components/agent/streamRecovery'
+
+export interface UseAgentStreamOptions {
+  /** Called once when SSE goes stale during an active stream. */
+  onStale?: () => void
+  /** How often to check staleness while streaming (ms). */
+  pollMs?: number
+}
+
+/**
+ * W12: Monitor an active agent SSE stream for heartbeat staleness.
+ * Generation record polling stays independent (see useGenerationPolling).
+ */
+export function useAgentStream(options: UseAgentStreamOptions = {}) {
+  const unreachable = ref(false)
+  const lastActivityAt = ref(Date.now())
+  let timer: ReturnType<typeof setInterval> | undefined
+  let monitoring = false
+  let staleNotified = false
+
+  function touch() {
+    lastActivityAt.value = Date.now()
+    staleNotified = false
+    if (unreachable.value) unreachable.value = false
+  }
+
+  function start() {
+    stop()
+    monitoring = true
+    staleNotified = false
+    unreachable.value = false
+    lastActivityAt.value = Date.now()
+    const pollMs = options.pollMs ?? 5000
+    timer = setInterval(() => {
+      if (!monitoring) return
+      if (isStreamStale(lastActivityAt.value) && !staleNotified) {
+        staleNotified = true
+        unreachable.value = true
+        options.onStale?.()
+      }
+    }, pollMs)
+  }
+
+  function stop() {
+    monitoring = false
+    if (timer) clearInterval(timer)
+    timer = undefined
+  }
+
+  function reset() {
+    unreachable.value = false
+    staleNotified = false
+    lastActivityAt.value = Date.now()
+  }
+
+  onUnmounted(stop)
+
+  return { unreachable, lastActivityAt, touch, start, stop, reset }
+}
+
+export const PHASE_LABELS: Record<string, string> = {
+  intake: '理解需求',
+  plan: '拟定方案',
+  await_confirm: '等待方案确认',
+  write_plan_node: '写入方案',
+  split: '拆解画布',
+  draft_copy: '起草文案',
+  await_copy_confirm: '等待文案确认',
+  write_copy_node: '写入文案',
+  await_topo: '等待拓扑确认',
+  orchestrate_gen: '出图进行中',
+  done: '已完成',
+  error: '出错',
+}
+
+export function formatPhaseLabel(phase: string | null | undefined): string {
+  if (!phase) return '未知'
+  return PHASE_LABELS[phase] ?? phase
+}

--- a/services/agent-runtime/app/main.py
+++ b/services/agent-runtime/app/main.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI, Header, HTTPException
 from fastapi.responses import StreamingResponse
 
 from app.config import settings
-from app.runs import RunRequest, stream_run_events
+from app.runs import RunRequest, get_thread_state, stream_run_events
 
 app = FastAPI(title="lnkpi-agent-runtime")
 
@@ -39,6 +39,20 @@ def _require_runtime_auth(x_lnkpi_service_token: str | None) -> None:
 @app.get("/health")
 def health():
     return {"ok": True, "service": "agent-runtime"}
+
+
+@app.get("/v1/threads/{thread_id}/state")
+async def thread_state(
+    thread_id: str,
+    x_lnkpi_service_token: str | None = Header(default=None),
+):
+    _require_runtime_auth(x_lnkpi_service_token)
+    overrides = _run_overrides.get("checkpointer")
+    data = await get_thread_state(
+        thread_id,
+        checkpointer=overrides,
+    )
+    return data
 
 
 @app.post("/v1/runs")

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -379,6 +379,39 @@ async def _save_new_assistant_messages(
         pass
 
 
+async def get_thread_state(
+    thread_id: str,
+    *,
+    checkpointer: Any | None = None,
+) -> dict[str, Any]:
+    """W12: Read LangGraph checkpoint phase for reconnect UI."""
+
+    class _NoOpNest:
+        async def close(self) -> None:
+            pass
+
+    cp = checkpointer if checkpointer is not None else await _get_checkpointer()
+    graph = build_agent_graph(
+        nest=_NoOpNest(),
+        llm=default_llm(),
+        skills_dir=resolve_skills_dir(),
+        checkpointer=cp,
+    )
+    config = {"configurable": {"thread_id": thread_id}}
+    snap = await graph.aget_state(config)
+    vals = getattr(snap, "values", None) or {}
+    next_nodes = [str(n) for n in (getattr(snap, "next", None) or [])]
+    phase = vals.get("phase")
+    phase_str = str(phase) if phase is not None else None
+    return {
+        "threadId": thread_id,
+        "phase": phase_str,
+        "nextNodes": next_nodes,
+        "interrupted": bool(next_nodes),
+        "finished": phase_str == "done" or (not next_nodes and bool(vals)),
+    }
+
+
 async def _load_history(nest: NestCanvasClient) -> list[Any]:
     """Load conversation history from AgentMessage table (C1 decision)."""
     try:

--- a/services/agent-runtime/tests/test_thread_state.py
+++ b/services/agent-runtime/tests/test_thread_state.py
@@ -1,0 +1,18 @@
+"""Tests for W12 get_thread_state endpoint."""
+
+from __future__ import annotations
+
+import pytest
+from langgraph.checkpoint.memory import MemorySaver
+
+from app.runs import get_thread_state
+
+
+@pytest.mark.asyncio
+async def test_get_thread_state_empty_thread():
+    cp = MemorySaver()
+    state = await get_thread_state("thread-empty", checkpointer=cp)
+    assert state["threadId"] == "thread-empty"
+    assert state["phase"] is None
+    assert state["nextNodes"] == []
+    assert state["interrupted"] is False


### PR DESCRIPTION
## Summary
- Runtime: `GET /v1/threads/{thread_id}/state` 暴露当前 phase / turn 状态
- Nest: 代理 `GET /api/agent/thread-state?threadId=` 供前端重连时拉取权威状态
- Web: 新增 `useAgentStream` composable 监控 SSE 心跳 staleness；`AgentSideRail` 集成 AbortController + 重连 banner/按钮，重连时 health check → thread-state → reconcile

## Test plan
- [x] `pnpm build` — exit 0
- [x] vitest `useAgentStream.test.ts` — 4 passed
- [x] pytest `test_thread_state.py` — 1 passed
- [ ] CI 全绿
- [ ] 生产复测 stale/重连流程


Made with [Cursor](https://cursor.com)