### PR TITLE
fix(agent): harden OTLP tracing for CVM Tempo export

### DIFF
--- a/deploy/enable-observability-cvm.sh
+++ b/deploy/enable-observability-cvm.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Enable W23 observability on CVM: reuse pintuotuo Tempo + rebuild agent-runtime.
+set -euo pipefail
+
+DEPLOY_DIR="${DEPLOY_DIR:-/opt/lnkpi}"
+ENV_FILE="${ENV_FILE:-${DEPLOY_DIR}/.env}"
+COMPOSE_FILE="${DEPLOY_DIR}/deploy/docker-compose.prod.yml"
+TEMPO_CONTAINER="${TEMPO_CONTAINER:-pintuotuo-tempo}"
+TEMPO_NETWORK="${TEMPO_NETWORK:-lnkpi-net}"
+OTEL_ENDPOINT="${OTEL_ENDPOINT:-http://pintuotuo-tempo:4318/v1/traces}"
+
+log() { echo "[$(date -u +%H:%M:%S)] $*"; }
+
+upsert_env() {
+  local key="$1" val="$2" tmp
+  tmp=$(mktemp)
+  touch "$ENV_FILE"
+  if grep -qE "^${key}=" "$ENV_FILE"; then
+    awk -v k="$key" -v v="$val" '
+      BEGIN { done=0 }
+      index($0, k "=") == 1 && !done { print k "=" v; done=1; next }
+      { print }
+      END { if (!done) print k "=" v }
+    ' "$ENV_FILE" >"$tmp"
+  else
+    cat "$ENV_FILE" >"$tmp"
+    printf '%s=%s\n' "$key" "$val" >>"$tmp"
+  fi
+  mv "$tmp" "$ENV_FILE"
+  chmod 600 "$ENV_FILE" 2>/dev/null || true
+}
+
+cd "$DEPLOY_DIR"
+
+log "=== Connect Tempo to ${TEMPO_NETWORK} ==="
+docker network connect "$TEMPO_NETWORK" "$TEMPO_CONTAINER" 2>/dev/null || log "tempo already on network (ok)"
+
+log "=== Write OTEL env ==="
+upsert_env LNKPI_OTEL_EXPORTER_OTLP_ENDPOINT "$OTEL_ENDPOINT"
+upsert_env LNKPI_LANGSMITH_OTEL_ENABLED "false"
+upsert_env LNKPI_OTEL_SERVICE_NAME "lnkpi-agent-runtime"
+
+log "=== Rebuild agent-runtime (latest tracing code) ==="
+export LNKPI_AGENT_RUNTIME_IMAGE="${LNKPI_AGENT_RUNTIME_IMAGE:-lnkpi-agent-runtime:local}"
+export DOCKER_BUILDKIT=1
+docker compose -f "$COMPOSE_FILE" build --progress=plain agent-runtime
+
+log "=== Recreate agent-runtime with new env ==="
+export LNKPI_API_IMAGE="${LNKPI_API_IMAGE:-$(docker inspect lnkpi-api --format '{{.Config.Image}}' 2>/dev/null || echo lnkpi-api:local)}"
+docker compose -f "$COMPOSE_FILE" up -d --no-deps --no-build --force-recreate agent-runtime
+
+log "=== Wait runtime health ==="
+for i in $(seq 1 12); do
+  if docker exec lnkpi-agent-runtime curl -fsS http://127.0.0.1:8000/health >/dev/null 2>&1; then
+    log "runtime healthy"
+    break
+  fi
+  sleep 5
+done
+
+log "=== Verify tracing module ==="
+docker exec lnkpi-agent-runtime python -c "
+from app.tracing import is_tracing_enabled, uses_langsmith_otel
+from app.config import settings
+print('endpoint=', settings.otel_exporter_otlp_endpoint)
+print('tracing=', is_tracing_enabled())
+print('langsmith_otel=', uses_langsmith_otel())
+"
+
+log "=== Done. Run agent flow then query Tempo: ==="
+echo "  curl -s 'http://127.0.0.1:3200/api/search?limit=5&tags=resource.service.name%3Dlnkpi-agent-runtime'"

--- a/services/agent-runtime/app/tracing.py
+++ b/services/agent-runtime/app/tracing.py
@@ -31,8 +31,17 @@ def uses_langsmith_otel() -> bool:
     return _langsmith_otel_active
 
 
+def _normalize_otlp_endpoint(endpoint: str) -> str:
+    ep = endpoint.strip().rstrip("/")
+    if not ep:
+        return ep
+    if ep.endswith("/v1/traces"):
+        return ep
+    return f"{ep}/v1/traces"
+
+
 def _apply_tracing_env() -> None:
