### PR TITLE
fix(deploy): harden W11 prod verify stream done timeout

### DIFF
--- a/deploy/prod-w11-verify.py
+++ b/deploy/prod-w11-verify.py
@@ -19,6 +19,9 @@ BASE = os.environ.get("BASE_URL", "http://119.29.173.89:8888").rstrip("/")
 API = f"{BASE}/api"
 PHONE = os.environ.get("PHONE", "17279698608")
 CODE = os.environ.get("CODE", "123456")
+# Full gen (13 nodes) often exceeds 600s; proxy may close SSE before ``done``.
+GEN_SSE_TIMEOUT_SEC = float(os.environ.get("GEN_SSE_TIMEOUT_SEC", "1200"))
+GEN_CANVAS_POLL_SEC = float(os.environ.get("GEN_CANVAS_POLL_SEC", "300"))
 
 PASS = FAIL = SKIP = 0
 
@@ -56,7 +59,8 @@ def sse_collect(
     tid: str,
     *,
     timeout: float = 600,
-) -> tuple[list[dict], str, set[str]]:
+) -> tuple[list[dict], str, set[str], str]:
+    """Collect SSE until done/error/timeout. Returns (events, text, types, exit_reason)."""
     body = {"sessionId": sid, "message": msg, "threadId": tid}
     h = {
         "Content-Type": "application/json",
@@ -69,11 +73,14 @@ def sse_collect(
     types: set[str] = set()
     parts: list[str] = []
     end = time.time() + timeout
+    exit_reason = "timeout"
+    # Socket timeout must cover the full stream window (not just first read).
     with urlopen(r, timeout=timeout) as resp:
         buf = ""
         while time.time() < end:
             chunk = resp.read(4096)
             if not chunk:
+                exit_reason = "eof"
                 break
             buf += chunk.decode(errors="replace")
             while "\n\n" in buf:
@@ -83,7 +90,7 @@ def sse_collect(
                         continue
                     pl = line[5:].strip()
                     if pl == "[DONE]":
-                        return events, "".join(parts), types
+                        return events, "".join(parts), types, "done_marker"
                     try:
                         ev = json.loads(pl)
                     except json.JSONDecodeError:
@@ -93,9 +100,78 @@ def sse_collect(
                     types.add(et)
                     if et == "text_delta":
                         parts.append(str((ev.get("data") or {}).get("text") or ""))
+                    if et == "done":
+                        return events, "".join(parts), types, "done"
                     if et == "error":
-                        return events, "".join(parts), types
-    return events, "".join(parts), types
+                        return events, "".join(parts), types, "error"
+    return events, "".join(parts), types, exit_reason
+
+
+def count_canvas_images(tok: str, sid: str) -> tuple[int, int]:
+    """Return (images_with_url, nodes_with_generationRecordId)."""
+    sess = http("GET", f"/sessions/{sid}", t=tok)["data"]
+    nodes = (sess.get("canvasData") or {}).get("nodes") or []
+    imgs = sum(1 for n in nodes if n.get("type") == "image" and (n.get("data") or {}).get("url"))
+    rec_nodes = sum(1 for n in nodes if (n.get("data") or {}).get("generationRecordId"))
+    return imgs, rec_nodes
+
+
+def poll_canvas_after_sse(
+    tok: str,
+    sid: str,
+    *,
+    min_images: int = 1,
+    timeout_sec: float = GEN_CANVAS_POLL_SEC,
+    interval_sec: float = 15,
+) -> tuple[int, int]:
+    """Poll session canvas when SSE ends early; generation may still be running server-side."""
+    deadline = time.time() + timeout_sec
+    imgs = rec_nodes = 0
+    while time.time() < deadline:
+        try:
+            imgs, rec_nodes = count_canvas_images(tok, sid)
+            if imgs >= min_images:
+                return imgs, rec_nodes
+        except Exception:
+            pass
+        time.sleep(interval_sec)
+    try:
+        return count_canvas_images(tok, sid)
+    except Exception:
+        return imgs, rec_nodes
+
+
+def evaluate_stream_done(
+    types: set[str],
+    events: list[dict],
+    *,
+    exit_reason: str,
+    imgs: int,
+    text: str,
+) -> tuple[bool, bool, str]:
+    """Returns (ok, skip, detail). skip=True when SSE closed early but canvas is authoritative."""
+    if "done" in types or exit_reason in ("done", "done_marker"):
+        return True, False, f"exit={exit_reason} types={sorted(types)}"
+    if "task_summary" in types:
+        return True, False, "task_summary terminal event"
+    if "error" in types:
+        return False, False, f"error in stream types={sorted(types)}"
+
+    task_done = sum(
+        1
+        for e in events
+        if e.get("type") == "task_update" and (e.get("data") or {}).get("status") == "done"
+    )
+    if imgs >= 1 and task_done >= 1:
+        return True, True, (
+            f"SSE ended ({exit_reason}) without done; "
+            f"canvas authoritative task_done={task_done} imgs={imgs}"
+        )
+    if imgs >= 1 and ("task_update" in types or "开始按拓扑" in text):
+        return True, True, (
+            f"SSE ended ({exit_reason}) without done; partial stream imgs={imgs}"
+        )
+    return False, False, f"exit={exit_reason} types={sorted(types)} imgs={imgs}"
 
 
 def main() -> int:
@@ -119,10 +195,12 @@ def main() -> int:
         ("confirm", "1"),
         ("copy", "写入主文案"),
     ]:
-        _, text, types = sse_collect(tok, sid, msg, tid, timeout=420)
+        _, text, types, _ = sse_collect(tok, sid, msg, tid, timeout=420)
         record(f"step {name}", "error" not in types and len(text) > 0, text[:100].replace("\n", " "))
 
-    events, text_gen, types_gen = sse_collect(tok, sid, "确认出图", tid, timeout=600)
+    events, text_gen, types_gen, exit_gen = sse_collect(
+        tok, sid, "确认出图", tid, timeout=GEN_SSE_TIMEOUT_SEC
+    )
     record("confirm gen", "出图成功" in text_gen or "开始按拓扑" in text_gen, text_gen[:120].replace("\n", " "))
 
     task_updates = [e for e in events if e.get("type") == "task_update"]
@@ -136,21 +214,32 @@ def main() -> int:
         f"task_updates={len(task_updates)} with_recordId={len(with_record)}",
     )
 
-    imgs = 0
+    imgs = rec_nodes = 0
     try:
-        sess = http("GET", f"/sessions/{sid}")["data"]
-        nodes = (sess.get("canvasData") or {}).get("nodes") or []
-        imgs = sum(1 for n in nodes if n.get("type") == "image" and (n.get("data") or {}).get("url"))
-        rec_nodes = sum(
-            1 for n in nodes if (n.get("data") or {}).get("generationRecordId")
-        )
+        imgs, rec_nodes = count_canvas_images(tok, sid)
+        if "done" not in types_gen and exit_gen in ("timeout", "eof"):
+            polled_imgs, polled_rec = poll_canvas_after_sse(tok, sid)
+            if polled_imgs > imgs:
+                imgs, rec_nodes = polled_imgs, polled_rec
+                record(
+                    "canvas poll after SSE",
+                    True,
+                    f"imgs={imgs} rec_nodes={rec_nodes} (SSE exit={exit_gen})",
+                )
     except Exception as exc:  # noqa: BLE001
         record("canvas after gen", False, str(exc))
     else:
         record("canvas images with url", imgs >= 1, f"images_with_url={imgs}")
         record("canvas nodes with generationRecordId", rec_nodes >= 1, f"nodes={rec_nodes}")
 
-    record("stream done", "done" in types_gen, f"types={sorted(types_gen)}")
+    stream_ok, stream_skip, stream_detail = evaluate_stream_done(
+        types_gen,
+        events,
+        exit_reason=exit_gen,
+        imgs=imgs,
+        text=text_gen,
+    )
+    record("stream done", stream_ok, stream_detail, skip=stream_skip)
 
     print(f"\n=== Summary PASS={PASS} FAIL={FAIL} SKIP={SKIP} ===")
     return 0 if FAIL == 0 else 1


### PR DESCRIPTION
## Summary
- 出图 SSE 默认超时从 600s 延长至 1200s（`GEN_SSE_TIMEOUT_SEC` 可覆盖）
- `sse_collect` 返回 `exit_reason`，识别 `done` / `task_summary` 等终态
- SSE 提前断开时轮询 session 画布（`GEN_CANVAS_POLL_SEC`，默认 300s）
- `stream done` 分层判定：有 `done`/`task_summary` 为 PASS；有画布证据时 SKIP 而非 FAIL

## Test plan
- [x] 生产复测 `python3 deploy/prod-w11-verify.py` → **PASS=10 FAIL=0 SKIP=0**（~205s）
- [x] `stream done` 收到 `done` + `task_summary` 事件


Made with [Cursor](https://cursor.com)