### PR TITLE
feat(agent): topo_revise canvas sync + Phase B prod verify

### DIFF
--- a/deploy/prod-phase-b-user-verify.py
+++ b/deploy/prod-phase-b-user-verify.py
@@ -163,6 +163,7 @@ def main() -> int:
     steps = [
         ("P0-1 plan", "天猫蓝牙耳机详情页营销方案，品牌 lnkpi，PhaseB复测"),
         ("P0-2 confirm plan", "1"),
+        ("P0-3 write copy", "写入主文案"),
     ]
     for name, msg in steps:
         _, text, types, exit_reason = sse_collect(tok, sid, msg, tid, timeout=420)
@@ -173,35 +174,52 @@ def main() -> int:
     phase = str(ts.get("phase") or "")
     record(
         "P1 await_topo thread-state",
-        phase in ("await_topo", "await_confirm", "split") or "确认出图" in json.dumps(ts),
+        phase == "await_topo" or "确认出图" in json.dumps(ts),
         f"phase={phase} interrupted={ts.get('interrupted')}",
     )
 
-    _, qtext, qtypes, _ = sse_collect(tok, sid, "查看主图", tid, timeout=120)
-    record(
-        "P1 topo query",
-        "error" not in qtypes and ("节点" in qtext or "主图" in qtext or "prompt" in qtext.lower()),
-        qtext[:100].replace("\n", " "),
-    )
-
-    _, add_text, add_types, _ = sse_collect(tok, sid, "增加场景图", tid, timeout=180)
-    record(
-        "P1 topo add",
-        "error" not in add_types and ("新增" in add_text or "场景" in add_text or "资产拓扑" in add_text),
-        add_text[:100].replace("\n", " "),
-    )
-
-    if TOPO_DELETE:
-        _, del_text, del_types, _ = sse_collect(tok, sid, "删掉 Banner", tid, timeout=180)
+    if phase != "await_topo":
+        record("P1 topo query", False, f"skip: phase={phase}", skip=True)
+        record("P1 topo add", False, f"skip: phase={phase}", skip=True)
+    else:
+        _, qtext, qtypes, _ = sse_collect(tok, sid, "查看主图", tid, timeout=120)
         record(
-            "P1 topo delete (optional)",
-            "error" not in del_types and ("移除" in del_text or "未找到" in del_text or "资产拓扑" in del_text),
-            del_text[:100].replace("\n", " "),
+            "P1 topo query",
+            "error" not in qtypes and ("节点" in qtext or "主图" in qtext or "prompt" in qtext.lower()),
+            qtext[:100].replace("\n", " "),
         )
 
