### PR TITLE
feat(agent): W24 Prometheus metrics for agent-runtime

### DIFF
--- a/services/agent-runtime/app/main.py
+++ b/services/agent-runtime/app/main.py
@@ -4,9 +4,10 @@ import json
 from typing import Any
 
 from fastapi import FastAPI, Header, HTTPException
-from fastapi.responses import StreamingResponse
+from fastapi.responses import Response, StreamingResponse
 
 from app.config import settings
+from app.metrics import metrics_payload
 from app.runs import RunRequest, get_thread_state, stream_run_events
 
 app = FastAPI(title="lnkpi-agent-runtime")
@@ -39,6 +40,13 @@ def _require_runtime_auth(x_lnkpi_service_token: str | None) -> None:
 @app.get("/health")
 def health():
     return {"ok": True, "service": "agent-runtime"}
+
+
+@app.get("/metrics")
+def metrics():
+    """W24: Prometheus scrape endpoint."""
+    payload, content_type = metrics_payload()
+    return Response(content=payload, media_type=content_type)
 
 
 @app.get("/v1/threads/{thread_id}/state")

--- a/services/agent-runtime/app/metrics.py
+++ b/services/agent-runtime/app/metrics.py
@@ -1,0 +1,71 @@
+"""W24: Prometheus metrics for agent-runtime observability."""
+
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from typing import Iterator
+
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Gauge, Histogram, generate_latest
+
+# Spec O1: key agent metrics with node_name / phase dimensions where useful.
+THREADS_TOTAL = Counter("agent_threads_total", "Total agent run streams started")
+THREADS_ACTIVE = Gauge("agent_threads_active", "Currently active agent run streams")
+NODES_EXECUTED = Counter(
+    "agent_nodes_executed_total",
+    "LangGraph nodes executed",
+    ["node_name"],
+)
+NODES_DURATION = Histogram(
+    "agent_nodes_duration_seconds",
+    "LangGraph node execution duration",
+    ["node_name"],
+    buckets=(0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 120, 300, 600),
+)
+TOOL_CALLS = Counter(
+    "agent_tool_calls_total",
+    "Nest canvas tool HTTP calls",
+    ["tool_name", "outcome"],
+)
+STREAM_ERRORS = Counter(
+    "agent_stream_errors_total",
+    "Agent stream terminal errors",
+    ["error_type"],
+)
+
+
+def metrics_payload() -> tuple[bytes, str]:
+    return generate_latest(), CONTENT_TYPE_LATEST
+
+
+def thread_started() -> None:
+    THREADS_TOTAL.inc()
+    THREADS_ACTIVE.inc()
+
+
+def thread_finished() -> None:
+    THREADS_ACTIVE.dec()
+
+
+def record_node_executed(node_name: str, duration_sec: float) -> None:
+    name = node_name or "unknown"
+    NODES_EXECUTED.labels(node_name=name).inc()
+    NODES_DURATION.labels(node_name=name).observe(max(duration_sec, 0.0))
+
+
+def record_tool_call(tool_name: str, *, success: bool) -> None:
+    outcome = "success" if success else "error"
+    TOOL_CALLS.labels(tool_name=tool_name or "unknown", outcome=outcome).inc()
+
+
+def record_stream_error(error_type: str) -> None:
+    STREAM_ERRORS.labels(error_type=error_type or "internal_error").inc()
+
+
+@contextmanager
+def track_node(node_name: str) -> Iterator[None]:
+    started = time.perf_counter()
+    try:
+        yield
+    finally:
+        record_node_executed(node_name, time.perf_counter() - started)

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel
 from app.config import settings
 from app.errors import AgentToolError, error_to_sse_payload, from_exception
 from app.graph.builder import build_agent_graph
+from app.metrics import record_stream_error, thread_finished, thread_started, track_node
 from app.graph.nodes.intake import modify_intent
 from app.tools.nest_client import NestCanvasClient
 
