### PR TITLE
feat(agent): P4-02/03 atomic harness APIs and atomic_create_gate

### DIFF
--- a/apps/server/src/agent/agent-canvas-tools.controller.ts
+++ b/apps/server/src/agent/agent-canvas-tools.controller.ts
@@ -418,6 +418,24 @@ export class AgentCanvasToolsController {
     return { code: 0, message: 'ok', data }
   }
 
+  @Post('run-text-generation')
+  async runTextGeneration(@Body() dto: RunImageGenerationDto) {
+    const data = await this.tools.runTextGeneration(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('run-prompt-generation')
+  async runPromptGeneration(@Body() dto: RunImageGenerationDto) {
+    const data = await this.tools.runPromptGeneration(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('run-audio-generation')
+  async runAudioGeneration(@Body() dto: RunImageGenerationDto) {
+    const data = await this.tools.runAudioGeneration(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
   @Post('get-generation-status')
   async getGenerationStatus(@Body() dto: SessionNodeDto) {
     const data = await this.tools.getGenerationStatus(dto)

--- a/apps/server/src/agent/agent-canvas-tools.service.test.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.test.ts
@@ -17,6 +17,9 @@ describe('AgentCanvasToolsService', () => {
   const prefsFindUnique = vi.fn()
   const generateImage = vi.fn()
   const generateVideo = vi.fn()
+  const generateText = vi.fn()
+  const generatePrompt = vi.fn()
+  const generateAudio = vi.fn()
   const getGeneration = vi.fn()
 
   const defaultPrefs = {
@@ -66,8 +69,23 @@ describe('AgentCanvasToolsService', () => {
       status: 'completed',
       url: 'https://cdn.example/img.png',
     })
+    generateText.mockResolvedValue({
+      id: 'gen-t1',
+      status: 'completed',
+      metadata: JSON.stringify({ text: '买它！限时优惠。' }),
+    })
+    generatePrompt.mockResolvedValue({
+      id: 'gen-p1',
+      status: 'completed',
+      metadata: JSON.stringify({ mode: 'image_prompt_multi_style', content: '扩写后的 prompt...' }),
+    })
+    generateAudio.mockResolvedValue({
+      id: 'gen-a1',
+      status: 'completed',
+      url: 'https://cdn.example/audio.mp3',
+    })
 
-    // Serialize concurrent $transaction callbacks. The real Postgres
+    // Serialize concurrent $transaction callbacks.
     // serializable / read-committed TX chain would queue concurrent
     // persist() calls so each one sees the post-commit state of the
     // previous. Without this queue, the mock would let N concurrent
@@ -98,7 +116,7 @@ describe('AgentCanvasToolsService', () => {
         },
         {
           provide: StudioService,
-          useValue: { generateImage, generateVideo, getGeneration },
+          useValue: { generateImage, generateVideo, generateText, generatePrompt, generateAudio, getGeneration },
         },
       ],
     }).compile()
@@ -362,6 +380,76 @@ describe('AgentCanvasToolsService', () => {
     expect(result.status).toBe('completed')
     expect(result.url).toBe('https://cdn.example/vid.mp4')
     expect(canvas.nodes[0].data.url).toBe('https://cdn.example/vid.mp4')
+  })
+
+  it('runTextGeneration calls Studio and writes content', async () => {
+    canvas = {
+      nodes: [
+        {
+          id: 'txt-1',
+          type: 'text',
+          position: { x: 0, y: 0 },
+          data: { prompt: '写一段天猫开场文案', status: 'draft' },
+        },
+      ],
+      edges: [],
+    }
+    const result = await svc.runTextGeneration({
+      sessionId: 's1',
+      userId: 'u1',
+      nodeId: 'txt-1',
+    })
+    expect(generateText).toHaveBeenCalled()
+    expect(result.status).toBe('completed')
+    expect(result.generationRecordId).toBe('gen-t1')
+    expect(canvas.nodes[0].data.content).toBe('买它！限时优惠。')
+    expect(canvas.nodes[0].data.status).toBe('completed')
+  })
+
+  it('runPromptGeneration writes content and promptMode', async () => {
+    canvas = {
+      nodes: [
+        {
+          id: 'prm-1',
+          type: 'prompt',
+          position: { x: 0, y: 0 },
+          data: { prompt: '蓝牙耳机白底图', status: 'draft' },
+        },
+      ],
+      edges: [],
+    }
+    const result = await svc.runPromptGeneration({
+      sessionId: 's1',
+      userId: 'u1',
+      nodeId: 'prm-1',
+    })
+    expect(generatePrompt).toHaveBeenCalled()
+    expect(result.status).toBe('completed')
+    expect(canvas.nodes[0].data.content).toBe('扩写后的 prompt...')
+    expect(canvas.nodes[0].data.promptMode).toBe('image_prompt_multi_style')
+  })
+
+  it('runAudioGeneration writes url and completed status', async () => {
+    canvas = {
+      nodes: [
+        {
+          id: 'aud-1',
+          type: 'audio',
+          position: { x: 0, y: 0 },
+          data: { prompt: '给这段文案配旁白', status: 'draft' },
+        },
+      ],
+      edges: [],
+    }
+    const result = await svc.runAudioGeneration({
+      sessionId: 's1',
+      userId: 'u1',
+      nodeId: 'aud-1',
+    })
+    expect(generateAudio).toHaveBeenCalled()
+    expect(result.status).toBe('completed')
+    expect(result.url).toBe('https://cdn.example/audio.mp3')
+    expect(canvas.nodes[0].data.url).toBe('https://cdn.example/audio.mp3')
   })
 
   it('runImageGeneration prefers node image fields over account defaults', async () => {

--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -129,6 +129,32 @@ function pickString(value: unknown, fallback: string): string {
   return typeof value === 'string' && value.trim() ? value : fallback
 }
 
+function parseRecordText(metadata: string | null | undefined, prompt: string): string {
+  if (!metadata) return prompt
+  try {
+    const meta = JSON.parse(metadata) as { text?: string }
+    return meta.text ?? prompt
+  } catch {
+    return prompt
+  }
+}
+
+function parseRecordPromptContent(
+  metadata: string | null | undefined,
+  prompt: string,
+): { content: string; mode: string | null } {
+  if (!metadata) return { content: prompt, mode: null }
+  try {
+    const meta = JSON.parse(metadata) as { content?: string; mode?: string; text?: string }
+    return {
+      content: meta.content ?? meta.text ?? prompt,
+      mode: meta.mode ?? null,
+    }
+  } catch {
+    return { content: prompt, mode: null }
+  }
+}
+
 function modalityDefaults(nodeType: NodeType | string, prefs: AccountGenPrefs): Record<string, unknown> {
   switch (nodeType) {
     case 'image':
@@ -755,6 +781,241 @@ export class AgentCanvasToolsService {
       }
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : '视频生成失败'
+      const errorActions: CanvasAction[] = [
+        {
+          type: 'update_node',
+          payload: {
+            id: input.nodeId,
+            data: { status: 'error', errorMessage },
+          },
+        },
+      ]
+      await this.persist(input.sessionId, errorActions)
+      allActions.push(...errorActions)
+      return { status: 'error', actions: allActions }
+    }
+  }
+
+  async runTextGeneration(input: {
+    sessionId: string
+    userId: string
+    nodeId: string
+  }): Promise<{ status: string; generationRecordId?: string; actions: CanvasAction[] }> {
+    const { canvas } = await this.loadOwnedSession(input.sessionId, input.userId)
+    const node = canvas.nodes.find((n) => n.id === input.nodeId)
+    if (!node) throw new NotFoundException('节点不存在')
+
+    const prompt = String(node.data?.prompt ?? node.data?.content ?? '').trim()
+    if (!prompt) throw new NotFoundException('节点缺少 prompt')
+
+    const started: CanvasAction[] = [
+      {
+        type: 'update_node',
+        payload: {
+          id: input.nodeId,
+          data: {
+            status: 'generating',
+            generationStartedAt: new Date().toISOString(),
+            prompt,
+          },
+        },
+      },
+    ]
+    await this.persist(input.sessionId, started)
+    const allActions = [...started]
+
+    try {
+      const prefs = await this.loadAccountGenPrefs(input.userId)
+      const refs = toStudioRefs(node, canvas)
+      const model = pickString(node.data?.textModel, prefs.defaultTextModel) || undefined
+      const record = await this.studio.generateText(
+        input.userId,
+        prompt,
+        model,
+        refs,
+        undefined,
+        undefined,
+        node.data?.textThinking === true,
+        node.data?.textThinkingEffort === 'max' ? 'max' : 'high',
+        { sessionId: input.sessionId, nodeId: input.nodeId },
+      )
+      const recordId = record.id
+      const content = parseRecordText(record.metadata, prompt)
+      const finishActions: CanvasAction[] = [
+        {
+          type: 'update_node',
+          payload: {
+            id: input.nodeId,
+            data: {
+              status: 'completed',
+              content,
+              generationRecordId: recordId,
+              errorMessage: null,
+            },
+          },
+        },
+      ]
+      await this.persist(input.sessionId, finishActions)
+      allActions.push(...finishActions)
+      return { status: 'completed', generationRecordId: recordId, actions: allActions }
+    } catch (err) {
+      if (err instanceof ForbiddenException || err instanceof NotFoundException) throw err
+      const errorMessage = err instanceof Error ? err.message : '文本生成失败'
+      const errorActions: CanvasAction[] = [
+        {
+          type: 'update_node',
+          payload: {
+            id: input.nodeId,
+            data: { status: 'error', errorMessage },
+          },
+        },
+      ]
+      await this.persist(input.sessionId, errorActions)
+      allActions.push(...errorActions)
+      return { status: 'error', actions: allActions }
+    }
+  }
+
+  async runPromptGeneration(input: {
+    sessionId: string
+    userId: string
+    nodeId: string
+  }): Promise<{ status: string; generationRecordId?: string; actions: CanvasAction[] }> {
+    const { canvas } = await this.loadOwnedSession(input.sessionId, input.userId)
+    const node = canvas.nodes.find((n) => n.id === input.nodeId)
+    if (!node) throw new NotFoundException('节点不存在')
+
+    const prompt = String(node.data?.prompt ?? '').trim()
+    if (!prompt) throw new NotFoundException('节点缺少 prompt')
+
+    const started: CanvasAction[] = [
+      {
+        type: 'update_node',
+        payload: {
+          id: input.nodeId,
+          data: {
+            status: 'generating',
+            generationStartedAt: new Date().toISOString(),
+          },
+        },
+      },
+    ]
+    await this.persist(input.sessionId, started)
+    const allActions = [...started]
+
+    try {
+      const prefs = await this.loadAccountGenPrefs(input.userId)
+      const model = pickString(node.data?.textModel, prefs.defaultTextModel) || undefined
+      const record = await this.studio.generatePrompt(
+        input.userId,
+        prompt,
+        model,
+        undefined,
+        { sessionId: input.sessionId, nodeId: input.nodeId },
+      )
+      const recordId = record.id
+      const parsed = parseRecordPromptContent(record.metadata, prompt)
+      const finishData: Record<string, unknown> = {
+        status: 'completed',
+        content: parsed.content,
+        generationRecordId: recordId,
+        errorMessage: null,
+      }
+      if (parsed.mode) finishData.promptMode = parsed.mode
+      const finishActions: CanvasAction[] = [
+        { type: 'update_node', payload: { id: input.nodeId, data: finishData } },
+      ]
+      await this.persist(input.sessionId, finishActions)
+      allActions.push(...finishActions)
+      return { status: 'completed', generationRecordId: recordId, actions: allActions }
+    } catch (err) {
+      if (err instanceof ForbiddenException || err instanceof NotFoundException) throw err
+      const errorMessage = err instanceof Error ? err.message : '提示词生成失败'
+      const errorActions: CanvasAction[] = [
+        {
+          type: 'update_node',
+          payload: {
+            id: input.nodeId,
+            data: { status: 'error', errorMessage },
+          },
+        },
+      ]
+      await this.persist(input.sessionId, errorActions)
+      allActions.push(...errorActions)
+      return { status: 'error', actions: allActions }
+    }
+  }
+
+  async runAudioGeneration(input: {
+    sessionId: string
+    userId: string
+    nodeId: string
+  }): Promise<{ url?: string; status: string; generationRecordId?: string; actions: CanvasAction[] }> {
+    const { canvas } = await this.loadOwnedSession(input.sessionId, input.userId)
+    const node = canvas.nodes.find((n) => n.id === input.nodeId)
+    if (!node) throw new NotFoundException('节点不存在')
+
+    const text = String(node.data?.prompt ?? node.data?.content ?? '').trim()
+    if (!text) throw new NotFoundException('节点缺少文本')
+
+    const started: CanvasAction[] = [
+      {
+        type: 'update_node',
+        payload: {
+          id: input.nodeId,
+          data: {
+            status: 'generating',
+            generationStartedAt: new Date().toISOString(),
+            prompt: text,
+          },
+        },
+      },
+    ]
+    await this.persist(input.sessionId, started)
+    const allActions = [...started]
+
+    try {
+      const prefs = await this.loadAccountGenPrefs(input.userId)
+      const refs = toStudioRefs(node, canvas)
+      const record = await this.studio.generateAudio(
+        input.userId,
+        text,
+        {
+          model: pickString(node.data?.audioModel, prefs.defaultAudioModel) || undefined,
+          voice: pickString(node.data?.audioVoice, prefs.audioVoice || 'female-shaonv'),
+          emotion: pickString(node.data?.audioEmotion, 'neutral'),
+          language: pickString(node.data?.audioLanguage, 'zh'),
+          speed: typeof node.data?.audioSpeed === 'number' ? node.data.audioSpeed : prefs.audioSpeed ?? 1,
+          volume: typeof node.data?.audioVolume === 'number' ? node.data.audioVolume : 1,
+          pitch: typeof node.data?.audioPitch === 'number' ? node.data.audioPitch : 0,
+        },
+        refs,
+        undefined,
+        undefined,
+        { sessionId: input.sessionId, nodeId: input.nodeId },
+      )
+      const recordId = record.id
+      const url = typeof record.url === 'string' && record.url ? record.url : undefined
+      const finishActions: CanvasAction[] = [
+        {
+          type: 'update_node',
+          payload: {
+            id: input.nodeId,
+            data: {
+              status: 'completed',
+              url,
+              generationRecordId: recordId,
+              errorMessage: null,
+            },
+          },
+        },
+      ]
+      await this.persist(input.sessionId, finishActions)
+      allActions.push(...finishActions)
+      return { url, status: 'completed', generationRecordId: recordId, actions: allActions }
+    } catch (err) {
+      if (err instanceof ForbiddenException || err instanceof NotFoundException) throw err
+      const errorMessage = err instanceof Error ? err.message : '音频生成失败'
       const errorActions: CanvasAction[] = [
         {
           type: 'update_node',

--- a/docs/adr/p4-atomic-create-adr.md
+++ b/docs/adr/p4-atomic-create-adr.md
@@ -1,0 +1,128 @@
+# ADR-003: P4 Atomic Studio Intent — Subgraph vs ReAct, Modality Defaults, Confirm Gate
+
+| 字段 | 值 |
+|------|-----|
+| 状态 | Accepted |
+| 日期 | 2026-08-03 |
+| 决策人 | Graph Engineering（P4-01） |
+| 关联 | [atomic-studio-intent-product-spec.md](../../.trae/documents/atomic-studio-intent-product-spec.md)、ADR-002（W6 flat gate） |
+
+---
+
+## 背景
+
+用户期望 Agent 从自然语言驱动「新建画布节点 → 填入 prompt/content → Studio 生产 → 结果反馈」，覆盖 image/text/video/audio/prompt 五模态。现有能力：
+
+- **Campaign**：多 HITL 门，不适合单句原子创作
+- **P3 single_node**：依赖已有节点 + `focusNodeId`，不新建节点
+- **chat**：无副作用
+- **Harness**：Agent internal 仅 image/video；text/audio/prompt 仅在 Studio/Web
+
+需在 P4 启动前锁定架构与产品默认值（D1/D2）。
+
+---
+
+## 决策
+
+### 1. 控制流：独立 `atomic_create_gate` 子图（flat register，对齐 ADR-002）
+
+**采用方案 A**：`intake` 路由 `flow_mode=atomic_create` → `register_atomic_create_gate` → `done`。
+
+**不采用** chat ReAct tool loop 或每模态独立 Skill 包。
+
+### 2. 模态默认值 D1 — 「分镜提示词」→ `text` 节点
+
+| 用户表述 | `target_type` | 节点写入字段 |
+|----------|---------------|--------------|
+| 分镜提示词、分镜脚本、脚本、广告词、文案 | **`text`** | `data.content` |
+| 显式「prompt 扩写 / 提示词模式 / 多模式扩写」 | `prompt` | `data.prompt` + Studio prompt 模式 |
+
+「提示词」三字** alone** 不触发 `prompt` 节点（避免与分镜文案混淆）。
+
+### 3. 高成本确认 D2 — video / audio 生成前 HITL
+
+| 模态 | HITL |
+|------|------|
+| image, text, prompt | 无（单轮直达） |
+| **video, audio** | **`await_atomic_confirm`**（`interrupt_before`） |
+
+流程：`parse → create_canvas_node(draft) → await_atomic_confirm → run_atomic_generation`。
+
+未确认 **不得** 调用 Studio（验收 A8）。
+
+### 4. Intake 路由优先级
+
+```
+1. marketing_intent 且非纯原子句     → campaign (decide_plan_mode)
+2. focus_node_id + single_node_gen   → single_node (P3)
+3. atomic_create_intent              → atomic_create
+4. else                              → chat
+```
+
+### 5. Harness 扩展（P4-02 执行，本 ADR 锁定契约）
+
+新增 Nest internal：`run-text-generation`、`run-prompt-generation`、`run-audio-generation`；对齐 `run-image-generation` 返回 `{ status, url?, generationRecordId?, actions[] }`。
+
+### 6. Stage 策略（继承 #114）
+
+`await_topo` 期间若存在 pending stage，atomic 画布 mutation 使用 `stage=True`；独立会话默认 persist。
+
+---
+
+## 理由
+
+| 方案 | 优点 | 缺点 | 结论 |
+|------|------|------|------|
+| **A atomic_create_gate** | 可 checkpoint、可测、与 P3 对称 | 需扩 Harness | **采用** |
+| B ReAct in chat | 灵活 | 无统一 HITL/恢复，双栈 | 否 |
+| C 每模态 Skill | 隔离 | 5× boilerplate | 否 |
+
+D1/D2 来自产品确认：分镜产出是**可读正文**而非 prompt 模板；video/audio 积分高需确认。
+
+---
+
+## 实现约定
+
+1. **模块**：`app/graph/subgraphs/atomic_create_gate.py` + `app/graph/nodes/atomic_*.py`
+2. **State 字段**：`atomic_spec`, `atomic_node_id`, `atomic_record_id`, `phase=await_atomic_confirm`
+3. **评测集**：`skills/atomic-create/eval-intent-set.yaml`（30 句，CI 校验 schema）
+4. **Taxonomy**：`skills/atomic-create/intent-taxonomy.yaml`（路由与模态枚举）
+5. **Flat 主图**：atomic gate 与 P3 `single_node_gate` 相同，仅 `register_*`，不 nested compile
+
+---
+
+## 后果
+
+### 正面
+
+- 用户侧栏单句即可建节点并生产
+- video/audio 成本可控
+- 与 Campaign/P3 路径正交，回归面清晰
+
+### 负面 / 风险
+
+- intake 路由复杂度上升 → 30 句评测集 + A7 误判率门槛
+- text/audio Harness 需与 Studio 扣费/record 对齐
+- `await_atomic_confirm` 为第四类 interrupt，Web 恢复 UI 需识别 `phase`
+
+---
+
+## 验收挂钩
+
+| ADR 条目 | 规格验收 |
+|----------|----------|
+| D1 text 默认 | A7 评测集分镜句 gold=text |
+| D2 confirm | A2b, A8 |
+| 方案 A 子图 | A1, A2 |
+
+---
+
+## 后续 PR
+
+| PR | 内容 |
+|----|------|
+| **P4-01** | 本 ADR + taxonomy + eval set（当前） |
+| P4-02 | Harness text/audio/prompt |
+| P4-03 | Graph atomic_create_gate + await_atomic_confirm |
+| P4-04 | Prompt parse few-shot |
+| P4-07 | prod-atomic-studio-verify.py |

--- a/services/agent-runtime/app/graph/atomic_intent.py
+++ b/services/agent-runtime/app/graph/atomic_intent.py
@@ -1,0 +1,185 @@
+"""P4: Atomic Studio Intent — routing and modality classification."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+from app.graph.intent import marketing_intent, modify_intent, single_node_gen_intent
+
+_TAXONOMY_PATH = (
+    Path(__file__).resolve().parents[2] / "skills" / "atomic-create" / "intent-taxonomy.yaml"
+)
+
+
+def _normalize(text: str) -> str:
+    return (text or "").replace(" ", "").lower()
+
+
+def _load_taxonomy() -> dict[str, Any]:
+    if not _TAXONOMY_PATH.is_file():
+        return {}
+    return yaml.safe_load(_TAXONOMY_PATH.read_text(encoding="utf-8")) or {}
+
+
+_TAXONOMY = _load_taxonomy()
+
+AtomicTargetType = Literal["image", "text", "video", "audio", "prompt"]
+
+ATOMIC_CREATE_HINTS = tuple(_TAXONOMY.get("atomic_create_hints") or (
+    "帮我生成",
+    "帮我做一张",
+    "生成一个",
+    "生成一张",
+    "做一个",
+    "来一张",
+    "来一段",
+    "写一段",
+    "配一段",
+))
+
+TEXT_DEFAULT_KEYWORDS = tuple(_TAXONOMY.get("text_default_keywords") or (
+    "分镜提示词",
+    "分镜脚本",
+    "脚本",
+    "广告词",
+    "文案",
+    "分镜",
+    "口播稿",
+))
+
+PROMPT_EXPLICIT_KEYWORDS = tuple(_TAXONOMY.get("prompt_explicit_keywords") or (
+    "prompt扩写",
+    "提示词模式",
+    "多模式扩写",
+    "扩写prompt",
+))
+
+VIDEO_KEYWORDS = ("视频", "短片", "短视频", "15s", "15秒", "30s", "30秒")
+AUDIO_KEYWORDS = ("配音", "旁白", "音频", "语音")
+IMAGE_KEYWORDS = ("图", "海报", "banner", "视觉", "主图")
+
+ATOMIC_CONFIRM_KEYWORDS = tuple(_TAXONOMY.get("atomic_confirm_keywords") or (
+    "确认生成",
+    "开始生成",
+    "确认",
+))
+
+ATOMIC_CANCEL_KEYWORDS = ("取消", "不要了", "算了", "放弃")
+
+# Full-campaign phrases — atomic keyword substrings (e.g. 「图」in「出图」) must not hijack.
+CAMPAIGN_OVERRIDE_PHRASES = (
+    "营销方案",
+    "拆画布",
+    "全链路",
+    "campaign",
+)
+
+
+def _is_campaign_override(text: str) -> bool:
+    return any(p in text for p in CAMPAIGN_OVERRIDE_PHRASES)
+
+
+def _has_prompt_explicit(text: str) -> bool:
+    n = _normalize(text)
+    if any(_normalize(k) in n for k in PROMPT_EXPLICIT_KEYWORDS):
+        return True
+    return "扩写" in text and ("prompt" in n or "提示词" in text)
+
+
+def atomic_create_intent(text: str) -> bool:
+    """True when user wants a single-shot create-and-generate flow."""
+    lowered = (text or "").strip().lower()
+    if not lowered:
+        return False
+    if _is_campaign_override(text):
+        return False
+    if _has_prompt_explicit(text):
+        return True
+    if any(h in lowered for h in ATOMIC_CREATE_HINTS):
+        return True
+    if any(h in text for h in TEXT_DEFAULT_KEYWORDS):
+        return True
+    if any(h in lowered for h in VIDEO_KEYWORDS):
+        return True
+    if any(h in text for h in AUDIO_KEYWORDS):
+        return True
+    if any(h in lowered for h in IMAGE_KEYWORDS):
+        return True
+    return False
+
+
+def resolve_intake_route(
+    text: str,
+    *,
+    focus_node_id: str | None,
+) -> Literal["campaign", "single_node", "atomic_create", "chat"]:
+    """Intake routing per ADR-003 priority."""
+    if (
+        focus_node_id
+        and single_node_gen_intent(text)
+        and not modify_intent(text)
+    ):
+        return "single_node"
+    if atomic_create_intent(text):
+        return "atomic_create"
+    if marketing_intent(text):
+        return "campaign"
+    return "chat"
+
+
+def parse_atomic_target_type(text: str) -> AtomicTargetType:
+    """Classify modality from user utterance (D1: storyboard → text)."""
+    t = (text or "").strip()
+    lowered = t.lower()
+    if _has_prompt_explicit(t):
+        return "prompt"
+    if any(k in t for k in AUDIO_KEYWORDS):
+        return "audio"
+    if any(k in t for k in TEXT_DEFAULT_KEYWORDS):
+        return "text"
+    if any(k in lowered for k in VIDEO_KEYWORDS):
+        return "video"
+    if any(k in lowered for k in IMAGE_KEYWORDS):
+        return "image"
+    return "image"
+
+
+def confirm_gate_for_type(target_type: AtomicTargetType) -> bool:
+    types = (_TAXONOMY.get("target_types") or {})
+    entry = types.get(target_type) or {}
+    if "confirm_gate" in entry:
+        return bool(entry["confirm_gate"])
+    return target_type in ("video", "audio")
+
+
+def build_atomic_spec(text: str) -> dict[str, Any]:
+    """Build atomic_spec from raw user utterance."""
+    utterance = (text or "").strip()
+    target_type = parse_atomic_target_type(utterance)
+    title = utterance[:24] + ("…" if len(utterance) > 24 else "")
+    return {
+        "target_type": target_type,
+        "prompt": utterance,
+        "title": title or target_type,
+        "confirm_gate": confirm_gate_for_type(target_type),
+    }
+
+
+AtomicConfirmDecision = Literal["none", "confirm", "cancel"]
+
+
+def classify_atomic_confirm(text: str) -> AtomicConfirmDecision:
+    """Classify user reply at await_atomic_confirm (D2)."""
+    lowered = (text or "").strip().lower()
+    if not lowered:
+        return "none"
+    if any(k in lowered for k in ATOMIC_CANCEL_KEYWORDS):
+        return "cancel"
+    if any(k in lowered for k in ATOMIC_CONFIRM_KEYWORDS):
+        return "confirm"
+    if lowered in ("ok", "okay", "yes", "1", "y"):
+        return "confirm"
+    return "none"

--- a/services/agent-runtime/app/graph/builder.py
+++ b/services/agent-runtime/app/graph/builder.py
@@ -13,6 +13,7 @@ from app.graph.nodes.done import make_done_node
 from app.graph.nodes.intake import make_intake_node
 from app.graph.nodes.split import make_split_node
 from app.graph.state import AgentRuntimeState
+from app.graph.subgraphs.atomic_create_gate import register_atomic_create_gate
 from app.graph.subgraphs.confirm_gate import register_confirm_gate
 from app.graph.subgraphs.copy_gate import register_copy_gate
 from app.graph.subgraphs.single_node_gate import register_single_node_gate
@@ -22,6 +23,8 @@ from app.graph.subgraphs.topo_gate import register_topo_gate
 def route_after_intake(state: AgentRuntimeState) -> str:
     if state.get("flow_mode") == "single_node":
         return "prepare_single_gen"
+    if state.get("flow_mode") == "atomic_create":
+        return "parse_atomic_intent"
     if state.get("skill_id"):
         return "decide_plan_mode"
     return "chat"
@@ -56,6 +59,7 @@ def build_agent_graph(
     register_copy_gate(graph, nest=nest, llm=llm)
     register_topo_gate(graph, nest=nest)
     register_single_node_gate(graph, nest=nest)
+    register_atomic_create_gate(graph, nest=nest)
 
     graph.add_edge(START, "intake")
     graph.add_conditional_edges(
@@ -63,6 +67,7 @@ def build_agent_graph(
         route_after_intake,
         {
             "prepare_single_gen": "prepare_single_gen",
+            "parse_atomic_intent": "parse_atomic_intent",
             "decide_plan_mode": "decide_plan_mode",
             "chat": "chat",
         },
@@ -83,5 +88,6 @@ def build_agent_graph(
             "await_confirm",
             "await_topo",
             "await_copy_confirm",
+            "await_atomic_confirm",
         ],
     )

--- a/services/agent-runtime/app/graph/nodes/atomic_create_node.py
+++ b/services/agent-runtime/app/graph/nodes/atomic_create_node.py
@@ -1,0 +1,51 @@
+"""P4: create draft canvas node for atomic create flow."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from langchain_core.messages import AIMessage
+
+
+def make_create_atomic_node(*, nest: Any) -> Callable:
+    async def create_atomic_node(state: dict) -> dict:
+        spec = state.get("atomic_spec") or {}
+        target_type = str(spec.get("target_type") or "image")
+        prompt = str(spec.get("prompt") or "").strip()
+        title = str(spec.get("title") or prompt[:24] or target_type)
+        key = f"atomic_{target_type}"
+
+        add_fn = getattr(nest, "add_nodes_batch", None)
+        if add_fn is None:
+            return {
+                "phase": "error",
+                "messages": [AIMessage(content="无法创建画布节点。")],
+            }
+        try:
+            batch = await add_fn(
+                [{"key": key, "title": title, "targetType": target_type, "prompt": prompt}],
+            )
+        except Exception as exc:  # noqa: BLE001
+            return {
+                "phase": "error",
+                "last_error": str(exc),
+                "messages": [AIMessage(content=f"创建节点失败：{exc}")],
+            }
+
+        nodes = batch.get("nodes") if isinstance(batch, dict) else None
+        node_id = None
+        if isinstance(nodes, list) and nodes:
+            node_id = str(nodes[0].get("nodeId") or "").strip() or None
+        if not node_id:
+            return {
+                "phase": "error",
+                "messages": [AIMessage(content="创建节点失败：未返回 nodeId。")],
+            }
+
+        return {
+            "phase": "atomic_create",
+            "atomic_node_id": node_id,
+            "messages": [AIMessage(content=f"已创建 {target_type} 节点，准备生产。")],
+        }
+
+    return create_atomic_node

--- a/services/agent-runtime/app/graph/nodes/atomic_parse.py
+++ b/services/agent-runtime/app/graph/nodes/atomic_parse.py
@@ -1,0 +1,42 @@
+"""P4: parse user utterance → atomic_spec."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from langchain_core.messages import AIMessage
+
+from app.graph.atomic_intent import build_atomic_spec
+
+
+def _latest_user_text(messages: list[Any]) -> str:
+    for msg in reversed(messages or []):
+        role = getattr(msg, "type", None) or (msg.get("role") if isinstance(msg, dict) else None)
+        content = getattr(msg, "content", None) or (msg.get("content") if isinstance(msg, dict) else "")
+        if role in ("human", "user") and content:
+            return str(content)
+    return ""
+
+
+def make_parse_atomic_intent_node() -> Callable:
+    async def parse_atomic_intent(state: dict) -> dict:
+        text = _latest_user_text(state.get("messages") or [])
+        if not text.strip():
+            return {
+                "phase": "error",
+                "last_error": "empty utterance",
+                "messages": [AIMessage(content="请描述要生成的内容（如图、文案、视频等）。")],
+            }
+        spec = build_atomic_spec(text)
+        target = spec["target_type"]
+        gate = "需确认" if spec["confirm_gate"] else "直达"
+        return {
+            "phase": "atomic_parse",
+            "flow_mode": "atomic_create",
+            "atomic_spec": spec,
+            "messages": [
+                AIMessage(content=f"原子创作：{target} 节点（{gate}）— {spec['title']}"),
+            ],
+        }
+
+    return parse_atomic_intent

--- a/services/agent-runtime/app/graph/nodes/await_atomic_confirm.py
+++ b/services/agent-runtime/app/graph/nodes/await_atomic_confirm.py
@@ -1,0 +1,49 @@
+"""P4: HITL gate before video/audio generation (D2)."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from langchain_core.messages import AIMessage
+
+from app.graph.atomic_intent import classify_atomic_confirm
+
+_NONE_TIP = "视频/音频生成将消耗积分。回复「确认生成」开始，或「取消」放弃。"
+_CANCEL_MSG = "已取消本次视频/音频生成。"
+
+
+def _latest_user_text(messages: list[Any]) -> str:
+    for msg in reversed(messages or []):
+        role = getattr(msg, "type", None) or (msg.get("role") if isinstance(msg, dict) else None)
+        content = getattr(msg, "content", None) or (msg.get("content") if isinstance(msg, dict) else "")
+        if role in ("human", "user") and content:
+            return str(content)
+    return ""
+
+
+def make_await_atomic_confirm_node() -> Callable:
+    async def await_atomic_confirm(state: dict) -> dict:
+        text = _latest_user_text(state.get("messages") or [])
+        decision = classify_atomic_confirm(text)
+        spec = state.get("atomic_spec") or {}
+        target = str(spec.get("target_type") or "video")
+
+        if decision == "none":
+            return {
+                "user_decision": "none",
+                "phase": "await_atomic_confirm",
+                "messages": [AIMessage(content=_NONE_TIP)],
+            }
+        if decision == "cancel":
+            return {
+                "user_decision": "revise",
+                "phase": "done",
+                "messages": [AIMessage(content=_CANCEL_MSG)],
+            }
+        return {
+            "user_decision": "confirm",
+            "phase": "await_atomic_confirm",
+            "messages": [AIMessage(content=f"已确认，开始 {target} 生成…")],
+        }
+
+    return await_atomic_confirm

--- a/services/agent-runtime/app/graph/nodes/intake.py
+++ b/services/agent-runtime/app/graph/nodes/intake.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable
 
+from app.graph.atomic_intent import resolve_intake_route
 from app.graph.intent import marketing_intent, modify_intent, single_node_gen_intent  # re-export for tests
 from app.graph.state import BRIEF_RESET_PREFIX
 from app.skills.loader import discover_skills
@@ -36,10 +37,12 @@ def make_intake_node(skills_dir: Path) -> Callable:
         existing_brief = state.get("user_brief")
         existing_plan = state.get("plan_draft")
         focus_node_id = str(state.get("focus_node_id") or "").strip() or None
-        is_single_node = bool(
-            focus_node_id and single_node_gen_intent(text) and not modify_intent(text)
+        route = resolve_intake_route(text, focus_node_id=focus_node_id)
+        is_single_node = route == "single_node"
+        is_atomic = route == "atomic_create"
+        is_modify = bool(
+            existing_brief and existing_plan and modify_intent(text) and not is_single_node and not is_atomic
         )
-        is_modify = bool(existing_brief and existing_plan and modify_intent(text) and not is_single_node)
 
         if is_single_node:
             mode = "create"
@@ -47,6 +50,11 @@ def make_intake_node(skills_dir: Path) -> Callable:
             flow_mode = "single_node"
             if not skill_id and "enterprise-marketing-campaign" in by_id:
                 skill_id = "enterprise-marketing-campaign"
+        elif is_atomic:
+            mode = "create"
+            proposed_brief = None
+            flow_mode = "atomic_create"
+            skill_id = None
         elif is_modify:
             mode = "modify"
             proposed_brief = None  # reducer keeps existing brief
@@ -61,6 +69,12 @@ def make_intake_node(skills_dir: Path) -> Callable:
             proposed_brief = None
             flow_mode = "campaign"
 
+        resolved_flow = (
+            flow_mode
+            if is_single_node or is_atomic
+            else "campaign"
+        )
+
         out: dict[str, Any] = {
             "phase": "intake",
             "skill_id": skill_id,
@@ -68,7 +82,7 @@ def make_intake_node(skills_dir: Path) -> Callable:
             "split_manifest": state.get("split_manifest") or [],
             "last_error": state.get("last_error"),
             "mode": mode,
-            "flow_mode": flow_mode if is_single_node else "campaign",
+            "flow_mode": resolved_flow,
         }
         if focus_node_id:
             out["focus_node_id"] = focus_node_id

--- a/services/agent-runtime/app/graph/nodes/run_atomic_gen.py
+++ b/services/agent-runtime/app/graph/nodes/run_atomic_gen.py
@@ -1,0 +1,84 @@
+"""P4: run Studio generation for one atomic-created node."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from langchain_core.messages import AIMessage
+
+
+def _is_success(result: Any) -> bool:
+    if not isinstance(result, dict):
+        return False
+    status = str(result.get("status") or "").lower()
+    if status in ("completed", "success"):
+        return True
+    url = result.get("url")
+    return isinstance(url, str) and bool(url.strip())
+
+
+def _result_record_id(result: Any) -> str | None:
+    if not isinstance(result, dict):
+        return None
+    rid = result.get("generationRecordId")
+    return str(rid) if rid else None
+
+
+def make_run_atomic_gen_node(*, nest: Any) -> Callable:
+    async def run_atomic_gen(state: dict) -> dict:
+        node_id = str(state.get("atomic_node_id") or "").strip()
+        spec = state.get("atomic_spec") or {}
+        target_type = str(spec.get("target_type") or "image")
+        title = str(spec.get("title") or target_type)
+
+        if not node_id:
+            return {
+                "phase": "error",
+                "last_error": "missing atomic_node_id",
+                "messages": [AIMessage(content="缺少画布节点，无法生产。")],
+            }
+
+        runners = {
+            "image": getattr(nest, "run_image_generation", None),
+            "video": getattr(nest, "run_video_generation", None),
+            "text": getattr(nest, "run_text_generation", None),
+            "prompt": getattr(nest, "run_prompt_generation", None),
+            "audio": getattr(nest, "run_audio_generation", None),
+        }
+        run = runners.get(target_type)
+        if run is None:
+            return {
+                "phase": "error",
+                "last_error": f"unsupported target_type: {target_type}",
+                "messages": [AIMessage(content=f"暂不支持 {target_type} 模态生产。")],
+            }
+
+        try:
+            result = await run(node_id)
+        except Exception as exc:  # noqa: BLE001
+            return {
+                "phase": "error",
+                "last_error": str(exc),
+                "messages": [AIMessage(content=f"生成失败：{exc}")],
+            }
+
+        record_id = _result_record_id(result)
+        if _is_success(result):
+            msg = f"「{title}」生成完成。"
+            if record_id:
+                msg += f"（record: {record_id}）"
+            return {
+                "phase": "done",
+                "atomic_record_id": record_id,
+                "messages": [AIMessage(content=msg)],
+            }
+
+        status = str(result.get("status") or "error") if isinstance(result, dict) else "error"
+        return {
+            "phase": "error",
+            "atomic_record_id": record_id,
+            "last_error": status,
+            "messages": [AIMessage(content=f"「{title}」生成未完成（{status}）。")],
+        }
+
+    return run_atomic_gen

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -86,6 +86,9 @@ class AgentRuntimeState(TypedDict, total=False):
         "write_copy_node",
         "await_topo",
         "orchestrate_gen",
+        "atomic_parse",
+        "atomic_create",
+        "await_atomic_confirm",
         "done",
         "error",
     ]
@@ -94,8 +97,11 @@ class AgentRuntimeState(TypedDict, total=False):
     session_id: str
     user_id: str
     prompt_version: str | None  # W19: active skill prompt template version
-    flow_mode: Literal["campaign", "single_node"] | None  # W28/W29
+    flow_mode: Literal["campaign", "single_node", "atomic_create"] | None  # W28/W29/P4
     focus_node_id: str | None  # W28: canvas node for single-node gen
+    atomic_spec: dict | None  # P4: parsed atomic create intent
+    atomic_node_id: str | None  # P4: created canvas node id
+    atomic_record_id: str | None  # P4: generation record id
 
     # 工作记忆（轻量；禁止存完整 canvas nodes/edges）
     plan_summary: str

--- a/services/agent-runtime/app/graph/subgraphs/atomic_create_gate.py
+++ b/services/agent-runtime/app/graph/subgraphs/atomic_create_gate.py
@@ -1,0 +1,63 @@
+"""P4: atomic_create_gate — parse → create node → confirm? → generate → done."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langgraph.graph import END, StateGraph
+
+from app.graph.nodes.atomic_create_node import make_create_atomic_node
+from app.graph.nodes.atomic_parse import make_parse_atomic_intent_node
+from app.graph.nodes.await_atomic_confirm import make_await_atomic_confirm_node
+from app.graph.nodes.run_atomic_gen import make_run_atomic_gen_node
+from app.graph.state import AgentRuntimeState
+
+
+def route_after_atomic_create(state: AgentRuntimeState) -> str:
+    if state.get("phase") == "error":
+        return "done"
+    spec = state.get("atomic_spec") or {}
+    if spec.get("confirm_gate"):
+        return "await_atomic_confirm"
+    return "run_atomic_gen"
+
+
+def route_after_atomic_confirm(state: AgentRuntimeState) -> str:
+    decision = state.get("user_decision") or "none"
+    if decision == "confirm":
+        return "run_atomic_gen"
+    if decision == "revise":
+        return "done"
+    return "end"
+
+
+def register_atomic_create_gate(graph: StateGraph, *, nest: Any) -> None:
+    graph.add_node("parse_atomic_intent", make_parse_atomic_intent_node())
+    graph.add_node("create_atomic_node", make_create_atomic_node(nest=nest))
+    graph.add_node("await_atomic_confirm", make_await_atomic_confirm_node())
+    graph.add_node("run_atomic_gen", make_run_atomic_gen_node(nest=nest))
+
+    graph.add_conditional_edges(
+        "parse_atomic_intent",
+        lambda s: "done" if s.get("phase") == "error" else "create_atomic_node",
+        {"create_atomic_node": "create_atomic_node", "done": "done"},
+    )
+    graph.add_conditional_edges(
+        "create_atomic_node",
+        route_after_atomic_create,
+        {
+            "await_atomic_confirm": "await_atomic_confirm",
+            "run_atomic_gen": "run_atomic_gen",
+            "done": "done",
+        },
+    )
+    graph.add_conditional_edges(
+        "await_atomic_confirm",
+        route_after_atomic_confirm,
+        {
+            "run_atomic_gen": "run_atomic_gen",
+            "done": "done",
+            "end": END,
+        },
+    )
+    graph.add_edge("run_atomic_gen", "done")

--- a/services/agent-runtime/app/tools/nest_client.py
+++ b/services/agent-runtime/app/tools/nest_client.py
@@ -29,6 +29,9 @@ _LONG_GEN_PATHS = frozenset({
     "/agent/internal/run-image-generation",
     "/agent/internal/wait-image-generation",
     "/agent/internal/run-video-generation",
+    "/agent/internal/run-text-generation",
+    "/agent/internal/run-prompt-generation",
+    "/agent/internal/run-audio-generation",
 })
 
 
@@ -276,6 +279,30 @@ class NestCanvasClient:
         timeout_sec = float(settings.image_gen_timeout_sec) + IMAGE_GEN_TIMEOUT_BUFFER_SEC
         return await self._post(
             "/agent/internal/run-video-generation",
+            {"sessionId": self._session_id, "userId": self._user_id, "nodeId": node_id},
+            timeout=timeout_sec,
+        )
+
+    async def run_text_generation(self, node_id: str) -> dict[str, Any]:
+        timeout_sec = float(settings.image_gen_timeout_sec) + IMAGE_GEN_TIMEOUT_BUFFER_SEC
+        return await self._post(
+            "/agent/internal/run-text-generation",
+            {"sessionId": self._session_id, "userId": self._user_id, "nodeId": node_id},
+            timeout=timeout_sec,
+        )
+
+    async def run_prompt_generation(self, node_id: str) -> dict[str, Any]:
+        timeout_sec = float(settings.image_gen_timeout_sec) + IMAGE_GEN_TIMEOUT_BUFFER_SEC
+        return await self._post(
+            "/agent/internal/run-prompt-generation",
+            {"sessionId": self._session_id, "userId": self._user_id, "nodeId": node_id},
+            timeout=timeout_sec,
+        )
+
+    async def run_audio_generation(self, node_id: str) -> dict[str, Any]:
+        timeout_sec = float(settings.image_gen_timeout_sec) + IMAGE_GEN_TIMEOUT_BUFFER_SEC
+        return await self._post(
+            "/agent/internal/run-audio-generation",
             {"sessionId": self._session_id, "userId": self._user_id, "nodeId": node_id},
             timeout=timeout_sec,
         )

--- a/services/agent-runtime/skills/atomic-create/eval-intent-set.yaml
+++ b/services/agent-runtime/skills/atomic-create/eval-intent-set.yaml
@@ -1,0 +1,169 @@
+# P4-01: 30-utterance gold set for atomic studio intent routing
+# Run: pytest tests/test_atomic_create_intent_eval.py
+version: 1
+meta:
+  spec: atomic-studio-intent-product-spec v1.1
+  adr: docs/adr/p4-atomic-create-adr.md
+  decisions:
+    D1: storyboard phrases → text node
+    D2: video/audio → confirm_gate true
+
+cases:
+  # --- image (6) ---
+  - id: img-01
+    utterance: 帮我生成一个模特人物图
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  - id: img-02
+    utterance: 生成一张白底产品图，蓝牙耳机
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  - id: img-03
+    utterance: 来一张运动风海报
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  - id: img-04
+    utterance: 帮我做一张场景图，客厅摆放耳机
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  - id: img-05
+    utterance: 生成一个 Banner 图
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  - id: img-06
+    utterance: 做一个品牌视觉图，极简风
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  # --- text / D1 分镜 (7) ---
+  - id: txt-01
+    utterance: 帮我生成一个蓝牙耳机的分镜提示词
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: text, confirm_gate: false }
+    notes: D1 分镜 → text 非 prompt
+
+  - id: txt-02
+    utterance: 写一段天猫详情页开场文案
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: text, confirm_gate: false }
+
+  - id: txt-03
+    utterance: 生成一个产品卖点脚本
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: text, confirm_gate: false }
+
+  - id: txt-04
+    utterance: 来一段30秒短视频口播稿
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: text, confirm_gate: false }
+
+  - id: txt-05
+    utterance: 帮我写广告词，强调降噪
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: text, confirm_gate: false }
+
+  - id: txt-06
+    utterance: 生成蓝牙耳机的分镜脚本，5个镜头
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: text, confirm_gate: false }
+
+  - id: txt-07
+    utterance: 写一段品牌故事文案
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: text, confirm_gate: false }
+
+  # --- prompt 显式 (3) ---
+  - id: prm-01
+    utterance: 帮我对「蓝牙耳机」做 prompt 扩写，出图用
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: prompt, confirm_gate: false }
+
+  - id: prm-02
+    utterance: 用提示词模式扩写：赛博朋克耳机主图
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: prompt, confirm_gate: false }
+
+  - id: prm-03
+    utterance: 多模式扩写这个主图 prompt
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: prompt, confirm_gate: false }
+
+  # --- audio + D2 confirm (5) ---
+  - id: aud-01
+    utterance: 给这段文案配一段旁白
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: audio, confirm_gate: true }
+
+  - id: aud-02
+    utterance: 生成一段女声配音，30字以内
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: audio, confirm_gate: true }
+
+  - id: aud-03
+    utterance: 帮我做一个产品介绍的音频
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: audio, confirm_gate: true }
+
+  - id: aud-04
+    utterance: 来一段英文旁白，运动风
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: audio, confirm_gate: true }
+
+  - id: aud-05
+    utterance: 配一段促销口播音频
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: audio, confirm_gate: true }
+
+  # --- video + D2 confirm (5) ---
+  - id: vid-01
+    utterance: 做一个15秒产品展示视频
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: video, confirm_gate: true }
+
+  - id: vid-02
+    utterance: 帮我生成一个蓝牙耳机旋转展示视频
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: video, confirm_gate: true }
+
+  - id: vid-03
+    utterance: 生成一段场景氛围视频
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: video, confirm_gate: true }
+
+  - id: vid-04
+    utterance: 来一段15s 竖屏商品视频
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: video, confirm_gate: true }
+
+  - id: vid-05
+    utterance: 做一个开箱短视频
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: video, confirm_gate: true }
+
+  # --- negative: campaign (2) ---
+  - id: neg-camp-01
+    utterance: 帮我做一套天猫蓝牙耳机详情页营销方案
+    focus_node_id: null
+    gold: { route: campaign, target_type: null, confirm_gate: false }
+
+  - id: neg-camp-02
+    utterance: 天猫详情页，拆14个画布节点，品牌lnkpi
+    focus_node_id: null
+    gold: { route: campaign, target_type: null, confirm_gate: false }
+
+  # --- negative: chat (1) ---
+  - id: neg-chat-01
+    utterance: 你好，今天天气怎么样
+    focus_node_id: null
+    gold: { route: chat, target_type: null, confirm_gate: false }
+
+  # --- negative: single_node P3 (1) ---
+  - id: neg-p3-01
+    utterance: 快速生成这张主图
+    focus_node_id: image-hero-001
+    gold: { route: single_node, target_type: image, confirm_gate: false }

