### PR TITLE
feat(agent): Graph Engineering P2 — context snapshot, prompt version, few-shot

### DIFF
--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -258,3 +258,19 @@ model GenProgress {
 
   @@index([threadId, createdAt])
 }
+
+// Context 快照：brief/plan/manifest 摘要外置，减少 LLM 上下文扫描（W18）
+model ContextSnapshot {
+  id            String   @id @default(cuid())
+  threadId      String
+  sessionId     String
+  stage         String   // plan | split
+  brief         String?
+  planSummary   String?
+  manifestJson  String?  // JSON 数组摘要
+  messageCount  Int?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@index([threadId, stage, createdAt])
+}

--- a/apps/server/src/agent/agent-canvas-tools.controller.ts
+++ b/apps/server/src/agent/agent-canvas-tools.controller.ts
@@ -281,6 +281,42 @@ class SaveGenProgressDto {
   summary?: string
 }
 
+// W18: Context snapshot DTOs
+class GetContextSnapshotDto {
+  @IsString()
+  threadId!: string
+
+  @IsOptional()
+  @IsString()
+  stage?: string
+}
+
+class SaveContextSnapshotDto {
+  @IsString()
+  threadId!: string
+
+  @IsString()
+  sessionId!: string
+
+  @IsString()
+  stage!: string
+
+  @IsOptional()
+  @IsString()
+  brief?: string
+
+  @IsOptional()
+  @IsString()
+  planSummary?: string
+
+  @IsOptional()
+  @IsString()
+  manifestJson?: string
+
+  @IsOptional()
+  messageCount?: number
+}
+
 @Controller('agent/internal')
 @UseGuards(AgentInternalGuard)
 export class AgentCanvasToolsController {
@@ -449,6 +485,19 @@ export class AgentCanvasToolsController {
   @Post('save-gen-progress')
   async saveGenProgress(@Body() dto: SaveGenProgressDto) {
     const data = await this.tools.saveGenProgress(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  // W18: Context snapshot endpoints
+  @Post('get-context-snapshot')
+  async getContextSnapshot(@Body() dto: GetContextSnapshotDto) {
+    const data = await this.tools.getContextSnapshot(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('save-context-snapshot')
+  async saveContextSnapshot(@Body() dto: SaveContextSnapshotDto) {
+    const data = await this.tools.saveContextSnapshot(dto)
     return { code: 0, message: 'ok', data }
   }
 }

--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -974,6 +974,70 @@ export class AgentCanvasToolsService {
     return { id: record.id }
   }
 
+  /**
+   * W18: Get latest context snapshot for a thread
+   */
+  async getContextSnapshot(input: {
+    threadId: string
+    stage?: string
+  }): Promise<{
+    id: string
+    stage: string
+    brief: string | null
+    planSummary: string | null
+    manifestJson: string | null
+    messageCount: number | null
+  } | null> {
+    const where: { threadId: string; stage?: string } = { threadId: input.threadId }
+    if (input.stage) {
+      where.stage = input.stage
+    }
+
+    const record = await this.prisma.contextSnapshot.findFirst({
+      where,
+      orderBy: { createdAt: 'desc' },
+    })
+
+    if (!record) {
+      return null
+    }
+
+    return {
+      id: record.id,
+      stage: record.stage,
+      brief: record.brief,
+      planSummary: record.planSummary,
+      manifestJson: record.manifestJson,
+      messageCount: record.messageCount,
+    }
+  }
+
+  /**
+   * W18: Save context snapshot (brief/plan/manifest summaries)
+   */
+  async saveContextSnapshot(input: {
+    threadId: string
+    sessionId: string
+    stage: string
+    brief?: string | null
+    planSummary?: string | null
+    manifestJson?: string | null
+    messageCount?: number | null
+  }): Promise<{ id: string }> {
+    const record = await this.prisma.contextSnapshot.create({
+      data: {
+        threadId: input.threadId,
+        sessionId: input.sessionId,
+        stage: input.stage,
+        brief: input.brief ?? null,
+        planSummary: input.planSummary ?? null,
+        manifestJson: input.manifestJson ?? null,
+        messageCount: input.messageCount ?? null,
+      },
+    })
+    return { id: record.id }
+  }
+
   private async pollGeneration(
     userId: string,
     recordId: string,

--- a/packages/shared/src/agentContract.ts
+++ b/packages/shared/src/agentContract.ts
@@ -506,3 +506,43 @@ export const SaveGenProgressResponseSchema = z.object({
 })
 
 export type SaveGenProgressResponse = z.infer<typeof SaveGenProgressResponseSchema>
+
+// ============================================================
+// context_snapshot (W18)
+// ============================================================
+
+export const GetContextSnapshotRequestSchema = z.object({
+  threadId: z.string(),
+  stage: z.string().optional(),
+})
+
+export type GetContextSnapshotRequest = z.infer<typeof GetContextSnapshotRequestSchema>
+
+export const GetContextSnapshotResponseSchema = z.object({
+  id: z.string(),
+  stage: z.string(),
+  brief: z.string().nullable().optional(),
+  planSummary: z.string().nullable().optional(),
+  manifestJson: z.string().nullable().optional(),
+  messageCount: z.number().nullable().optional(),
+})
+
+export type GetContextSnapshotResponse = z.infer<typeof GetContextSnapshotResponseSchema>
+
+export const SaveContextSnapshotRequestSchema = z.object({
+  threadId: z.string(),
+  sessionId: z.string(),
+  stage: z.string(),
+  brief: z.string().nullable().optional(),
+  planSummary: z.string().nullable().optional(),
+  manifestJson: z.string().nullable().optional(),
+  messageCount: z.number().nullable().optional(),
+})
+
+export type SaveContextSnapshotRequest = z.infer<typeof SaveContextSnapshotRequestSchema>
+
+export const SaveContextSnapshotResponseSchema = z.object({
+  id: z.string(),
+})
+
+export type SaveContextSnapshotResponse = z.infer<typeof SaveContextSnapshotResponseSchema>

--- a/scripts/verify-contract.ts
+++ b/scripts/verify-contract.ts
@@ -63,6 +63,10 @@ import {
   GetGenProgressResponseSchema,
   SaveGenProgressRequestSchema,
   SaveGenProgressResponseSchema,
+  GetContextSnapshotRequestSchema,
+  GetContextSnapshotResponseSchema,
+  SaveContextSnapshotRequestSchema,
+  SaveContextSnapshotResponseSchema,
   StageCanvasActionsRequestSchema,
   StageCanvasActionsResponseSchema,
   CommitStageRequestSchema,
@@ -176,6 +180,14 @@ const CONTRACTS: Record<string, { request: ContractMapping; response: ContractMa
   save_gen_progress: {
     request: { tsSchema: SaveGenProgressRequestSchema, pyModel: 'SaveGenProgressRequest' },
     response: { tsSchema: SaveGenProgressResponseSchema, pyModel: 'SaveGenProgressResponse' },
+  },
+  get_context_snapshot: {
+    request: { tsSchema: GetContextSnapshotRequestSchema, pyModel: 'GetContextSnapshotRequest' },
+    response: { tsSchema: GetContextSnapshotResponseSchema, pyModel: 'GetContextSnapshotResponse' },
+  },
+  save_context_snapshot: {
+    request: { tsSchema: SaveContextSnapshotRequestSchema, pyModel: 'SaveContextSnapshotRequest' },
+    response: { tsSchema: SaveContextSnapshotResponseSchema, pyModel: 'SaveContextSnapshotResponse' },
   },
 }
 

--- a/services/agent-runtime/app/config.py
+++ b/services/agent-runtime/app/config.py
@@ -29,6 +29,9 @@ class Settings(BaseSettings):
     langsmith_otel_enabled: bool = True
     langsmith_api_key: str = ""  # Optional — dev/staging LangSmith Cloud
     langsmith_project: str = "lnkpi-agent"
+    # W19: JSON map skill_id -> pinned prompt version for rollback, e.g.
+    # {"enterprise-marketing-campaign":"1.0.0"}
+    prompt_version_overrides: str = "{}"
 
     class Config:
         env_prefix = "LNKPI_"

--- a/services/agent-runtime/app/contract.py
+++ b/services/agent-runtime/app/contract.py
@@ -538,3 +538,44 @@ class SaveGenProgressResponse(BaseModel):
     """Response for save_gen_progress endpoint."""
 
     id: str
+
+
+# ============================================================
+# context_snapshot (W18)
+# ============================================================
+
+
+class GetContextSnapshotRequest(BaseModel):
+    """Request for get_context_snapshot endpoint."""
+
+    threadId: str
+    stage: Optional[str] = None
+
+
+class GetContextSnapshotResponse(BaseModel):
+    """Response for get_context_snapshot endpoint."""
+
+    id: str
+    stage: str
+    brief: Optional[str] = None
+    planSummary: Optional[str] = None
+    manifestJson: Optional[str] = None
+    messageCount: Optional[int] = None
+
+
+class SaveContextSnapshotRequest(BaseModel):
+    """Request for save_context_snapshot endpoint."""
+
+    threadId: str
+    sessionId: str
+    stage: str
+    brief: Optional[str] = None
+    planSummary: Optional[str] = None
+    manifestJson: Optional[str] = None
+    messageCount: Optional[int] = None
+
+
+class SaveContextSnapshotResponse(BaseModel):
+    """Response for save_context_snapshot endpoint."""
+
+    id: str

--- a/services/agent-runtime/app/graph/context_snapshot.py
+++ b/services/agent-runtime/app/graph/context_snapshot.py
@@ -1,0 +1,159 @@
+"""W18: Context snapshot storage — brief/plan/manifest summaries outside checkpoint."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Literal
+
+logger = logging.getLogger(__name__)
+
+ContextStage = Literal["plan", "split"]
+
+
+def manifest_summary_json(manifest: list[Any] | None) -> str | None:
+    """Compact manifest summary for LLM context without full checkpoint payload."""
+    items: list[dict[str, str]] = []
+    for raw in manifest or []:
+        if not isinstance(raw, dict) or not raw.get("key"):
+            continue
+        items.append(
+            {
+                "key": str(raw["key"]),
+                "title": str(raw.get("title") or raw["key"]),
+                "target_type": str(raw.get("target_type") or "image"),
+            }
+        )
+    if not items:
+        return None
+    return json.dumps(items, ensure_ascii=False)
+
+
+def build_snapshot_payload(
+    state: dict,
+    stage: ContextStage,
+) -> dict[str, Any]:
+    """Build save payload from graph state at a key node."""
+    from app.graph.copy_sot import brief_from_messages
+
+    brief = str(state.get("user_brief") or state.get("copy_sot_brief") or "").strip()
+    if not brief:
+        brief = brief_from_messages(list(state.get("messages") or []))
+
+    plan_summary = str(state.get("plan_summary") or "").strip()
+    if not plan_summary:
+        plan_draft = str(state.get("plan_draft") or state.get("copy_sot_plan") or "").strip()
+        plan_summary = plan_draft[:500] if plan_draft else ""
+
+    manifest_json = manifest_summary_json(list(state.get("split_manifest") or []))
+    message_count = len(state.get("messages") or [])
+
+    return {
+        "threadId": str(state.get("thread_id") or ""),
+        "sessionId": str(state.get("session_id") or ""),
+        "stage": stage,
+        "brief": brief or None,
+        "planSummary": plan_summary or None,
+        "manifestJson": manifest_json,
+        "messageCount": message_count,
+    }
+
+
+async def save_context_snapshot(nest: Any, payload: dict[str, Any]) -> str | None:
+    """Persist snapshot via nest client; returns snapshot id or None on failure."""
+    thread_id = str(payload.get("threadId") or "").strip()
+    session_id = str(payload.get("sessionId") or "").strip()
+    if not thread_id or not session_id:
+        return None
+    save = getattr(nest, "save_context_snapshot", None)
+    if save is None:
+        return None
+    try:
+        result = await save(
+            thread_id=thread_id,
+            session_id=session_id,
+            stage=str(payload.get("stage") or "plan"),
+            brief=payload.get("brief"),
+            plan_summary=payload.get("planSummary"),
+            manifest_json=payload.get("manifestJson"),
+            message_count=payload.get("messageCount"),
+        )
+        return str(result.get("id") or "") or None
+    except Exception as exc:  # noqa: BLE001 — snapshot is best-effort
+        logger.warning("Failed to save context snapshot: %s", exc)
+        return None
+
+
+async def load_context_snapshot(
+    nest: Any | None,
+    thread_id: str,
+    *,
+    stage: ContextStage | None = None,
+) -> dict[str, Any] | None:
+    """Load latest snapshot for thread; optional stage filter prefers that stage."""
+    if nest is None or not thread_id:
+        return None
+    get = getattr(nest, "get_context_snapshot", None)
+    if get is None:
+        return None
+    try:
+        return await get(thread_id=thread_id, stage=stage)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to load context snapshot: %s", exc)
+        return None
+
+
+def brief_from_snapshot(snapshot: dict[str, Any] | None) -> str:
+    if not snapshot:
+        return ""
+    return str(snapshot.get("brief") or "").strip()
+
+
+def plan_summary_from_snapshot(snapshot: dict[str, Any] | None) -> str:
+    if not snapshot:
+        return ""
+    return str(snapshot.get("planSummary") or "").strip()
+
+
+def manifest_from_snapshot(snapshot: dict[str, Any] | None) -> list[dict[str, str]]:
+    if not snapshot:
+        return []
+    raw = snapshot.get("manifestJson")
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(str(raw))
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [item for item in parsed if isinstance(item, dict)]
+
+
+async def persist_snapshot_from_state(
+    nest: Any,
+    state: dict,
+    stage: ContextStage,
+) -> dict[str, Any]:
+    """Save snapshot and return state patch (context_snapshot_id)."""
+    payload = build_snapshot_payload(state, stage)
+    snap_id = await save_context_snapshot(nest, payload)
+    if not snap_id:
+        return {}
+    return {"context_snapshot_id": snap_id}
+
+
+async def resolve_brief_for_llm(state: dict, nest: Any | None = None) -> str:
+    """Resolve user brief without scanning full message history when snapshot exists."""
+    brief = str(state.get("user_brief") or state.get("copy_sot_brief") or "").strip()
+    if brief:
+        return brief
+    thread_id = str(state.get("thread_id") or "").strip()
+    if thread_id and nest is not None:
+        snap = await load_context_snapshot(nest, thread_id, stage="plan")
+        brief = brief_from_snapshot(snap)
+        if brief:
+            return brief
+    from app.graph.copy_sot import brief_from_messages
+
+    return brief_from_messages(list(state.get("messages") or []))

--- a/services/agent-runtime/app/graph/copy_sot.py
+++ b/services/agent-runtime/app/graph/copy_sot.py
@@ -59,11 +59,30 @@ def plan_content_from_node(node: dict[str, Any]) -> str:
 
 
 async def resolve_copy_sot(state: dict, nest: Any | None = None) -> CopySoT:
-    """Resolve brief + plan from state, snapshot fields, messages, and canvas plan node."""
+    """Resolve brief + plan from state, snapshot fields, DB snapshot, messages, canvas."""
+    from app.graph.context_snapshot import (
+        brief_from_snapshot,
+        load_context_snapshot,
+        plan_summary_from_snapshot,
+    )
+
     brief = str(
         state.get("user_brief") or state.get("copy_sot_brief") or ""
     ).strip()
     plan = str(state.get("plan_draft") or state.get("copy_sot_plan") or "").strip()
+
+    thread_id = str(state.get("thread_id") or "").strip()
+    if nest is not None and thread_id and (not brief or not plan):
+        snap = await load_context_snapshot(nest, thread_id, stage="split")
+        if snap is None and not brief:
+            snap = await load_context_snapshot(nest, thread_id, stage="plan")
+        if snap:
+            if not brief:
+                brief = brief_from_snapshot(snap)
+            if not plan:
+                plan_summary = plan_summary_from_snapshot(snap)
+                if plan_summary:
+                    plan = plan_summary
 
     if not brief:
         brief = brief_from_messages(list(state.get("messages") or []))

--- a/services/agent-runtime/app/graph/few_shot.py
+++ b/services/agent-runtime/app/graph/few_shot.py
@@ -1,0 +1,84 @@
+"""W20: Few-shot example loading and unified LLM message assembly."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+
+logger = logging.getLogger(__name__)
+
+_FEW_SHOT_REL = "assets/few-shots.yaml"
+
+
+def _skills_root(skills_dir: Path | str | None) -> Path:
+    if skills_dir is not None:
+        return Path(skills_dir)
+    from app.config import settings
+
+    return Path(settings.skills_dir)
+
+
+def load_few_shots(skill_path: Path) -> dict[str, list[tuple[str, str]]]:
+    """Load node -> [(user, assistant), ...] from skill assets/few-shots.yaml."""
+    path = skill_path / _FEW_SHOT_REL
+    if not path.is_file():
+        return {}
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to load few-shots from %s: %s", path, exc)
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    nodes = raw.get("nodes") or raw
+    if not isinstance(nodes, dict):
+        return {}
+    out: dict[str, list[tuple[str, str]]] = {}
+    for node_name, pairs in nodes.items():
+        if not isinstance(pairs, list):
+            continue
+        examples: list[tuple[str, str]] = []
+        for item in pairs:
+            if not isinstance(item, dict):
+                continue
+            user = str(item.get("user") or "").strip()
+            assistant = str(item.get("assistant") or "").strip()
+            if user and assistant:
+                examples.append((user, assistant))
+        if examples:
+            out[str(node_name)] = examples
+    return out
+
+
+def few_shots_for_skill(
+    skill_id: str | None,
+    node_name: str,
+    *,
+    skills_dir: Path | str | None = None,
+) -> list[tuple[str, str]]:
+    if not skill_id:
+        return []
+    root = _skills_root(skills_dir)
+    skill_path = root / str(skill_id)
+    if not skill_path.is_dir():
+        return []
+    return load_few_shots(skill_path).get(node_name, [])
+
+
+def build_llm_messages(
+    *,
+    system: str,
+    user: str,
+    few_shots: list[tuple[str, str]] | None = None,
+) -> list[BaseMessage]:
+    """Assemble system + optional few-shot pairs + final user turn."""
+    messages: list[BaseMessage] = [SystemMessage(content=system)]
+    for example_user, example_assistant in few_shots or []:
+        messages.append(HumanMessage(content=example_user))
+        messages.append(AIMessage(content=example_assistant))
+    messages.append(HumanMessage(content=user))
+    return messages

--- a/services/agent-runtime/app/graph/nodes/draft_copy.py
+++ b/services/agent-runtime/app/graph/nodes/draft_copy.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage
 
 from app.graph.copy_alignment import (
     _MAX_COPY_ATTEMPTS,
@@ -10,6 +10,7 @@ from app.graph.copy_alignment import (
     validate_copy_alignment,
 )
 from app.graph.copy_sot import resolve_copy_sot, snapshot_copy_sot_fields
+from app.graph.few_shot import build_llm_messages, few_shots_for_skill
 
 _COPY_SYSTEM = (
     "你是电商主文案写手。只输出主文案 Markdown 正文，禁止寒暄、禁止解释过程。"
@@ -88,11 +89,16 @@ def make_draft_copy_node(*, nest: Any, llm: Any) -> Callable:
                 user_revision=user_revision,
                 alignment_feedback=alignment_feedback,
             )
+            few_shots = few_shots_for_skill(
+                str(state.get("skill_id") or "") or None,
+                "draft_copy",
+            )
             result = await llm.ainvoke(
-                [
-                    SystemMessage(content=_COPY_SYSTEM),
-                    HumanMessage(content=content),
-                ]
+                build_llm_messages(
+                    system=_COPY_SYSTEM,
+                    user=content,
+                    few_shots=few_shots,
+                )
             )
             draft = str(getattr(result, "content", "") or "").strip()
             if not draft:

--- a/services/agent-runtime/app/graph/nodes/plan/__init__.py
+++ b/services/agent-runtime/app/graph/nodes/plan/__init__.py
@@ -37,7 +37,7 @@ def register_plan_nodes(
     """
     graph.add_node("decide_plan_mode", make_decide_plan_mode_node(skills_dir=skills_dir))
     graph.add_node("generate_plan", make_generate_plan_node(llm=llm, skills_dir=skills_dir, nest=nest))
-    graph.add_node("revise_manifest", make_revise_manifest_node(llm=llm))
+    graph.add_node("revise_manifest", make_revise_manifest_node(llm=llm, skills_dir=skills_dir))
     graph.add_node("compose_confirm", make_compose_confirm_node(skills_dir=skills_dir))
 
     # Linear pipeline (revise_manifest is transparent when not node_revise)

--- a/services/agent-runtime/app/graph/nodes/plan/__init__.py
+++ b/services/agent-runtime/app/graph/nodes/plan/__init__.py
@@ -36,7 +36,7 @@ def register_plan_nodes(
     ``route_after_plan``, and update inbound edges to point to ``"decide_plan_mode"``.
     """
     graph.add_node("decide_plan_mode", make_decide_plan_mode_node(skills_dir=skills_dir))
-    graph.add_node("generate_plan", make_generate_plan_node(llm=llm, skills_dir=skills_dir))
+    graph.add_node("generate_plan", make_generate_plan_node(llm=llm, skills_dir=skills_dir, nest=nest))
     graph.add_node("revise_manifest", make_revise_manifest_node(llm=llm))
     graph.add_node("compose_confirm", make_compose_confirm_node(skills_dir=skills_dir))
 

--- a/services/agent-runtime/app/graph/nodes/plan/_shared.py
+++ b/services/agent-runtime/app/graph/nodes/plan/_shared.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
+from app.graph.few_shot import build_llm_messages, few_shots_for_skill
 from app.graph.plan_clean import strip_plan_preamble
 from app.skills.loader import discover_skills, load_skill
 
@@ -224,6 +225,8 @@ async def revise_operations_via_llm(
     llm: Any,
     split_manifest: list[dict] | None,
     user_text: str,
+    skill_id: str | None = None,
+    skills_dir: Any = None,
 ) -> list[dict] | None:
     """Ask LLM for node operations (rename/add/delete). None = parse failure / fallback."""
     human = (
@@ -231,13 +234,10 @@ async def revise_operations_via_llm(
         f"用户修改意见：{user_text}\n\n"
         "输出操作列表 JSON 数组。"
     )
+    few_shots = few_shots_for_skill(skill_id, "revise_manifest", skills_dir=skills_dir)
+    messages = build_llm_messages(system=NODE_OPS_SYSTEM, user=human, few_shots=few_shots)
     try:
-        ai = await llm.ainvoke(
-            [
-                SystemMessage(content=NODE_OPS_SYSTEM),
-                HumanMessage(content=human),
-            ]
-        )
+        ai = await llm.ainvoke(messages)
     except Exception as exc:  # noqa: BLE001
         logger.warning("node ops LLM call failed: %s", exc)
         return None

--- a/services/agent-runtime/app/graph/nodes/plan/generate_plan.py
+++ b/services/agent-runtime/app/graph/nodes/plan/generate_plan.py
@@ -19,7 +19,7 @@ from app.graph.nodes.plan._shared import (
 )
 
 
-def make_generate_plan_node(*, llm: Any, skills_dir: Path) -> Callable:
+def make_generate_plan_node(*, llm: Any, skills_dir: Path, nest: Any | None = None) -> Callable:
     """Create the generate_plan node."""
 
     async def generate_plan(state: dict) -> dict:
@@ -27,7 +27,9 @@ def make_generate_plan_node(*, llm: Any, skills_dir: Path) -> Callable:
         skill = load_skill_by_id(skill_id, skills_dir)
 
         user_text = latest_user_text(state.get("messages") or [])
-        user_brief = str(state.get("user_brief") or "").strip()
+        from app.graph.context_snapshot import resolve_brief_for_llm
+
+        user_brief = await resolve_brief_for_llm(state, nest)
         mode = state.get("mode") or "create"
         existing_plan = str(state.get("plan_draft") or "").strip()
 

--- a/services/agent-runtime/app/graph/nodes/plan/generate_plan.py
+++ b/services/agent-runtime/app/graph/nodes/plan/generate_plan.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable
 
+from app.graph.few_shot import build_llm_messages, few_shots_for_skill
 from app.graph.nodes.plan._shared import (
     CREATE_INSTRUCTION,
     MODIFY_INSTRUCTION,
@@ -53,12 +54,12 @@ def make_generate_plan_node(*, llm: Any, skills_dir: Path, nest: Any | None = No
             instruction = CREATE_INSTRUCTION
             human_content = f"{instruction}\n用户需求：{user_text}"
 
-        from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
-
-        messages = [
-            SystemMessage(content=system_prompt),
-            HumanMessage(content=human_content),
-        ]
+        few_shots = few_shots_for_skill(skill_id, "generate_plan", skills_dir=skills_dir)
+        messages = build_llm_messages(
+            system=system_prompt,
+            user=human_content,
+            few_shots=few_shots,
+        )
         ai = await llm.ainvoke(messages)
         plan_md = strip_plan_preamble(str(getattr(ai, "content", ai) or ""))
         summary = summarize(plan_md)

--- a/services/agent-runtime/app/graph/nodes/plan/generate_plan.py
+++ b/services/agent-runtime/app/graph/nodes/plan/generate_plan.py
@@ -17,6 +17,7 @@ from app.graph.nodes.plan._shared import (
     strip_plan_preamble,
     summarize,
 )
+from app.prompt_version import record_prompt_usage
 
 
 def make_generate_plan_node(*, llm: Any, skills_dir: Path, nest: Any | None = None) -> Callable:
@@ -25,6 +26,11 @@ def make_generate_plan_node(*, llm: Any, skills_dir: Path, nest: Any | None = No
     async def generate_plan(state: dict) -> dict:
         skill_id = state.get("skill_id")
         skill = load_skill_by_id(skill_id, skills_dir)
+        record_prompt_usage(
+            skill_id=str(skill.index.skill_id),
+            prompt_version=skill.prompt_version,
+            node_name="generate_plan",
+        )
 
         user_text = latest_user_text(state.get("messages") or [])
         from app.graph.context_snapshot import resolve_brief_for_llm
@@ -60,6 +66,7 @@ def make_generate_plan_node(*, llm: Any, skills_dir: Path, nest: Any | None = No
         return {
             "plan_draft": plan_md,
             "plan_summary": summary,
+            "prompt_version": skill.prompt_version,
         }
 
     return generate_plan

--- a/services/agent-runtime/app/graph/nodes/plan/revise_manifest.py
+++ b/services/agent-runtime/app/graph/nodes/plan/revise_manifest.py
@@ -7,12 +7,13 @@ pipeline can stay fully wired without conditional routing.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Callable
 
 from app.graph.nodes.plan._shared import latest_user_text, revise_operations_via_llm
 
 
-def make_revise_manifest_node(*, llm: Any) -> Callable:
+def make_revise_manifest_node(*, llm: Any, skills_dir: Path) -> Callable:
     """Create the revise_manifest node."""
 
     async def revise_manifest(state: dict) -> dict:
@@ -28,6 +29,8 @@ def make_revise_manifest_node(*, llm: Any) -> Callable:
             llm=llm,
             split_manifest=split_manifest,
             user_text=user_text,
+            skill_id=str(state.get("skill_id") or "") or None,
+            skills_dir=skills_dir,
         )
 
         return {"node_operations": ops}

--- a/services/agent-runtime/app/graph/nodes/split.py
+++ b/services/agent-runtime/app/graph/nodes/split.py
@@ -9,6 +9,7 @@ from app.graph.state import SplitManifestItem
 from app.graph.canvas_stage import rollback_stage_safe, stage_failure_message
 from app.graph.chain_refs import build_chain_ref_order
 from app.graph.copy_sot import snapshot_copy_sot_fields
+from app.graph.context_snapshot import persist_snapshot_from_state
 from app.graph.mermaid_topo import manifest_to_mermaid
 from app.graph.topo import precompute_gen_order
 from app.graph.topo_trim import trim_manifest_items
@@ -397,6 +398,8 @@ def make_split_node(*, nest: Any, skills_dir: Path) -> Callable:
             **snapshot_copy_sot_fields(state),
         }
         out.update(_gen_order_fields(list(manifest)))
+        snap_patch = await persist_snapshot_from_state(nest, {**state, **out}, "split")
+        out.update(snap_patch)
         return out
 
     return split

--- a/services/agent-runtime/app/graph/nodes/write_plan_node.py
+++ b/services/agent-runtime/app/graph/nodes/write_plan_node.py
@@ -5,6 +5,7 @@ from typing import Any, Callable
 from langchain_core.messages import AIMessage
 
 from app.graph.copy_sot import snapshot_copy_sot_fields
+from app.graph.context_snapshot import persist_snapshot_from_state
 from app.graph.canvas_stage import rollback_stage_safe, stage_failure_message
 from app.graph.hitl_resume import GATE_DECISION_CLEAR
 from app.graph.plan_clean import strip_plan_preamble
@@ -40,6 +41,11 @@ def make_write_plan_node(*, nest: Any) -> Callable:
             f"{(state.get('plan_summary') or draft[:200]).strip()}\n"
             "已写入画布「营销方案」节点。接下来将拆解画布骨架（先不出图），请稍后确认拓扑与出图。"
         )
+        snap_patch = await persist_snapshot_from_state(
+            nest,
+            {**state, "plan_draft": draft},
+            "plan",
+        )
         return {
             "phase": "write_plan_node",
             "plan_node_id": plan_node_id,
@@ -47,6 +53,7 @@ def make_write_plan_node(*, nest: Any) -> Callable:
             "messages": [AIMessage(content=confirmed)],
             **GATE_DECISION_CLEAR,
             **snapshot_copy_sot_fields({**state, "plan_draft": draft}),
+            **snap_patch,
         }
 
     return write_plan_node

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -104,6 +104,7 @@ class AgentRuntimeState(TypedDict, total=False):
     node_operations: list[dict] | None
     # W3/W15: gen_queue removed; gen_completed/gen_failed removed from checkpoint (P0-02)
     gen_progress_id: str | None  # W15: Pointer to GenProgress table
+    context_snapshot_id: str | None  # W18: Pointer to latest ContextSnapshot
     last_error: str | None
     copy_draft: str | None
     copy_node_id: str | None

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -93,6 +93,7 @@ class AgentRuntimeState(TypedDict, total=False):
     thread_id: str
     session_id: str
     user_id: str
+    prompt_version: str | None  # W19: active skill prompt template version
 
     # 工作记忆（轻量；禁止存完整 canvas nodes/edges）
     plan_summary: str

--- a/services/agent-runtime/app/metrics.py
+++ b/services/agent-runtime/app/metrics.py
@@ -32,6 +32,11 @@ STREAM_ERRORS = Counter(
     "Agent stream terminal errors",
     ["error_type"],
 )
+PROMPT_INVOCATIONS = Counter(
+    "agent_prompt_invocations_total",
+    "LLM prompt template invocations",
+    ["skill_id", "prompt_version", "node_name"],
+)
 
 
 def metrics_payload() -> tuple[bytes, str]:
@@ -60,6 +65,14 @@ def record_tool_call(tool_name: str, *, success: bool) -> None:
 
 def record_stream_error(error_type: str) -> None:
     STREAM_ERRORS.labels(error_type=error_type or "internal_error").inc()
+
+
+def record_prompt_invocation(skill_id: str, prompt_version: str, node_name: str) -> None:
+    PROMPT_INVOCATIONS.labels(
+        skill_id=skill_id or "unknown",
+        prompt_version=prompt_version or "unknown",
+        node_name=node_name or "unknown",
+    ).inc()
 
 
 @contextmanager

--- a/services/agent-runtime/app/prompt_version.py
+++ b/services/agent-runtime/app/prompt_version.py
@@ -1,0 +1,80 @@
+"""W19: Prompt template versioning — load, rollback, and observability."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from opentelemetry import trace
+
+from app.config import settings
+from app.metrics import record_prompt_invocation
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_VERSION = "1.0.0"
+_PROMPTS_DIR = "assets/prompts"
+
+
+def parse_version_overrides(raw: str | None = None) -> dict[str, str]:
+    """Parse LNKPI_PROMPT_VERSION_OVERRIDES JSON map (skill_id -> version)."""
+    text = raw if raw is not None else settings.prompt_version_overrides
+    if not text or not str(text).strip():
+        return {}
+    try:
+        parsed = json.loads(str(text))
+    except json.JSONDecodeError:
+        logger.warning("Invalid prompt_version_overrides JSON; ignoring")
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return {str(k): str(v) for k, v in parsed.items() if k and v}
+
+
+def resolve_active_version(
+    skill_id: str,
+    *,
+    declared_version: str,
+    overrides: dict[str, str] | None = None,
+) -> str:
+    """Pick runtime version: per-skill override wins, else declared frontmatter version."""
+    pin = (overrides or parse_version_overrides()).get(skill_id)
+    return pin or declared_version or _DEFAULT_VERSION
+
+
+def resolve_prompt_body(
+    skill_path: Any,
+    *,
+    default_body: str,
+    active_version: str,
+) -> tuple[str, str]:
+    """Load versioned prompt body; fall back to SKILL.md body when file missing."""
+    version_file = skill_path / _PROMPTS_DIR / f"{active_version}.md"
+    if version_file.is_file():
+        return version_file.read_text(encoding="utf-8").strip(), active_version
+    return default_body.strip(), active_version
+
+
+def record_prompt_usage(
+    *,
+    skill_id: str,
+    prompt_version: str,
+    node_name: str,
+) -> None:
+    """Log + metrics (+ trace attribute when span is active)."""
+    sid = skill_id or "unknown"
+    ver = prompt_version or _DEFAULT_VERSION
+    node = node_name or "unknown"
+    logger.info(
+        "prompt_invocation skill_id=%s prompt_version=%s node=%s",
+        sid,
+        ver,
+        node,
+    )
+    record_prompt_invocation(sid, ver, node)
+    span = trace.get_current_span()
+    if span and span.is_recording():
+        span.set_attribute("prompt.skill_id", sid)
+        span.set_attribute("prompt.version", ver)
+        span.set_attribute("prompt.node", node)

--- a/services/agent-runtime/app/skills/loader.py
+++ b/services/agent-runtime/app/skills/loader.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import yaml
 
+from app.prompt_version import resolve_active_version, resolve_prompt_body
 from app.skills.models import LoadedSkill, SkillIndexEntry
 
 logger = logging.getLogger(__name__)
@@ -73,12 +74,21 @@ def load_skill(entry: SkillIndexEntry) -> LoadedSkill:
     max_downstream_raw = metadata.get("lnkpi.max_downstream", _DEFAULT_MAX_DOWNSTREAM)
     max_downstream = int(max_downstream_raw)
 
+    declared_version = str(metadata.get("lnkpi.prompt_version") or "1.0.0")
+    active_version = resolve_active_version(entry.skill_id, declared_version=declared_version)
+    body, active_version = resolve_prompt_body(
+        entry.path,
+        default_body=body,
+        active_version=active_version,
+    )
+
     return LoadedSkill(
         index=entry,
         body=body,
         frontmatter=frontmatter,
         canvas_manifest=canvas_manifest,
         max_downstream=max_downstream,
+        prompt_version=active_version,
     )
 
 

--- a/services/agent-runtime/app/skills/models.py
+++ b/services/agent-runtime/app/skills/models.py
@@ -17,3 +17,4 @@ class LoadedSkill:
     frontmatter: dict
     canvas_manifest: dict | None
     max_downstream: int
+    prompt_version: str

--- a/services/agent-runtime/app/tools/nest_client.py
+++ b/services/agent-runtime/app/tools/nest_client.py
@@ -354,6 +354,40 @@ class NestCanvasClient:
             },
         )
 
+    async def get_context_snapshot(
+        self, thread_id: str, stage: str | None = None
+    ) -> dict[str, Any] | None:
+        """Get latest context snapshot for thread (W18)."""
+        payload: dict[str, Any] = {"threadId": thread_id}
+        if stage:
+            payload["stage"] = stage
+        result = await self._post("/agent/internal/get-context-snapshot", payload)
+        return result if result else None
+
+    async def save_context_snapshot(
+        self,
+        thread_id: str,
+        session_id: str,
+        stage: str,
+        brief: str | None = None,
+        plan_summary: str | None = None,
+        manifest_json: str | None = None,
+        message_count: int | None = None,
+    ) -> dict[str, Any]:
+        """Save context snapshot (W18)."""
+        return await self._post(
+            "/agent/internal/save-context-snapshot",
+            {
+                "threadId": thread_id,
+                "sessionId": session_id,
+                "stage": stage,
+                "brief": brief,
+                "planSummary": plan_summary,
+                "manifestJson": manifest_json,
+                "messageCount": message_count,
+            },
+        )
+
     async def stage_canvas_actions(self, actions: list[dict[str, Any]]) -> dict[str, Any]:
         return await self._post(
             "/agent/internal/stage-canvas-actions",

--- a/services/agent-runtime/skills/enterprise-marketing-campaign/SKILL.md
+++ b/services/agent-runtime/skills/enterprise-marketing-campaign/SKILL.md
@@ -10,6 +10,7 @@ metadata:
   author: lnkpi
   lnkpi.canvas_manifest: assets/canvas-manifest.yaml
   lnkpi.max_downstream: "16"
+  lnkpi.prompt_version: "1.1.0"
   lnkpi.topology_mode_default: full
 allowed-tools: upsert_prompt_node add_nodes_batch connect_nodes set_node_prompt attach_refs run_image_generation get_generation_status
 ---

--- a/services/agent-runtime/skills/enterprise-marketing-campaign/assets/few-shots.yaml
+++ b/services/agent-runtime/skills/enterprise-marketing-campaign/assets/few-shots.yaml
@@ -1,0 +1,52 @@
+version: 1
+nodes:
+  generate_plan:
+    - user: "请根据用户需求输出完整企业营销方案 Markdown。用户需求：帮我做 lnkpi 蓝牙耳机天猫详情页方案"
+      assistant: |
+        # lnkpi TWS 蓝牙耳机营销方案
+
+        ## 1. 定位与目标
+
+        | 维度 | 内容 |
+        | --- | --- |
+        | 产品品类 | TWS 降噪蓝牙耳机 |
+        | 品牌名称 | lnkpi |
+        | 销售渠道 | 天猫详情页 |
+
+        ## 2. 核心卖点
+
+        - 主动降噪，通勤静享
+        - 长续航，单耳 8h
+
+        ## 3. 视觉资产清单
+
+        - 白底图、主图、场景图、Banner、主文案
+  revise_manifest:
+    - user: |
+        现有节点：
+        - hero_main | 主图 | image
+        - copy_main | 主文案 | text
+
+        用户修改意见：增加一个客厅场景图 scene_living
+
+        输出操作列表 JSON 数组。
+      assistant: |
+        [{"op":"add","key":"scene_living","title":"客厅场景图","target_type":"image","prompt_hint":"现代客厅佩戴耳机"}]
+  draft_copy:
+    - user: |
+        【用户需求锚定】
+        lnkpi TWS 蓝牙耳机，天猫详情页
+
+        【已确认营销方案】
+        # lnkpi TWS 蓝牙耳机营销方案
+        产品品类：TWS 降噪耳机
+
+        【必须出现的关键词】lnkpi、蓝牙耳机、降噪
+
+        请撰写电商主文案 Markdown 正文。
+      assistant: |
+        ## 听见纯粹，lnkpi 降噪旗舰
+
+        lnkpi TWS 蓝牙耳机，专为通勤与办公打造。主动降噪隔绝喧嚣，长续航陪伴全天。
+
+        **核心卖点**：降噪 | 长续航 | 舒适佩戴

--- a/services/agent-runtime/skills/enterprise-marketing-campaign/assets/prompts/1.0.0.md
+++ b/services/agent-runtime/skills/enterprise-marketing-campaign/assets/prompts/1.0.0.md
@@ -1,0 +1,12 @@
+# Enterprise marketing campaign (v1.0.0)
+
+## Instructions
+
+1. Clarify product category and sales channel.
+2. Draft a structured marketing plan in Markdown.
+3. Ask the user to confirm before splitting the canvas.
+
+## Split and image generation
+
+- Follow `assets/canvas-manifest.yaml` when splitting the canvas.
+- Do not call `run_image_generation` during plan; only after user confirms image generation.

--- a/services/agent-runtime/tests/test_builtin_skill.py
+++ b/services/agent-runtime/tests/test_builtin_skill.py
@@ -9,6 +9,7 @@ def test_builtin_marketing_skill_loads():
     ids = {e.skill_id for e in entries}
     assert "enterprise-marketing-campaign" in ids
     loaded = load_skill(next(e for e in entries if e.skill_id == "enterprise-marketing-campaign"))
+    assert loaded.prompt_version == "1.1.0"
     keys = {i["key"] for i in loaded.canvas_manifest["items"]}
     assert "white_bg" in keys and "hero_main" in keys
     assert "product_turnaround" in keys

--- a/services/agent-runtime/tests/test_context_snapshot.py
+++ b/services/agent-runtime/tests/test_context_snapshot.py
@@ -1,0 +1,151 @@
+"""W18: Context snapshot storage roundtrip and LLM context resolution."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from app.graph.context_snapshot import (
+    build_snapshot_payload,
+    load_context_snapshot,
+    manifest_summary_json,
+    persist_snapshot_from_state,
+    resolve_brief_for_llm,
+    save_context_snapshot,
+)
+
+
+class _FakeNest:
+    def __init__(self) -> None:
+        self.saved: list[dict[str, Any]] = []
+        self.store: dict[str, dict[str, Any]] = {}
+
+    async def save_context_snapshot(
+        self,
+        *,
+        thread_id: str,
+        session_id: str,
+        stage: str,
+        brief: str | None = None,
+        plan_summary: str | None = None,
+        manifest_json: str | None = None,
+        message_count: int | None = None,
+    ) -> dict[str, str]:
+        snap_id = f"snap-{len(self.saved) + 1}"
+        row = {
+            "id": snap_id,
+            "threadId": thread_id,
+            "sessionId": session_id,
+            "stage": stage,
+            "brief": brief,
+            "planSummary": plan_summary,
+            "manifestJson": manifest_json,
+            "messageCount": message_count,
+        }
+        self.saved.append(row)
+        key = f"{thread_id}:{stage}"
+        self.store[key] = row
+        self.store[thread_id] = row
+        return {"id": snap_id}
+
+    async def get_context_snapshot(
+        self, *, thread_id: str, stage: str | None = None
+    ) -> dict[str, Any] | None:
+        if stage:
+            return self.store.get(f"{thread_id}:{stage}")
+        return self.store.get(thread_id)
+
+
+def test_manifest_summary_json_compact():
+    raw = manifest_summary_json(
+        [
+            {"key": "hero", "title": "主图", "target_type": "image", "node_id": "n1"},
+            {"key": "copy_main", "title": "主文案", "target_type": "text"},
+        ]
+    )
+    assert raw is not None
+    parsed = json.loads(raw)
+    assert len(parsed) == 2
+    assert parsed[0]["key"] == "hero"
+    assert "node_id" not in parsed[0]
+
+
+def test_build_snapshot_payload_from_state():
+    payload = build_snapshot_payload(
+        {
+            "thread_id": "t1",
+            "session_id": "s1",
+            "user_brief": "做耳机广告",
+            "plan_summary": "降噪旗舰",
+            "split_manifest": [{"key": "hero", "title": "主图", "target_type": "image"}],
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+        "split",
+    )
+    assert payload["threadId"] == "t1"
+    assert payload["stage"] == "split"
+    assert payload["brief"] == "做耳机广告"
+    assert payload["planSummary"] == "降噪旗舰"
+    assert payload["messageCount"] == 1
+    assert json.loads(payload["manifestJson"]) == [
+        {"key": "hero", "title": "主图", "target_type": "image"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_save_and_load_roundtrip():
+    nest = _FakeNest()
+    payload = build_snapshot_payload(
+        {
+            "thread_id": "t1",
+            "session_id": "s1",
+            "user_brief": "brief",
+            "plan_summary": "plan",
+        },
+        "plan",
+    )
+    snap_id = await save_context_snapshot(nest, payload)
+    assert snap_id == "snap-1"
+    loaded = await load_context_snapshot(nest, "t1", stage="plan")
+    assert loaded is not None
+    assert loaded["brief"] == "brief"
+    assert loaded["planSummary"] == "plan"
+
+
+@pytest.mark.asyncio
+async def test_persist_snapshot_from_state_returns_id():
+    nest = _FakeNest()
+    patch = await persist_snapshot_from_state(
+        nest,
+        {
+            "thread_id": "t1",
+            "session_id": "s1",
+            "user_brief": "耳机",
+            "plan_draft": "# 方案",
+            "plan_summary": "摘要",
+        },
+        "plan",
+    )
+    assert patch["context_snapshot_id"] == "snap-1"
+    assert len(nest.saved) == 1
+
+
+@pytest.mark.asyncio
+async def test_resolve_brief_for_llm_prefers_snapshot_over_messages():
+    nest = _FakeNest()
+    await nest.save_context_snapshot(
+        thread_id="t1",
+        session_id="s1",
+        stage="plan",
+        brief="来自快照的 brief",
+        plan_summary="plan",
+    )
+    # Many messages — snapshot should win without scanning all
+    messages = [{"role": "user", "content": f"noise-{i}"} for i in range(50)]
+    brief = await resolve_brief_for_llm(
+        {"thread_id": "t1", "messages": messages},
+        nest,
+    )
+    assert brief == "来自快照的 brief"

--- a/services/agent-runtime/tests/test_copy_sot.py
+++ b/services/agent-runtime/tests/test_copy_sot.py
@@ -38,12 +38,31 @@ async def test_resolve_copy_sot_falls_back_to_plan_node():
                 "data": {"content": "# lnkpi 蓝牙耳机企业营销方案\n| 产品类别 | TWS 耳机 |"},
             }
 
+        async def get_context_snapshot(self, *, thread_id: str, stage: str | None = None):
+            return None
+
     sot = await resolve_copy_sot(
         {"plan_node_id": "plan-1", "messages": [HumanMessage(content="请帮我做lnkpi耳机方案")]},
         FakeNest(),
     )
     assert "lnkpi" in sot.user_brief.lower() or "耳机" in sot.user_brief
     assert "蓝牙耳机" in sot.plan_draft or "TWS" in sot.plan_draft
+
+
+@pytest.mark.asyncio
+async def test_resolve_copy_sot_falls_back_to_context_snapshot():
+    class FakeNest:
+        async def get_context_snapshot(self, *, thread_id: str, stage: str | None = None):
+            if stage == "split":
+                return {
+                    "brief": "快照 brief",
+                    "planSummary": "快照 plan 摘要",
+                }
+            return None
+
+    sot = await resolve_copy_sot({"thread_id": "t1", "messages": []}, FakeNest())
+    assert sot.user_brief == "快照 brief"
+    assert sot.plan_draft == "快照 plan 摘要"
 
 
 def test_snapshot_copy_sot_fields():

--- a/services/agent-runtime/tests/test_few_shot.py
+++ b/services/agent-runtime/tests/test_few_shot.py
@@ -1,0 +1,61 @@
+"""W20: Few-shot loading and build_llm_messages assembly."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+from app.graph.few_shot import build_llm_messages, few_shots_for_skill, load_few_shots
+
+
+def test_load_few_shots_from_yaml(tmp_path: Path):
+    skill_dir = tmp_path / "demo-skill"
+    assets = skill_dir / "assets"
+    assets.mkdir(parents=True)
+    (assets / "few-shots.yaml").write_text(
+        yaml.dump(
+            {
+                "nodes": {
+                    "generate_plan": [
+                        {"user": "u1", "assistant": "a1"},
+                        {"user": "u2", "assistant": "a2"},
+                    ]
+                }
+            },
+            allow_unicode=True,
+        ),
+        encoding="utf-8",
+    )
+    loaded = load_few_shots(skill_dir)
+    assert loaded["generate_plan"] == [("u1", "a1"), ("u2", "a2")]
+
+
+def test_build_llm_messages_order():
+    msgs = build_llm_messages(
+        system="sys",
+        user="final",
+        few_shots=[("ex-u", "ex-a")],
+    )
+    assert [type(m).__name__ for m in msgs] == [
+        "SystemMessage",
+        "HumanMessage",
+        "AIMessage",
+        "HumanMessage",
+    ]
+    assert isinstance(msgs[0], SystemMessage) and msgs[0].content == "sys"
+    assert isinstance(msgs[1], HumanMessage) and msgs[1].content == "ex-u"
+    assert isinstance(msgs[2], AIMessage) and msgs[2].content == "ex-a"
+    assert isinstance(msgs[3], HumanMessage) and msgs[3].content == "final"
+
+
+def test_builtin_skill_few_shots():
+    root = Path(__file__).resolve().parents[1] / "skills"
+    shots = few_shots_for_skill(
+        "enterprise-marketing-campaign",
+        "generate_plan",
+        skills_dir=root,
+    )
+    assert len(shots) >= 1
+    assert "lnkpi" in shots[0][1].lower()

--- a/services/agent-runtime/tests/test_prompt_version.py
+++ b/services/agent-runtime/tests/test_prompt_version.py
@@ -1,0 +1,115 @@
+"""W19: Prompt version loading, rollback, and metrics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.prompt_version import (
+    parse_version_overrides,
+    record_prompt_usage,
+    resolve_active_version,
+    resolve_prompt_body,
+)
+from app.skills.loader import discover_skills, load_skill
+
+
+def test_parse_version_overrides_json():
+    raw = '{"enterprise-marketing-campaign": "1.0.0", "other": "2.0.0"}'
+    assert parse_version_overrides(raw) == {
+        "enterprise-marketing-campaign": "1.0.0",
+        "other": "2.0.0",
+    }
+    assert parse_version_overrides("{bad json") == {}
+
+
+def test_resolve_active_version_override_wins():
+    ver = resolve_active_version(
+        "enterprise-marketing-campaign",
+        declared_version="1.1.0",
+        overrides={"enterprise-marketing-campaign": "1.0.0"},
+    )
+    assert ver == "1.0.0"
+
+
+def test_load_skill_default_prompt_version(tmp_path: Path):
+    skill_dir = tmp_path / "valid-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: valid-skill\n"
+        "description: A valid skill for tests.\n"
+        "metadata:\n"
+        "  lnkpi.prompt_version: \"2.0.0\"\n"
+        "---\n"
+        "# Current body\n"
+    )
+    loaded = load_skill(discover_skills(tmp_path)[0])
+    assert loaded.prompt_version == "2.0.0"
+    assert loaded.body == "# Current body"
+
+
+def test_load_skill_version_rollback_from_assets(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    skill_dir = tmp_path / "valid-skill"
+    prompts = skill_dir / "assets" / "prompts"
+    prompts.mkdir(parents=True)
+    (prompts / "1.0.0.md").write_text("# Rolled back body\n")
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: valid-skill\n"
+        "description: A valid skill for tests.\n"
+        "metadata:\n"
+        "  lnkpi.prompt_version: \"1.1.0\"\n"
+        "---\n"
+        "# Current body\n"
+    )
+    monkeypatch.setenv(
+        "LNKPI_PROMPT_VERSION_OVERRIDES",
+        '{"valid-skill": "1.0.0"}',
+    )
+    from app.config import Settings
+
+    monkeypatch.setattr(
+        "app.prompt_version.settings",
+        Settings(prompt_version_overrides='{"valid-skill": "1.0.0"}'),
+    )
+
+    loaded = load_skill(discover_skills(tmp_path)[0])
+    assert loaded.prompt_version == "1.0.0"
+    assert loaded.body == "# Rolled back body"
+
+
+def test_resolve_prompt_body_fallback_to_default(tmp_path: Path):
+    skill_dir = tmp_path / "skill"
+    skill_dir.mkdir()
+    body, ver = resolve_prompt_body(skill_dir, default_body="# default", active_version="9.9.9")
+    assert ver == "9.9.9"
+    assert body == "# default"
+
+
+def test_record_prompt_usage_increments_metrics():
+    from prometheus_client import REGISTRY
+
+    before = REGISTRY.get_sample_value(
+        "agent_prompt_invocations_total",
+        {
+            "skill_id": "enterprise-marketing-campaign",
+            "prompt_version": "1.1.0",
+            "node_name": "generate_plan",
+        },
+    )
+    record_prompt_usage(
+        skill_id="enterprise-marketing-campaign",
+        prompt_version="1.1.0",
+        node_name="generate_plan",
+    )
+    after = REGISTRY.get_sample_value(
+        "agent_prompt_invocations_total",
+        {
+            "skill_id": "enterprise-marketing-campaign",
+            "prompt_version": "1.1.0",
+            "node_name": "generate_plan",
+        },
+    )
+    assert float(after or 0) >= float(before or 0) + 1


### PR DESCRIPTION
## Summary
- **P2-01 W18**: `ContextSnapshot` 模型 + 契约 + `write_plan`/`split` 写入；`generate_plan`/`resolve_copy_sot` 读 snapshot 减少 messages 扫描
- **P2-02 W19**: Skill `lnkpi.prompt_version` + `assets/prompts/*.md` 回滚；`LNKPI_PROMPT_VERSION_OVERRIDES`；`agent_prompt_invocations_total` metrics
- **P2-03 W20**: `assets/few-shots.yaml` + `build_llm_messages`；接入 `generate_plan` / `revise_manifest` / `draft_copy`

## Test plan
- [x] `pytest tests/test_context_snapshot.py tests/test_copy_sot.py` — 10 passed
- [x] `pytest tests/test_prompt_version.py tests/test_few_shot.py tests/test_draft_copy.py` — 14 passed
- [x] `npx tsx scripts/verify-contract.ts` — all contracts pass
- [ ] CI green
- [ ] 部署后 `prisma db push` 创建 `ContextSnapshot` 表

## Deploy notes
合并后 CVM 需执行 `pnpm --filter @lnkpi/server exec prisma db push` 以创建 `ContextSnapshot` 表。

Made with [Cursor](https://cursor.com)