@@ -467,6 +468,7 @@ async def stream_run_events(
 
     proxy = NestEventProxy(inner_nest, emit)
     graph_llm = llm if llm is not None else default_llm()
+    thread_started()
 
     active_checkpointer = checkpointer if checkpointer is not None else await _get_checkpointer()
     graph = build_agent_graph(
@@ -521,38 +523,42 @@ async def stream_run_events(
             async for update in graph.astream(input_state, config, stream_mode="updates"):
                 if not isinstance(update, dict):
                     continue
-                for _node, delta in update.items():
-                    if not isinstance(delta, dict):
-                        continue
-                    force_choice = delta.get("force_choice")
-                    if force_choice:
-                        await emit(
-                            {
-                                "type": "force_choice",
-                                "data": {"kind": str(force_choice)},
-                            }
-                        )
-                    messages = delta.get("messages")
-                    if not messages:
-                        continue
-                    seq = messages if isinstance(messages, list) else [messages]
-                    for msg in seq:
-                        content = getattr(msg, "content", None)
-                        if content is None and isinstance(msg, dict):
-                            content = msg.get("content")
-                        if not content:
+                for node_name, delta in update.items():
+                    with track_node(str(node_name)):
+                        if not isinstance(delta, dict):
                             continue
-                        # Prefer AI replies for text_delta
-                        msg_type = getattr(msg, "type", None) or (
-                            msg.get("role") if isinstance(msg, dict) else None
-                        )
-                        if msg_type in ("ai", "assistant") or isinstance(msg, AIMessage):
-                            await emit({"type": "text_delta", "data": {"text": str(content)}})
+                        force_choice = delta.get("force_choice")
+                        if force_choice:
+                            await emit(
+                                {
+                                    "type": "force_choice",
+                                    "data": {"kind": str(force_choice)},
+                                }
+                            )
+                        messages = delta.get("messages")
+                        if not messages:
+                            continue
+                        seq = messages if isinstance(messages, list) else [messages]
+                        for msg in seq:
+                            content = getattr(msg, "content", None)
+                            if content is None and isinstance(msg, dict):
+                                content = msg.get("content")
+                            if not content:
+                                continue
+                            # Prefer AI replies for text_delta
+                            msg_type = getattr(msg, "type", None) or (
+                                msg.get("role") if isinstance(msg, dict) else None
+                            )
+                            if msg_type in ("ai", "assistant") or isinstance(msg, AIMessage):
+                                await emit({"type": "text_delta", "data": {"text": str(content)}})
             await emit({"type": "done", "data": {}})
         except AgentToolError as exc:
+            record_stream_error(exc.error["error_type"])
             await emit({"type": "error", "data": error_to_sse_payload(exc.error)})
         except Exception as exc:  # noqa: BLE001 — surface to Nest SSE
-            await emit({"type": "error", "data": error_to_sse_payload(from_exception("stream_run", exc))})
+            err = from_exception("stream_run", exc)
+            record_stream_error(err["error_type"])
+            await emit({"type": "error", "data": error_to_sse_payload(err)})
         finally:
             # W2: save only new assistant messages from this turn (user saved at entry)
             try:
@@ -589,6 +595,7 @@ async def stream_run_events(
                 break
             yield item
     finally:
+        thread_finished()
         hb_task.cancel()
         try:
             await hb_task

--- a/services/agent-runtime/app/tools/nest_client.py
+++ b/services/agent-runtime/app/tools/nest_client.py
@@ -12,6 +12,7 @@ from app.errors import (
     from_nest_message,
     tool_timeout_error,
 )
+from app.metrics import record_tool_call
 from app.tools.circuit_breaker import CircuitBreaker
 
 DEFAULT_HTTP_TIMEOUT_SEC = 30.0
@@ -98,6 +99,7 @@ class NestCanvasClient:
     ) -> dict[str, Any]:
         name = tool_name or _tool_name_from_path(path)
         if self._breaker.is_open(name):
+            record_tool_call(name, success=False)
             raise AgentToolError(circuit_open_error(name))
 
         effective_timeout = timeout if timeout is not None else _default_timeout_sec(path)
@@ -112,11 +114,13 @@ class NestCanvasClient:
             response.raise_for_status()
         except httpx.TimeoutException as exc:
             self._breaker.record_failure(name)
+            record_tool_call(name, success=False)
             raise AgentToolError(tool_timeout_error(name)) from exc
         except httpx.HTTPStatusError as exc:
             err = from_http_status(name, exc.response.status_code)
             if err["error_type"] == "downstream_unavailable":
                 self._breaker.record_failure(name)
+            record_tool_call(name, success=False)
             raise AgentToolError(err) from exc
 
         payload = response.json()
@@ -124,9 +128,11 @@ class NestCanvasClient:
             err = from_nest_message(name, str(payload.get("message", "Nest request failed")), code=payload.get("code"))
             if err["error_type"] in ("downstream_unavailable", "tool_timeout"):
                 self._breaker.record_failure(name)
+            record_tool_call(name, success=False)
             raise AgentToolError(err)
 
         self._breaker.record_success(name)
+        record_tool_call(name, success=True)
         return payload["data"]
 
     async def upsert_prompt_node(

--- a/services/agent-runtime/pyproject.toml
+++ b/services/agent-runtime/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "pyyaml>=6.0",
   "pydantic>=2.0",
   "pydantic-settings>=2.0",
+  "prometheus-client>=0.21",
 ]
 
 [project.optional-dependencies]

--- a/services/agent-runtime/tests/test_metrics.py
+++ b/services/agent-runtime/tests/test_metrics.py
@@ -1,0 +1,55 @@
+"""Tests for W24 Prometheus metrics."""
+
+from __future__ import annotations
+
+from prometheus_client import REGISTRY
+
+from app import metrics
+
+
+def _sample_value(name: str, labels: dict[str, str] | None = None) -> float:
+    value = REGISTRY.get_sample_value(name, labels or {})
+    return float(value or 0.0)
+
+
+def test_thread_gauge_and_counter():
+    before_total = _sample_value("agent_threads_total")
+    before_active = _sample_value("agent_threads_active")
+
+    metrics.thread_started()
+    metrics.thread_started()
+    assert _sample_value("agent_threads_total") == before_total + 2
+    assert _sample_value("agent_threads_active") == before_active + 2
+
+    metrics.thread_finished()
+    assert _sample_value("agent_threads_active") == before_active + 1
+
+
+def test_node_and_tool_metrics():
+    metrics.record_node_executed("await_confirm", 0.12)
+    metrics.record_tool_call("getNode", success=True)
+    metrics.record_tool_call("getNode", success=False)
+    metrics.record_stream_error("tool_timeout")
+
+    assert _sample_value("agent_nodes_executed_total", {"node_name": "await_confirm"}) >= 1
+    assert _sample_value("agent_tool_calls_total", {"tool_name": "getNode", "outcome": "success"}) >= 1
+    assert _sample_value("agent_tool_calls_total", {"tool_name": "getNode", "outcome": "error"}) >= 1
+    assert _sample_value("agent_stream_errors_total", {"error_type": "tool_timeout"}) >= 1
+
+
+def test_metrics_payload_contains_series():
+    payload, content_type = metrics.metrics_payload()
+    text = payload.decode()
+    assert "agent_threads_total" in text
+    assert content_type.startswith("text/plain")
+
+
+def test_metrics_endpoint(client=None):
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+
+    tc = TestClient(app)
+    resp = tc.get("/metrics")
+    assert resp.status_code == 200
+    assert "agent_threads_total" in resp.text


### PR DESCRIPTION
## Summary
- **W24 Observability**: `GET /metrics` Prometheus 端点
- 指标：`agent_threads_*`、`agent_nodes_executed/duration`、`agent_tool_calls`、`agent_stream_errors`
- 接入点：`stream_run_events` 节点执行、`nest_client._post` 工具调用

## Test plan
- [x] pytest `test_metrics.py` + `test_nest_client` — 17 passed
- [x] `pnpm build` — exit 0
- [ ] CI 全绿
- [ ] 生产 `curl agent-runtime:8000/metrics` 可见 series


Made with [Cursor](https://cursor.com)