### PR TITLE
feat(agent): P4-05 canvas summary 注入 atomic parse

### DIFF
--- a/deploy/prod-atomic-studio-verify.py
+++ b/deploy/prod-atomic-studio-verify.py
@@ -19,6 +19,7 @@ import os
 import sys
 import time
 import uuid
+from http.client import IncompleteRead
 from typing import Any
 from urllib.parse import quote
 from urllib.request import Request, urlopen
@@ -77,33 +78,42 @@ def sse_collect(t: str, sid: str, msg: str, tid: str, *, timeout: float = 300) -
     exit_reason = "timeout"
     with urlopen(r, timeout=timeout) as resp:
         buf = ""
-        while time.time() < end:
-            chunk = resp.read(4096)
-            if not chunk:
-                exit_reason = "eof"
-                break
-            buf += chunk.decode(errors="replace")
-            while "\n\n" in buf:
-                block, buf = buf.split("\n\n", 1)
-                for line in block.splitlines():
-                    if not line.startswith("data:"):
-                        continue
-                    pl = line[5:].strip()
-                    if pl == "[DONE]":
-                        return events, "".join(parts), types, "done_marker"
-                    try:
-                        ev = json.loads(pl)
-                    except json.JSONDecodeError:
-                        continue
-                    events.append(ev)
-                    et = str(ev.get("type") or "")
-                    types.add(et)
-                    if et == "text_delta":
-                        parts.append(str((ev.get("data") or {}).get("text") or ""))
-                    if et == "done":
-                        return events, "".join(parts), types, "done"
-                    if et == "error":
-                        return events, "".join(parts), types, "error"
+        try:
+            while time.time() < end:
+                try:
+                    chunk = resp.read(4096)
+                except IncompleteRead as exc:
+                    if exc.partial:
+                        buf += exc.partial.decode(errors="replace")
+                    exit_reason = "eof"
+                    break
+                if not chunk:
+                    exit_reason = "eof"
+                    break
+                buf += chunk.decode(errors="replace")
+                while "\n\n" in buf:
+                    block, buf = buf.split("\n\n", 1)
+                    for line in block.splitlines():
+                        if not line.startswith("data:"):
+                            continue
+                        pl = line[5:].strip()
+                        if pl == "[DONE]":
+                            return events, "".join(parts), types, "done_marker"
+                        try:
+                            ev = json.loads(pl)
+                        except json.JSONDecodeError:
+                            continue
+                        events.append(ev)
+                        et = str(ev.get("type") or "")
+                        types.add(et)
+                        if et == "text_delta":
+                            parts.append(str((ev.get("data") or {}).get("text") or ""))
+                        if et == "done":
+                            return events, "".join(parts), types, "done"
+                        if et == "error":
+                            return events, "".join(parts), types, "error"
+        except IncompleteRead:
+            exit_reason = "eof"
     return events, "".join(parts), types, exit_reason
 
 

--- a/services/agent-runtime/app/graph/atomic_parse_util.py
+++ b/services/agent-runtime/app/graph/atomic_parse_util.py
@@ -1,4 +1,4 @@
-"""P4-04: atomic utterance prompt extraction + few-shot loading."""
+"""P4-04/05: atomic utterance parse — prompt extraction, canvas context, few-shots."""
 
 from __future__ import annotations
 
@@ -11,6 +11,8 @@ import yaml
 
 from app.graph.few_shot import load_few_shots
 from app.graph.atomic_intent import build_atomic_spec, confirm_gate_for_type
