### PR TITLE
feat(agent): P3 single-node quick generation (W28–W30)

### DIFF
--- a/apps/server/src/agent/agent-runtime.client.ts
+++ b/apps/server/src/agent/agent-runtime.client.ts
@@ -10,6 +10,7 @@ export interface RuntimeRunInput {
   userDecision?: 'confirm' | 'revise' | 'replan' | 'confirm_gen' | 'topo_revise' | 'node_revise'
   /** Runtime skill id after UI→runtime mapping */
   skillId?: string
+  focusNodeId?: string
   llmModel?: string
   llmApiKey?: string
   llmBaseUrl?: string
@@ -97,6 +98,7 @@ export class AgentRuntimeClient {
         llm_model: input.llmModel,
         llm_api_key: input.llmApiKey,
         llm_base_url: input.llmBaseUrl,
+        focus_node_id: input.focusNodeId,
       }),
     })
 

--- a/apps/server/src/agent/agent.controller.ts
+++ b/apps/server/src/agent/agent.controller.ts
@@ -42,6 +42,11 @@ class ConversationDto {
   @IsString()
   skillId?: string
 
+  /** W28: 单节点快速生成目标画布 node id */
+  @IsOptional()
+  @IsString()
+  focusNodeId?: string
+
   /** 规划阶段 LLM 模型（含 channel 编码），Nest 解析凭证后转发 */
   @IsOptional()
   @IsString()
@@ -150,6 +155,7 @@ export class AgentController {
         idempotencyKey,
         dto.skillId,
         dto.model,
+        dto.focusNodeId,
       )) {
         res.write(`data: ${JSON.stringify(event)}\n\n`)
       }

