### PR TITLE
feat(deploy): P2-04~07 observability + graph timeline API

### DIFF
--- a/apps/server/src/agent/agent-runtime.client.ts
+++ b/apps/server/src/agent/agent-runtime.client.ts
@@ -23,6 +23,22 @@ export interface RuntimeThreadState {
   finished: boolean
 }
 
+export interface RuntimeThreadTimelineEntry {
+  step: number | null
+  source: string | null
+  phase: string | null
+  nextNodes: string[]
+  skillId: string | null
+  promptVersion: string | null
+  interrupted: boolean
+}
+
+export interface RuntimeThreadTimeline {
+  threadId: string
+  entries: RuntimeThreadTimelineEntry[]
+  checkpointCount: number
+}
+
 /**
  * HTTP client for Python agent-runtime (`GET /health`, `POST /v1/runs` NDJSON).
  * Nest sends `x-lnkpi-service-token` (AGENT_RUNTIME_SERVICE_TOKEN) on /v1/runs;
@@ -65,6 +81,27 @@ export class AgentRuntimeClient {
       })
       if (!res.ok) return null
       return (await res.json()) as RuntimeThreadState
+    } catch {
+      return null
+    }
+  }
+
+  async getThreadTimeline(threadId: string): Promise<RuntimeThreadTimeline | null> {
+    const url = `${this.baseUrl.replace(/\/$/, '')}/v1/threads/${encodeURIComponent(threadId)}/timeline`
+    const headers: Record<string, string> = {}
+    const token =
+      this.serviceToken?.trim() || process.env.AGENT_RUNTIME_SERVICE_TOKEN?.trim()
+    if (token) {
+      headers['x-lnkpi-service-token'] = token
+    }
+    try {
+      const res = await fetch(url, {
+        method: 'GET',
+        headers,
+        signal: AbortSignal.timeout(8000),
+      })
+      if (!res.ok) return null
+      return (await res.json()) as RuntimeThreadTimeline
     } catch {
       return null
     }

--- a/apps/server/src/agent/agent.controller.ts
+++ b/apps/server/src/agent/agent.controller.ts
@@ -93,6 +93,16 @@ export class AgentController {
     return { code: 0, message: 'ok', data }
   }
 
+  /** W27: Graph phase timeline from checkpoint history (debug / ops). */
+  @Get('thread-timeline')
+  @UseGuards(AuthGuard)
+  async threadTimeline(
+    @Query('threadId') threadId: string,
+  ) {
+    const data = await this.agentService.getThreadTimeline(threadId)
+    return { code: 0, message: 'ok', data }
+  }
+
   @Post('chat/optimize-prompt')
   async optimizePrompt(@Body() dto: OptimizePromptDto) {
     const data = await this.agentService.optimizePrompt(dto.prompt, dto.style)

--- a/apps/server/src/agent/agent.service.ts
+++ b/apps/server/src/agent/agent.service.ts
@@ -183,6 +183,26 @@ export class AgentService {
     return client.getThreadState(threadId.trim())
   }
 
+  /** W27: Graph control-flow phase timeline (checkpoint history). */
+  async getThreadTimeline(threadId: string): Promise<{
+    threadId: string
+    entries: Array<{
+      step: number | null
+      source: string | null
+      phase: string | null
+      nextNodes: string[]
+      skillId: string | null
+      promptVersion: string | null
+      interrupted: boolean
+    }>
+    checkpointCount: number
+  } | null> {
+    const runtimeUrl = process.env.AGENT_RUNTIME_URL?.trim()
+    if (!runtimeUrl || !threadId.trim()) return null
+    const client = this.createRuntimeClient(runtimeUrl)
+    return client.getThreadTimeline(threadId.trim())
+  }
+
   /** Overridable in unit tests */
   createRuntimeClient(baseUrl: string): AgentRuntimeClient {
     return new AgentRuntimeClient(

--- a/deploy/.env.production.example
+++ b/deploy/.env.production.example
@@ -51,3 +51,10 @@ LNKPI_OPENAI_BASE_URL=https://api.openai.com/v1
 LNKPI_OPENAI_CHAT_MODEL=
 LNKPI_IMAGE_GEN_CONCURRENCY=3
 LNKPI_IMAGE_GEN_TIMEOUT_SEC=180
+
+# W23 OTLP tracing（生产默认开启；enable-agent-runtime.sh 写入并连接 Tempo）
+# 复用同机 pintuotuo Tempo：http://pintuotuo-tempo:4318/v1/traces
+# 设 ENABLE_OBSERVABILITY=false 可跳过（仅本地调试）
+LNKPI_OTEL_EXPORTER_OTLP_ENDPOINT=http://pintuotuo-tempo:4318/v1/traces
+LNKPI_LANGSMITH_OTEL_ENABLED=false
+LNKPI_OTEL_SERVICE_NAME=lnkpi-agent-runtime

--- a/deploy/AGENT_RUNTIME_PRODUCTION.md
+++ b/deploy/AGENT_RUNTIME_PRODUCTION.md
@@ -82,33 +82,73 @@ LNKPI_IMAGE_GEN_TIMEOUT_SEC=180
 
 ---
 
-## 2.4 W23 可观测性：OTel Collector → Tempo（可选）
+## 2.4 W23 可观测性：OTLP → Tempo（生产默认开启）
 
-默认 **关闭**。推荐栈：**LangSmith OTel 自动埋点（LangGraph/LLM）+ OTel Collector + Tempo + Grafana**。
+**默认行为（2026-08 起）**：`deploy/enable-agent-runtime.sh` 在 CVM 部署时自动：
+
+1. 将 `pintuotuo-tempo` 接入 `lnkpi-net`
+2. 写入 `.env`：`LNKPI_OTEL_EXPORTER_OTLP_ENDPOINT=http://pintuotuo-tempo:4318/v1/traces`
+3. 重建 `agent-runtime` 并验证 `is_tracing_enabled()`
+
+关闭 tracing（本地调试）：`ENABLE_OBSERVABILITY=false bash deploy/enable-agent-runtime.sh`
 
 | 环境 | 配置 |
 |------|------|
-| **生产** | `LNKPI_OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318` + `LANGSMITH_OTEL_ONLY=true`（无 API Key） |
-| **开发** | 同上 + `LANGSMITH_API_KEY=...` 可同时看 LangSmith Cloud |
+| **生产（CVM 默认）** | 直连同机 Tempo（见上）；`LNKPI_LANGSMITH_OTEL_ENABLED=false` |
+| **独立 Collector 栈** | `docker compose -f deploy/docker-compose.observability.yml up -d` + `LNKPI_OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318` |
+| **开发 + LangSmith Cloud** | 同上 Collector + `LNKPI_LANGSMITH_OTEL_ENABLED=true` + `LNKPI_LANGSMITH_API_KEY=...` |
 
-启用步骤：
+手动补启用（已部署但未写 OTEL env）：
 
 ```bash
 cd /opt/lnkpi
-docker compose -f deploy/docker-compose.prod.yml \
-  -f deploy/docker-compose.observability.yml up -d
-
-# .env 追加:
-# LNKPI_OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
-# LNKPI_LANGSMITH_OTEL_ENABLED=true
-
-docker compose -f deploy/docker-compose.prod.yml up -d --no-build agent-runtime
+bash deploy/enable-observability-cvm.sh
 ```
 
 - **Grafana Explore → Tempo**（本机）：`http://127.0.0.1:3000`
+- 查询示例：`curl -s 'http://127.0.0.1:3200/api/search?limit=5&tags=resource.service.name%3Dlnkpi-agent-runtime'`
 - Span 链：`agent.run`（业务）+ LangSmith 自动 `chain/llm` + `tool.call`（Nest HTTP）
 
 后续 Nest 侧补 Node OTel 后，Collector 可统一接收全链路 trace。
+
+---
+
+## 2.5 W24/W25 Metrics：Prometheus + Grafana
+
+`agent-runtime` 暴露 `GET /metrics`（仅内网，容器 `:8000`）。
+
+| 文件 | 用途 |
+|------|------|
+| `deploy/observability/prometheus/agent-runtime-scrape.yml` | Prometheus scrape 片段 |
+| `deploy/observability/prometheus/agent-runtime-alerts.yml` | 告警规则（stream/tool/threads/scrape） |
+| `deploy/observability/grafana/dashboards/agent-runtime-dashboard.json` | Grafana 面板 JSON |
+
+**启用 scrape**（CVM，Prometheus 与 lnkpi 同 Docker 网络）：
+
+```yaml
+# prometheus.yml additional_scrape_configs 引入 agent-runtime-scrape.yml
+```
+
+**导入 Dashboard**：Grafana → Dashboards → Import → 上传 `agent-runtime-dashboard.json`，选择 Prometheus 数据源。
+
+**校验告警规则**：
+
+```bash
+promtool check rules deploy/observability/prometheus/agent-runtime-alerts.yml
+```
+
+---
+
+## 2.6 W27 Graph 控制流回放 API
+
+与画布 `/replay/:sessionId`（快照回放）区分：按 **threadId** 查询 LangGraph checkpoint **phase 时间线**。
+
+| 层 | 路径 |
+|----|------|
+| Runtime | `GET /v1/threads/{threadId}/timeline`（需 `x-lnkpi-service-token`） |
+| Nest 代理 | `GET /api/agent/thread-timeline?threadId=...`（需登录） |
+
+响应示例：`{ threadId, entries: [{ phase, nextNodes, step, promptVersion, ... }], checkpointCount }`
 
 ---
 

--- a/deploy/enable-agent-runtime.sh
+++ b/deploy/enable-agent-runtime.sh
@@ -130,6 +130,22 @@ fi
 [[ -n "$(get_env LNKPI_IMAGE_GEN_CONCURRENCY)" ]] || upsert_env LNKPI_IMAGE_GEN_CONCURRENCY "3"
 [[ -n "$(get_env LNKPI_IMAGE_GEN_TIMEOUT_SEC)" ]] || upsert_env LNKPI_IMAGE_GEN_TIMEOUT_SEC "180"
 
+# W23: OTLP tracing — default on in production (reuse pintuotuo Tempo on lnkpi-net)
+ENABLE_OBSERVABILITY="${ENABLE_OBSERVABILITY:-true}"
+if [[ "$ENABLE_OBSERVABILITY" == "true" ]]; then
+  TEMPO_CONTAINER="${TEMPO_CONTAINER:-pintuotuo-tempo}"
+  TEMPO_NETWORK="${TEMPO_NETWORK:-lnkpi-net}"
+  OTEL_ENDPOINT="${OTEL_ENDPOINT:-http://pintuotuo-tempo:4318/v1/traces}"
+  log "=== Enable OTLP tracing (W23) ==="
+  docker network connect "$TEMPO_NETWORK" "$TEMPO_CONTAINER" 2>/dev/null || log "tempo already on ${TEMPO_NETWORK} (ok)"
+  upsert_env LNKPI_OTEL_EXPORTER_OTLP_ENDPOINT "$OTEL_ENDPOINT"
+  upsert_env LNKPI_LANGSMITH_OTEL_ENABLED "false"
+  upsert_env LNKPI_OTEL_SERVICE_NAME "lnkpi-agent-runtime"
+  log "OTEL endpoint -> ${OTEL_ENDPOINT}"
+else
+  log "ENABLE_OBSERVABILITY=false — OTLP tracing skipped"
+fi
+
 # Keep current api image tag on recreate
 if docker inspect lnkpi-api --format '{{.Config.Image}}' >/dev/null 2>&1; then
   export LNKPI_API_IMAGE
@@ -202,6 +218,17 @@ if echo "$MSG" | grep -q 'not configured'; then
 fi
 if ! echo "$MSG" | grep -qi 'Invalid service token\|Unauthorized'; then
   log "WARN: unexpected internal response (continuing)"
+fi
+
+if [[ "$ENABLE_OBSERVABILITY" == "true" ]]; then
+  log "=== Verify tracing module (W23) ==="
+  docker exec lnkpi-agent-runtime python -c "
+from app.tracing import is_tracing_enabled, uses_langsmith_otel
+from app.config import settings
+print('endpoint=', settings.otel_exporter_otlp_endpoint)
+print('tracing=', is_tracing_enabled())
+print('langsmith_otel=', uses_langsmith_otel())
+" || log "WARN: tracing verify failed (Tempo may be unreachable)"
 fi
 
 # Confirm no public 8000 binding on host (best-effort)

--- a/deploy/enable-observability-cvm.sh
+++ b/deploy/enable-observability-cvm.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Manual W23 observability enable (legacy). Production deploy uses enable-agent-runtime.sh.
 # Enable W23 observability on CVM: reuse pintuotuo Tempo + rebuild agent-runtime.
 set -euo pipefail
 

--- a/deploy/observability/grafana/dashboards/agent-runtime-dashboard.json
+++ b/deploy/observability/grafana/dashboards/agent-runtime-dashboard.json
@@ -1,0 +1,122 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [{ "expr": "agent_threads_active", "legendFormat": "active", "refId": "A" }],
+      "title": "Active agent threads",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "id": 2,
+      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [{ "expr": "increase(agent_threads_total[1h])", "legendFormat": "started/h", "refId": "A" }],
+      "title": "Threads started (1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "id": 3,
+      "targets": [{ "expr": "sum(increase(agent_stream_errors_total[1h]))", "legendFormat": "errors", "refId": "A" }],
+      "title": "Stream errors (1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "id": 4,
+      "targets": [{ "expr": "sum(increase(agent_tool_calls_total[1h]))", "legendFormat": "calls", "refId": "A" }],
+      "title": "Tool calls (1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "id": 5,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(agent_nodes_duration_seconds_bucket[5m])) by (le, node_name))",
+          "legendFormat": "{{node_name}} p95",
+          "refId": "A"
+        }
+      ],
+      "title": "Node duration p95 (5m rate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "id": 6,
+      "targets": [
+        {
+          "expr": "sum(rate(agent_tool_calls_total[5m])) by (tool_name, outcome)",
+          "legendFormat": "{{tool_name}} {{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Tool calls rate by outcome",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 12 },
+      "id": 7,
+      "targets": [
+        {
+          "expr": "sum(rate(agent_prompt_invocations_total[5m])) by (node_name, prompt_version)",
+          "legendFormat": "{{node_name}} v{{prompt_version}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Prompt invocations by version (P2-02)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["lnkpi", "agent-runtime"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" },
+        "hide": 0,
+        "label": "Prometheus",
+        "name": "DS_PROMETHEUS",
+        "query": "prometheus",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timezone": "browser",
+  "title": "lnkpi Agent Runtime",
+  "uid": "lnkpi-agent-runtime",
+  "version": 1
+}

--- a/deploy/observability/prometheus/agent-runtime-alerts.yml
+++ b/deploy/observability/prometheus/agent-runtime-alerts.yml
@@ -1,0 +1,49 @@
+# Prometheus alerting rules for lnkpi agent-runtime (W25).
+# Validate: promtool check rules agent-runtime-alerts.yml
+
+groups:
+  - name: lnkpi_agent_runtime
+    rules:
+      - alert: AgentStreamErrorsElevated
+        expr: increase(agent_stream_errors_total[5m]) > 3
+        for: 2m
+        labels:
+          severity: warning
+          service: lnkpi-agent-runtime
+        annotations:
+          summary: Agent stream errors elevated
+          description: >-
+            agent_stream_errors_total increased by more than 3 in 5m
+            ({{ $labels.error_type }}).
+
+      - alert: AgentToolCallErrorsElevated
+        expr: increase(agent_tool_calls_total{outcome="error"}[5m]) > 10
+        for: 2m
+        labels:
+          severity: warning
+          service: lnkpi-agent-runtime
+        annotations:
+          summary: Nest tool call errors elevated
+          description: >-
+            agent_tool_calls_total{outcome="error"} increased by more than 10 in 5m
+            (tool={{ $labels.tool_name }}).
+
+      - alert: AgentThreadsActiveHigh
+        expr: agent_threads_active > 20
+        for: 5m
+        labels:
+          severity: warning
+          service: lnkpi-agent-runtime
+        annotations:
+          summary: High concurrent agent threads
+          description: agent_threads_active={{ $value }} for 5m — check stuck runs or load.
+
+      - alert: AgentRuntimeMetricsMissing
+        expr: absent(agent_threads_total) or absent(up{job="lnkpi-agent-runtime"})
+        for: 10m
+        labels:
+          severity: critical
+          service: lnkpi-agent-runtime
+        annotations:
+          summary: Agent runtime metrics scrape missing
+          description: Prometheus cannot scrape lnkpi-agent-runtime /metrics for 10m.

--- a/deploy/observability/prometheus/agent-runtime-scrape.yml
+++ b/deploy/observability/prometheus/agent-runtime-scrape.yml
@@ -1,0 +1,15 @@
+# Prometheus scrape config snippet for lnkpi agent-runtime (W24).
+# Merge into pintuotuo/CVM prometheus.yml or use as file_sd / additional_scrape_configs.
+#
+# agent-runtime is NOT published on host :8000; scrape via docker network:
+#   targets: ['lnkpi-agent-runtime:8000']
+
+scrape_configs:
+  - job_name: lnkpi-agent-runtime
+    metrics_path: /metrics
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['lnkpi-agent-runtime:8000']
+        labels:
+          service: lnkpi-agent-runtime
+          env: production

--- a/services/agent-runtime/app/main.py
+++ b/services/agent-runtime/app/main.py
@@ -74,6 +74,32 @@ async def thread_state(
     return data
 
 
+@app.get("/v1/threads/{thread_id}/timeline")
+async def thread_timeline(
+    thread_id: str,
+    x_lnkpi_service_token: str | None = Header(default=None),
+):
+    """W27: Graph control-flow phase timeline from checkpoint history."""
+    _require_runtime_auth(x_lnkpi_service_token)
+    from app.graph.builder import build_agent_graph
+    from app.runs import default_llm, resolve_skills_dir, _get_checkpointer
+
+    class _NoOpNest:
+        async def close(self) -> None:
+            pass
+
+    overrides = _run_overrides.get("checkpointer")
+    cp = overrides if overrides is not None else await _get_checkpointer()
+    graph = build_agent_graph(
+        nest=_NoOpNest(),
+        llm=default_llm(),
+        skills_dir=resolve_skills_dir(),
+        checkpointer=cp,
+    )
+    data = await get_thread_timeline(thread_id, graph=graph)
+    return data
+
+
 @app.post("/v1/runs")
 async def create_run(
     body: RunRequest,

--- a/services/agent-runtime/app/replay.py
+++ b/services/agent-runtime/app/replay.py
@@ -1,0 +1,66 @@
+"""W27: Graph control-flow replay — checkpoint phase timeline (not canvas replay)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _phase_entry(
+    *,
+    step: Any,
+    source: Any,
+    phase: str | None,
+    next_nodes: list[str],
+    skill_id: Any,
+    prompt_version: Any,
+) -> dict[str, Any]:
+    return {
+        "step": int(step) if step is not None else None,
+        "source": str(source) if source is not None else None,
+        "phase": phase,
+        "nextNodes": next_nodes,
+        "skillId": str(skill_id) if skill_id else None,
+        "promptVersion": str(prompt_version) if prompt_version else None,
+        "interrupted": bool(next_nodes),
+    }
+
+
+async def get_thread_timeline(
+    thread_id: str,
+    *,
+    graph: Any,
+    limit: int = 100,
+) -> dict[str, Any]:
+    """List phase transitions from LangGraph checkpoint history (newest→oldest scan)."""
+    config = {"configurable": {"thread_id": thread_id}}
+    raw: list[dict[str, Any]] = []
+    async for snap in graph.aget_state_history(config, limit=limit):
+        vals = getattr(snap, "values", None) or {}
+        meta = getattr(snap, "metadata", None) or {}
+        phase = vals.get("phase")
+        phase_str = str(phase) if phase is not None else None
+        next_nodes = [str(n) for n in (getattr(snap, "next", None) or [])]
+        raw.append(
+            _phase_entry(
+                step=meta.get("step"),
+                source=meta.get("source"),
+                phase=phase_str,
+                next_nodes=next_nodes,
+                skill_id=vals.get("skill_id"),
+                prompt_version=vals.get("prompt_version"),
+            )
+        )
+
+    raw.reverse()
+    timeline: list[dict[str, Any]] = []
+    last_phase: str | None = None
+    for entry in raw:
+        if entry["phase"] != last_phase:
+            timeline.append(entry)
+            last_phase = entry["phase"]
+
+    return {
+        "threadId": thread_id,
+        "entries": timeline,
+        "checkpointCount": len(raw),
+    }

--- a/services/agent-runtime/tests/test_thread_timeline.py
+++ b/services/agent-runtime/tests/test_thread_timeline.py
@@ -1,0 +1,56 @@
+"""W27: Graph phase timeline from checkpoint history."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.replay import get_thread_timeline
+
+
+class _Snap:
+    def __init__(self, *, values: dict, metadata: dict, next_nodes: list[str]):
+        self.values = values
+        self.metadata = metadata
+        self.next = next_nodes
+
+
+class _FakeGraph:
+    def __init__(self, snaps: list[_Snap]):
+        self._snaps = snaps
+
+    async def aget_state_history(self, config, limit=100):  # noqa: ARG002
+        for snap in self._snaps:
+            yield snap
+
+
+@pytest.mark.asyncio
+async def test_timeline_collapses_same_phase():
+    graph = _FakeGraph(
+        [
+            _Snap(values={"phase": "done"}, metadata={"step": 3}, next_nodes=[]),
+            _Snap(values={"phase": "await_confirm"}, metadata={"step": 2}, next_nodes=["await_confirm"]),
+            _Snap(values={"phase": "await_confirm"}, metadata={"step": 1}, next_nodes=["await_confirm"]),
+            _Snap(values={"phase": "plan"}, metadata={"step": 0}, next_nodes=[]),
+        ]
+    )
+    result = await get_thread_timeline("t1", graph=graph)
+    assert result["threadId"] == "t1"
+    assert result["checkpointCount"] == 4
+    phases = [e["phase"] for e in result["entries"]]
+    assert phases == ["plan", "await_confirm", "done"]
+
+
+@pytest.mark.asyncio
+async def test_timeline_includes_prompt_version():
+    graph = _FakeGraph(
+        [
+            _Snap(
+                values={"phase": "await_confirm", "skill_id": "enterprise-marketing-campaign", "prompt_version": "1.1.0"},
+                metadata={"step": 1, "source": "loop"},
+                next_nodes=["await_confirm"],
+            ),
+        ]
+    )
+    result = await get_thread_timeline("t2", graph=graph)
+    assert result["entries"][0]["promptVersion"] == "1.1.0"
+    assert result["entries"][0]["skillId"] == "enterprise-marketing-campaign"


### PR DESCRIPTION
## Summary
- **P2-04 W23**: `enable-agent-runtime.sh` 默认开启 OTLP → pintuotuo Tempo
- **P2-05 W24**: Prometheus scrape 片段 + Grafana dashboard JSON
- **P2-06 W25**: Prometheus 告警规则
- **P2-07 W27**: `GET /v1/threads/{id}/timeline` + Nest `/api/agent/thread-timeline`

## Test plan
- [x] `pytest tests/test_thread_timeline.py` — 2 passed
- [ ] CI green
- [ ] 部署后验证 tracing + Grafana dashboard import

Made with [Cursor](https://cursor.com)