### PR TITLE
fix(agent): P4-07 text/prompt/audio Harness + 全量回归脚本

### DIFF
--- a/deploy/prod-atomic-studio-verify.py
+++ b/deploy/prod-atomic-studio-verify.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
-"""Production smoke verify for P4 atomic_create_gate (image path, no full gen wait).
+"""Production smoke verify for P4 atomic_create_gate — image/text/prompt (A1 partial).
 
-Checks:
-  1. Runtime health
-  2. SSE「帮我生成一个模特人物图」→ atomic_create path (not campaign plan gate)
-  3. thread-state phase await_atomic_confirm absent for image; canvas gets new node
+Checks per modality:
+  - SSE atomic_create path (not campaign plan gate)
+  - Canvas node created
+  - Generation completes (record/content) or clear error
+
+Video/audio confirm gates: deploy/prod-atomic-confirm-gate-verify.py
 
 Usage:
   python3 deploy/prod-atomic-studio-verify.py
@@ -25,9 +27,15 @@ BASE = os.environ.get("BASE_URL", "http://119.29.173.89:8888").rstrip("/")
 API = f"{BASE}/api"
 PHONE = os.environ.get("PHONE", "17279698608")
 CODE = os.environ.get("CODE", "123456")
-SSE_TIMEOUT_SEC = float(os.environ.get("SSE_TIMEOUT_SEC", "180"))
+SSE_TIMEOUT_SEC = float(os.environ.get("SSE_TIMEOUT_SEC", "300"))
 
 PASS = FAIL = 0
+
+CASES: list[tuple[str, str, str]] = [
+    ("image", "帮我生成一个模特人物图", "image"),
+    ("text", "帮我写广告词，强调降噪", "text"),
+    ("prompt", "帮我对「蓝牙耳机」做 prompt 扩写，出图用", "prompt"),
+]
 
 
 def record(case: str, ok: bool, detail: str = "") -> None:
@@ -53,7 +61,7 @@ def http(m: str, p: str, b: dict | None = None, t: str | None = None) -> Any:
         return json.loads(resp.read())
 
 