--- a/apps/server/src/agent/agent.service.ts
+++ b/apps/server/src/agent/agent.service.ts
@@ -57,6 +57,7 @@ export class AgentService {
     idempotencyKey?: string,
     skillId?: string,
     model?: string,
+    focusNodeId?: string,
   ): AsyncGenerator<AgentStreamEvent> {
     // Register idempotency key (if provided) before starting
     if (idempotencyKey) {
@@ -82,6 +83,7 @@ export class AgentService {
           userDecision,
           skillId,
           model,
+          focusNodeId,
         )) {
           if (event.type === 'text_delta') {
             assistantText += (event.data as { text: string }).text
@@ -200,6 +202,7 @@ export class AgentService {
     userDecision?: 'confirm' | 'revise' | 'replan' | 'confirm_gen' | 'topo_revise' | 'node_revise',
     skillId?: string,
     model?: string,
+    focusNodeId?: string,
   ): AsyncGenerator<AgentStreamEvent> {
     let assistantText = ''
     const canvasActions: CanvasAction[] = []
@@ -228,6 +231,7 @@ export class AgentService {
       llmModel,
       llmApiKey,
       llmBaseUrl,
+      focusNodeId,
     })) {
       if (event.type === 'text_delta') {
         assistantText += (event.data as { text: string }).text

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -53,6 +53,8 @@ const props = defineProps<{
   sessionId: string
   /** 当前登录用户非画布所有者时为 true，禁止 Agent 写入画布 */
   readOnly?: boolean
+  /** W30: 画布选中节点 id，配合「快速生成」走单节点路径 */
+  selectedNodeId?: string | null
 }>()
 
 const emit = defineEmits<{
@@ -406,6 +408,7 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
         userDecision,
         skillId: activeSkillId.value,
         model: planningModel.value || undefined,
+        focusNodeId: props.selectedNodeId || undefined,
       }),
     })
 

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -2727,6 +2727,7 @@ onMounted(() => {
         ref="agentRailRef"
         :session-id="sessionId"
         :read-only="agentReadOnly"
+        :selected-node-id="selectedNodeId"
         @canvas-actions="handleAgentActions"
         @turn-complete="handleAgentTurnComplete"
         @focus-node="focusNodeById"

--- a/deploy/prod-single-node-gen-verify.py
+++ b/deploy/prod-single-node-gen-verify.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Production verify for P3 — single-node quick generation (W28–W30).
+
+Flow:
+  1. Create session + seed one manual image node on canvas
+  2. SSE「快速生成这张主图」with focusNodeId → skip plan/topo gates
+  3. Assert thread-state phase is not await_confirm; gen path started
+
+Usage:
+  python3 deploy/prod-single-node-gen-verify.py
+  BASE_URL=http://119.29.173.89:8888 PHONE=17279698608 CODE=123456 python3 deploy/prod-single-node-gen-verify.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import uuid
+from typing import Any
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+BASE = os.environ.get("BASE_URL", "http://119.29.173.89:8888").rstrip("/")
+API = f"{BASE}/api"
+PHONE = os.environ.get("PHONE", "17279698608")
+CODE = os.environ.get("CODE", "123456")
+GEN_SSE_TIMEOUT_SEC = float(os.environ.get("GEN_SSE_TIMEOUT_SEC", "600"))
+
+PASS = FAIL = SKIP = 0
+
+
+def record(case: str, ok: bool, detail: str = "", *, skip: bool = False) -> None:
+    global PASS, FAIL, SKIP
+    if skip:
+        SKIP += 1
+        icon = "⏭️"
+    elif ok:
+        PASS += 1
+        icon = "✅"
+    else:
+        FAIL += 1
+        icon = "❌"
+    line = f"{icon} {case}"
+    if detail:
+        line += f" — {detail[:220]}"
+    print(line)
+
+
+def http(m: str, p: str, b: dict | None = None, t: str | None = None) -> Any:
+    h = {"Content-Type": "application/json", "Accept": "application/json"}
+    if t:
+        h["Authorization"] = f"Bearer {t}"
+    r = Request(f"{API}{p}", data=None if b is None else json.dumps(b).encode(), headers=h, method=m)
+    with urlopen(r, timeout=120) as resp:
+        return json.loads(resp.read())
+
+
+def sse_collect(
+    t: str,
+    sid: str,
+    msg: str,
+    tid: str,
+    *,
+    focus_node_id: str | None = None,
+    timeout: float = 420,
+) -> tuple[list[dict], str, set[str], str]:
+    body: dict[str, Any] = {"sessionId": sid, "message": msg, "threadId": tid}
+    if focus_node_id:
+        body["focusNodeId"] = focus_node_id
+    body["skillId"] = "enterprise-marketing-campaign"
+    h = {
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+        "Authorization": f"Bearer {t}",
+        "Idempotency-Key": f"ik_{uuid.uuid4().hex}",
+    }
+    r = Request(f"{API}/agent/chat/conversation", data=json.dumps(body).encode(), headers=h, method="POST")
+    events: list[dict] = []
+    types: set[str] = set()
+    parts: list[str] = []
+    end = time.time() + timeout
+    exit_reason = "timeout"
+    with urlopen(r, timeout=timeout) as resp:
+        buf = ""
+        while time.time() < end:
+            chunk = resp.read(4096)
+            if not chunk:
+                exit_reason = "eof"
+                break
+            buf += chunk.decode(errors="replace")
+            while "\n\n" in buf:
+                block, buf = buf.split("\n\n", 1)
+                for line in block.splitlines():
+                    if not line.startswith("data:"):
+                        continue
+                    pl = line[5:].strip()
+                    if pl == "[DONE]":
+                        return events, "".join(parts), types, "done_marker"
+                    try:
+                        ev = json.loads(pl)
+                    except json.JSONDecodeError:
+                        continue
+                    events.append(ev)
+                    et = str(ev.get("type") or "")
+                    types.add(et)
+                    if et == "text_delta":
+                        parts.append(str((ev.get("data") or {}).get("text") or ""))
+                    if et == "done":
+                        return events, "".join(parts), types, "done"
+                    if et == "error":
+                        return events, "".join(parts), types, "error"
+    return events, "".join(parts), types, exit_reason
+
+
+def thread_state(tok: str, tid: str) -> dict[str, Any]:
+    return http("GET", f"/agent/thread-state?threadId={quote(tid, safe='')}", t=tok).get("data") or {}
+
+
+def seed_image_node(tok: str, sid: str) -> str:
+    sess = http("GET", f"/sessions/{sid}", t=tok)["data"]
+    canvas = sess.get("canvasData") or {"nodes": [], "edges": []}
+    node_id = f"image-p3-{int(time.time())}"
+    nodes = list(canvas.get("nodes") or [])
+    nodes.append(
+        {
+            "id": node_id,
+            "type": "image",
+            "position": {"x": 800, "y": 400},
+            "data": {
+                "title": "P3单节点主图",
+                "prompt": "电商白底产品主图，P3单节点快速生成复测",
+                "status": "draft",
+            },
+        }
+    )
+    patch = {"nodes": nodes, "edges": canvas.get("edges") or [], "viewport": canvas.get("viewport")}
+    http("PUT", f"/sessions/{sid}", {"canvasData": patch}, t=tok)
+    return node_id
+
+
+def main() -> int:
+    print("=== P3 single-node quick gen production verify ===")
+    print(f"BASE={BASE}\n")
+
+    try:
+        http("POST", "/auth/send-code", {"phone": PHONE})
+    except Exception:
+        pass
+    try:
+        tok = http("POST", "/auth/login", {"phone": PHONE, "code": CODE})["data"]["token"]
+        record("Login", True)
+    except Exception as exc:  # noqa: BLE001
+        record("Login", False, str(exc))
+        return 1
+
+    rt = http("GET", "/agent/runtime-health", t=tok)
+    record("Runtime health", bool((rt.get("data") or {}).get("ok")))
+
+    sid = http("POST", "/sessions", {"title": f"P3-single-{int(time.time())}"}, t=tok)["data"]["id"]
+    tid = f"{sid}:{uuid.uuid4()}"
+    record("Create session", True, sid)
+
+    try:
+        focus_id = seed_image_node(tok, sid)
+        record("Seed image node", True, focus_id)
+    except Exception as exc:  # noqa: BLE001
+        record("Seed image node", False, str(exc))
+        return 1
+
+    events, text, types, exit_reason = sse_collect(
+        tok,
+        sid,
+        "快速生成这张主图",
+        tid,
+        focus_node_id=focus_id,
+        timeout=GEN_SSE_TIMEOUT_SEC,
+    )
+    record("SSE stream started", len(events) >= 1, f"events={len(events)} exit={exit_reason}")
+
+    skipped_plan = "await_confirm" not in types and "单节点快速生成" in text
+    record(
+        "Single-node path (no plan gate)",
+        skipped_plan or "task_update" in types or "gen" in text.lower(),
+        f"types={sorted(types)} snippet={text[:120]!r}",
+    )
+
+    ts = thread_state(tok, tid)
+    phase = ts.get("phase")
+    next_nodes = ts.get("nextNodes") or []
+    not_at_plan = "await_confirm" not in next_nodes and phase not in ("await_confirm", "compose_confirm")
+    record(
+        "thread-state skips plan gate",
+        not_at_plan,
+        f"phase={phase} next={next_nodes}",
+    )
+    record(
+        "thread-state gen or done phase",
+        phase in ("orchestrate_gen", "done", None) or any("gen" in str(n) for n in next_nodes),
+        f"phase={phase}",
+    )
+
+    print(f"\n=== Summary PASS={PASS} FAIL={FAIL} SKIP={SKIP} ===")
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/agent-runtime/app/graph/builder.py
+++ b/services/agent-runtime/app/graph/builder.py
@@ -15,10 +15,13 @@ from app.graph.nodes.split import make_split_node
 from app.graph.state import AgentRuntimeState
 from app.graph.subgraphs.confirm_gate import register_confirm_gate
 from app.graph.subgraphs.copy_gate import register_copy_gate
+from app.graph.subgraphs.single_node_gate import register_single_node_gate
 from app.graph.subgraphs.topo_gate import register_topo_gate
 
 
 def route_after_intake(state: AgentRuntimeState) -> str:
+    if state.get("flow_mode") == "single_node":
+        return "prepare_single_gen"
     if state.get("skill_id"):
         return "decide_plan_mode"
     return "chat"
@@ -52,12 +55,17 @@ def build_agent_graph(
     register_confirm_gate(graph, nest=nest, llm=llm, skills_dir=skills_path)
     register_copy_gate(graph, nest=nest, llm=llm)
     register_topo_gate(graph, nest=nest)
+    register_single_node_gate(graph, nest=nest)
 
     graph.add_edge(START, "intake")
     graph.add_conditional_edges(
         "intake",
         route_after_intake,
-        {"decide_plan_mode": "decide_plan_mode", "chat": "chat"},
+        {
+            "prepare_single_gen": "prepare_single_gen",
+            "decide_plan_mode": "decide_plan_mode",
+            "chat": "chat",
+        },
     )
     graph.add_edge("chat", END)
     graph.add_edge("write_plan_node", "split")

--- a/services/agent-runtime/app/graph/intent.py
+++ b/services/agent-runtime/app/graph/intent.py
@@ -163,6 +163,17 @@ def modify_intent(text: str) -> bool:
     return any(h in lowered for h in MODIFY_HINTS)
 
 
+def single_node_gen_intent(text: str) -> bool:
+    """Quick-gen one canvas node — must pair with focus_node_id in intake."""
+    lowered = (text or "").strip().lower()
+    if not lowered:
+        return False
+    if any(h in lowered for h in SINGLE_NODE_GEN_HINTS):
+        return True
+    # Short regen commands when user selected a node
+    return lowered in ("快速生成", "重生成", "再生成", "生成")
+
+
 TopoDecision = Literal["none", "confirm_gen", "topo_revise", "node_revise"]
 
 
@@ -230,6 +241,21 @@ COPY_CONFIRM_HINTS = (
     "用这个",
     "就这个",
     "写入",
+)
+
+# W28: single-node quick generation (requires focus_node_id in state)
+SINGLE_NODE_GEN_HINTS = (
+    "只生成",
+    "仅生成",
+    "快速生成",
+    "只出图",
+    "只出这张",
+    "只生成这张",
+    "重新生成这张",
+    "单节点",
+    "这张主图",
+    "生成这张",
+    "重跑这张",
 )
 
 CopyDecision = Literal["none", "confirm", "revise"]

--- a/services/agent-runtime/app/graph/nodes/intake.py
+++ b/services/agent-runtime/app/graph/nodes/intake.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable
 
-from app.graph.intent import marketing_intent, modify_intent  # re-export for tests
+from app.graph.intent import marketing_intent, modify_intent, single_node_gen_intent  # re-export for tests
 from app.graph.state import BRIEF_RESET_PREFIX
 from app.skills.loader import discover_skills
 
@@ -35,9 +35,19 @@ def make_intake_node(skills_dir: Path) -> Callable:
 
         existing_brief = state.get("user_brief")
         existing_plan = state.get("plan_draft")
-        is_modify = bool(existing_brief and existing_plan and modify_intent(text))
+        focus_node_id = str(state.get("focus_node_id") or "").strip() or None
+        is_single_node = bool(
+            focus_node_id and single_node_gen_intent(text) and not modify_intent(text)
+        )
+        is_modify = bool(existing_brief and existing_plan and modify_intent(text) and not is_single_node)
 
-        if is_modify:
+        if is_single_node:
+            mode = "create"
+            proposed_brief = None
+            flow_mode = "single_node"
+            if not skill_id and "enterprise-marketing-campaign" in by_id:
+                skill_id = "enterprise-marketing-campaign"
+        elif is_modify:
             mode = "modify"
             proposed_brief = None  # reducer keeps existing brief
         elif marketing_intent(text):
@@ -49,6 +59,7 @@ def make_intake_node(skills_dir: Path) -> Callable:
         else:
             mode = "create"
             proposed_brief = None
+            flow_mode = "campaign"
 
         out: dict[str, Any] = {
             "phase": "intake",
@@ -57,7 +68,10 @@ def make_intake_node(skills_dir: Path) -> Callable:
             "split_manifest": state.get("split_manifest") or [],
             "last_error": state.get("last_error"),
             "mode": mode,
+            "flow_mode": flow_mode if is_single_node else "campaign",
         }
+        if focus_node_id:
+            out["focus_node_id"] = focus_node_id
         if proposed_brief is not None:
             out["user_brief"] = proposed_brief
         return out

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -94,6 +94,8 @@ class AgentRuntimeState(TypedDict, total=False):
     session_id: str
     user_id: str
     prompt_version: str | None  # W19: active skill prompt template version
+    flow_mode: Literal["campaign", "single_node"] | None  # W28/W29
+    focus_node_id: str | None  # W28: canvas node for single-node gen
 
     # 工作记忆（轻量；禁止存完整 canvas nodes/edges）
     plan_summary: str

--- a/services/agent-runtime/app/graph/subgraphs/single_node_gate.py
+++ b/services/agent-runtime/app/graph/subgraphs/single_node_gate.py
@@ -1,0 +1,86 @@
+"""W29: single_node_gate — focus canvas node → gen fan-out → done (no plan/split)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.messages import AIMessage
+
+from app.graph.state import SplitManifestItem
+
+_GEN_TYPES = frozenset({"image", "video"})
+
+
+def manifest_item_from_canvas_node(node: dict[str, Any]) -> SplitManifestItem | None:
+    """Build one manifest row from a canvas node snapshot."""
+    node_id = str(node.get("id") or "").strip()
+    if not node_id:
+        return None
+    node_type = str(node.get("type") or "image")
+    target = node_type if node_type in _GEN_TYPES else "image"
+    data = node.get("data") if isinstance(node.get("data"), dict) else {}
+    hint = str(data.get("prompt") or data.get("content") or "").strip()
+    suffix = node_id.replace("-", "_")[-12:]
+    key = f"single_{suffix}" if suffix else "single_node"
+    return SplitManifestItem(
+        key=key,
+        title=str(node.get("title") or key),
+        target_type=target,  # type: ignore[arg-type]
+        node_id=node_id,
+        depends_on=[],
+        auto_generate=True,
+        prompt_hint=hint,
+    )
+
+
+def make_prepare_single_gen_node(*, nest: Any) -> Any:
+    """Resolve focus_node_id → single-item manifest, then hand off to start_gen."""
+
+    async def prepare_single_gen(state: dict) -> dict:
+        node_id = str(state.get("focus_node_id") or "").strip()
+        if not node_id:
+            return {
+                "phase": "error",
+                "last_error": "missing focus_node_id",
+                "messages": [AIMessage(content="未指定要生成的画布节点，请先选中节点后重试。")],
+            }
+        get_node = getattr(nest, "get_node", None)
+        if get_node is None:
+            return {
+                "phase": "error",
+                "messages": [AIMessage(content="无法读取画布节点。")],
+            }
+        try:
+            node = await get_node(node_id)
+        except Exception as exc:  # noqa: BLE001
+            return {
+                "phase": "error",
+                "last_error": str(exc),
+                "messages": [AIMessage(content=f"读取节点失败：{exc}")],
+            }
+        item = manifest_item_from_canvas_node(node if isinstance(node, dict) else {})
+        if item is None:
+            return {
+                "phase": "error",
+                "messages": [AIMessage(content="节点无效，无法快速生成。")],
+            }
+        key = str(item["key"])
+        title = str(item.get("title") or key)
+        return {
+            "phase": "orchestrate_gen",
+            "flow_mode": "single_node",
+            "split_manifest": [item],
+            "gen_ordered_keys": [key],
+            "user_decision": "confirm_gen",
+            "messages": [
+                AIMessage(content=f"单节点快速生成：{title}（跳过方案/拓扑全链路）。")
+            ],
+        }
+
+    return prepare_single_gen
+
+
+def register_single_node_gate(graph: Any, *, nest: Any) -> None:
+    """Register prepare_single_gen; reuses topo_gate start_gen → collect_gen → done."""
+    graph.add_node("prepare_single_gen", make_prepare_single_gen_node(nest=nest))
+    graph.add_edge("prepare_single_gen", "start_gen")

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -190,6 +190,7 @@ class RunRequest(BaseModel):
     llm_model: str | None = None
     llm_api_key: str | None = None
     llm_base_url: str | None = None
+    focus_node_id: str | None = None  # W28: single-node quick gen target
 
 
 class NestEventProxy:
@@ -564,6 +565,7 @@ async def stream_run_events(
             "user_id": req.user_id,
             "thread_id": thread_id,
             "requested_skill_id": req.skill_id,
+            "focus_node_id": req.focus_node_id,
         }
 
     async def run_graph() -> None:

--- a/services/agent-runtime/tests/test_single_node_intent.py
+++ b/services/agent-runtime/tests/test_single_node_intent.py
@@ -1,0 +1,22 @@
+"""Tests for W28 single_node_gen_intent."""
+
+from __future__ import annotations
+
+from app.graph.intent import marketing_intent, single_node_gen_intent
+
+
+def test_single_node_gen_intent_keywords():
+    assert single_node_gen_intent("快速生成这张主图")
+    assert single_node_gen_intent("只生成这张")
+    assert single_node_gen_intent("重新生成这张")
+
+
+def test_single_node_gen_intent_does_not_match_full_campaign():
+    text = "帮我做一套蓝牙音箱天猫详情页营销方案并出图"
+    assert marketing_intent(text)
+    assert not single_node_gen_intent(text)
+
+
+def test_single_node_short_commands():
+    assert single_node_gen_intent("快速生成")
+    assert not single_node_gen_intent("确认出图")

--- a/services/agent-runtime/tests/test_single_node_subgraph.py
+++ b/services/agent-runtime/tests/test_single_node_subgraph.py
@@ -1,0 +1,72 @@
+"""W29: single_node_gate subgraph tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from app.graph.subgraphs.single_node_gate import manifest_item_from_canvas_node
+
+
+def test_manifest_item_from_canvas_node():
+    item = manifest_item_from_canvas_node(
+        {
+            "id": "image-1234567890",
+            "type": "image",
+            "title": "主图",
+            "data": {"prompt": "白底产品图"},
+        }
+    )
+    assert item is not None
+    assert item["node_id"] == "image-1234567890"
+    assert item["target_type"] == "image"
+    assert item["prompt_hint"] == "白底产品图"
+
+
+@pytest.mark.asyncio
+async def test_intake_routes_single_node_without_plan(tmp_path):
+    from pathlib import Path
+
+    from langchain_core.messages import HumanMessage
+
+    from app.graph.nodes.intake import make_intake_node
+
+    skills = Path(__file__).resolve().parents[1] / "skills"
+    intake = make_intake_node(skills)
+    out = await intake(
+        {
+            "messages": [HumanMessage(content="快速生成这张主图")],
+            "focus_node_id": "image-abc",
+        }
+    )
+    assert out.get("flow_mode") == "single_node"
+    assert out.get("focus_node_id") == "image-abc"
+
+
+@pytest.mark.asyncio
+async def test_prepare_single_gen_builds_manifest():
+    """prepare_single_gen resolves focus node → manifest without plan/split."""
+
+    class FakeNest:
+        async def get_node(self, node_id: str) -> dict:
+            return {
+                "id": node_id,
+                "type": "image",
+                "title": "主图",
+                "data": {"prompt": "test prompt"},
+            }
+
+    from app.graph.subgraphs.single_node_gate import make_prepare_single_gen_node
+
+    node_fn = make_prepare_single_gen_node(nest=FakeNest())
+    out = await node_fn({"focus_node_id": "image-abc"})
+    assert out.get("phase") == "orchestrate_gen"
+    assert out.get("flow_mode") == "single_node"
+    assert out.get("user_decision") == "confirm_gen"
+    manifest = out.get("split_manifest") or []
+    assert len(manifest) == 1
+    assert manifest[0]["node_id"] == "image-abc"
+    assert manifest[0]["target_type"] == "image"
+    assert "单节点快速生成" in out["messages"][0].content


### PR DESCRIPTION
## Summary
- **W28**: `single_node_gen_intent()` + intake routes to `flow_mode=single_node` when `focus_node_id` is set
- **W29**: New `single_node_gate` subgraph (`prepare_single_gen` → `start_gen`) skips plan/split/topo confirm gates
- **W30**: End-to-end API wiring — `focusNodeId` from web → Nest → agent-runtime; production verify script

## Test plan
- [x] `pytest tests/test_single_node_intent.py tests/test_single_node_subgraph.py` — 6 passed
- [x] `pytest tests/test_intake_gate.py tests/test_subgraph_gates.py` — 13 passed
- [x] `pnpm build`
- [ ] CI green
- [ ] Post-deploy: `python3 deploy/prod-single-node-gen-verify.py`


Made with [Cursor](https://cursor.com)