-    events, gen_text, gen_types, exit_gen = sse_collect(
-        tok, sid, "确认出图", tid, timeout=GEN_SSE_TIMEOUT_SEC
-    )
+        _, add_text, add_types, _ = sse_collect(tok, sid, "增加场景图", tid, timeout=180)
+        record(
+            "P1 topo add",
+            "error" not in add_types and ("新增" in add_text or "场景" in add_text or "资产拓扑" in add_text),
+            add_text[:100].replace("\n", " "),
+        )
+
+        if TOPO_DELETE:
+            _, del_text, del_types, _ = sse_collect(tok, sid, "删掉 Banner", tid, timeout=180)
+            record(
+                "P1 topo delete (optional)",
+                "error" not in del_types and ("移除" in del_text or "未找到" in del_text or "资产拓扑" in del_text),
+                del_text[:100].replace("\n", " "),
+            )
+
+    events: list[dict] = []
+    gen_text = ""
+    gen_types: set[str] = set()
+    exit_gen = "skipped"
+    if phase == "await_topo" or thread_state(tok, tid).get("phase") == "await_topo":
+        events, gen_text, gen_types, exit_gen = sse_collect(
+            tok, sid, "确认出图", tid, timeout=GEN_SSE_TIMEOUT_SEC
+        )
+    else:
+        record("P2 confirm gen stream", False, "skip: not at await_topo", skip=True)
+        record("P2 canvas images with url", False, "skip", skip=True)
+        record("P2 canvas generationRecordId", False, "skip", skip=True)
+        record("P2 stream/gen terminal", False, "skip", skip=True)
+        print(f"\n=== Summary PASS={PASS} FAIL={FAIL} SKIP={SKIP} ===")
+        return 0 if FAIL == 0 else 1
+
     record(
         "P2 confirm gen stream",
         "error" not in gen_types

--- a/deploy/prod-phase-b-user-verify.py
+++ b/deploy/prod-phase-b-user-verify.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Production Phase B user-path verification: await_topo → topo ops → confirm gen.
+
+Covers Phase A plan/confirm plus:
+  - await_topo gate (thread-state phase)
+  - topo_revise query/add (optional delete via TOPO_DELETE=1)
+  - confirm_gen + gen SSE + canvas poll
+
+Usage:
+  python3 deploy/prod-phase-b-user-verify.py
+  BASE_URL=http://119.29.173.89:8888 PHONE=17279698608 CODE=123456 python3 deploy/prod-phase-b-user-verify.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import uuid
+from typing import Any
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+BASE = os.environ.get("BASE_URL", "http://119.29.173.89:8888").rstrip("/")
+API = f"{BASE}/api"
+PHONE = os.environ.get("PHONE", "17279698608")
+CODE = os.environ.get("CODE", "123456")
+GEN_SSE_TIMEOUT_SEC = float(os.environ.get("GEN_SSE_TIMEOUT_SEC", "900"))
+GEN_CANVAS_POLL_SEC = float(os.environ.get("GEN_CANVAS_POLL_SEC", "300"))
+TOPO_DELETE = os.environ.get("TOPO_DELETE", "0") == "1"
+
+PASS = FAIL = SKIP = 0
+
+
+def record(case: str, ok: bool, detail: str = "", *, skip: bool = False) -> None:
+    global PASS, FAIL, SKIP
+    if skip:
+        SKIP += 1
+        icon = "⏭️"
+    elif ok:
+        PASS += 1
+        icon = "✅"
+    else:
+        FAIL += 1
+        icon = "❌"
+    line = f"{icon} {case}"
+    if detail:
+        line += f" — {detail[:220]}"
+    print(line)
+
+
+def http(m: str, p: str, b: dict | None = None, t: str | None = None) -> Any:
+    h = {"Content-Type": "application/json", "Accept": "application/json"}
+    if t:
+        h["Authorization"] = f"Bearer {t}"
+    r = Request(f"{API}{p}", data=None if b is None else json.dumps(b).encode(), headers=h, method=m)
+    with urlopen(r, timeout=120) as resp:
+        return json.loads(resp.read())
+
+
+def sse_collect(
+    t: str,
+    sid: str,
+    msg: str,
+    tid: str,
+    *,
+    timeout: float = 420,
+) -> tuple[list[dict], str, set[str], str]:
+    body = {"sessionId": sid, "message": msg, "threadId": tid}
+    h = {
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+        "Authorization": f"Bearer {t}",
+        "Idempotency-Key": f"ik_{uuid.uuid4().hex}",
+    }
+    r = Request(f"{API}/agent/chat/conversation", data=json.dumps(body).encode(), headers=h, method="POST")
+    events: list[dict] = []
+    types: set[str] = set()
+    parts: list[str] = []
+    end = time.time() + timeout
+    exit_reason = "timeout"
+    with urlopen(r, timeout=timeout) as resp:
+        buf = ""
+        while time.time() < end:
+            chunk = resp.read(4096)
+            if not chunk:
+                exit_reason = "eof"
+                break
+            buf += chunk.decode(errors="replace")
+            while "\n\n" in buf:
+                block, buf = buf.split("\n\n", 1)
+                for line in block.splitlines():
+                    if not line.startswith("data:"):
+                        continue
+                    pl = line[5:].strip()
+                    if pl == "[DONE]":
+                        return events, "".join(parts), types, "done_marker"
+                    try:
+                        ev = json.loads(pl)
+                    except json.JSONDecodeError:
+                        continue
+                    events.append(ev)
+                    et = str(ev.get("type") or "")
+                    types.add(et)
+                    if et == "text_delta":
+                        parts.append(str((ev.get("data") or {}).get("text") or ""))
+                    if et == "done":
+                        return events, "".join(parts), types, "done"
+                    if et == "error":
+                        return events, "".join(parts), types, "error"
+    return events, "".join(parts), types, exit_reason
+
+
+def thread_state(tok: str, tid: str) -> dict[str, Any]:
+    return http("GET", f"/agent/thread-state?threadId={quote(tid, safe='')}", t=tok).get("data") or {}
+
+
+def count_canvas_images(tok: str, sid: str) -> tuple[int, int]:
+    sess = http("GET", f"/sessions/{sid}", t=tok)["data"]
+    nodes = (sess.get("canvasData") or {}).get("nodes") or []
+    imgs = sum(1 for n in nodes if n.get("type") == "image" and (n.get("data") or {}).get("url"))
+    rec_nodes = sum(1 for n in nodes if (n.get("data") or {}).get("generationRecordId"))
+    return imgs, rec_nodes
+
+
+def poll_canvas_after_sse(tok: str, sid: str, *, min_images: int = 1) -> tuple[int, int]:
+    deadline = time.time() + GEN_CANVAS_POLL_SEC
+    imgs = rec_nodes = 0
+    while time.time() < deadline:
+        try:
+            imgs, rec_nodes = count_canvas_images(tok, sid)
+            if imgs >= min_images:
+                return imgs, rec_nodes
+        except Exception:
+            pass
+        time.sleep(15)
+    return count_canvas_images(tok, sid)
+
+
+def main() -> int:
+    print("=== Phase B production user-path verify ===")
+    print(f"BASE={BASE}  TOPO_DELETE={TOPO_DELETE}\n")
+
+    try:
+        http("POST", "/auth/send-code", {"phone": PHONE})
+    except Exception:
+        pass
+    try:
+        tok = http("POST", "/auth/login", {"phone": PHONE, "code": CODE})["data"]["token"]
+        record("P0 Login", True)
+    except Exception as exc:  # noqa: BLE001
+        record("P0 Login", False, str(exc))
+        return 1
+
+    rt = http("GET", "/agent/runtime-health", t=tok)
+    record("Runtime health", bool((rt.get("data") or {}).get("ok")))
+
+    sid = http("POST", "/sessions", {"title": f"PhaseB-{int(time.time())}"}, t=tok)["data"]["id"]
+    tid = f"{sid}:{uuid.uuid4()}"
+    record("Create session", True, sid)
+
+    steps = [
+        ("P0-1 plan", "天猫蓝牙耳机详情页营销方案，品牌 lnkpi，PhaseB复测"),
+        ("P0-2 confirm plan", "1"),
+    ]
+    for name, msg in steps:
+        _, text, types, exit_reason = sse_collect(tok, sid, msg, tid, timeout=420)
+        ok = "error" not in types and len(text) > 0
+        record(name, ok, f"exit={exit_reason} text={text[:80].replace(chr(10), ' ')}")
+
+    ts = thread_state(tok, tid)
+    phase = str(ts.get("phase") or "")
+    record(
+        "P1 await_topo thread-state",
+        phase in ("await_topo", "await_confirm", "split") or "确认出图" in json.dumps(ts),
+        f"phase={phase} interrupted={ts.get('interrupted')}",
+    )
+
+    _, qtext, qtypes, _ = sse_collect(tok, sid, "查看主图", tid, timeout=120)
+    record(
+        "P1 topo query",
+        "error" not in qtypes and ("节点" in qtext or "主图" in qtext or "prompt" in qtext.lower()),
+        qtext[:100].replace("\n", " "),
+    )
+
+    _, add_text, add_types, _ = sse_collect(tok, sid, "增加场景图", tid, timeout=180)
+    record(
+        "P1 topo add",
+        "error" not in add_types and ("新增" in add_text or "场景" in add_text or "资产拓扑" in add_text),
+        add_text[:100].replace("\n", " "),
+    )
+
+    if TOPO_DELETE:
+        _, del_text, del_types, _ = sse_collect(tok, sid, "删掉 Banner", tid, timeout=180)
+        record(
+            "P1 topo delete (optional)",
+            "error" not in del_types and ("移除" in del_text or "未找到" in del_text or "资产拓扑" in del_text),
+            del_text[:100].replace("\n", " "),
+        )
+
+    events, gen_text, gen_types, exit_gen = sse_collect(
+        tok, sid, "确认出图", tid, timeout=GEN_SSE_TIMEOUT_SEC
+    )
+    record(
+        "P2 confirm gen stream",
+        "error" not in gen_types
+        and ("出图" in gen_text or "开始按拓扑" in gen_text or "task_update" in gen_types),
+        f"exit={exit_gen} types={sorted(gen_types)[:8]}",
+    )
+
+    imgs, rec_nodes = count_canvas_images(tok, sid)
+    if "done" not in gen_types and exit_gen in ("timeout", "eof"):
+        polled_imgs, polled_rec = poll_canvas_after_sse(tok, sid)
+        if polled_imgs > imgs:
+            imgs, rec_nodes = polled_imgs, polled_rec
+            record("P2 canvas poll after SSE", True, f"imgs={imgs} rec_nodes={rec_nodes}")
+    record("P2 canvas images with url", imgs >= 1, f"images_with_url={imgs}")
+    record("P2 canvas generationRecordId", rec_nodes >= 1, f"nodes={rec_nodes}")
+
+    stream_ok = (
+        "done" in gen_types
+        or exit_gen in ("done", "done_marker")
+        or "task_summary" in gen_types
+        or imgs >= 1
+    )
+    record("P2 stream/gen terminal", stream_ok, f"exit={exit_gen} imgs={imgs}")
+
+    print(f"\n=== Summary PASS={PASS} FAIL={FAIL} SKIP={SKIP} ===")
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/agent-runtime/app/graph/intent.py
+++ b/services/agent-runtime/app/graph/intent.py
@@ -75,6 +75,15 @@ NODE_REVISE_HINTS = (
     "再加",
 )
 
+# await_topo node: topology query keywords (handled in topo_revise)
+TOPO_QUERY_HINTS = (
+    "查看",
+    "查询",
+    "看一下",
+    "prompt是什么",
+    "什么prompt",
+)
+
 # await_topo node: topology revision keywords
 TOPO_REVISE_HINTS = (
     "要改拓扑",
@@ -164,11 +173,17 @@ def classify_topo_decision(text: str) -> TopoDecision:
     lowered = t.lower()
     if any(h in t or h in lowered for h in CONFIRM_GEN_HINTS):
         return "confirm_gen"
-    # Check node revision before topo revision (higher priority)
-    if any(h in t for h in NODE_REVISE_HINTS):
-        return "node_revise"
+    if any(h in t for h in TOPO_QUERY_HINTS):
+        return "topo_revise"
     if any(h in t for h in TOPO_REVISE_HINTS):
         return "topo_revise"
+    if any(h in t for h in ("增加", "加上", "补一个", "补一张", "再加")):
+        return "topo_revise"
+    if any(h in t for h in ("改为", "改成", "调整", "换成", "修改")):
+        return "topo_revise"
+    # Plan-level revise (no concrete single-node op) → full modify flow
+    if any(h in t for h in NODE_REVISE_HINTS):
+        return "node_revise"
     if t in ("确认", "1", "A", "a") or t.lower() == "ok":
         return "confirm_gen"
     return "none"

--- a/services/agent-runtime/app/graph/nodes/await_topo.py
+++ b/services/agent-runtime/app/graph/nodes/await_topo.py
@@ -6,12 +6,9 @@ from langchain_core.messages import AIMessage
 
 from app.graph.intent import classify_copy_decision, classify_topo_decision
 
-# 修复 P0-1（拓扑确认门节点内容修改）：
-# 原来只有 topo_revise（只支持删节点），用户说"把模特定妆改为双人模特"会被误判为
-# topo_revise，进 topo_revise 节点后因只支持删除而返回"未识别具体改动"。
-# 现在拆分为：
-# - node_revise: 节点内容修改（改为/调整/增加/换）→ 回退到 plan 走 modify 模式
-# - topo_revise: 纯拓扑删除（删掉/去掉/移除）→ 进 topo_revise 节点
+# await_topo 拓扑门路由：
+# - topo_revise: 删/增/改/查节点（即时画布 + Mermaid）
+# - node_revise: 方案级修订（更偏/强调等）→ plan modify 模式
 
 _NONE_TIP = "请确认出图，或说明如何调整（例如「删掉 Banner」或「把模特定妆改为双人模特」）；主文案可用「写入主文案」。"
 

--- a/services/agent-runtime/app/graph/nodes/topo_revise.py
+++ b/services/agent-runtime/app/graph/nodes/topo_revise.py
@@ -1,12 +1,55 @@
-"""Heuristic topology revise: add/remove template keys and refresh Mermaid."""
+"""Heuristic topology revise at await_topo: query/add/update/remove + Mermaid refresh."""
 
 from __future__ import annotations
 
-from typing import Any, Callable
+import re
+from typing import Any, Callable, Literal
 
 from langchain_core.messages import AIMessage
 
 from app.graph.mermaid_topo import manifest_to_mermaid
+
+TopoOp = Literal["query", "remove", "add", "update", "unknown"]
+
+_REMOVE_PREFIXES = ("删掉", "删除", "去掉", "移除")
+_ADD_PREFIXES = ("增加", "加上", "补一个", "补一张", "再加")
+_QUERY_PREFIXES = ("查看", "查询", "看一下")
+_UPDATE_PATTERNS = (
+    re.compile(r"把(.+?)(?:改为|改成|换成)(.+)"),
+    re.compile(r"(?:调整|修改)(.+)"),
+)
+
+
+def _parse_topo_op(text: str) -> TopoOp:
+    t = text.strip()
+    if not t:
+        return "unknown"
+    lowered = t.lower()
+    if any(h in t for h in _QUERY_PREFIXES) or "prompt" in lowered:
+        return "query"
+    if any(p in t for p in _REMOVE_PREFIXES):
+        return "remove"
+    if any(p in t for p in _ADD_PREFIXES):
+        return "add"
+    if any(h in t for h in ("改为", "改成", "调整", "换成", "修改")):
+        return "update"
+    return "unknown"
+
+
+def _strip_target(raw: str) -> str:
+    return raw.strip().strip("「」\"' 。.")
+
+
+def _find_manifest_item(manifest: list[dict[str, Any]], target: str) -> dict[str, Any] | None:
+    target = _strip_target(target)
+    if not target:
+        return None
+    for it in manifest:
+        title = str(it.get("title") or "")
+        key = str(it.get("key") or "")
+        if target in title or target == key or target.lower() == key.lower():
+            return it
+    return None
 
 
 def _removed_node_ids(
@@ -24,17 +67,15 @@ def _removed_node_ids(
     return ids
 
 
-def _apply_heuristic(manifest: list[dict[str, Any]], text: str) -> tuple[list[dict[str, Any]], str]:
-    """Return (new_manifest, note). Supports 删掉/去掉 {title|key}."""
+def _apply_remove(manifest: list[dict[str, Any]], text: str) -> tuple[list[dict[str, Any]], str]:
     t = text.strip()
-    remove_prefixes = ("删掉", "删除", "去掉", "移除")
     target = ""
-    for p in remove_prefixes:
+    for p in _REMOVE_PREFIXES:
         if p in t:
-            target = t.split(p, 1)[-1].strip().strip("「」\"' 。.")
+            target = _strip_target(t.split(p, 1)[-1])
             break
     if not target:
-        return manifest, "未识别具体改动；请说明例如「删掉 Banner」。"
+        return manifest, "未识别删除目标；请说明例如「删掉 Banner」。"
 
     next_items: list[dict[str, Any]] = []
     removed = False
@@ -44,9 +85,8 @@ def _apply_heuristic(manifest: list[dict[str, Any]], text: str) -> tuple[list[di
         if target in title or target == key or target.lower() == key.lower():
             removed = True
             continue
-        deps = [d for d in (it.get("depends_on") or []) if str(d) != key]
         item = dict(it)
-        item["depends_on"] = deps
+        item["depends_on"] = [d for d in (it.get("depends_on") or []) if str(d) != key]
         next_items.append(item)
 
     if not removed:
@@ -55,11 +95,160 @@ def _apply_heuristic(manifest: list[dict[str, Any]], text: str) -> tuple[list[di
     removed_keys = {str(it.get("key")) for it in manifest} - {str(it.get("key")) for it in next_items}
     cleaned: list[dict[str, Any]] = []
     for it in next_items:
-        deps = [d for d in (it.get("depends_on") or []) if str(d) not in removed_keys]
         item = dict(it)
-        item["depends_on"] = deps
+        item["depends_on"] = [d for d in (it.get("depends_on") or []) if str(d) not in removed_keys]
         cleaned.append(item)
     return cleaned, f"已从拓扑移除「{target}」。"
+
+
+def _parse_add_title(text: str) -> str:
+    for p in _ADD_PREFIXES:
+        if p in text:
+            return _strip_target(text.split(p, 1)[-1])
+    return ""
+
+
+def _parse_update(text: str) -> tuple[str, str] | None:
+    for pat in _UPDATE_PATTERNS:
+        m = pat.search(text.strip())
+        if m:
+            if len(m.groups()) == 2:
+                return _strip_target(m.group(1)), _strip_target(m.group(2))
+            return _strip_target(m.group(1)), _strip_target(m.group(1))
+    return None
+
+
+def _parse_query_target(text: str) -> str:
+    t = text.strip()
+    for p in _QUERY_PREFIXES:
+        if p in t:
+            return _strip_target(t.split(p, 1)[-1].replace("节点", ""))
+    if "prompt" in t.lower():
+        for it in t.replace("的prompt", " ").replace("prompt", " ").split():
+            if len(it.strip()) >= 2:
+                return _strip_target(it)
+    return ""
+
+
+def _slug_key(title: str, manifest: list[dict[str, Any]]) -> str:
+    ascii_key = re.sub(r"[^a-zA-Z0-9_]+", "_", title).strip("_").lower()
+    base = ascii_key[:24] if ascii_key else f"added_{len(manifest) + 1}"
+    keys = {str(it.get("key")) for it in manifest if it.get("key")}
+    if base not in keys:
+        return base
+    idx = 2
+    while f"{base}_{idx}" in keys:
+        idx += 1
+    return f"{base}_{idx}"
+
+
+def _format_node_query(item: dict[str, Any], node: dict[str, Any]) -> str:
+    data = node.get("data") if isinstance(node.get("data"), dict) else {}
+    prompt = str(data.get("prompt") or data.get("content") or item.get("prompt_hint") or "")
+    title = str(item.get("title") or item.get("key") or "")
+    key = str(item.get("key") or "")
+    node_id = str(item.get("node_id") or node.get("id") or "")
+    lines = [
+        f"节点「{title}」",
+        f"- key: {key}",
+        f"- node_id: {node_id}",
+        f"- target_type: {item.get('target_type') or 'image'}",
+    ]
+    if prompt:
+        lines.append(f"- prompt: {prompt[:500]}")
+    deps = item.get("depends_on") or []
+    if deps:
+        lines.append(f"- depends_on: {', '.join(str(d) for d in deps)}")
+    return "\n".join(lines)
+
+
+async def _apply_add(
+    nest: Any,
+    state: dict[str, Any],
+    manifest: list[dict[str, Any]],
+    title: str,
+) -> tuple[list[dict[str, Any]], str]:
+    if not title:
+        return manifest, "未识别要增加的节点名称；请说明例如「增加场景图」。"
+    key = _slug_key(title, manifest)
+    add_fn = getattr(nest, "add_nodes_batch", None)
+    connect_fn = getattr(nest, "connect_nodes", None)
+    if add_fn is None:
+        return manifest, "画布新增 API 不可用。"
+
+    batch_item = {
+        "key": key,
+        "title": title,
+        "targetType": "image",
+        "prompt": title,
+    }
+    batch = await add_fn([batch_item])
+    node_id = ""
+    for n in batch.get("nodes") or []:
+        if str(n.get("key") or "") == key:
+            node_id = str(n.get("nodeId") or "")
+            break
+    if not node_id:
+        return manifest, f"新增节点「{title}」失败，未返回 nodeId。"
+
+    plan_node_id = str(state.get("plan_node_id") or "").strip()
+    if connect_fn is not None and plan_node_id:
+        await connect_fn([{"source": plan_node_id, "target": node_id}])
+
+    new_item = {
+        "key": key,
+        "title": title,
+        "target_type": "image",
+        "prompt_hint": title,
+        "depends_on": [],
+        "node_id": node_id,
+    }
+    return manifest + [new_item], f"已新增节点「{title}」（key={key}）。"
+
+
+async def _apply_update(
+    nest: Any,
+    manifest: list[dict[str, Any]],
+    target: str,
+    new_value: str,
+) -> tuple[list[dict[str, Any]], str]:
+    item = _find_manifest_item(manifest, target)
+    if item is None:
+        return manifest, f"未找到名为「{target}」的节点。"
+    node_id = str(item.get("node_id") or "").strip()
+    set_fn = getattr(nest, "set_node_prompt", None)
+    if not node_id or set_fn is None:
+        return manifest, f"「{target}」尚未绑定画布 node_id，无法更新。"
+
+    await set_fn(node_id, new_value, title=new_value)
+    updated = [dict(it) for it in manifest]
+    for it in updated:
+        if str(it.get("key")) == str(item.get("key")):
+            it["title"] = new_value
+            it["prompt_hint"] = new_value
+            break
+    return updated, f"已更新节点「{target}」为「{new_value}」。"
+
+
+async def _apply_query(
+    nest: Any,
+    manifest: list[dict[str, Any]],
+    target: str,
+) -> tuple[list[dict[str, Any]], str]:
+    if not target:
+        return manifest, "请说明要查询的节点，例如「查看主图」。"
+    item = _find_manifest_item(manifest, target)
+    if item is None:
+        return manifest, f"未找到名为「{target}」的节点。"
+    node_id = str(item.get("node_id") or "").strip()
+    get_fn = getattr(nest, "get_node", None)
+    if not node_id or get_fn is None:
+        title = str(item.get("title") or item.get("key") or target)
+        hint = str(item.get("prompt_hint") or "")
+        body = f"节点「{title}」（manifest 缓存）\n- prompt_hint: {hint or '(空)'}"
+        return manifest, body
+    node = await get_fn(node_id)
+    return manifest, _format_node_query(item, node)
 
 
 def make_topo_revise_node(*, nest: Any) -> Callable:
@@ -73,13 +262,25 @@ def make_topo_revise_node(*, nest: Any) -> Callable:
                 break
 
         manifest = [dict(x) for x in (state.get("split_manifest") or []) if isinstance(x, dict)]
-        new_manifest, note = _apply_heuristic(manifest, text)
+        op = _parse_topo_op(text)
+        new_manifest = manifest
+        note = "未识别具体改动；请说明例如「删掉 Banner」「增加场景图」「把主图改为运动风」或「查看主图」。"
 
-        if new_manifest != manifest:
-            remove_fn = getattr(nest, "remove_nodes", None)
-            node_ids = _removed_node_ids(manifest, new_manifest)
-            if node_ids and remove_fn is not None:
-                await remove_fn(node_ids)
+        if op == "remove":
+            new_manifest, note = _apply_remove(manifest, text)
+            if new_manifest != manifest:
+                remove_fn = getattr(nest, "remove_nodes", None)
+                node_ids = _removed_node_ids(manifest, new_manifest)
+                if node_ids and remove_fn is not None:
+                    await remove_fn(node_ids)
+        elif op == "add":
+            new_manifest, note = await _apply_add(nest, state, manifest, _parse_add_title(text))
+        elif op == "update":
+            parsed = _parse_update(text)
+            if parsed:
+                new_manifest, note = await _apply_update(nest, manifest, parsed[0], parsed[1])
+        elif op == "query":
+            new_manifest, note = await _apply_query(nest, manifest, _parse_query_target(text))
 
         emit_list = getattr(nest, "emit_task_list", None)
         if emit_list is not None and new_manifest != manifest:
@@ -96,8 +297,11 @@ def make_topo_revise_node(*, nest: Any) -> Callable:
                 ]
             )
 
-        mermaid = manifest_to_mermaid(new_manifest)
-        body = f"{note}\n\n当前资产拓扑：\n{mermaid}\n\n确认无误后回复「确认出图」。"
+        if op == "query":
+            body = note
+        else:
+            mermaid = manifest_to_mermaid(new_manifest)
+            body = f"{note}\n\n当前资产拓扑：\n{mermaid}\n\n确认无误后回复「确认出图」。"
         emit = getattr(nest, "emit_text", None)
         if emit is not None:
             await emit(body)

--- a/services/agent-runtime/app/graph/nodes/topo_revise.py
+++ b/services/agent-runtime/app/graph/nodes/topo_revise.py
@@ -9,6 +9,21 @@ from langchain_core.messages import AIMessage
 from app.graph.mermaid_topo import manifest_to_mermaid
 
 
+def _removed_node_ids(
+    before: list[dict[str, Any]], after: list[dict[str, Any]]
+) -> list[str]:
+    after_keys = {str(it.get("key")) for it in after if it.get("key")}
+    ids: list[str] = []
+    for it in before:
+        key = str(it.get("key") or "")
+        if not key or key in after_keys:
+            continue
+        node_id = str(it.get("node_id") or "").strip()
+        if node_id:
+            ids.append(node_id)
+    return ids
+
+
 def _apply_heuristic(manifest: list[dict[str, Any]], text: str) -> tuple[list[dict[str, Any]], str]:
     """Return (new_manifest, note). Supports 删掉/去掉 {title|key}."""
     t = text.strip()
@@ -59,6 +74,12 @@ def make_topo_revise_node(*, nest: Any) -> Callable:
 
         manifest = [dict(x) for x in (state.get("split_manifest") or []) if isinstance(x, dict)]
         new_manifest, note = _apply_heuristic(manifest, text)
+
+        if new_manifest != manifest:
+            remove_fn = getattr(nest, "remove_nodes", None)
+            node_ids = _removed_node_ids(manifest, new_manifest)
+            if node_ids and remove_fn is not None:
+                await remove_fn(node_ids)
 
         emit_list = getattr(nest, "emit_task_list", None)
         if emit_list is not None and new_manifest != manifest:

--- a/services/agent-runtime/tests/test_await_topo.py
+++ b/services/agent-runtime/tests/test_await_topo.py
@@ -22,12 +22,16 @@ def test_classify_topo_revise():
 
 # 修复 P0-1：node_revise 决策检测（节点内容修改 vs 拓扑删除）
 def test_classify_node_revise():
-    """节点内容修改动词应识别为 node_revise，而非 topo_revise。"""
-    assert classify_topo_decision("把模特定妆改为双人模特") == "node_revise"
-    assert classify_topo_decision("改成更偏天猫详情页") == "node_revise"
-    assert classify_topo_decision("调整主图配色") == "node_revise"
-    assert classify_topo_decision("增加产品材质特写图") == "node_revise"
-    assert classify_topo_decision("加上一个场景图") == "node_revise"
+    """Plan-level revise (更偏/强调) still routes to node_revise."""
+    assert classify_topo_decision("更偏天猫详情页") == "node_revise"
+    assert classify_topo_decision("强调运动风") == "node_revise"
+
+
+def test_classify_topo_revise_add_update_query():
+    assert classify_topo_decision("删掉 Banner") == "topo_revise"
+    assert classify_topo_decision("增加场景图") == "topo_revise"
+    assert classify_topo_decision("把模特定妆改为双人模特") == "topo_revise"
+    assert classify_topo_decision("查看主图") == "topo_revise"
 
 
 def test_classify_topo_revise_still_works_for_deletions():
@@ -49,6 +53,22 @@ class FakeNest:
 
     async def remove_nodes(self, node_ids: list[str]) -> dict[str, Any]:
         self.calls.append(("remove_nodes", node_ids))
+        return {"actions": []}
+
+    async def get_node(self, node_id: str) -> dict[str, Any]:
+        self.calls.append(("get_node", node_id))
+        return {"id": node_id, "data": {"prompt": f"prompt-for-{node_id}"}}
+
+    async def set_node_prompt(self, node_id: str, prompt: str, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("set_node_prompt", {"node_id": node_id, "prompt": prompt, **kwargs}))
+        return {"nodeId": node_id, "actions": []}
+
+    async def add_nodes_batch(self, items: list[dict[str, Any]], **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("add_nodes_batch", items))
+        return {"nodes": [{"key": it["key"], "nodeId": f"new-{it['key']}"} for it in items]}
+
+    async def connect_nodes(self, edges: list[dict[str, str]], **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("connect_nodes", edges))
         return {"actions": []}
 
 
@@ -105,6 +125,56 @@ async def test_topo_revise_calls_remove_nodes_when_canvas_ids_present():
     )
     assert "banner" not in {str(i["key"]) for i in out["split_manifest"]}
     assert ("remove_nodes", ["img-banner"]) in nest.calls
+
+
+@pytest.mark.asyncio
+async def test_topo_revise_add_node_on_canvas():
+    nest = FakeNest()
+    node = make_topo_revise_node(nest=nest)
+    out = await node(
+        {
+            "messages": [HumanMessage(content="增加场景图")],
+            "plan_node_id": "plan-1",
+            "split_manifest": [
+                {"key": "hero_main", "title": "主图", "node_id": "img-1", "depends_on": []},
+            ],
+        }
+    )
+    keys = {str(i["key"]) for i in out["split_manifest"]}
+    assert len(keys) == 2
+    assert any(c[0] == "add_nodes_batch" for c in nest.calls)
+
+
+@pytest.mark.asyncio
+async def test_topo_revise_update_node_on_canvas():
+    nest = FakeNest()
+    node = make_topo_revise_node(nest=nest)
+    await node(
+        {
+            "messages": [HumanMessage(content="把主图改为运动风主图")],
+            "split_manifest": [
+                {"key": "hero_main", "title": "主图", "node_id": "img-1", "depends_on": []},
+            ],
+        }
+    )
+    set_calls = [c for c in nest.calls if c[0] == "set_node_prompt"]
+    assert set_calls and set_calls[0][1]["node_id"] == "img-1"
+
+
+@pytest.mark.asyncio
+async def test_topo_revise_query_node():
+    nest = FakeNest()
+    node = make_topo_revise_node(nest=nest)
+    out = await node(
+        {
+            "messages": [HumanMessage(content="查看主图")],
+            "split_manifest": [
+                {"key": "hero_main", "title": "主图", "node_id": "img-1", "depends_on": []},
+            ],
+        }
+    )
+    assert any(c[0] == "get_node" for c in nest.calls)
+    assert "prompt-for-img-1" in out["messages"][0].content
 
 
 @pytest.mark.asyncio
@@ -200,7 +270,7 @@ async def test_node_revise_sets_modify_mode_and_routes_to_plan():
     node = make_await_topo_node()
     out = await node(
         {
-            "messages": [HumanMessage(content="把模特定妆改为双人模特")],
+            "messages": [HumanMessage(content="更偏天猫详情页风格")],
         }
     )
     assert out["user_decision"] == "node_revise"
@@ -379,7 +449,7 @@ async def test_modify_split_pauses_at_await_topo_interrupt():
             "split_manifest": [{"key": "hero_main", "title": "主图", "node_id": "img-1"}],
             "messages": [
                 AIMessage(content="请确认拓扑"),
-                HumanMessage(content="增加运动场景图节点"),
+                HumanMessage(content="更偏运动风详情页"),
             ],
             "user_decision": "node_revise",
         },

--- a/services/agent-runtime/tests/test_await_topo.py
+++ b/services/agent-runtime/tests/test_await_topo.py
@@ -47,6 +47,10 @@ class FakeNest:
     async def emit_text(self, text: str) -> None:
         self.calls.append(("emit_text", text))
 
+    async def remove_nodes(self, node_ids: list[str]) -> dict[str, Any]:
+        self.calls.append(("remove_nodes", node_ids))
+        return {"actions": []}
+
 
 @pytest.mark.asyncio
 async def test_topo_revise_removes_by_title():
@@ -72,6 +76,35 @@ async def test_topo_revise_removes_by_title():
     assert "copy_main" in keys
     assert out["phase"] == "await_topo"
     assert "flowchart" in out["messages"][0].content or "资产拓扑" in out["messages"][0].content
+
+
+@pytest.mark.asyncio
+async def test_topo_revise_calls_remove_nodes_when_canvas_ids_present():
+    nest = FakeNest()
+    node = make_topo_revise_node(nest=nest)
+    out = await node(
+        {
+            "messages": [HumanMessage(content="删掉 Banner")],
+            "split_manifest": [
+                {
+                    "key": "copy_main",
+                    "title": "主文案",
+                    "target_type": "text",
+                    "node_id": "text-1",
+                    "depends_on": [],
+                },
+                {
+                    "key": "banner",
+                    "title": "Banner",
+                    "target_type": "image",
+                    "node_id": "img-banner",
+                    "depends_on": ["copy_main"],
+                },
+            ],
+        }
+    )
+    assert "banner" not in {str(i["key"]) for i in out["split_manifest"]}
+    assert ("remove_nodes", ["img-banner"]) in nest.calls
 
 
 @pytest.mark.asyncio

--- a/services/agent-runtime/tests/test_intent.py
+++ b/services/agent-runtime/tests/test_intent.py
@@ -25,7 +25,8 @@ def test_classify_copy_decision():
 def test_classify_topo_decision():
     assert classify_topo_decision("确认出图") == "confirm_gen"
     assert classify_topo_decision("删掉 Banner") == "topo_revise"
-    assert classify_topo_decision("改为双人模特") == "node_revise"
+    assert classify_topo_decision("改为双人模特") == "topo_revise"
+    assert classify_topo_decision("更偏天猫") == "node_revise"
 
 
 def test_classify_user_decision():


### PR DESCRIPTION
## Summary
- **topo_revise** 支持删/增/改/查节点，并同步 Nest 画布（remove_nodes / add_nodes_batch / set_node_prompt / get_node）
- **intent** 简单 NL 操作走 topo_revise；方案级「更偏/强调」仍走 node_revise → plan modify
- 新增 **deploy/prod-phase-b-user-verify.py**：plan → confirm → await_topo → query/add → 确认出图 → canvas poll

## Test plan
- [x] `pytest tests/test_await_topo.py tests/test_intent.py` (18 passed)
- [ ] `python3 deploy/prod-phase-b-user-verify.py`（生产，约 15–20 min 含出图）
- [ ] 可选 `TOPO_DELETE=1` 测删节点