### PR TITLE
fix(agent): Phase B topo stage + canvas gen path

### DIFF
--- a/apps/server/src/agent/agent-canvas-tools.controller.ts
+++ b/apps/server/src/agent/agent-canvas-tools.controller.ts
@@ -107,6 +107,10 @@ class RemoveNodesDto {
   @IsArray()
   @IsString({ each: true })
   nodeIds!: string[]
+
+  @IsOptional()
+  @IsBoolean()
+  stage?: boolean
 }
 
 // W32: Remove edges DTO
@@ -117,6 +121,10 @@ class RemoveEdgesDto {
   @IsArray()
   @IsString({ each: true })
   edgeIds!: string[]
+
+  @IsOptional()
+  @IsBoolean()
+  stage?: boolean
 }
 
 class SetNodePromptDto {

--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -355,6 +355,7 @@ export class AgentCanvasToolsService {
   async removeNodes(input: {
     sessionId: string
     nodeIds: string[]
+    stage?: boolean
   }): Promise<{ actions: CanvasAction[] }> {
     const { canvas } = await this.loadSession(input.sessionId)
     const actions: CanvasAction[] = []
@@ -376,7 +377,7 @@ export class AgentCanvasToolsService {
       })
     }
 
-    await this.persist(input.sessionId, actions)
+    await this.applyOrStage(input.sessionId, actions, input.stage)
     return { actions }
   }
 
@@ -386,6 +387,7 @@ export class AgentCanvasToolsService {
   async removeEdges(input: {
     sessionId: string
     edgeIds: string[]
+    stage?: boolean
   }): Promise<{ actions: CanvasAction[] }> {
     const { canvas } = await this.loadSession(input.sessionId)
     const actions: CanvasAction[] = []
@@ -401,7 +403,7 @@ export class AgentCanvasToolsService {
       })
     }
 
-    await this.persist(input.sessionId, actions)
+    await this.applyOrStage(input.sessionId, actions, input.stage)
     return { actions }
   }
 

--- a/packages/shared/src/agentContract.ts
+++ b/packages/shared/src/agentContract.ts
@@ -361,6 +361,7 @@ export type SaveAgentMessageResponse = z.infer<typeof SaveAgentMessageResponseSc
 export const RemoveNodesRequestSchema = z.object({
   sessionId: z.string(),
   nodeIds: z.array(z.string()),
+  stage: z.boolean().optional(),
 })
 
 export type RemoveNodesRequest = z.infer<typeof RemoveNodesRequestSchema>
@@ -378,6 +379,7 @@ export type RemoveNodesResponse = z.infer<typeof RemoveNodesResponseSchema>
 export const RemoveEdgesRequestSchema = z.object({
   sessionId: z.string(),
   edgeIds: z.array(z.string()),
+  stage: z.boolean().optional(),
 })
 
 export type RemoveEdgesRequest = z.infer<typeof RemoveEdgesRequestSchema>

--- a/services/agent-runtime/app/contract.py
+++ b/services/agent-runtime/app/contract.py
@@ -392,6 +392,7 @@ class RemoveNodesRequest(BaseModel):
 
     sessionId: str
     nodeIds: list[str]
+    stage: Optional[bool] = None
 
 
 class RemoveNodesResponse(BaseModel):
@@ -410,6 +411,7 @@ class RemoveEdgesRequest(BaseModel):
 
     sessionId: str
     edgeIds: list[str]
+    stage: Optional[bool] = None
 
 
 class RemoveEdgesResponse(BaseModel):

--- a/services/agent-runtime/app/graph/nodes/topo_revise.py
+++ b/services/agent-runtime/app/graph/nodes/topo_revise.py
@@ -182,7 +182,7 @@ async def _apply_add(
         "targetType": "image",
         "prompt": title,
     }
-    batch = await add_fn([batch_item])
+    batch = await add_fn([batch_item], stage=True)
     node_id = ""
     for n in batch.get("nodes") or []:
         if str(n.get("key") or "") == key:
