### PR TITLE
docs(agent): P4-01 atomic create ADR, taxonomy, and eval set

### DIFF
--- a/docs/adr/p4-atomic-create-adr.md
+++ b/docs/adr/p4-atomic-create-adr.md
@@ -1,0 +1,128 @@
+# ADR-003: P4 Atomic Studio Intent — Subgraph vs ReAct, Modality Defaults, Confirm Gate
+
+| 字段 | 值 |
+|------|-----|
+| 状态 | Accepted |
+| 日期 | 2026-08-03 |
+| 决策人 | Graph Engineering（P4-01） |
+| 关联 | [atomic-studio-intent-product-spec.md](../../.trae/documents/atomic-studio-intent-product-spec.md)、ADR-002（W6 flat gate） |
+
+---
+
+## 背景
+
+用户期望 Agent 从自然语言驱动「新建画布节点 → 填入 prompt/content → Studio 生产 → 结果反馈」，覆盖 image/text/video/audio/prompt 五模态。现有能力：
+
+- **Campaign**：多 HITL 门，不适合单句原子创作
+- **P3 single_node**：依赖已有节点 + `focusNodeId`，不新建节点
+- **chat**：无副作用
+- **Harness**：Agent internal 仅 image/video；text/audio/prompt 仅在 Studio/Web
+
+需在 P4 启动前锁定架构与产品默认值（D1/D2）。
+
+---
+
+## 决策
+
+### 1. 控制流：独立 `atomic_create_gate` 子图（flat register，对齐 ADR-002）
+
+**采用方案 A**：`intake` 路由 `flow_mode=atomic_create` → `register_atomic_create_gate` → `done`。
+
+**不采用** chat ReAct tool loop 或每模态独立 Skill 包。
+
+### 2. 模态默认值 D1 — 「分镜提示词」→ `text` 节点
+
+| 用户表述 | `target_type` | 节点写入字段 |
+|----------|---------------|--------------|
+| 分镜提示词、分镜脚本、脚本、广告词、文案 | **`text`** | `data.content` |
+| 显式「prompt 扩写 / 提示词模式 / 多模式扩写」 | `prompt` | `data.prompt` + Studio prompt 模式 |
+
+「提示词」三字** alone** 不触发 `prompt` 节点（避免与分镜文案混淆）。
+
+### 3. 高成本确认 D2 — video / audio 生成前 HITL
+
+| 模态 | HITL |
+|------|------|
+| image, text, prompt | 无（单轮直达） |
+| **video, audio** | **`await_atomic_confirm`**（`interrupt_before`） |
+
+流程：`parse → create_canvas_node(draft) → await_atomic_confirm → run_atomic_generation`。
+
+未确认 **不得** 调用 Studio（验收 A8）。
+
+### 4. Intake 路由优先级
+
+```
+1. marketing_intent 且非纯原子句     → campaign (decide_plan_mode)
+2. focus_node_id + single_node_gen   → single_node (P3)
+3. atomic_create_intent              → atomic_create
+4. else                              → chat
+```
+
+### 5. Harness 扩展（P4-02 执行，本 ADR 锁定契约）
+
+新增 Nest internal：`run-text-generation`、`run-prompt-generation`、`run-audio-generation`；对齐 `run-image-generation` 返回 `{ status, url?, generationRecordId?, actions[] }`。
+
+### 6. Stage 策略（继承 #114）
+
+`await_topo` 期间若存在 pending stage，atomic 画布 mutation 使用 `stage=True`；独立会话默认 persist。
+
+---
+
+## 理由
+
+| 方案 | 优点 | 缺点 | 结论 |
+|------|------|------|------|
+| **A atomic_create_gate** | 可 checkpoint、可测、与 P3 对称 | 需扩 Harness | **采用** |
+| B ReAct in chat | 灵活 | 无统一 HITL/恢复，双栈 | 否 |
+| C 每模态 Skill | 隔离 | 5× boilerplate | 否 |
+
+D1/D2 来自产品确认：分镜产出是**可读正文**而非 prompt 模板；video/audio 积分高需确认。
+
+---
+
+## 实现约定
+
+1. **模块**：`app/graph/subgraphs/atomic_create_gate.py` + `app/graph/nodes/atomic_*.py`
+2. **State 字段**：`atomic_spec`, `atomic_node_id`, `atomic_record_id`, `phase=await_atomic_confirm`
+3. **评测集**：`skills/atomic-create/eval-intent-set.yaml`（30 句，CI 校验 schema）
+4. **Taxonomy**：`skills/atomic-create/intent-taxonomy.yaml`（路由与模态枚举）
+5. **Flat 主图**：atomic gate 与 P3 `single_node_gate` 相同，仅 `register_*`，不 nested compile
+
+---
+
+## 后果
+
+### 正面
+
+- 用户侧栏单句即可建节点并生产
+- video/audio 成本可控
+- 与 Campaign/P3 路径正交，回归面清晰
+
+### 负面 / 风险
+
+- intake 路由复杂度上升 → 30 句评测集 + A7 误判率门槛
+- text/audio Harness 需与 Studio 扣费/record 对齐
+- `await_atomic_confirm` 为第四类 interrupt，Web 恢复 UI 需识别 `phase`
+
+---
+
+## 验收挂钩
+
+| ADR 条目 | 规格验收 |
+|----------|----------|
+| D1 text 默认 | A7 评测集分镜句 gold=text |
+| D2 confirm | A2b, A8 |
+| 方案 A 子图 | A1, A2 |
+
+---
+
+## 后续 PR
+
+| PR | 内容 |
+|----|------|
+| **P4-01** | 本 ADR + taxonomy + eval set（当前） |
+| P4-02 | Harness text/audio/prompt |
+| P4-03 | Graph atomic_create_gate + await_atomic_confirm |
+| P4-04 | Prompt parse few-shot |
+| P4-07 | prod-atomic-studio-verify.py |