-    endpoint = (settings.otel_exporter_otlp_endpoint or "").strip()
+    endpoint = _normalize_otlp_endpoint(settings.otel_exporter_otlp_endpoint or "")
     if endpoint:
         os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = endpoint
     os.environ["OTEL_SERVICE_NAME"] = settings.otel_service_name
@@ -68,17 +77,24 @@ def setup_tracing(*, force: bool = False) -> None:
         try:
             from langsmith.integrations.otel import configure as configure_langsmith_otel
 
-            configure_langsmith_otel(project_name=settings.langsmith_project or "lnkpi-agent")
-            _langsmith_otel_active = True
-            _tracer = trace.get_tracer(settings.otel_service_name)
-            _initialized = True
-            logger.info(
-                "W23 LangSmith OTel enabled endpoint=%s project=%s otel_only=%s",
-                settings.otel_exporter_otlp_endpoint or "(langsmith cloud)",
-                settings.langsmith_project,
-                os.environ.get("LANGSMITH_OTEL_ONLY", "false"),
+            configured = configure_langsmith_otel(
+                project_name=settings.langsmith_project or "lnkpi-agent"
             )
-            return
+            if configured:
+                _langsmith_otel_active = True
+                _tracer = trace.get_tracer(settings.otel_service_name)
+                _initialized = True
+                logger.info(
+                    "W23 LangSmith OTel enabled endpoint=%s project=%s otel_only=%s",
+                    os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT") or "(langsmith cloud)",
+                    settings.langsmith_project,
+                    os.environ.get("LANGSMITH_OTEL_ONLY", "false"),
+                )
+                return
+            logger.warning(
+                "LangSmith OTel configure returned false (missing API key?); "
+                "falling back to manual OTLP exporter"
+            )
         except ImportError:
             logger.warning("langsmith[otel] not installed; falling back to manual OTLP exporter")
         except Exception as exc:  # noqa: BLE001
@@ -90,7 +106,7 @@ def setup_tracing(*, force: bool = False) -> None:
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
 
-    endpoint = (settings.otel_exporter_otlp_endpoint or "").strip()
+    endpoint = _normalize_otlp_endpoint(settings.otel_exporter_otlp_endpoint or "")
     if not endpoint:
         _tracer = trace.get_tracer(settings.otel_service_name)
         _initialized = True

--- a/services/agent-runtime/tests/test_tracing.py
+++ b/services/agent-runtime/tests/test_tracing.py
@@ -52,6 +52,33 @@ def test_trace_node_skipped_when_langsmith_otel(monkeypatch: pytest.MonkeyPatch)
     assert len(exporter.get_finished_spans()) == 0
 
 
+def test_normalize_otlp_endpoint():
+    assert tracing._normalize_otlp_endpoint("http://tempo:4318") == "http://tempo:4318/v1/traces"
+    assert (
+        tracing._normalize_otlp_endpoint("http://tempo:4318/v1/traces")
+        == "http://tempo:4318/v1/traces"
+    )
+    assert tracing._normalize_otlp_endpoint("  ") == ""
+
+
+def test_langsmith_configure_false_falls_back_to_manual_otlp(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(settings, "otel_exporter_otlp_endpoint", "http://127.0.0.1:4318")
+    monkeypatch.setattr(settings, "langsmith_otel_enabled", True)
+
+    def _fake_configure(*_args, **_kwargs):
+        return False
+
+    monkeypatch.setattr(
+        "langsmith.integrations.otel.configure",
+        _fake_configure,
+        raising=False,
+    )
+
+    tracing.setup_tracing(force=True)
+    assert tracing.uses_langsmith_otel() is False
+    assert tracing.is_tracing_enabled() is True
+
+
 def test_agent_run_span(monkeypatch: pytest.MonkeyPatch):
     exporter = InMemorySpanExporter()
     monkeypatch.setattr(settings, "otel_exporter_otlp_endpoint", "http://127.0.0.1:4318")


### PR DESCRIPTION
## Summary
- 自动补全 OTLP HTTP endpoint 的 `/v1/traces` 路径，修复 Tempo 404
- LangSmith `configure()` 返回 false（无 API Key）时回退到手动 OTLP exporter
- 新增 `deploy/enable-observability-cvm.sh`：复用 pintuotuo Tempo，仅 recreate agent-runtime

## Test plan
- [x] `pytest services/agent-runtime/tests/test_tracing.py` (6 passed)
- [x] `pnpm build`
- [ ] CVM rebuild agent-runtime 后复测 Tempo trace


Made with [Cursor](https://cursor.com)