-def sse_collect(t: str, sid: str, msg: str, tid: str, *, timeout: float = 180) -> tuple[list[dict], str, set[str], str]:
+def sse_collect(t: str, sid: str, msg: str, tid: str, *, timeout: float = 300) -> tuple[list[dict], str, set[str], str]:
     body: dict[str, Any] = {"sessionId": sid, "message": msg, "threadId": tid}
     h = {
         "Content-Type": "application/json",
@@ -103,14 +111,50 @@ def thread_state(tok: str, tid: str) -> dict[str, Any]:
     return http("GET", f"/agent/thread-state?threadId={quote(tid, safe='')}", t=tok).get("data") or {}
 
 
-def canvas_node_count(tok: str, sid: str) -> int:
+def latest_node(tok: str, sid: str, node_type: str) -> dict[str, Any] | None:
     sess = http("GET", f"/sessions/{sid}", t=tok)["data"]
     canvas = sess.get("canvasData") or {}
-    return len(canvas.get("nodes") or [])
+    nodes = [n for n in (canvas.get("nodes") or []) if n.get("type") == node_type]
+    return nodes[-1] if nodes else None
+
+
+def verify_modality(tok: str, label: str, utterance: str, node_type: str) -> None:
+    sid = http("POST", "/sessions", {"title": f"P4-{label}-{int(time.time())}"}, t=tok)["data"]["id"]
+    tid = f"{sid}:{uuid.uuid4()}"
+    _, text, types, exit_reason = sse_collect(tok, sid, utterance, tid, timeout=SSE_TIMEOUT_SEC)
+
+    atomic_ok = "原子创作" in text and f"{node_type} 节点" in text
+    not_campaign = "await_confirm" not in types and "拟定拆解约" not in text[:200]
+    record(f"{label} atomic path", atomic_ok and not_campaign, text[:120])
+
+    node = latest_node(tok, sid, node_type)
+    data = (node or {}).get("data") or {}
+    has_output = bool(
+        data.get("generationRecordId")
+        or data.get("url")
+        or (node_type == "text" and str(data.get("content") or "").strip())
+        or (node_type == "prompt" and str(data.get("prompt") or "").strip())
+    )
+    gen_ok = "生成完成" in text or has_output
+    not_unsupported = "暂不支持" not in text
+    record(
+        f"{label} gen completed",
+        gen_ok and not_unsupported and "error" not in types,
+        f"exit={exit_reason} rec={data.get('generationRecordId')} content={'yes' if data.get('content') else 'no'}",
+    )
+
+    ts = thread_state(tok, tid)
+    phase = ts.get("phase")
+    next_nodes = ts.get("nextNodes") or []
+    record(
+        f"{label} not stuck at plan gate",
+        "await_confirm" not in next_nodes and phase not in ("await_confirm",),
+        f"phase={phase}",
+    )
 
 
 def main() -> int:
-    print("=== P4 atomic_create production smoke verify ===")
+    print("=== P4 atomic_create production smoke verify (image/text/prompt) ===")
     print(f"BASE={BASE}\n")
 
     try:
@@ -127,37 +171,8 @@ def main() -> int:
     rt = http("GET", "/agent/runtime-health", t=tok)
     record("Runtime health", bool((rt.get("data") or {}).get("ok")))
 
-    sid = http("POST", "/sessions", {"title": f"P4-atomic-{int(time.time())}"}, t=tok)["data"]["id"]
-    tid = f"{sid}:{uuid.uuid4()}"
-    record("Create session", True, sid)
-
-    before_nodes = canvas_node_count(tok, sid)
-    events, text, types, exit_reason = sse_collect(
-        tok, sid, "帮我生成一个模特人物图", tid, timeout=SSE_TIMEOUT_SEC,
-    )
-    record("SSE stream", len(events) >= 1, f"events={len(events)} exit={exit_reason}")
-
-    atomic_path = "原子创作" in text or "atomic" in text.lower()
-    not_campaign = "await_confirm" not in types and "营销方案" not in text[:200]
-    record("Atomic path (not campaign plan)", atomic_path or not_campaign, text[:120])
-
-    after_nodes = canvas_node_count(tok, sid)
-    record("Canvas node created", after_nodes > before_nodes, f"{before_nodes} -> {after_nodes}")
-
-    ts = thread_state(tok, tid)
-    phase = ts.get("phase")
-    next_nodes = ts.get("nextNodes") or []
-    record(
-        "Not stuck at plan gate",
-        "await_confirm" not in next_nodes and phase not in ("await_confirm",),
-        f"phase={phase} next={next_nodes}",
-    )
-    record(
-        "Gen started or completed",
-        phase in ("done", "orchestrate_gen", "atomic_create", "await_atomic_confirm", None)
-        or any("gen" in str(n) for n in next_nodes),
-        f"phase={phase}",
-    )
+    for label, utterance, node_type in CASES:
+        verify_modality(tok, label, utterance, node_type)
 
     print(f"\n=== Summary PASS={PASS} FAIL={FAIL} ===")
     return 0 if FAIL == 0 else 1

--- a/deploy/prod-p4-full-regression.py
+++ b/deploy/prod-p4-full-regression.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""P4-07 production regression — atomic modalities + Phase A/B/C/P3 smoke.
+
+Runs (in order):
+  1. prod-atomic-studio-verify.py      — image/text/prompt atomic_create
+  2. prod-atomic-confirm-gate-verify.py — video/audio await_atomic_confirm
+  3. prod-single-node-gen-verify.py    — P3 regression (A5)
+  4. prod-phase-b-user-verify.py       — Phase B (optional, SKIP_PHASE_B=1)
+
+Usage:
+  python3 deploy/prod-p4-full-regression.py
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+SCRIPTS = [
+    ROOT / "prod-atomic-studio-verify.py",
+    ROOT / "prod-atomic-confirm-gate-verify.py",
+    ROOT / "prod-single-node-gen-verify.py",
+]
+if os.environ.get("SKIP_PHASE_B", "").strip() not in ("1", "true", "yes"):
+    SCRIPTS.append(ROOT / "prod-phase-b-user-verify.py")
+
+
+def main() -> int:
+    print("=== P4-07 full production regression ===\n")
+    failed: list[str] = []
+    for script in SCRIPTS:
+        print(f"--- {script.name} ---")
+        rc = subprocess.call([sys.executable, str(script)])
+        print()
+        if rc != 0:
+            failed.append(script.name)
+    if failed:
+        print(f"FAILED: {', '.join(failed)}")
+        return 1
+    print("All regression scripts PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -277,20 +277,7 @@ class NestEventProxy:
         )
 
     async def run_image_generation(self, node_id: str) -> dict[str, Any]:
-        await self._emit(
-            {"type": "node_status", "data": {"nodeId": node_id, "status": "generating"}}
-        )
-        result = await self._forward_actions(
-            await self._inner.run_image_generation(node_id)
-        )
-        status = str(result.get("status") or "completed")
-        payload: dict[str, Any] = {"nodeId": node_id, "status": status}
-        if result.get("url"):
-            payload["url"] = result["url"]
-        if result.get("generationRecordId"):
-            payload["generationRecordId"] = result["generationRecordId"]
-        await self._emit({"type": "node_status", "data": payload})
-        return result
+        return await self._run_studio_generation(node_id, "run_image_generation")
 
     async def start_image_generation(self, node_id: str) -> dict[str, Any]:
         await self._emit(
@@ -314,17 +301,31 @@ class NestEventProxy:
         return result
 
     async def run_video_generation(self, node_id: str) -> dict[str, Any]:
+        return await self._run_studio_generation(node_id, "run_video_generation")
+
+    async def run_text_generation(self, node_id: str) -> dict[str, Any]:
+        return await self._run_studio_generation(node_id, "run_text_generation")
+
+    async def run_prompt_generation(self, node_id: str) -> dict[str, Any]:
+        return await self._run_studio_generation(node_id, "run_prompt_generation")
+
+    async def run_audio_generation(self, node_id: str) -> dict[str, Any]:
+        return await self._run_studio_generation(node_id, "run_audio_generation")
+
+    async def _run_studio_generation(self, node_id: str, method: str) -> dict[str, Any]:
         await self._emit(
             {"type": "node_status", "data": {"nodeId": node_id, "status": "generating"}}
         )
-        inner = getattr(self._inner, "run_video_generation", None)
+        inner = getattr(self._inner, method, None)
         if inner is None:
-            raise RuntimeError("video_not_supported")
+            raise RuntimeError(f"{method}_not_supported")
         result = await self._forward_actions(await inner(node_id))
         status = str(result.get("status") or "completed")
         payload: dict[str, Any] = {"nodeId": node_id, "status": status}
         if result.get("url"):
             payload["url"] = result["url"]
+        if result.get("generationRecordId"):
+            payload["generationRecordId"] = result["generationRecordId"]
         await self._emit({"type": "node_status", "data": payload})
         return result
 

--- a/services/agent-runtime/tests/test_atomic_create_subgraph.py
+++ b/services/agent-runtime/tests/test_atomic_create_subgraph.py
@@ -30,6 +30,10 @@ class FakeNest:
         self.calls.append(("run_video_generation", node_id))
         return {"status": "completed", "url": "https://cdn/v.mp4"}
 
+    async def run_text_generation(self, node_id: str) -> dict[str, Any]:
+        self.calls.append(("run_text_generation", node_id))
+        return {"status": "completed", "generationRecordId": "rec-text-1"}
+
 
 @pytest.mark.asyncio
 async def test_parse_atomic_intent_image():
@@ -58,6 +62,24 @@ async def test_create_atomic_node_then_image_gen():
     done = await run({**created, "atomic_spec": spec})
     assert done["phase"] == "done"
     assert any(c[0] == "run_image_generation" for c in nest.calls)
+
+
+@pytest.mark.asyncio
+async def test_text_atomic_gen_direct():
+    nest = FakeNest()
+    create = make_create_atomic_node(nest=nest)
+    spec = {
+        "target_type": "text",
+        "prompt": "广告词，强调降噪",
+        "title": "广告词",
+        "confirm_gate": False,
+    }
+    created = await create({"atomic_spec": spec})
+    assert route_after_atomic_create({**created, "atomic_spec": spec}) == "run_atomic_gen"
+    run = make_run_atomic_gen_node(nest=nest)
+    done = await run({**created, "atomic_spec": spec})
+    assert done["phase"] == "done"
+    assert any(c[0] == "run_text_generation" for c in nest.calls)
 
 
 @pytest.mark.asyncio

--- a/services/agent-runtime/tests/test_nest_event_proxy.py
+++ b/services/agent-runtime/tests/test_nest_event_proxy.py
@@ -1,0 +1,46 @@
+"""NestEventProxy forwards P4 Harness modalities to inner client."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.runs import NestEventProxy
+
+
+class FakeInner:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    async def run_text_generation(self, node_id: str) -> dict:
+        self.calls.append(("run_text_generation", node_id))
+        return {
+            "status": "completed",
+            "generationRecordId": "rec-text-1",
+            "actions": [{"type": "update_node", "payload": {"id": node_id}}],
+        }
+
+
+@pytest.mark.asyncio
+async def test_proxy_forwards_run_text_generation():
+    inner = FakeInner()
+    events: list[dict] = []
+
+    async def capture(ev: dict) -> None:
+        events.append(ev)
+
+    proxy = NestEventProxy(inner, capture)
+    result = await proxy.run_text_generation("node-text-1")
+    assert result["status"] == "completed"
+    assert inner.calls == [("run_text_generation", "node-text-1")]
+    assert any(ev.get("type") == "node_status" for ev in events)
+    assert any(ev.get("type") == "canvas_action" for ev in events)
+
+
+@pytest.mark.asyncio
+async def test_proxy_run_text_generation_missing_inner_raises():
+    async def noop(_ev: dict) -> None:
+        return None
+
+    proxy = NestEventProxy(object(), noop)
+    with pytest.raises(RuntimeError, match="run_text_generation_not_supported"):
+        await proxy.run_text_generation("node-x")


### PR DESCRIPTION
## Summary
- 修复 `NestEventProxy` 未转发 `run_text_generation` / `run_prompt_generation` / `run_audio_generation`，导致生产 atomic_create 对 text/prompt 报「暂不支持」
- 统一 `_run_studio_generation`  helper，image/video 同样走该路径
- 扩展 `prod-atomic-studio-verify.py` 覆盖 image/text/prompt 三模态（A1）
- 新增 `deploy/prod-p4-full-regression.py` 编排 P4 + P3 + Phase B 回归

## Test plan
- [x] `pytest tests/test_nest_event_proxy.py tests/test_atomic_create_subgraph.py`
- [x] `pnpm build`
- [ ] CI green
- [ ] Merge → agent-runtime 部署 → `python3 deploy/prod-atomic-studio-verify.py` text/prompt PASS
- [ ] `python3 deploy/prod-p4-full-regression.py`


Made with [Cursor](https://cursor.com)