--- a/services/agent-runtime/skills/atomic-create/eval-intent-set.yaml
+++ b/services/agent-runtime/skills/atomic-create/eval-intent-set.yaml
@@ -1,0 +1,169 @@
+# P4-01: 30-utterance gold set for atomic studio intent routing
+# Run: pytest tests/test_atomic_create_intent_eval.py
+version: 1
+meta:
+  spec: atomic-studio-intent-product-spec v1.1
+  adr: docs/adr/p4-atomic-create-adr.md
+  decisions:
+    D1: storyboard phrases → text node
+    D2: video/audio → confirm_gate true
+
+cases:
+  # --- image (6) ---
+  - id: img-01
+    utterance: 帮我生成一个模特人物图
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  - id: img-02
+    utterance: 生成一张白底产品图，蓝牙耳机
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  - id: img-03
+    utterance: 来一张运动风海报
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  - id: img-04
+    utterance: 帮我做一张场景图，客厅摆放耳机
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  - id: img-05
+    utterance: 生成一个 Banner 图
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  - id: img-06
+    utterance: 做一个品牌视觉图，极简风
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  # --- text / D1 分镜 (7) ---
+  - id: txt-01
+    utterance: 帮我生成一个蓝牙耳机的分镜提示词
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: text, confirm_gate: false }
+    notes: D1 分镜 → text 非 prompt
+
+  - id: txt-02
+    utterance: 写一段天猫详情页开场文案
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: text, confirm_gate: false }
+
+  - id: txt-03
+    utterance: 生成一个产品卖点脚本
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: text, confirm_gate: false }
+
+  - id: txt-04
+    utterance: 来一段30秒短视频口播稿
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: text, confirm_gate: false }
+
+  - id: txt-05
+    utterance: 帮我写广告词，强调降噪
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: text, confirm_gate: false }
+
+  - id: txt-06
+    utterance: 生成蓝牙耳机的分镜脚本，5个镜头
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: text, confirm_gate: false }
+
+  - id: txt-07
+    utterance: 写一段品牌故事文案
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: text, confirm_gate: false }
+
+  # --- prompt 显式 (3) ---
+  - id: prm-01
+    utterance: 帮我对「蓝牙耳机」做 prompt 扩写，出图用
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: prompt, confirm_gate: false }
+
+  - id: prm-02
+    utterance: 用提示词模式扩写：赛博朋克耳机主图
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: prompt, confirm_gate: false }
+
+  - id: prm-03
+    utterance: 多模式扩写这个主图 prompt
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: prompt, confirm_gate: false }
+
+  # --- audio + D2 confirm (5) ---
+  - id: aud-01
+    utterance: 给这段文案配一段旁白
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: audio, confirm_gate: true }
+
+  - id: aud-02
+    utterance: 生成一段女声配音，30字以内
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: audio, confirm_gate: true }
+
+  - id: aud-03
+    utterance: 帮我做一个产品介绍的音频
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: audio, confirm_gate: true }
+
+  - id: aud-04
+    utterance: 来一段英文旁白，运动风
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: audio, confirm_gate: true }
+
+  - id: aud-05
+    utterance: 配一段促销口播音频
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: audio, confirm_gate: true }
+
+  # --- video + D2 confirm (5) ---
+  - id: vid-01
+    utterance: 做一个15秒产品展示视频
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: video, confirm_gate: true }
+
+  - id: vid-02
+    utterance: 帮我生成一个蓝牙耳机旋转展示视频
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: video, confirm_gate: true }
+
+  - id: vid-03
+    utterance: 生成一段场景氛围视频
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: video, confirm_gate: true }
+
+  - id: vid-04
+    utterance: 来一段15s 竖屏商品视频
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: video, confirm_gate: true }
+
+  - id: vid-05
+    utterance: 做一个开箱短视频
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: video, confirm_gate: true }
+
+  # --- negative: campaign (2) ---
+  - id: neg-camp-01
+    utterance: 帮我做一套天猫蓝牙耳机详情页营销方案
+    focus_node_id: null
+    gold: { route: campaign, target_type: null, confirm_gate: false }
+
+  - id: neg-camp-02
+    utterance: 天猫详情页，拆14个画布节点，品牌lnkpi
+    focus_node_id: null
+    gold: { route: campaign, target_type: null, confirm_gate: false }
+
+  # --- negative: chat (1) ---
+  - id: neg-chat-01
+    utterance: 你好，今天天气怎么样
+    focus_node_id: null
+    gold: { route: chat, target_type: null, confirm_gate: false }
+
+  # --- negative: single_node P3 (1) ---
+  - id: neg-p3-01
+    utterance: 快速生成这张主图
+    focus_node_id: image-hero-001
+    gold: { route: single_node, target_type: image, confirm_gate: false }

