### PR TITLE
feat(agent): Phase C2 dock skillId + planning model E2E

### DIFF
--- a/apps/server/src/agent/agent-runtime.client.ts
+++ b/apps/server/src/agent/agent-runtime.client.ts
@@ -8,6 +8,11 @@ export interface RuntimeRunInput {
   /** W5 修复：用户结构化决策（confirm/revise/...），用于触发 agent-runtime 的
    *  Command(resume=user_decision) 精确恢复 interrupt，避免重跑 route_entry→intake 卡死 */
   userDecision?: 'confirm' | 'revise' | 'replan' | 'confirm_gen' | 'topo_revise' | 'node_revise'
+  /** Runtime skill id after UI→runtime mapping */
+  skillId?: string
+  llmModel?: string
+  llmApiKey?: string
+  llmBaseUrl?: string
 }
 
 export interface RuntimeThreadState {
@@ -88,6 +93,10 @@ export class AgentRuntimeClient {
         // W5 修复：把结构化决策转发给 agent-runtime
         // 与 RunRequest.user_decision 字段对应，触发 Command(resume=...) 恢复 interrupt
         user_decision: input.userDecision,
+        skill_id: input.skillId,
+        llm_model: input.llmModel,
+        llm_api_key: input.llmApiKey,
+        llm_base_url: input.llmBaseUrl,
       }),
     })
 

--- a/apps/server/src/agent/agent-skill-map.test.ts
+++ b/apps/server/src/agent/agent-skill-map.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { mapUiSkillId } from './agent-skill-map'
+
+describe('mapUiSkillId', () => {
+  it('returns undefined for missing input', () => {
+    expect(mapUiSkillId()).toBeUndefined()
+    expect(mapUiSkillId('')).toBeUndefined()
+  })
+
+  it('maps canvas to enterprise-marketing-campaign', () => {
+    expect(mapUiSkillId('canvas')).toBe('enterprise-marketing-campaign')
+  })
+
+  it('returns undefined for unmapped dock skills', () => {
+    expect(mapUiSkillId('storyboard')).toBeUndefined()
+    expect(mapUiSkillId('polish')).toBeUndefined()
+    expect(mapUiSkillId('organize')).toBeUndefined()
+  })
+
+  it('returns undefined for unknown skill ids', () => {
+    expect(mapUiSkillId('unknown-skill')).toBeUndefined()
+  })
+})

--- a/apps/server/src/agent/agent-skill-map.ts
+++ b/apps/server/src/agent/agent-skill-map.ts
@@ -1,0 +1,11 @@
+export const SKILL_UI_TO_RUNTIME: Record<string, string | undefined> = {
+  canvas: 'enterprise-marketing-campaign',
+  storyboard: undefined,
+  polish: undefined,
+  organize: undefined,
+}
+
+export function mapUiSkillId(uiSkillId?: string): string | undefined {
+  if (!uiSkillId) return undefined
+  return SKILL_UI_TO_RUNTIME[uiSkillId]
+}

--- a/apps/server/src/agent/agent.controller.ts
+++ b/apps/server/src/agent/agent.controller.ts
@@ -36,6 +36,16 @@ class ConversationDto {
   @IsOptional()
   @IsIn(['confirm', 'revise', 'replan', 'confirm_gen', 'topo_revise', 'node_revise'])
   userDecision?: 'confirm' | 'revise' | 'replan' | 'confirm_gen' | 'topo_revise' | 'node_revise'
+
+  /** Dock 技能 id（UI 命名），Nest 映射后转发给 agent-runtime */
+  @IsOptional()
+  @IsString()
+  skillId?: string
+
+  /** 规划阶段 LLM 模型（含 channel 编码），Nest 解析凭证后转发 */
+  @IsOptional()
+  @IsString()
+  model?: string
 }
 
 class OptimizePromptDto {
@@ -138,6 +148,8 @@ export class AgentController {
         dto.threadId,
         dto.userDecision,
         idempotencyKey,
+        dto.skillId,
+        dto.model,
       )) {
         res.write(`data: ${JSON.stringify(event)}\n\n`)
       }

--- a/apps/server/src/agent/agent.module.ts
+++ b/apps/server/src/agent/agent.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common'
 import { CanvasModule } from '../canvas/canvas.module'
+import { ProviderModule } from '../provider/provider.module'
 import { SessionsModule } from '../sessions/sessions.module'
 import { StudioModule } from '../studio/studio.module'
 import { AgentCanvasToolsController } from './agent-canvas-tools.controller'