--- a/services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml
+++ b/services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml
@@ -1,0 +1,95 @@
+# P4 Atomic Studio Intent — routing & modality taxonomy
+# Consumed by parse_atomic_intent + intake routing (P4-03+)
+version: 1
+
+routes:
+  atomic_create:
+    description: 新建画布节点并提交 Studio 生产（单句原子闭环）
+    flow_mode: atomic_create
+  single_node:
+    description: 已有节点快速再生（P3，需 focus_node_id）
+    flow_mode: single_node
+  campaign:
+    description: 营销方案全链路
+    flow_mode: campaign
+  chat:
+    description: 无副作用闲聊
+    flow_mode: campaign  # phase=done via chat node
+
+target_types:
+  image:
+    node_type: image
+    studio_tool: run_image_generation
+    confirm_gate: false
+    write_field: prompt
+  text:
+    node_type: text
+    studio_tool: run_text_generation
+    confirm_gate: false
+    write_field: content
+    notes: |
+      D1 默认：分镜提示词、脚本、广告词、文案 → text（非 prompt 节点）
+  prompt:
+    node_type: prompt
+    studio_tool: run_prompt_generation
+    confirm_gate: false
+    write_field: prompt
+    trigger_phrases:
+      - prompt扩写
+      - 提示词模式
+      - 多模式扩写
+      - 扩写prompt
+  audio:
+    node_type: audio
+    studio_tool: run_audio_generation
+    confirm_gate: true
+    write_field: content
+  video:
+    node_type: video
+    studio_tool: run_video_generation
+    confirm_gate: true
+    write_field: prompt
+
+intake_priority:
+  - id: campaign_override
+    when: marketing_intent and not atomic_create_intent
+    route: campaign
+  - id: single_node
+    when: focus_node_id and single_node_gen_intent and not modify_intent
+    route: single_node
+  - id: atomic_create
+    when: atomic_create_intent and not marketing_intent
+    route: atomic_create
+  - id: fallback
+    when: default
+    route: chat
+
+atomic_create_hints:
+  - 帮我生成
+  - 帮我做一张
+  - 生成一个
+  - 生成一张
+  - 做一个
+  - 来一张
+  - 来一段
+  - 写一段
+  - 配一段
+
+text_default_keywords:
+  - 分镜提示词
+  - 分镜脚本
+  - 脚本
+  - 广告词
+  - 文案
+  - 分镜
+
+prompt_explicit_keywords:
+  - prompt扩写
+  - 提示词模式
+  - 多模式扩写
+  - 扩写prompt
+
+atomic_confirm_keywords:
+  - 确认生成
+  - 开始生成
+  - 确认