--- a/services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml
+++ b/services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml
@@ -1,0 +1,95 @@
+# P4 Atomic Studio Intent — routing & modality taxonomy
+# Consumed by parse_atomic_intent + intake routing (P4-03+)
+version: 1
+
+routes:
+  atomic_create:
+    description: 新建画布节点并提交 Studio 生产（单句原子闭环）
+    flow_mode: atomic_create
+  single_node:
+    description: 已有节点快速再生（P3，需 focus_node_id）
+    flow_mode: single_node
+  campaign:
+    description: 营销方案全链路
+    flow_mode: campaign
+  chat:
+    description: 无副作用闲聊
+    flow_mode: campaign  # phase=done via chat node
+
+target_types:
+  image:
+    node_type: image
+    studio_tool: run_image_generation
+    confirm_gate: false
+    write_field: prompt
+  text:
+    node_type: text
+    studio_tool: run_text_generation
+    confirm_gate: false
+    write_field: content
+    notes: |
+      D1 默认：分镜提示词、脚本、广告词、文案 → text（非 prompt 节点）
+  prompt:
+    node_type: prompt
+    studio_tool: run_prompt_generation
+    confirm_gate: false
+    write_field: prompt
+    trigger_phrases:
+      - prompt扩写
+      - 提示词模式
+      - 多模式扩写
+      - 扩写prompt
+  audio:
+    node_type: audio
+    studio_tool: run_audio_generation
+    confirm_gate: true
+    write_field: content
+  video:
+    node_type: video
+    studio_tool: run_video_generation
+    confirm_gate: true
+    write_field: prompt
+
+intake_priority:
+  - id: campaign_override
+    when: marketing_intent and not atomic_create_intent
+    route: campaign
+  - id: single_node
+    when: focus_node_id and single_node_gen_intent and not modify_intent
+    route: single_node
+  - id: atomic_create
+    when: atomic_create_intent and not marketing_intent
+    route: atomic_create
+  - id: fallback
+    when: default
+    route: chat
+
+atomic_create_hints:
+  - 帮我生成
+  - 帮我做一张
+  - 生成一个
+  - 生成一张
+  - 做一个
+  - 来一张
+  - 来一段
+  - 写一段
+  - 配一段
+
+text_default_keywords:
+  - 分镜提示词
+  - 分镜脚本
+  - 脚本
+  - 广告词
+  - 文案
+  - 分镜
+
+prompt_explicit_keywords:
+  - prompt扩写
+  - 提示词模式
+  - 多模式扩写
+  - 扩写prompt
+
+atomic_confirm_keywords:
+  - 确认生成
+  - 开始生成
+  - 确认