@@ -9,7 +10,7 @@ import { AgentInternalGuard } from './agent-internal.guard'
 import { AgentService } from './agent.service'
 
 @Module({
-  imports: [CanvasModule, SessionsModule, StudioModule],
+  imports: [CanvasModule, ProviderModule, SessionsModule, StudioModule],
   controllers: [AgentController, AgentCanvasToolsController],
   providers: [AgentService, AgentCanvasToolsService, AgentInternalGuard],
   exports: [AgentService, AgentCanvasToolsService],

--- a/apps/server/src/agent/agent.service.dock.test.ts
+++ b/apps/server/src/agent/agent.service.dock.test.ts
@@ -1,0 +1,117 @@
+import 'reflect-metadata'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AgentService } from './agent.service'
+import { AgentRuntimeClient } from './agent-runtime.client'
+
+describe('AgentService dock forwarding', () => {
+  const agentMessageCreate = vi.fn()
+  const resolveForGeneration = vi.fn()
+
+  let service: AgentService
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    process.env.AGENT_RUNTIME_URL = 'http://127.0.0.1:8000'
+    agentMessageCreate.mockResolvedValue({})
+    resolveForGeneration.mockResolvedValue({
+      channelId: 'platform',
+      modelName: 'gpt-4o-mini',
+      apiFormat: 'openai',
+      credentials: { apiKey: 'sk-test', baseUrl: 'https://api.example.com/v1' },
+      source: 'platform',
+    })
+
+    service = new AgentService(
+      {
+        agentMessage: {
+          create: agentMessageCreate,
+          findMany: vi.fn(),
+        },
+        session: {
+          findUnique: vi.fn(),
+          update: vi.fn(),
+        },
+        idempotencyRecord: {
+          create: vi.fn(),
+          findUnique: vi.fn(),
+          updateMany: vi.fn(),
+          deleteMany: vi.fn(),
+        },
+      } as never,
+      { create: vi.fn() } as never,
+      { createFromAgent: vi.fn() } as never,
+      { resolveForGeneration } as never,
+    )
+  })
+
+  it('forwards mapped skillId and resolved model to runtime', async () => {
+    const streamRun = vi.fn(async function* () {
+      yield { type: 'text_delta', data: { text: 'ok' } }
+      yield { type: 'done', data: {} }
+    })
+
+    vi.spyOn(service, 'createRuntimeClient').mockReturnValue({
+      healthOk: vi.fn().mockResolvedValue(true),
+      streamRun,
+    } as unknown as AgentRuntimeClient)
+
+    for await (const _ of service.streamConversation(
+      's1',
+      'hello',
+      'u1',
+      'thread-1',
+      undefined,
+      undefined,
+      'canvas',
+      'platform::gpt-4o-mini',
+    )) {
+      // drain
+    }
+
+    expect(resolveForGeneration).toHaveBeenCalledWith('u1', 'platform::gpt-4o-mini', 'text')
+    expect(streamRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 's1',
+        threadId: 'thread-1',
+        message: 'hello',
+        skillId: 'enterprise-marketing-campaign',
+        llmModel: 'gpt-4o-mini',
+        llmApiKey: 'sk-test',
+        llmBaseUrl: 'https://api.example.com/v1',
+      }),
+    )
+  })
+
+  it('skips provider resolution when model is omitted', async () => {
+    const streamRun = vi.fn(async function* () {
+      yield { type: 'done', data: {} }
+    })
+
+    vi.spyOn(service, 'createRuntimeClient').mockReturnValue({
+      healthOk: vi.fn().mockResolvedValue(true),
+      streamRun,
+    } as unknown as AgentRuntimeClient)
+
+    for await (const _ of service.streamConversation(
+      's1',
+      'hello',
+      'u1',
+      undefined,
+      undefined,
+      undefined,
+      'storyboard',
+    )) {
+      // drain
+    }
+
+    expect(resolveForGeneration).not.toHaveBeenCalled()
+    expect(streamRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skillId: undefined,
+        llmModel: undefined,
+        llmApiKey: undefined,
+        llmBaseUrl: undefined,
+      }),
+    )
+  })
+})

--- a/apps/server/src/agent/agent.service.test.ts
+++ b/apps/server/src/agent/agent.service.test.ts
@@ -50,6 +50,7 @@ describe('AgentService streamConversation', () => {
       } as never,
       { create: vi.fn() } as never,
       { createFromAgent: vi.fn() } as never,
+      { resolveForGeneration: vi.fn() } as never,
     )
   })
 
@@ -192,6 +193,7 @@ describe('AgentService idempotency', () => {
       } as never,
       { create: vi.fn() } as never,
       { createFromAgent: vi.fn() } as never,
+      { resolveForGeneration: vi.fn() } as never,
     )
   })
 
@@ -295,6 +297,7 @@ describe('AgentService checkRuntimeHealth', () => {
       } as never,
       { create: vi.fn() } as never,
       { createFromAgent: vi.fn() } as never,
+      { resolveForGeneration: vi.fn() } as never,
     )
   })
 

--- a/apps/server/src/agent/agent.service.ts
+++ b/apps/server/src/agent/agent.service.ts
@@ -5,7 +5,9 @@ import { IMAGE_MODELS, TEXT_MODELS, VIDEO_MODELS } from '@lnkpi/shared'
 import { MaterialService } from '../canvas/material.service'
 import { ShotService } from '../canvas/shot.service'
 import { PrismaService } from '../prisma/prisma.service'
+import { ProviderResolverService } from '../provider/provider-resolver.service'
 import { AgentRuntimeClient } from './agent-runtime.client'