@@ -193,7 +193,7 @@ async def _apply_add(
 
     plan_node_id = str(state.get("plan_node_id") or "").strip()
     if connect_fn is not None and plan_node_id:
-        await connect_fn([{"source": plan_node_id, "target": node_id}])
+        await connect_fn([{"source": plan_node_id, "target": node_id}], stage=True)
 
     new_item = {
         "key": key,
@@ -220,7 +220,7 @@ async def _apply_update(
     if not node_id or set_fn is None:
         return manifest, f"「{target}」尚未绑定画布 node_id，无法更新。"
 
-    await set_fn(node_id, new_value, title=new_value)
+    await set_fn(node_id, new_value, title=new_value, stage=True)
     updated = [dict(it) for it in manifest]
     for it in updated:
         if str(it.get("key")) == str(item.get("key")):
@@ -272,7 +272,7 @@ def make_topo_revise_node(*, nest: Any) -> Callable:
                 remove_fn = getattr(nest, "remove_nodes", None)
                 node_ids = _removed_node_ids(manifest, new_manifest)
                 if node_ids and remove_fn is not None:
-                    await remove_fn(node_ids)
+                    await remove_fn(node_ids, stage=True)
         elif op == "add":
             new_manifest, note = await _apply_add(nest, state, manifest, _parse_add_title(text))
         elif op == "update":

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -233,6 +233,20 @@ class NestEventProxy:
             await self._inner.connect_nodes(edges, **kwargs)
         )
 
+    async def remove_nodes(
+        self, node_ids: list[str], **kwargs: Any
+    ) -> dict[str, Any]:
+        return await self._forward_actions(
+            await self._inner.remove_nodes(node_ids, **kwargs)
+        )
+
+    async def remove_edges(
+        self, edge_ids: list[str], **kwargs: Any
+    ) -> dict[str, Any]:
+        return await self._forward_actions(
+            await self._inner.remove_edges(edge_ids, **kwargs)
+        )
+
     async def set_node_prompt(self, node_id: str, prompt: str, **kwargs: Any) -> dict[str, Any]:
         return await self._forward_actions(
             await self._inner.set_node_prompt(node_id, prompt, **kwargs)

--- a/services/agent-runtime/app/tools/nest_client.py
+++ b/services/agent-runtime/app/tools/nest_client.py
@@ -190,19 +190,25 @@ class NestCanvasClient:
             body["stage"] = True
         return await self._post("/agent/internal/connect-nodes", body)
 
-    async def remove_nodes(self, node_ids: list[str]) -> dict[str, Any]:
+    async def remove_nodes(self, node_ids: list[str], *, stage: bool = False) -> dict[str, Any]:
         """W31: Remove nodes and their associated edges."""
-        return await self._post(
-            "/agent/internal/remove-nodes",
-            {"sessionId": self._session_id, "nodeIds": node_ids},
-        )
+        body: dict[str, Any] = {
+            "sessionId": self._session_id,
+            "nodeIds": node_ids,
+        }
+        if stage:
+            body["stage"] = True
+        return await self._post("/agent/internal/remove-nodes", body)
 
-    async def remove_edges(self, edge_ids: list[str]) -> dict[str, Any]:
+    async def remove_edges(self, edge_ids: list[str], *, stage: bool = False) -> dict[str, Any]:
         """W32: Remove edges from canvas."""
-        return await self._post(
-            "/agent/internal/remove-edges",
-            {"sessionId": self._session_id, "edgeIds": edge_ids},
-        )
+        body: dict[str, Any] = {
+            "sessionId": self._session_id,
+            "edgeIds": edge_ids,
+        }
+        if stage:
+            body["stage"] = True
+        return await self._post("/agent/internal/remove-edges", body)
 
     async def set_node_prompt(
         self, node_id: str, prompt: str, *, title: str | None = None, stage: bool = False

--- a/services/agent-runtime/tests/test_await_topo.py
+++ b/services/agent-runtime/tests/test_await_topo.py
@@ -51,8 +51,8 @@ class FakeNest:
     async def emit_text(self, text: str) -> None:
         self.calls.append(("emit_text", text))
 
-    async def remove_nodes(self, node_ids: list[str]) -> dict[str, Any]:
-        self.calls.append(("remove_nodes", node_ids))
+    async def remove_nodes(self, node_ids: list[str], **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("remove_nodes", node_ids, kwargs))
         return {"actions": []}
 
     async def get_node(self, node_id: str) -> dict[str, Any]:
@@ -64,11 +64,11 @@ class FakeNest:
         return {"nodeId": node_id, "actions": []}
 
     async def add_nodes_batch(self, items: list[dict[str, Any]], **kwargs: Any) -> dict[str, Any]:
-        self.calls.append(("add_nodes_batch", items))
+        self.calls.append(("add_nodes_batch", items, kwargs))
         return {"nodes": [{"key": it["key"], "nodeId": f"new-{it['key']}"} for it in items]}
 
     async def connect_nodes(self, edges: list[dict[str, str]], **kwargs: Any) -> dict[str, Any]:
-        self.calls.append(("connect_nodes", edges))
+        self.calls.append(("connect_nodes", edges, kwargs))
         return {"actions": []}
 
 
@@ -161,7 +161,7 @@ async def test_topo_revise_calls_remove_nodes_when_canvas_ids_present():
         }
     )
     assert "banner" not in {str(i["key"]) for i in out["split_manifest"]}
-    assert ("remove_nodes", ["img-banner"]) in nest.calls
+    assert ("remove_nodes", ["img-banner"], {"stage": True}) in nest.calls
 
 
 @pytest.mark.asyncio
@@ -180,6 +180,8 @@ async def test_topo_revise_add_node_on_canvas():
     keys = {str(i["key"]) for i in out["split_manifest"]}
     assert len(keys) == 2
     assert any(c[0] == "add_nodes_batch" for c in nest.calls)
+    batch_call = next(c for c in nest.calls if c[0] == "add_nodes_batch")
+    assert batch_call[2].get("stage") is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- **Root cause**: `topo_revise` called `addNodesBatch`/`removeNodes`/`setNodePrompt` with direct `persist` while split skeleton was still staged → `ConflictException` → SSE error; subsequent「确认出图」mis-routed to `topo_revise` as unknown op → no gen / no canvas recordId
- **Fix**: pass `stage=True` for all topo mutations at `await_topo`; add `stage` support to `removeNodes`/`removeEdges`; forward `remove_nodes` on streaming nest wrapper

## Test plan
- [x] `pytest tests/test_await_topo.py` — 28 passed
- [x] `pnpm build`
- [ ] CI green
- [ ] Post-deploy: `prod-phase-b-user-verify.py`, `prod-phase-c-user-verify.py`, `prod-v5-gen-crash-recovery-verify.py`


Made with [Cursor](https://cursor.com)