+
+_DEICTIC_HINTS = ("这个", "这张", "该", "主图", "当前", "刚才")
 
 _STRIP_PREFIXES = (
     "帮我生成一个",
@@ -43,6 +45,59 @@ def load_atomic_parse_few_shots(skills_dir: Path | str | None = None) -> list[tu
     return load_few_shots(skill).get("parse_atomic_intent", [])
 
 
+def canvas_summary_nodes(canvas_summary: dict[str, Any] | None) -> list[dict[str, Any]]:
+    raw = (canvas_summary or {}).get("nodes") or []
+    return [n for n in raw if isinstance(n, dict)]
+
+
+def format_canvas_context_line(nodes: list[dict[str, Any]]) -> str:
+    """Compact canvas stats for parse context (P4-05)."""
+    if not nodes:
+        return "画布为空"
+    by_type: dict[str, int] = {}
+    for node in nodes:
+        kind = str(node.get("type") or "unknown")
+        by_type[kind] = by_type.get(kind, 0) + 1
+    counts = ", ".join(f"{k}×{v}" for k, v in sorted(by_type.items()))
+    titles = [str(n.get("title") or "").strip() for n in nodes if n.get("title")]
+    titles = [t for t in titles if t][:8]
+    title_bit = f"；已有：{'、'.join(titles)}" if titles else ""
+    return f"画布 {len(nodes)} 节点（{counts}）{title_bit}"
+
+
+def _existing_titles(nodes: list[dict[str, Any]]) -> set[str]:
+    return {str(n.get("title") or "").strip() for n in nodes if str(n.get("title") or "").strip()}
+
+
+def dedupe_atomic_title(title: str, nodes: list[dict[str, Any]]) -> str:
+    """Avoid creating another node with the same title when canvas already has one."""
+    base = (title or "").strip()
+    if not base:
+        return title
+    existing = _existing_titles(nodes)
+    if base not in existing:
+        return base
+    for i in range(2, 20):
+        candidate = f"{base} ({i})"
+        if candidate not in existing:
+            return candidate
+    return f"{base} ({len(nodes) + 1})"
+
+
+def resolve_focus_seed(utterance: str, focus_node_id: str | None, nodes: list[dict[str, Any]]) -> str | None:
+    """Seed prompt/title from focused canvas node when user uses deictic reference."""
+    if not focus_node_id or not nodes:
+        return None
+    if not any(h in (utterance or "") for h in _DEICTIC_HINTS):
+        return None
+    for node in nodes:
+        if str(node.get("id") or "") != focus_node_id:
+            continue
+        title = str(node.get("title") or "").strip()
+        return title or None
+    return None
+
+
 def extract_atomic_prompt(utterance: str) -> str:
     """Strip leading atomic hint prefixes; keep semantic payload for node prompt."""
     t = (utterance or "").strip()
@@ -56,14 +111,35 @@ def extract_atomic_prompt(utterance: str) -> str:
     return t or utterance.strip()
 
 
-def build_atomic_spec_enriched(utterance: str) -> dict[str, Any]:
-    """Keyword routing + cleaner prompt/title (P4-04)."""
+def build_atomic_spec_enriched(
+    utterance: str,
+    *,
+    canvas_summary: dict[str, Any] | None = None,
+    focus_node_id: str | None = None,
+) -> dict[str, Any]:
+    """Keyword routing + prompt/title cleanup + canvas context (P4-04/05)."""
+    nodes = canvas_summary_nodes(canvas_summary)
     base = build_atomic_spec(utterance)
     prompt = extract_atomic_prompt(utterance)
+    focus_seed = resolve_focus_seed(utterance, focus_node_id, nodes)
+    if focus_seed:
+        if "扩写" in utterance or base.get("target_type") == "prompt":
+            if not prompt or prompt in ("这个主图 prompt", "主图 prompt", "这个主图"):
+                prompt = focus_seed
+            elif focus_seed not in prompt:
+                prompt = f"{focus_seed}；{prompt}"
+        elif len(prompt) <= 8:
+            prompt = focus_seed
+
     if prompt:
         base["prompt"] = prompt
         if len(prompt) <= 28:
             base["title"] = prompt
+
+    if nodes:
+        base["title"] = dedupe_atomic_title(str(base.get("title") or ""), nodes)
+        base["canvas_context"] = format_canvas_context_line(nodes)
+
     return base
 
 

--- a/services/agent-runtime/app/graph/nodes/atomic_parse.py
+++ b/services/agent-runtime/app/graph/nodes/atomic_parse.py
@@ -18,7 +18,7 @@ def _latest_user_text(messages: list[Any]) -> str:
     return ""
 
 
-def make_parse_atomic_intent_node() -> Callable:
+def make_parse_atomic_intent_node(*, nest: Any | None = None) -> Callable:
     async def parse_atomic_intent(state: dict) -> dict:
         text = _latest_user_text(state.get("messages") or [])
         if not text.strip():
@@ -27,15 +27,31 @@ def make_parse_atomic_intent_node() -> Callable:
                 "last_error": "empty utterance",
                 "messages": [AIMessage(content="请描述要生成的内容（如图、文案、视频等）。")],
             }
-        spec = build_atomic_spec_enriched(text)
+
+        canvas_summary = None
+        if nest is not None:
+            summary_fn = getattr(nest, "get_canvas_summary", None)
+            if summary_fn is not None:
+                try:
+                    canvas_summary = await summary_fn()
+                except Exception:  # noqa: BLE001 — parse fallback without canvas
+                    canvas_summary = None
+
+        spec = build_atomic_spec_enriched(
+            text,
+            canvas_summary=canvas_summary,
+            focus_node_id=state.get("focus_node_id"),
+        )
         target = spec["target_type"]
         gate = "需确认" if spec["confirm_gate"] else "直达"
+        ctx = spec.get("canvas_context")
+        ctx_note = f" [{ctx}]" if ctx else ""
         return {
             "phase": "atomic_parse",
             "flow_mode": "atomic_create",
             "atomic_spec": spec,
             "messages": [
-                AIMessage(content=f"原子创作：{target} 节点（{gate}）— {spec['title']}"),
+                AIMessage(content=f"原子创作：{target} 节点（{gate}）— {spec['title']}{ctx_note}"),
             ],
         }
 

--- a/services/agent-runtime/app/graph/subgraphs/atomic_create_gate.py
+++ b/services/agent-runtime/app/graph/subgraphs/atomic_create_gate.py
@@ -32,7 +32,7 @@ def route_after_atomic_confirm(state: AgentRuntimeState) -> str:
 
 
 def register_atomic_create_gate(graph: StateGraph, *, nest: Any) -> None:
-    graph.add_node("parse_atomic_intent", make_parse_atomic_intent_node())
+    graph.add_node("parse_atomic_intent", make_parse_atomic_intent_node(nest=nest))
     graph.add_node("create_atomic_node", make_create_atomic_node(nest=nest))
     graph.add_node("await_atomic_confirm", make_await_atomic_confirm_node())
     graph.add_node("run_atomic_gen", make_run_atomic_gen_node(nest=nest))

--- a/services/agent-runtime/tests/test_atomic_create_subgraph.py
+++ b/services/agent-runtime/tests/test_atomic_create_subgraph.py
@@ -36,6 +36,22 @@ class FakeNest:
 
 
 @pytest.mark.asyncio
+async def test_parse_atomic_intent_with_canvas_summary():
+    class SummaryNest:
+        async def get_canvas_summary(self) -> dict:
+            return {
+                "nodes": [
+                    {"id": "img1", "type": "image", "title": "模特人物图", "status": "completed"},
+                ]
+            }
+
+    node = make_parse_atomic_intent_node(nest=SummaryNest())
+    out = await node({"messages": [HumanMessage(content="帮我生成一个模特人物图")]})
+    assert out["atomic_spec"]["title"] == "模特人物图 (2)"
+    assert "canvas_context" in out["atomic_spec"]
+
+
+@pytest.mark.asyncio
 async def test_parse_atomic_intent_image():
     node = make_parse_atomic_intent_node()
     out = await node({"messages": [HumanMessage(content="帮我生成一个模特人物图")]})

--- a/services/agent-runtime/tests/test_atomic_parse_util.py
+++ b/services/agent-runtime/tests/test_atomic_parse_util.py
@@ -9,7 +9,9 @@ import pytest
 from app.graph.atomic_intent import atomic_create_intent
 from app.graph.atomic_parse_util import (
     build_atomic_spec_enriched,
+    dedupe_atomic_title,
     extract_atomic_prompt,
+    format_canvas_context_line,
     load_atomic_parse_few_shots,
     parse_few_shot_json,
 )
@@ -31,6 +33,49 @@ def test_build_atomic_spec_enriched_uses_clean_prompt():
     spec = build_atomic_spec_enriched("帮我生成一个模特人物图")
     assert spec["target_type"] == "image"
     assert spec["prompt"] == "模特人物图"
+
+
+def test_build_atomic_spec_dedupes_title_from_canvas():
+    summary = {
+        "nodes": [
+            {"id": "n1", "type": "image", "title": "模特人物图", "status": "completed"},
+        ]
+    }
+    spec = build_atomic_spec_enriched("帮我生成一个模特人物图", canvas_summary=summary)
+    assert spec["title"] == "模特人物图 (2)"
+    assert "canvas_context" in spec
+
+
+def test_build_atomic_spec_focus_seed_for_prompt_expand():
+    summary = {
+        "nodes": [
+            {"id": "hero-1", "type": "image", "title": "主图", "status": "completed"},
+        ]
+    }
+    spec = build_atomic_spec_enriched(
+        "多模式扩写这个主图 prompt",
+        canvas_summary=summary,
+        focus_node_id="hero-1",
+    )
+    assert spec["target_type"] == "prompt"
+    assert "主图" in spec["prompt"]
+
+
+def test_format_canvas_context_line():
+    line = format_canvas_context_line(
+        [
+            {"type": "image", "title": "主图"},
+            {"type": "text", "title": "主文案"},
+        ]
+    )
+    assert "2 节点" in line
+    assert "image×1" in line
+    assert "主图" in line
+
+
+def test_dedupe_atomic_title():
+    nodes = [{"title": "Banner"}, {"title": "Banner (2)"}]
+    assert dedupe_atomic_title("Banner", nodes) == "Banner (3)"
 
 
 def test_parse_few_shot_json_roundtrip():


### PR DESCRIPTION
## Summary
- `parse_atomic_intent` 调用 `get_canvas_summary`：标题去重、focus 节点指代 seed prompt、回复附带画布摘要
- 含 SSE verify 容错（#120 合并后可 rebase 去重）

## Test plan
- [x] `pytest tests/test_atomic_parse_util.py tests/test_atomic_create_subgraph.py` — 15/15 PASS
- [x] `prod-p4-full-regression.py` — 全 PASS（含 Phase B）


Made with [Cursor](https://cursor.com)