--- a/services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml
+++ b/services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml
@@ -82,6 +82,7 @@ text_default_keywords:
   - 广告词
   - 文案
   - 分镜
+  - 口播稿
 
 prompt_explicit_keywords:
   - prompt扩写

--- a/services/agent-runtime/tests/test_atomic_create_intent.py
+++ b/services/agent-runtime/tests/test_atomic_create_intent.py
@@ -1,0 +1,56 @@
+"""P4: atomic intent routing against eval-intent-set gold labels."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from app.graph.atomic_intent import (
+    atomic_create_intent,
+    build_atomic_spec,
+    parse_atomic_target_type,
+    resolve_intake_route,
+)
+
+EVAL_PATH = Path(__file__).resolve().parents[1] / "skills" / "atomic-create" / "eval-intent-set.yaml"
+
+
+@pytest.fixture(scope="module")
+def eval_cases() -> list[dict]:
+    doc = yaml.safe_load(EVAL_PATH.read_text(encoding="utf-8"))
+    return doc["cases"]
+
+
+def test_eval_routing_gold(eval_cases: list[dict]):
+    mismatches: list[str] = []
+    for case in eval_cases:
+        utterance = case["utterance"]
+        focus = case.get("focus_node_id")
+        gold = case["gold"]
+        route = resolve_intake_route(utterance, focus_node_id=focus)
+        if route != gold["route"]:
+            mismatches.append(f"{case['id']}: route {route} != {gold['route']}")
+            continue
+        if gold["route"] == "atomic_create":
+            spec = build_atomic_spec(utterance)
+            if spec["target_type"] != gold["target_type"]:
+                mismatches.append(
+                    f"{case['id']}: target {spec['target_type']} != {gold['target_type']}"
+                )
+            if spec["confirm_gate"] != gold["confirm_gate"]:
+                mismatches.append(
+                    f"{case['id']}: confirm_gate {spec['confirm_gate']} != {gold['confirm_gate']}"
+                )
+    assert not mismatches, "\n".join(mismatches)
+
+
+def test_d1_storyboard_is_text_not_prompt():
+    assert parse_atomic_target_type("帮我生成一个蓝牙耳机的分镜提示词") == "text"
+    assert parse_atomic_target_type("用提示词模式扩写白底图") == "prompt"
+
+
+def test_atomic_create_intent_negative_campaign():
+    assert not atomic_create_intent("帮我做一套天猫蓝牙耳机详情页营销方案")
+    assert atomic_create_intent("帮我生成一个模特人物图")

--- a/services/agent-runtime/tests/test_atomic_create_intent_eval.py
+++ b/services/agent-runtime/tests/test_atomic_create_intent_eval.py
@@ -1,0 +1,76 @@
+"""P4-01: eval-intent-set.yaml schema validation + gold coverage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+EVAL_PATH = Path(__file__).resolve().parents[1] / "skills" / "atomic-create" / "eval-intent-set.yaml"
+TAXONOMY_PATH = Path(__file__).resolve().parents[1] / "skills" / "atomic-create" / "intent-taxonomy.yaml"
+
+VALID_ROUTES = frozenset({"atomic_create", "single_node", "campaign", "chat"})
+VALID_TARGET_TYPES = frozenset({"image", "text", "video", "audio", "prompt"})
+
+
+@pytest.fixture(scope="module")
+def eval_doc() -> dict:
+    return yaml.safe_load(EVAL_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def taxonomy_doc() -> dict:
+    return yaml.safe_load(TAXONOMY_PATH.read_text(encoding="utf-8"))
+
+
+def test_eval_set_has_30_cases(eval_doc: dict):
+    cases = eval_doc.get("cases") or []
+    assert len(cases) == 30
+    ids = [c["id"] for c in cases]
+    assert len(ids) == len(set(ids)), "duplicate case ids"
+
+
+def test_eval_gold_schema(eval_doc: dict):
+    for case in eval_doc["cases"]:
+        assert "utterance" in case and case["utterance"].strip()
+        gold = case["gold"]
+        assert gold["route"] in VALID_ROUTES
+        if gold["route"] == "atomic_create":
+            assert gold["target_type"] in VALID_TARGET_TYPES
+            tt = gold["target_type"]
+            expect_confirm = tt in ("video", "audio")
+            assert gold["confirm_gate"] is expect_confirm, f"{case['id']} confirm_gate mismatch"
+        else:
+            assert gold.get("target_type") is None or gold["route"] == "single_node"
+
+
+def test_d1_storyboard_cases_are_text(eval_doc: dict):
+    storyboard_ids = {"txt-01", "txt-06"}
+    for case in eval_doc["cases"]:
+        if case["id"] in storyboard_ids:
+            assert case["gold"]["target_type"] == "text", case["id"]
+
+
+def test_d2_video_audio_all_require_confirm(eval_doc: dict):
+    for case in eval_doc["cases"]:
+        tt = case["gold"].get("target_type")
+        if tt in ("video", "audio"):
+            assert case["gold"]["confirm_gate"] is True, case["id"]
+
+
+def test_taxonomy_confirm_flags_match_d2(taxonomy_doc: dict):
+    types = taxonomy_doc["target_types"]
+    assert types["video"]["confirm_gate"] is True
+    assert types["audio"]["confirm_gate"] is True
+    assert types["image"]["confirm_gate"] is False
+    assert types["text"]["confirm_gate"] is False
+
+
+def test_modality_coverage(eval_doc: dict):
+    atomic = [c for c in eval_doc["cases"] if c["gold"]["route"] == "atomic_create"]
+    by_type = {t: 0 for t in VALID_TARGET_TYPES}
+    for c in atomic:
+        by_type[c["gold"]["target_type"]] += 1
+    for t in VALID_TARGET_TYPES:
+        assert by_type[t] >= 1, f"missing atomic_create case for {t}"

--- a/services/agent-runtime/tests/test_atomic_create_subgraph.py
+++ b/services/agent-runtime/tests/test_atomic_create_subgraph.py
@@ -1,0 +1,89 @@
+"""P4: atomic_create_gate subgraph tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from app.graph.nodes.atomic_create_node import make_create_atomic_node
+from app.graph.nodes.atomic_parse import make_parse_atomic_intent_node
+from app.graph.nodes.await_atomic_confirm import make_await_atomic_confirm_node
+from app.graph.nodes.run_atomic_gen import make_run_atomic_gen_node
+from app.graph.subgraphs.atomic_create_gate import route_after_atomic_confirm, route_after_atomic_create
+
+
+class FakeNest:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Any]] = []
+
+    async def add_nodes_batch(self, items: list[dict[str, Any]], **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("add_nodes_batch", items))
+        return {"nodes": [{"key": items[0]["key"], "nodeId": "node-atomic-1"}]}
+
+    async def run_image_generation(self, node_id: str) -> dict[str, Any]:
+        self.calls.append(("run_image_generation", node_id))
+        return {"status": "completed", "generationRecordId": "rec-img-1"}
+
+    async def run_video_generation(self, node_id: str) -> dict[str, Any]:
+        self.calls.append(("run_video_generation", node_id))
+        return {"status": "completed", "url": "https://cdn/v.mp4"}
+
+
+@pytest.mark.asyncio
+async def test_parse_atomic_intent_image():
+    node = make_parse_atomic_intent_node()
+    out = await node({"messages": [HumanMessage(content="帮我生成一个模特人物图")]})
+    assert out["flow_mode"] == "atomic_create"
+    assert out["atomic_spec"]["target_type"] == "image"
+    assert out["atomic_spec"]["confirm_gate"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_atomic_node_then_image_gen():
+    nest = FakeNest()
+    create = make_create_atomic_node(nest=nest)
+    spec = {
+        "target_type": "image",
+        "prompt": "模特人物图",
+        "title": "模特人物图",
+        "confirm_gate": False,
+    }
+    created = await create({"atomic_spec": spec})
+    assert created["atomic_node_id"] == "node-atomic-1"
+    assert route_after_atomic_create({**created, "atomic_spec": spec}) == "run_atomic_gen"
+
+    run = make_run_atomic_gen_node(nest=nest)
+    done = await run({**created, "atomic_spec": spec})
+    assert done["phase"] == "done"
+    assert any(c[0] == "run_image_generation" for c in nest.calls)
+
+
+@pytest.mark.asyncio
+async def test_video_routes_to_confirm_gate():
+    spec = {
+        "target_type": "video",
+        "prompt": "15秒产品展示视频",
+        "title": "视频",
+        "confirm_gate": True,
+    }
+    assert route_after_atomic_create({"atomic_spec": spec, "atomic_node_id": "v1"}) == "await_atomic_confirm"
+
+
+@pytest.mark.asyncio
+async def test_await_atomic_confirm_then_gen():
+    nest = FakeNest()
+    await_node = make_await_atomic_confirm_node()
+    pending = await await_node({"messages": [HumanMessage(content="")]})
+    assert pending["user_decision"] == "none"
+
+    confirmed = await await_node({"messages": [HumanMessage(content="确认生成")]})
+    assert confirmed["user_decision"] == "confirm"
+    assert route_after_atomic_confirm(confirmed) == "run_atomic_gen"
+
+    run = make_run_atomic_gen_node(nest=nest)
+    spec = {"target_type": "video", "title": "视频", "confirm_gate": True}
+    out = await run({"atomic_node_id": "node-atomic-1", "atomic_spec": spec})
+    assert out["phase"] == "done"
+    assert any(c[0] == "run_video_generation" for c in nest.calls)


### PR DESCRIPTION
## Summary
- **P4-02 Harness**：Nest 新增 `run-text-generation` / `run-prompt-generation` / `run-audio-generation` internal API，对齐 image/video 返回契约；Runtime `nest_client` 同步扩展
- **P4-03 Graph**：新增 `atomic_create_gate` 子图（parse → create node → await_atomic_confirm → run_atomic_gen → done），intake 路由 `flow_mode=atomic_create`，video/audio 走 D2 确认门
- **Intent**：`atomic_intent.py` + taxonomy 更新，30 句 eval gold 路由全 PASS

## Test plan
- [x] vitest agent-canvas-tools — 29/29 PASS
- [x] pytest atomic_create_* — 13/13 PASS
- [x] pytest test_intake_gate — PASS
- [ ] CI green

## 依赖
- 基于 P4-01（ADR-003）；若 #115 未 merge，本 PR 会一并包含 P4-01 commit


Made with [Cursor](https://cursor.com)