--- a/services/agent-runtime/tests/test_atomic_create_intent_eval.py
+++ b/services/agent-runtime/tests/test_atomic_create_intent_eval.py
@@ -1,0 +1,76 @@
+"""P4-01: eval-intent-set.yaml schema validation + gold coverage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+EVAL_PATH = Path(__file__).resolve().parents[1] / "skills" / "atomic-create" / "eval-intent-set.yaml"
+TAXONOMY_PATH = Path(__file__).resolve().parents[1] / "skills" / "atomic-create" / "intent-taxonomy.yaml"
+
+VALID_ROUTES = frozenset({"atomic_create", "single_node", "campaign", "chat"})
+VALID_TARGET_TYPES = frozenset({"image", "text", "video", "audio", "prompt"})
+
+
+@pytest.fixture(scope="module")
+def eval_doc() -> dict:
+    return yaml.safe_load(EVAL_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def taxonomy_doc() -> dict:
+    return yaml.safe_load(TAXONOMY_PATH.read_text(encoding="utf-8"))
+
+
+def test_eval_set_has_30_cases(eval_doc: dict):
+    cases = eval_doc.get("cases") or []
+    assert len(cases) == 30
+    ids = [c["id"] for c in cases]
+    assert len(ids) == len(set(ids)), "duplicate case ids"
+
+
+def test_eval_gold_schema(eval_doc: dict):
+    for case in eval_doc["cases"]:
+        assert "utterance" in case and case["utterance"].strip()
+        gold = case["gold"]
+        assert gold["route"] in VALID_ROUTES
+        if gold["route"] == "atomic_create":
+            assert gold["target_type"] in VALID_TARGET_TYPES
+            tt = gold["target_type"]
+            expect_confirm = tt in ("video", "audio")
+            assert gold["confirm_gate"] is expect_confirm, f"{case['id']} confirm_gate mismatch"
+        else:
+            assert gold.get("target_type") is None or gold["route"] == "single_node"
+
+
+def test_d1_storyboard_cases_are_text(eval_doc: dict):
+    storyboard_ids = {"txt-01", "txt-06"}
+    for case in eval_doc["cases"]:
+        if case["id"] in storyboard_ids:
+            assert case["gold"]["target_type"] == "text", case["id"]
+
+
+def test_d2_video_audio_all_require_confirm(eval_doc: dict):
+    for case in eval_doc["cases"]:
+        tt = case["gold"].get("target_type")
+        if tt in ("video", "audio"):
+            assert case["gold"]["confirm_gate"] is True, case["id"]
+
+
+def test_taxonomy_confirm_flags_match_d2(taxonomy_doc: dict):
+    types = taxonomy_doc["target_types"]
+    assert types["video"]["confirm_gate"] is True
+    assert types["audio"]["confirm_gate"] is True
+    assert types["image"]["confirm_gate"] is False
+    assert types["text"]["confirm_gate"] is False
+
+
+def test_modality_coverage(eval_doc: dict):
+    atomic = [c for c in eval_doc["cases"] if c["gold"]["route"] == "atomic_create"]
+    by_type = {t: 0 for t in VALID_TARGET_TYPES}
+    for c in atomic:
+        by_type[c["gold"]["target_type"]] += 1
+    for t in VALID_TARGET_TYPES:
+        assert by_type[t] >= 1, f"missing atomic_create case for {t}"


### PR DESCRIPTION
## Summary
- 新增 ADR-003：锁定 Atomic Studio Intent 的 `flow_mode=atomic_create`、D1（分镜→text）、D2（video/audio 生成前确认门）
- 新增 `intent-taxonomy.yaml` 意图分类与 `eval-intent-set.yaml` 30 句 gold 集
- 新增 schema 校验测试，确保 eval 集与 taxonomy 一致

## Test plan
- [x] `python3 -m pytest services/agent-runtime/tests/test_atomic_create_intent_eval.py`
- [ ] CI green

## 后续
- P4-02: Harness text/audio/prompt internal API
- P4-03: Graph `atomic_create_gate` + `await_atomic_confirm`


Made with [Cursor](https://cursor.com)