### PR TITLE
feat(agent): W16 degradation paths — force choice on max revise / partial gen

### DIFF
--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -34,6 +34,7 @@ import {
   checkRuntimeHealthViaNest,
   RUNTIME_UNREACHABLE_SNIPPET,
 } from '@/components/agent/streamRecovery'
+import ForceChoiceDialog, { type ForceChoiceKind } from '@/components/agent/ForceChoiceDialog.vue'
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
@@ -63,6 +64,8 @@ const chatContainer = ref<HTMLElement>()
 const agentThreadId = ref(createAgentThreadId(props.sessionId))
 const taskProgress = ref<AgentTaskProgressState>(emptyTaskProgress())
 const showTaskCard = computed(() => taskProgress.value.items.length > 0)
+const forceChoiceOpen = ref(false)
+const forceChoiceKind = ref<ForceChoiceKind | null>(null)
 
 const taskRecordPolling = useGenerationPolling((results) => {
   for (const { task, record } of results) {
@@ -298,6 +301,10 @@ async function send() {
   const message = `${skillPrefix}${input.value.trim()}`
   input.value = ''
   // W5 修复：手动输入若匹配确认/修改关键词，也带上 userDecision 触发 Command(resume=...)
+  await sendMessage(message, mapPresetToDecision(message))
+}
+
+async function onForceChoiceAction(message: string) {
   await sendMessage(message, mapPresetToDecision(message))
 }
 
@@ -607,6 +614,14 @@ function handleEvent(event: { type: string; data: unknown }) {
     }
     case 'ping':
       break
+    case 'force_choice': {
+      const kind = (event.data as { kind?: string }).kind
+      if (kind === 'plan_max_revise' || kind === 'copy_max_revise' || kind === 'gen_partial') {
+        forceChoiceKind.value = kind
+        forceChoiceOpen.value = true
+      }
+      break
+    }
     case 'error':
       agent.appendText(`\n\n⚠️ ${(event.data as { message: string }).message}`)
       break
@@ -997,6 +1012,11 @@ defineExpose({ openPanel, reconcileFromNodes })
           </div>
         </div>
       </Teleport>
+      <ForceChoiceDialog
+        v-model="forceChoiceOpen"
+        :kind="forceChoiceKind"
+        @action="onForceChoiceAction"
+      />
     </div>
   </aside>
 </template>

--- a/apps/web/src/components/agent/ForceChoiceDialog.vue
+++ b/apps/web/src/components/agent/ForceChoiceDialog.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+export type ForceChoiceKind = 'plan_max_revise' | 'copy_max_revise' | 'gen_partial'
+
+const props = defineProps<{
+  modelValue: boolean
+  kind: ForceChoiceKind | null
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+  action: [message: string]
+}>()
+
+const COPY: Record<
+  ForceChoiceKind,
+  { title: string; body: string; primary: string; secondary?: string }
+> = {
+  plan_max_revise: {
+    title: '方案修订已达上限',
+    body: '已修订 3 次。请确认当前方案继续，或关闭后重新描述需求。',
+    primary: '确认当前方案',
+    secondary: '稍后再说',
+  },
+  copy_max_revise: {
+    title: '文案修订已达上限',
+    body: '已修订 3 次。请确认写入当前主文案，或关闭后手动调整。',
+    primary: '写入主文案',
+    secondary: '稍后再说',
+  },
+  gen_partial: {
+    title: '部分出图未完成',
+    body: '部分节点已成功出图，部分失败或需人工处理。可确认已完成结果，或稍后重试失败项。',
+    primary: '确认已完成',
+    secondary: '稍后处理',
+  },
+}
+
+const ACTION_MSG: Record<ForceChoiceKind, { primary: string; secondary?: string }> = {
+  plan_max_revise: { primary: '1', secondary: '先不确认，我稍后继续' },
+  copy_max_revise: { primary: '写入主文案', secondary: '先不写入，我稍后继续' },
+  gen_partial: { primary: '确认已完成出图', secondary: '稍后重试失败项' },
+}
+
+const meta = () => (props.kind ? COPY[props.kind] : null)
+
+function close() {
+  emit('update:modelValue', false)
+}
+
+function onPrimary() {
+  if (!props.kind) return
+  emit('action', ACTION_MSG[props.kind].primary)
+  close()
+}
+
+function onSecondary() {
+  if (!props.kind) return
+  const msg = ACTION_MSG[props.kind].secondary
+  if (msg) emit('action', msg)
+  close()
+}
+</script>
+
+<template>
+  <div
+    v-if="modelValue && kind && meta()"
+    class="fixed inset-0 z-[80] flex items-center justify-center bg-black/55 px-4"
+    @click.self="close"
+  >
+    <div
+      class="w-full max-w-md rounded-2xl border border-white/10 bg-[#1e1e1e] p-5 text-white shadow-2xl"
+      role="dialog"
+      aria-modal="true"
+    >
+      <h2 class="text-base font-semibold">{{ meta()!.title }}</h2>
+      <p class="mt-3 text-sm leading-relaxed text-white/70">{{ meta()!.body }}</p>
+      <div class="mt-5 flex justify-end gap-2">
+        <button
+          v-if="meta()!.secondary"
+          type="button"
+          class="rounded-lg px-3 py-1.5 text-sm text-white/70 transition hover:bg-white/5"
+          @click="onSecondary"
+        >
+          {{ meta()!.secondary }}
+        </button>
+        <button
+          type="button"
+          class="rounded-lg bg-indigo-500 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-indigo-400"
+          @click="onPrimary"
+        >
+          {{ meta()!.primary }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/services/agent-runtime/app/graph/limits.py
+++ b/services/agent-runtime/app/graph/limits.py
@@ -1,0 +1,4 @@
+"""W16: Loop engineering limits for HITL gates."""
+
+MAX_PLAN_REVISE = 3
+MAX_COPY_REVISE = 3

--- a/services/agent-runtime/app/graph/nodes/await_confirm.py
+++ b/services/agent-runtime/app/graph/nodes/await_confirm.py
@@ -5,8 +5,13 @@ from typing import Any, Callable
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
 from app.graph.intent import classify_user_decision
+from app.graph.limits import MAX_PLAN_REVISE
 
 _NONE_DECISION_TIP = "请选择 1/A 确认方案，或 2/B、3/C / 说明修改后再确认。"
+_MAX_PLAN_REVISE_TIP = (
+    f"已达最大修订次数（{MAX_PLAN_REVISE} 次），请确认当前方案（回复 1/确认），"
+    "或放弃本轮后重新描述需求。"
+)
 
 
 def _latest_user_text(messages: list[Any]) -> str:
@@ -68,11 +73,23 @@ def make_await_confirm_node(*, llm: Any) -> Callable:
         # 修复 P0-3 盲点：await_confirm → revise → plan 路径不经过 intake，
         # mode 不会被更新为 modify。这里在 revise 时同步设 mode=modify，
         # 让 plan 节点走增量修改分支（保留未提及的节点/文案）。
-        if decision == "revise" and state.get("user_brief") and state.get("plan_draft"):
-            out["mode"] = "modify"
+        if decision == "revise":
+            revise_count = int(state.get("plan_revise_count") or 0)
+            if revise_count >= MAX_PLAN_REVISE:
+                return {
+                    "user_decision": "none",
+                    "phase": "await_confirm",
+                    "force_choice": "plan_max_revise",
+                    "messages": [AIMessage(content=_MAX_PLAN_REVISE_TIP)],
+                }
+            out["plan_revise_count"] = revise_count + 1
+            if state.get("user_brief") and state.get("plan_draft"):
+                out["mode"] = "modify"
         elif decision == "none":
             out["messages"] = [AIMessage(content=_NONE_DECISION_TIP)]
         elif decision == "confirm":
+            out["plan_revise_count"] = 0
+            out["force_choice"] = None
             out["messages"] = [
                 AIMessage(content="正在写入确认方案并拆解画布骨架（先不出图），请稍候…")
             ]

--- a/services/agent-runtime/app/graph/nodes/await_copy_confirm.py
+++ b/services/agent-runtime/app/graph/nodes/await_copy_confirm.py
@@ -5,10 +5,15 @@ from typing import Any, Callable, Literal
 from langchain_core.messages import AIMessage
 
 from app.graph.intent import classify_copy_decision
+from app.graph.limits import MAX_COPY_REVISE
 
 Decision = Literal["none", "confirm", "revise"]
 
 _NONE_TIP = "请确认主文案后回复「写入主文案」，或说明如何修改。"
+_MAX_COPY_REVISE_TIP = (
+    f"已达最大修订次数（{MAX_COPY_REVISE} 次），请确认当前文案（回复「写入主文案」），"
+    "或说明放弃本轮。"
+)
 
 
 def _latest_user_text(messages: list[Any]) -> str:
@@ -34,15 +39,27 @@ def make_await_copy_confirm_node() -> Callable:
                 "messages": [AIMessage(content=_NONE_TIP)],
             }
         if decision == "revise":
+            revise_count = int(state.get("copy_revise_count") or 0)
+            if revise_count >= MAX_COPY_REVISE:
+                return {
+                    "user_decision": "none",
+                    "phase": "await_copy_confirm",
+                    "copy_revise_only": False,
+                    "force_choice": "copy_max_revise",
+                    "messages": [AIMessage(content=_MAX_COPY_REVISE_TIP)],
+                }
             return {
                 "user_decision": "revise",
                 "phase": "await_copy_confirm",
                 "copy_revise_only": True,
+                "copy_revise_count": revise_count + 1,
             }
         return {
             "user_decision": "confirm",
             "phase": "await_copy_confirm",
             "copy_revise_only": False,
+            "copy_revise_count": 0,
+            "force_choice": None,
         }
 
     return await_copy_confirm

--- a/services/agent-runtime/app/graph/nodes/collect_gen.py
+++ b/services/agent-runtime/app/graph/nodes/collect_gen.py
@@ -133,7 +133,8 @@ def make_collect_gen_node(*, nest: Any) -> Callable:
         else:
             msg = "无可自动生成的图片/视频节点。"
 
-        return {
+        partial = success_n > 0 and (fail_n > 0 or needs_user_n > 0)
+        result: dict[str, Any] = {
             "phase": "orchestrate_gen",
             "gen_progress_id": gen_progress_id,
             # Legacy bridges for done.py
@@ -150,5 +151,8 @@ def make_collect_gen_node(*, nest: Any) -> Callable:
             "gen_fail_details": None,
             "gen_max_concurrency": None,
         }
+        if partial:
+            result["force_choice"] = "gen_partial"
+        return result
 
     return collect_gen

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -119,6 +119,11 @@ class AgentRuntimeState(TypedDict, total=False):
     copy_node_id: str | None
     copy_revise_only: bool
 
+    # W16: revision counters for force-choice degradation
+    plan_revise_count: int
+    copy_revise_count: int
+    force_choice: Literal["plan_max_revise", "copy_max_revise", "gen_partial"] | None
+
     # node_revise: 拓扑确认门下检测到"节点内容修改"意图（改为/调整/增加等），
     # 回退到 plan 走 modify 模式增量修改方案，区别于 topo_revise（纯拓扑删除）
     user_decision: Literal[

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -524,6 +524,14 @@ async def stream_run_events(
                 for _node, delta in update.items():
                     if not isinstance(delta, dict):
                         continue
+                    force_choice = delta.get("force_choice")
+                    if force_choice:
+                        await emit(
+                            {
+                                "type": "force_choice",
+                                "data": {"kind": str(force_choice)},
+                            }
+                        )
                     messages = delta.get("messages")
                     if not messages:
                         continue

--- a/services/agent-runtime/tests/test_await_confirm.py
+++ b/services/agent-runtime/tests/test_await_confirm.py
@@ -87,6 +87,39 @@ def test_classify_pianhao_is_not_revise():
 
 
 @pytest.mark.asyncio
+async def test_revise_blocked_after_max_plan_revise():
+    node = make_await_confirm_node(llm=_FakeLLM())
+    base = {
+        "messages": [HumanMessage(content="改成运动鞋")],
+        "phase": "await_confirm",
+        "user_brief": "洁具详情页",
+        "plan_draft": "# plan",
+        "plan_revise_count": 3,
+    }
+    out = await node(base)
+    assert out["user_decision"] == "none"
+    assert out.get("force_choice") == "plan_max_revise"
+    assert "最大修订" in out["messages"][0].content
+
+
+@pytest.mark.asyncio
+async def test_revise_increments_plan_revise_count():
+    node = make_await_confirm_node(llm=_FakeLLM())
+    out = await node(
+        {
+            "messages": [HumanMessage(content="改成双人模特")],
+            "phase": "await_confirm",
+            "user_brief": "帮我做一套洁具详情页营销方案",
+            "plan_draft": "# 洁具详情页方案\n## 定位...",
+            "plan_revise_count": 1,
+        }
+    )
+    assert out["user_decision"] == "revise"
+    assert out["plan_revise_count"] == 2
+    assert out["mode"] == "modify"
+
+
+@pytest.mark.asyncio
 async def test_revise_decision_sets_modify_mode_when_brief_and_plan_exist():
     # 修复 P0-3 盲点：await_confirm → revise → plan 路径不经过 intake，
     # 必须在 await_confirm 节点同步设 mode=modify，否则 plan 会走 create 分支
@@ -105,6 +138,7 @@ async def test_revise_decision_sets_modify_mode_when_brief_and_plan_exist():
         "revise + 已有 brief/plan 时必须设 mode=modify，"
         "否则 plan 节点会走 create 分支重新生成全新方案"
     )
+    assert out.get("plan_revise_count") == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- **W16 Loop Engineering**: 方案/文案门修订上限 3 次 → `force_choice: plan_max_revise | copy_max_revise`
- 出图部分成功 → `force_choice: gen_partial`
- SSE 新事件 `force_choice`；前端 `ForceChoiceDialog` 一键发送确认/放弃

## Test plan
- [x] pytest `test_await_confirm` — 16 passed
- [x] `pnpm build` — exit 0
- [ ] CI 全绿
- [ ] 生产：连续 4 次方案修改触发强制选择弹窗


Made with [Cursor](https://cursor.com)