+import { mapUiSkillId } from './agent-skill-map'
 
 @Injectable()
 export class AgentService {
@@ -15,6 +17,7 @@ export class AgentService {
     @Inject(PrismaService) private readonly prisma: PrismaService,
     @Inject(ShotService) private readonly shotService: ShotService,
     @Inject(MaterialService) private readonly materialService: MaterialService,
+    @Inject(ProviderResolverService) private readonly providerResolver: ProviderResolverService,
   ) {
     this.agent = new CanvasAgent(
       process.env.OPENAI_API_KEY,
@@ -52,6 +55,8 @@ export class AgentService {
     threadId?: string,
     userDecision?: 'confirm' | 'revise' | 'replan' | 'confirm_gen' | 'topo_revise' | 'node_revise',
     idempotencyKey?: string,
+    skillId?: string,
+    model?: string,
   ): AsyncGenerator<AgentStreamEvent> {
     // Register idempotency key (if provided) before starting
     if (idempotencyKey) {
@@ -75,6 +80,8 @@ export class AgentService {
           userId,
           threadId,
           userDecision,
+          skillId,
+          model,
         )) {
           if (event.type === 'text_delta') {
             assistantText += (event.data as { text: string }).text
@@ -191,9 +198,22 @@ export class AgentService {
     userId: string,
     threadId?: string,
     userDecision?: 'confirm' | 'revise' | 'replan' | 'confirm_gen' | 'topo_revise' | 'node_revise',
+    skillId?: string,
+    model?: string,
   ): AsyncGenerator<AgentStreamEvent> {
     let assistantText = ''
     const canvasActions: CanvasAction[] = []
+
+    const runtimeSkillId = mapUiSkillId(skillId)
+    let llmModel: string | undefined
+    let llmApiKey: string | undefined
+    let llmBaseUrl: string | undefined
+    if (model && userId) {
+      const resolved = await this.providerResolver.resolveForGeneration(userId, model, 'text')
+      llmModel = resolved.modelName
+      llmApiKey = resolved.credentials.apiKey
+      llmBaseUrl = resolved.credentials.baseUrl
+    }
 
     for await (const event of client.streamRun({
       sessionId,
@@ -204,6 +224,10 @@ export class AgentService {
       // W5 修复：把前端结构化决策（按钮点击）传给 agent-runtime
       // 让它走 Command(resume=...) 精确恢复 interrupt，不再重跑 route_entry→intake
       userDecision,
+      skillId: runtimeSkillId,
+      llmModel,
+      llmApiKey,
+      llmBaseUrl,
     })) {
       if (event.type === 'text_delta') {
         assistantText += (event.data as { text: string }).text

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -39,6 +39,10 @@ import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGener
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
 import { useClickOutside } from '@/composables/useClickOutside'
+import { useProviderBootstrap } from '@/composables/useProviderBootstrap'
+import { AGENT_SKILLS } from '@/constants/agentSkillMap'
+import UniversalModelSelector from '@/components/canvas/UniversalModelSelector.vue'
+import { ElMessage } from 'element-plus'
 
 const props = defineProps<{
   sessionId: string
@@ -137,21 +141,10 @@ function clamp(v: number, min: number, max: number) {
 
 const speech = useSpeechRecognition()
 
+const { preferences, load: loadProviderBootstrap } = useProviderBootstrap()
+const planningModel = ref(preferences.value?.defaultTextModel ?? '')
+
 /* ---- 技能选择 ---- */
-interface AgentSkill {
-  id: string
-  label: string
-  desc: string
-  icon: 'canvas' | 'storyboard' | 'polish' | 'organize'
-}
-
-const AGENT_SKILLS: AgentSkill[] = [
-  { id: 'canvas', label: '画布编排', desc: '创建节点与连线，驱动画布创作', icon: 'canvas' },
-  { id: 'storyboard', label: '分镜脚本', desc: '拆解剧情，生成分镜与镜头描述', icon: 'storyboard' },
-  { id: 'polish', label: '提示词优化', desc: '润色扩写提示词，提升生成质量', icon: 'polish' },
-  { id: 'organize', label: '素材整理', desc: '归纳画布素材，梳理创作结构', icon: 'organize' },
-]
-
 const activeSkillId = ref('canvas')
 const activeSkill = computed(() => AGENT_SKILLS.find((s) => s.id === activeSkillId.value) ?? AGENT_SKILLS[0])
 const skillMenuOpen = ref(false)
@@ -181,6 +174,11 @@ function applyHistoryPrompt(content: string) {
 
 onMounted(() => {
   void loadHistory()
+  void loadProviderBootstrap().then(() => {
+    if (!planningModel.value && preferences.value?.defaultTextModel) {
+      planningModel.value = preferences.value.defaultTextModel
+    }
+  })
 })
 
 watch(
@@ -297,8 +295,7 @@ async function send() {
     return
   }
 
-  const skillPrefix = activeSkillId.value === 'canvas' ? '' : `【技能：${activeSkill.value.label}】`
-  const message = `${skillPrefix}${input.value.trim()}`
+  const message = input.value.trim()
   input.value = ''
   // W5 修复：手动输入若匹配确认/修改关键词，也带上 userDecision 触发 Command(resume=...)
   await sendMessage(message, mapPresetToDecision(message))
@@ -351,6 +348,12 @@ async function createOwnCanvas() {
 }
 
 async function sendMessage(message: string, userDecision?: 'confirm' | 'revise') {
+  const selectableTextModels = preferences.value?.selectableTextModels ?? []
+  if (planningModel.value && !selectableTextModels.includes(planningModel.value)) {
+    ElMessage.warning('当前规划模型已停用，请重新选择')
+    return
+  }
+
   if (props.readOnly) {
     agent.addUserMessage(message)
     agent.startAssistantMessage()
@@ -391,6 +394,8 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
         message,
         threadId: agentThreadId.value,
         userDecision,
+        skillId: activeSkillId.value,
+        model: planningModel.value || undefined,
       }),
     })
 
@@ -943,15 +948,14 @@ defineExpose({ openPanel, reconcileFromNodes })
               />
 
               <div class="agent-dock-actions">
-                <!-- 一期不打通规划模型选择：避免停用模型误导 -->
-                <span class="px-1 text-[10px] opacity-50">规划模型由服务端配置</span>
+                <UniversalModelSelector v-model="planningModel" type="text" />
 
-                <!-- 技能选择（一期仅文案前缀装饰，未打通 Runtime skillId） -->
+                <!-- 技能选择 -->
                 <div ref="skillMenuRef" class="relative">
                   <button
                     type="button"
                     class="neo-ctl flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-xs"
-                    title="技能（一期未打通 Runtime）"
+                    title="技能"
                     @click="skillMenuOpen = !skillMenuOpen"
                   >
                     <svg viewBox="0 0 24 24" class="h-3.5 w-3.5 text-[var(--neo-accent-text)]" fill="none" stroke="currentColor" stroke-width="1.75">
@@ -988,7 +992,10 @@ defineExpose({ openPanel, reconcileFromNodes })
                         </svg>
                       </span>
                       <span class="min-w-0">
-                        <span class="block text-xs font-medium">{{ skill.label }}</span>
+                        <span class="flex items-center gap-1.5">
+                          <span class="text-xs font-medium">{{ skill.label }}</span>
+                          <span v-if="!skill.ready" class="rounded px-1 py-px text-[9px] opacity-50 ring-1 ring-current">开发中</span>
+                        </span>
                         <span class="block truncate text-[10px] opacity-60">{{ skill.desc }}</span>
                       </span>
                     </button>

--- a/apps/web/src/constants/agentSkillMap.ts
+++ b/apps/web/src/constants/agentSkillMap.ts
@@ -1,0 +1,15 @@
+export interface AgentSkillDef {
+  id: string
+  label: string
+  desc: string
+  icon: 'canvas' | 'storyboard' | 'polish' | 'organize'
+  runtimeSkillId: string | null
+  ready: boolean
+}
+
+export const AGENT_SKILLS: AgentSkillDef[] = [
+  { id: 'canvas', label: '画布编排', desc: '创建节点与连线，驱动画布创作', icon: 'canvas', runtimeSkillId: 'enterprise-marketing-campaign', ready: true },
+  { id: 'storyboard', label: '分镜脚本', desc: '拆解剧情，生成分镜与镜头描述', icon: 'storyboard', runtimeSkillId: null, ready: false },
+  { id: 'polish', label: '提示词优化', desc: '润色扩写提示词，提升生成质量', icon: 'polish', runtimeSkillId: null, ready: false },
+  { id: 'organize', label: '素材整理', desc: '归纳画布素材，梳理创作结构', icon: 'organize', runtimeSkillId: null, ready: false },
+]

--- a/deploy/prod-phase-c2-dock-verify.py
+++ b/deploy/prod-phase-c2-dock-verify.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Production Phase C2 dock skillId/model verification.
+
+Covers dock → Nest → Runtime path:
+  - skillId=canvas + marketing brief → plan-like response
+  - skillId=storyboard + greeting → chat (no canvas node plan)
+
+Usage:
+  python3 deploy/prod-phase-c2-dock-verify.py
+  BASE_URL=http://119.29.173.89:8888 PHONE=17279698608 CODE=123456 python3 deploy/prod-phase-c2-dock-verify.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import uuid
+from typing import Any
+from urllib.request import Request, urlopen
+
+BASE = os.environ.get("BASE_URL", "http://119.29.173.89:8888").rstrip("/")
+API = f"{BASE}/api"
+PHONE = os.environ.get("PHONE", "17279698608")
+CODE = os.environ.get("CODE", "123456")
+SSE_TIMEOUT_SEC = float(os.environ.get("SSE_TIMEOUT_SEC", "420"))
+
+PASS = FAIL = SKIP = 0
+
+
+def record(case: str, ok: bool, detail: str = "", *, skip: bool = False) -> None:
+    global PASS, FAIL, SKIP
+    if skip:
+        SKIP += 1
+        icon = "⏭️"
+    elif ok:
+        PASS += 1
+        icon = "✅"
+    else:
+        FAIL += 1
+        icon = "❌"
+    line = f"{icon} {case}"
+    if detail:
+        line += f" — {detail[:220]}"
+    print(line)
+
+
+def http(m: str, p: str, b: dict | None = None, t: str | None = None) -> Any:
+    h = {"Content-Type": "application/json", "Accept": "application/json"}
+    if t:
+        h["Authorization"] = f"Bearer {t}"
+    r = Request(f"{API}{p}", data=None if b is None else json.dumps(b).encode(), headers=h, method=m)
+    with urlopen(r, timeout=120) as resp:
+        return json.loads(resp.read())
+
+
+def sse_collect(
+    t: str,
+    sid: str,
+    msg: str,
+    tid: str,
+    *,
+    timeout: float = 420,
+    skillId: str | None = None,
+    model: str | None = None,
+) -> tuple[list[dict], str, set[str], str]:
+    body: dict[str, Any] = {"sessionId": sid, "message": msg, "threadId": tid}
+    if skillId:
+        body["skillId"] = skillId
+    if model:
+        body["model"] = model
+    h = {
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+        "Authorization": f"Bearer {t}",
+        "Idempotency-Key": f"ik_{uuid.uuid4().hex}",
+    }
+    r = Request(f"{API}/agent/chat/conversation", data=json.dumps(body).encode(), headers=h, method="POST")
+    events: list[dict] = []
+    types: set[str] = set()
+    parts: list[str] = []
+    end = time.time() + timeout
+    exit_reason = "timeout"
+    with urlopen(r, timeout=timeout) as resp:
+        buf = ""
+        while time.time() < end:
+            chunk = resp.read(4096)
+            if not chunk:
+                exit_reason = "eof"
+                break
+            buf += chunk.decode(errors="replace")
+            while "\n\n" in buf:
+                block, buf = buf.split("\n\n", 1)
+                for line in block.splitlines():
+                    if not line.startswith("data:"):
+                        continue
+                    pl = line[5:].strip()
+                    if pl == "[DONE]":
+                        return events, "".join(parts), types, "done_marker"
+                    try:
+                        ev = json.loads(pl)
+                    except json.JSONDecodeError:
+                        continue
+                    events.append(ev)
+                    et = str(ev.get("type") or "")
+                    types.add(et)
+                    if et == "text_delta":
+                        parts.append(str((ev.get("data") or {}).get("text") or ""))
+                    if et == "done":
+                        return events, "".join(parts), types, "done"
+                    if et == "error":
+                        return events, "".join(parts), types, "error"
+    return events, "".join(parts), types, exit_reason
+
+
+def plan_like(text: str) -> bool:
+    markers = ("方案", "画布节点", "拟定拆解", "营销", "详情页")
+    return any(m in text for m in markers)
+
+
+def canvas_plan_phrase(text: str) -> bool:
+    return "拟定拆解约" in text and "画布节点" in text
+
+
+def main() -> int:
+    print("=== Phase C2 dock skillId/model verify ===")
+    print(f"BASE={BASE}\n")
+
+    try:
+        http("POST", "/auth/send-code", {"phone": PHONE})
+    except Exception:
+        pass
+    try:
+        tok = http("POST", "/auth/login", {"phone": PHONE, "code": CODE})["data"]["token"]
+        record("P0 Login", True)
+    except Exception as exc:  # noqa: BLE001
+        record("P0 Login", False, str(exc))
+        return 1
+
+    rt = http("GET", "/agent/runtime-health", t=tok)
+    record("P0 Runtime health", bool((rt.get("data") or {}).get("ok")))
+
+    # P1: canvas skillId + marketing brief → plan-like response
+    sid1 = http("POST", "/sessions", {"title": f"PhaseC2-canvas-{int(time.time())}"}, t=tok)["data"]["id"]
+    tid1 = f"{sid1}:{uuid.uuid4()}"
+    record("P1 Create session (canvas)", True, sid1)
+
+    brief = "天猫蓝牙耳机详情页营销方案，品牌 lnkpi，PhaseC2 dock canvas 复测"
+    _, text1, types1, exit1 = sse_collect(
+        tok, sid1, brief, tid1, timeout=SSE_TIMEOUT_SEC, skillId="canvas"
+    )
+    ok1 = "error" not in types1 and len(text1) > 0 and plan_like(text1)
+    record(
+        "P1 canvas skillId plan stream",
+        ok1,
+        f"exit={exit1} text={text1[:100].replace(chr(10), ' ')}",
+    )
+
+    # P2: storyboard skillId + greeting → chat (no canvas node plan)
+    sid2 = http("POST", "/sessions", {"title": f"PhaseC2-storyboard-{int(time.time())}"}, t=tok)["data"]["id"]
+    tid2 = f"{sid2}:{uuid.uuid4()}"
+    record("P2 Create session (storyboard)", True, sid2)
+
+    _, text2, types2, exit2 = sse_collect(
+        tok, sid2, "你好", tid2, timeout=SSE_TIMEOUT_SEC, skillId="storyboard"
+    )
+    ok2 = (
+        "error" not in types2
+        and len(text2) > 0
+        and not canvas_plan_phrase(text2)
+    )
+    record(
+        "P2 storyboard skillId chat stream",
+        ok2,
+        f"exit={exit2} text={text2[:100].replace(chr(10), ' ')}",
+    )
+
+    print(f"\n=== Summary PASS={PASS} FAIL={FAIL} SKIP={SKIP} ===")
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/superpowers/plans/2026-08-03-agent-phase-c2-dock-model-skillid.md
+++ b/docs/superpowers/plans/2026-08-03-agent-phase-c2-dock-model-skillid.md
@@ -1,0 +1,365 @@
+# Phase C 二期：Dock model/skillId 端到端 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Agent 侧栏 dock 的 skillId 与规划 model 经 Web → Nest → Runtime 全链路生效。
+
+**Architecture:** Nest `ProviderResolver.resolveForGeneration(userId, model, 'text')` 解 credentials；Runtime `resolve_llm(req)` 构建 per-request `ChatOpenAI`；`intake` 读 `requested_skill_id` 优先于关键词。
+
+**Tech Stack:** Vue 3 + NestJS + Python LangGraph + `@lnkpi/shared` contract
+
+## Global Constraints
+
+- MVP A：skillId + model 端到端；**不含**真实规划积分扣费 / DockCreditBadge
+- 浏览器不传 apiKey；credentials 仅 Nest → Runtime service-token 内网
+- Phase B/C 生产脚本回归必须 PASS
+- 合并走 feature 分支 + PR + CI 全绿 + Squash merge
+
+**Spec:** `docs/superpowers/specs/2026-08-03-agent-phase-c2-dock-model-skillid-design.md`
+
+---
+
+## File Map
+
+| 文件 | 职责 |
+| --- | --- |
+| `services/agent-runtime/app/runs.py` | `RunRequest` 扩展、`resolve_llm()` |
+| `services/agent-runtime/app/graph/nodes/intake.py` | `requested_skill_id` 门控 |
+| `apps/server/src/agent/agent.controller.ts` | `ConversationDto` 扩展 |
+| `apps/server/src/agent/agent.service.ts` | resolve model + 转发 |
+| `apps/server/src/agent/agent-runtime.client.ts` | `RuntimeRunInput` 扩展 |
+| `apps/web/src/constants/agentSkillMap.ts` | UI skillId → Runtime skill_id |
+| `apps/web/src/components/agent/AgentSideRail.vue` | model 选择器 + POST body |
+| `deploy/prod-phase-c2-dock-verify.py` | 可选生产验收 |
+
+---
+
+### Task 1: Runtime — `resolve_llm` + `RunRequest` 扩展
+
+**Files:**
+- Modify: `services/agent-runtime/app/runs.py`
+- Create: `services/agent-runtime/tests/test_runs_llm.py`
+
+**Interfaces:**
+- Produces: `resolve_llm(req: RunRequest) -> ChatOpenAI`, `RunRequest.skill_id`, `RunRequest.llm_model`, `RunRequest.llm_api_key`, `RunRequest.llm_base_url`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# services/agent-runtime/tests/test_runs_llm.py
+from app.runs import RunRequest, resolve_llm, default_llm
+
+def test_resolve_llm_uses_default_when_no_override():
+    req = RunRequest(session_id="s1", user_id="u1", message="hi")
+    assert resolve_llm(req) is not None  # same config as default_llm()
+
+def test_resolve_llm_uses_override_credentials():
+    req = RunRequest(
+        session_id="s1", user_id="u1", message="hi",
+        llm_model="gpt-test", llm_api_key="sk-test", llm_base_url="https://api.example/v1",
+    )
+    llm = resolve_llm(req)
+    assert llm.model_name == "gpt-test"
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+```bash
+cd services/agent-runtime && python3 -m pytest tests/test_runs_llm.py -v
+```
+
+- [ ] **Step 3: Implement**
+
+```python
+# runs.py — extend RunRequest
+class RunRequest(BaseModel):
+    ...
+    skill_id: str | None = None
+    llm_model: str | None = None
+    llm_api_key: str | None = None
+    llm_base_url: str | None = None
+
+def resolve_llm(req: RunRequest) -> Any:
+    if req.llm_model and req.llm_api_key:
+        return ChatOpenAI(
+            api_key=req.llm_api_key,
+            base_url=req.llm_base_url or settings.openai_base_url,
+            model=req.llm_model,
+            temperature=0.4,
+        )
+    if req.llm_model and not req.llm_api_key:
+        return ChatOpenAI(
+            api_key=settings.openai_api_key or "sk-placeholder",
+            base_url=settings.openai_base_url,
+            model=req.llm_model,
+            temperature=0.4,
+        )
+    return default_llm()
+
+# stream_run_events — replace graph_llm = ...
+graph_llm = resolve_llm(req)
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(agent-runtime): per-request LLM override via RunRequest"
+```
+
+---
+
+### Task 2: Runtime — intake `requested_skill_id` 门控
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/nodes/intake.py`
+- Modify: `services/agent-runtime/app/runs.py` (input_state + interrupt update)
+- Modify: `services/agent-runtime/tests/test_intake_gate.py`
+
+**Interfaces:**
+- Consumes: `RunRequest.skill_id`
+- Produces: `intake` reads `state["requested_skill_id"]`; validates against `discover_skills()`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+@pytest.mark.asyncio
+async def test_intake_explicit_skill_overrides_non_marketing_text():
+    node = make_intake_node(SKILLS_DIR)
+    out = await node({
+        "messages": [HumanMessage(content="你好")],
+        "requested_skill_id": "enterprise-marketing-campaign",
+    })
+    assert out.get("skill_id") == "enterprise-marketing-campaign"
+
+@pytest.mark.asyncio
+async def test_intake_invalid_requested_skill_falls_back_to_chat():
+    node = make_intake_node(SKILLS_DIR)
+    out = await node({
+        "messages": [HumanMessage(content="你好")],
+        "requested_skill_id": "nonexistent-skill",
+    })
+    assert out.get("skill_id") is None
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Implement intake logic**
+
+```python
+# intake.py — after entries = discover_skills(...)
+requested = str(state.get("requested_skill_id") or "").strip()
+by_id = {e.skill_id: e for e in entries}
+skill_id: str | None = None
+if requested and requested in by_id:
+    skill_id = requested
+elif marketing_intent(text):
+    preferred = "enterprise-marketing-campaign"
+    ...
+```
+
+```python
+# runs.py — fresh turn input_state
+input_state = {
+    ...
+    "requested_skill_id": req.skill_id,
+}
+```
+
+- [ ] **Step 4: Run intake tests — expect PASS**
+
+```bash
+python3 -m pytest tests/test_intake_gate.py tests/test_runs_llm.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+---
+
+### Task 3: Nest — DTO + ProviderResolver + Runtime 转发
+
+**Files:**
+- Modify: `apps/server/src/agent/agent.controller.ts`
+- Modify: `apps/server/src/agent/agent.service.ts`
+- Modify: `apps/server/src/agent/agent-runtime.client.ts`
+- Create: `apps/server/src/agent/agent.service.dock.test.ts` (或扩展现有 test)
+
+**Interfaces:**
+- Consumes: `ProviderResolver.resolveForGeneration(userId, model, 'text')`
+- Produces: Runtime body `{ skill_id, llm_model, llm_api_key, llm_base_url }`
+
+- [ ] **Step 1: Extend DTO**
+
+```typescript
+class ConversationDto {
+  ...
+  @IsOptional() @IsString() skillId?: string
+  @IsOptional() @IsString() model?: string
+}
+```
+
+- [ ] **Step 2: Map UI skillId → Runtime skill_id in service**
+
+```typescript
+const SKILL_UI_TO_RUNTIME: Record<string, string | undefined> = {
+  canvas: 'enterprise-marketing-campaign',
+  storyboard: undefined,
+  polish: undefined,
+  organize: undefined,
+}
+
+function mapSkillId(uiSkillId?: string): string | undefined {
+  if (!uiSkillId) return undefined
+  return SKILL_UI_TO_RUNTIME[uiSkillId]
+}
+```
+
+- [ ] **Step 3: Resolve model when present**
+
+```typescript
+let llmModel: string | undefined
+let llmApiKey: string | undefined
+let llmBaseUrl: string | undefined
+if (model && userId) {
+  const resolved = await this.providerResolver.resolveForGeneration(userId, model, 'text')
+  llmModel = resolved.modelName
+  llmApiKey = resolved.credentials.apiKey
+  llmBaseUrl = resolved.credentials.baseUrl
+}
+```
+
+- [ ] **Step 4: Forward in agent-runtime.client.ts**
+
+```typescript
+export interface RuntimeRunInput {
+  ...
+  skillId?: string
+  llmModel?: string
+  llmApiKey?: string
+  llmBaseUrl?: string
+}
+
+body: JSON.stringify({
+  ...
+  skill_id: input.skillId,
+  llm_model: input.llmModel,
+  llm_api_key: input.llmApiKey,
+  llm_base_url: input.llmBaseUrl,
+})
+```
+
+- [ ] **Step 5: Wire controller → service**
+
+- [ ] **Step 6: Unit test forward payload**
+
+- [ ] **Step 7: Commit**
+
+---
+
+### Task 4: Web — skill 映射 + UniversalModelSelector + POST body
+
+**Files:**
+- Create: `apps/web/src/constants/agentSkillMap.ts`
+- Modify: `apps/web/src/components/agent/AgentSideRail.vue`
+
+**Interfaces:**
+- Consumes: `useProviderBootstrap`, `UniversalModelSelector`
+- Produces: POST `{ skillId: activeSkillId, model: selectedModel }`
+
+- [ ] **Step 1: Create skill map + runtime skill id helper**
+
+```typescript
+// apps/web/src/constants/agentSkillMap.ts
+export const AGENT_SKILLS = [
+  { id: 'canvas', label: '画布编排', runtimeSkillId: 'enterprise-marketing-campaign', ready: true },
+  { id: 'storyboard', label: '分镜脚本', runtimeSkillId: null, ready: false },
+  ...
+] as const
+```
+
+- [ ] **Step 2: Add planning model state + bootstrap load**
+
+```typescript
+import UniversalModelSelector from '@/components/canvas/UniversalModelSelector.vue'
+import { useProviderBootstrap } from '@/composables/useProviderBootstrap'
+
+const { load, preferences } = useProviderBootstrap()
+const planningModel = ref('')
+
+onMounted(async () => {
+  await load()
+  planningModel.value = preferences.value?.defaultTextModel ?? ''
+})
+```
+
+- [ ] **Step 3: Replace static span with UniversalModelSelector**
+
+- [ ] **Step 4: Remove skill prefix hack; add send guard**
+
+```typescript
+// delete skillPrefix lines
+const selectable = preferences.value?.selectableTextModels ?? []
+if (planningModel.value && !selectable.includes(planningModel.value)) {
+  // toast + return
+}
+body: JSON.stringify({
+  sessionId, message, threadId, userDecision,
+  skillId: activeSkillId.value,
+  model: planningModel.value || undefined,
+})
+```
+
+- [ ] **Step 5: Mark unready skills in menu (`开发中`)**
+
+- [ ] **Step 6: Manual smoke — pnpm build**
+
+- [ ] **Step 7: Commit**
+
+---
+
+### Task 5: 回归测试 + 可选生产脚本
+
+**Files:**
+- Create: `deploy/prod-phase-c2-dock-verify.py`
+
+- [ ] **Step 1: Run existing prod scripts**
+
+```bash
+python3 deploy/prod-phase-b-user-verify.py
+python3 deploy/prod-phase-c-user-verify.py
+```
+
+- [ ] **Step 2: Add Phase C2 script (minimal)**
+
+- P0 login + runtime health
+- POST conversation with `skillId=canvas` + marketing brief → plan 流
+- POST with `skillId=storyboard` + "你好" → chat 回复（无 plan 节点）
+
+- [ ] **Step 3: Run runtime + nest tests + pnpm build**
+
+- [ ] **Step 4: Commit + PR**
+
+---
+
+## Spec Coverage Check
+
+| Spec § | Task |
+| --- | --- |
+| skillId 优先级 | Task 2 |
+| UI 映射 | Task 3 + Task 4 |
+| 去前缀 | Task 4 |
+| model Nest resolve | Task 3 |
+| Runtime resolve_llm | Task 1 |
+| 停用 model UX | Task 4 |
+| Phase B/C 回归 | Task 5 |
+| 积分非目标 | — (excluded) |
+
+## Execution Handoff
+
+Plan saved. Two execution options:
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task, review between tasks
+2. **Inline Execution** — implement tasks in this session with checkpoints
+
+Which approach?

--- a/docs/superpowers/specs/2026-08-03-agent-phase-c2-dock-model-skillid-design.md
+++ b/docs/superpowers/specs/2026-08-03-agent-phase-c2-dock-model-skillid-design.md
@@ -1,0 +1,137 @@
+# Phase C 二期：Agent Dock model/skillId 端到端（MVP A）
+
+> 状态：已确认  
+> 依赖：Phase C 画布同步出图（#106）、Phase B await_topo/topo_revise（#104/#105）  
+> 范围：**skillId + model 端到端**；积分徽章与真实规划扣费不在本 MVP
+
+## 1. 目标
+
+用户在 Agent 侧栏 dock 选择的 **技能** 与 **规划模型**，经 Web → Nest → Runtime 全链路生效：
+
+1. `skillId` 驱动 `intake` 选 Skill 包（显式优先于关键词启发式）
+2. `model` 驱动规划 LLM（平台模型 + 用户 BYOK，与 Studio Dock 一致）
+3. 去掉「【技能：…】」文案前缀 hack
+4. 停用/不可选模型发送前拦截，避免「发送无回复」
+
+## 2. 非目标
+
+- 真实规划积分扣费 / `DockCreditBadge` 对齐
+- 新增 `storyboard` / `polish` / `organize` Runtime Skill 包
+- `/技能名` 斜杠唤起
+- Canvas Studio Dock 改动（其 model 链路已独立）
+
+## 3. 架构
+
+```
+AgentSideRail
+  POST /api/agent/chat/conversation
+    { sessionId, message, threadId, userDecision?, skillId?, model? }
+      ↓
+Nest agent.service
+  ProviderResolver.resolveText(model, userId) → { model, apiKey, baseUrl }
+      ↓
+Runtime POST /v1/runs
+    { session_id, user_id, message, thread_id, user_decision?,
+      skill_id?, llm_model?, llm_api_key?, llm_base_url? }
+      ↓
+stream_run_events → resolve_llm(req) → build_agent_graph(llm=...)
+intake: requested_skill_id 优先 → skill_id → plan | chat
+```
+
+**Model 解析方案（锁定）**：Nest 侧 ProviderResolver 解 BYOK，Runtime 仅收内部 service-token 保护的 credentials 字段；浏览器不传 apiKey。
+
+## 4. skillId 门控
+
+### 4.1 优先级
+
+1. 请求体 `skillId`（经 UI 映射表 → Runtime skill 目录名）
+2. 关键词 `marketing_intent(text)` 启发式（保留兼容）
+3. 无 skill → `chat` 分支
+
+### 4.2 UI → Runtime 映射（MVP 静态）
+
+| UI `skillId` | Runtime `skill_id` | 行为 |
+| --- | --- | --- |
+| `canvas` | `enterprise-marketing-campaign` | 营销 plan 流程 |
+| `storyboard` | — | `chat`；菜单标注「开发中」 |
+| `polish` | — | `chat` |
+| `organize` | — | `chat` |
+
+映射表位于 `AgentSideRail.vue`（或抽 `agentSkillMap.ts`）。Runtime `intake` 校验 `discover_skills()` 中存在才写入 `skill_id`。
+
+### 4.3 移除前缀 hack
+
+删除 `【技能：${label}】` 拼接；`message` 为用户原始输入。
+
+## 5. model 选择
+
+### 5.1 前端
+
+- 恢复 `UniversalModelSelector`（`type="text"`）
+- 数据源：`useProviderBootstrap().preferences.selectableTextModels`
+- 默认：`defaultTextModel` → 平台默认
+- 发送前：若当前 model 不在 selectable 列表或 disabled → toast 阻止发送
+
+### 5.2 Nest
+
+- `ConversationDto` 增加可选 `model?: string`（encoded channel model，与 Studio 同格式）
+- `streamConversation` 调用 ProviderResolver；失败返回 400 + 可读错误
+- 转发 Runtime：`llm_model`, `llm_api_key`, `llm_base_url`（仅内网）
+
+### 5.3 Runtime
+
+- `RunRequest` 增加 `skill_id?`, `llm_model?`, `llm_api_key?`, `llm_base_url?`
+- `resolve_llm(req)`：有 `llm_api_key` + `llm_model` 则构建 per-request `ChatOpenAI`；否则 `default_llm()`
+- 新 turn `input_state` 注入 `requested_skill_id: req.skill_id`
+
+## 6. API / Contract
+
+| 层 | 变更 |
+| --- | --- |
+| `apps/server/.../agent.controller.ts` | `ConversationDto.skillId?`, `ConversationDto.model?` |
+| `apps/server/.../agent-runtime.client.ts` | `RuntimeRunInput` 扩展 |
+| `services/agent-runtime/app/runs.py` | `RunRequest` 扩展 |
+| `packages/shared/src/agentContract.ts` | 可选 `AgentConversationRequest` Zod |
+| `scripts/verify-contract.ts` | 若新增 shared schema 则注册 |
+
+## 7. 错误处理
+
+| 场景 | 行为 |
+| --- | --- |
+| 未知 skillId（映射为 null） | intake → chat，不报错 |
+| 映射 skill 目录不存在 | intake 忽略，fallback 启发式或 chat |
+| model 不可 resolve | Nest 400，前端 toast |
+| Runtime LLM 调用失败 | 现有 error SSE + `last_error` |
+
+## 8. 测试
+
+### 8.1 单元
+
+- `test_intake_gate.py`：显式 `requested_skill_id=enterprise-marketing-campaign` + 非营销文案 → plan
+- `test_intake_gate.py`：`requested_skill_id` 无效 → chat
+- `test_runs_llm.py`（新）：`resolve_llm` override vs default
+- Nest：`agent.service` 转发 skillId/model 字段
+
+### 8.2 生产回归
+
+- `deploy/prod-phase-b-user-verify.py` PASS
+- `deploy/prod-phase-c-user-verify.py` PASS
+
+### 8.3 可选 E2E
+
+- `deploy/prod-phase-c2-dock-verify.py`：canvas skill + model → 营销 plan；storyboard → chat
+
+## 9. 成功标准
+
+1. 侧栏选「画布编排」+ 营销需求 → 进入 `enterprise-marketing-campaign` plan（不依赖关键词 alone）
+2. 侧栏选「分镜脚本」+ 任意消息 → `chat`，无前缀污染
+3. 切换规划 model 后 plan 节点 LLM 使用该 model（可通过 trace/log 或响应差异验证）
+4. BYOK text model 可选且能正常 plan
+5. 停用 model 无法发送
+6. Phase B/C 生产脚本仍 PASS
+
+## 10. 文档修订
+
+| 日期 | 说明 |
+| --- | --- |
+| 2026-08-03 | MVP A 规格：skillId + model E2E，积分二期 |

--- a/services/agent-runtime/app/graph/nodes/intake.py
+++ b/services/agent-runtime/app/graph/nodes/intake.py
@@ -21,10 +21,13 @@ def make_intake_node(skills_dir: Path) -> Callable:
     async def intake(state: dict) -> dict:
         text = _latest_user_text(state.get("messages") or [])
         entries = discover_skills(skills_dir)
+        requested = str(state.get("requested_skill_id") or "").strip()
+        by_id = {e.skill_id: e for e in entries}
         skill_id: str | None = None
-        if marketing_intent(text):
+        if requested and requested in by_id:
+            skill_id = requested
+        elif marketing_intent(text):
             preferred = "enterprise-marketing-campaign"
-            by_id = {e.skill_id: e for e in entries}
             if preferred in by_id:
                 skill_id = preferred
             elif entries:

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -546,6 +546,7 @@ async def stream_run_events(
             "session_id": req.session_id,
             "user_id": req.user_id,
             "thread_id": thread_id,
+            "requested_skill_id": req.skill_id,
         }
 
     async def run_graph() -> None:

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -181,6 +181,10 @@ class RunRequest(BaseModel):
     thread_id: str | None = None
     # W5修复：添加user_decision字段，支持用户确认/修改/换方向
     user_decision: str | None = None  # "confirm" | "revise" | "replan"
+    skill_id: str | None = None
+    llm_model: str | None = None
+    llm_api_key: str | None = None
+    llm_base_url: str | None = None
 
 
 class NestEventProxy:
@@ -314,6 +318,26 @@ def default_llm() -> Any:
         model=settings.openai_chat_model or "gpt-4o",
         temperature=0.4,
     )
+
+
+def resolve_llm(req: RunRequest) -> Any:
+    if req.llm_model and req.llm_api_key:
+        kwargs: dict[str, Any] = {
+            "api_key": req.llm_api_key,
+            "model": req.llm_model,
+            "temperature": 0.4,
+        }
+        if req.llm_base_url:
+            kwargs["base_url"] = req.llm_base_url
+        return ChatOpenAI(**kwargs)
+    if req.llm_model:
+        return ChatOpenAI(
+            api_key=settings.openai_api_key or "sk-placeholder",
+            base_url=settings.openai_base_url,
+            model=req.llm_model,
+            temperature=0.4,
+        )
+    return default_llm()
 
 
 def default_nest(*, session_id: str, user_id: str) -> NestCanvasClient:
@@ -473,7 +497,7 @@ async def stream_run_events(
         await queue.put(event)
 
     proxy = NestEventProxy(inner_nest, emit)
-    graph_llm = llm if llm is not None else default_llm()
+    graph_llm = llm if llm is not None else resolve_llm(req)
     thread_started()
 
     active_checkpointer = checkpointer if checkpointer is not None else await _get_checkpointer()

--- a/services/agent-runtime/tests/test_intake_gate.py
+++ b/services/agent-runtime/tests/test_intake_gate.py
@@ -29,6 +29,26 @@ async def test_intake_hello_sets_no_skill():
 
 
 @pytest.mark.asyncio
+async def test_intake_explicit_skill_overrides_non_marketing_text():
+    node = make_intake_node(SKILLS_DIR)
+    out = await node({
+        "messages": [HumanMessage(content="你好")],
+        "requested_skill_id": "enterprise-marketing-campaign",
+    })
+    assert out.get("skill_id") == "enterprise-marketing-campaign"
+
+
+@pytest.mark.asyncio
+async def test_intake_invalid_requested_skill_falls_back_to_chat():
+    node = make_intake_node(SKILLS_DIR)
+    out = await node({
+        "messages": [HumanMessage(content="你好")],
+        "requested_skill_id": "nonexistent-skill",
+    })
+    assert out.get("skill_id") is None
+
+
+@pytest.mark.asyncio
 async def test_intake_marketing_sets_enterprise_skill():
     node = make_intake_node(SKILLS_DIR)
     out = await node(

--- a/services/agent-runtime/tests/test_runs_llm.py
+++ b/services/agent-runtime/tests/test_runs_llm.py
@@ -1,0 +1,21 @@
+from app.runs import RunRequest, resolve_llm, default_llm
+
+
+def test_resolve_llm_uses_default_when_no_override():
+    req = RunRequest(session_id="s1", user_id="u1", message="hi")
+    llm = resolve_llm(req)
+    default = default_llm()
+    assert llm.model_name == default.model_name
+
+
+def test_resolve_llm_uses_override_credentials():
+    req = RunRequest(
+        session_id="s1",
+        user_id="u1",
+        message="hi",
+        llm_model="gpt-test",
+        llm_api_key="sk-test",
+        llm_base_url="https://api.example/v1",
+    )
+    llm = resolve_llm(req)
+    assert llm.model_name == "gpt-test"


### PR DESCRIPTION
## Summary

Phase C2 实现 Agent 侧栏 dock 的 `skillId` 与规划 `model` 经 Web → Nest → Runtime 全链路生效。

### Task 1 — Runtime LLM override
- `RunRequest` 扩展 `skill_id` / `llm_model` / `llm_api_key` / `llm_base_url`
- `resolve_llm(req)` 按请求构建 per-request `ChatOpenAI`
- 单元测试：`tests/test_runs_llm.py`

### Task 2 — Intake skill gate
- `intake` 读取 `requested_skill_id`，优先于关键词营销意图
- 无效 skill 回退 chat 模式
- 单元测试：`tests/test_intake_gate.py`

### Task 3 — Nest 转发
- `ConversationDto` 新增 `skillId` / `model`
- `ProviderResolver.resolveForGeneration` 解析凭证
- UI skillId → Runtime skill_id 映射（canvas → enterprise-marketing-campaign）
- 单元测试：`agent.service.dock.test.ts`

### Task 4 — Web dock UX
- `agentSkillMap.ts` 技能映射与 ready 标记
- `AgentSideRail.vue`：`UniversalModelSelector` + POST body 携带 `skillId` / `model`
- 移除 skill 前缀 hack

### Task 5 — 回归 + 生产脚本
- 本地 pytest + `pnpm build` 通过
- 新增 `deploy/prod-phase-c2-dock-verify.py`：canvas 营销 brief → plan 流；storyboard + 你好 → chat 流

## Test plan

- [x] `cd services/agent-runtime && python3 -m pytest tests/test_intake_gate.py tests/test_runs_llm.py -q` — 12 passed
- [x] `pnpm build` — 全 workspace 构建通过
- [x] Nest dock 单元测试 `agent.service.dock.test.ts`
- [ ] CI (`.github/workflows/ci.yml`) 全绿
- [ ] 可选生产验收：`python3 deploy/prod-phase-c2-dock-verify.py`
- [ ] Phase B/C 回归：`python3 deploy/prod-phase-b-user-verify.py` / `prod-phase-c-user-verify.py`


Made with [Cursor](https://cursor.com)