### PR TITLE
feat(agent): L1-03 atomic_regenerate loop

### DIFF
--- a/deploy/prod-atomic-regenerate-verify.py
+++ b/deploy/prod-atomic-regenerate-verify.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Prod smoke: atomic_create turn 1 → forced fail mock not available — use image regen path.
+
+Turn 1: 帮我生成一个模特人物图  → node created + gen ok
+Turn 2: 再试一次               → same thread, no second node, gen called again
+
+Reuse SSE helpers from prod-atomic-studio-verify.py.
+Assert: session node count for title stable; second SSE has「重新生成」or completed again.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import uuid
+from http.client import IncompleteRead
+from typing import Any
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+BASE = os.environ.get("BASE_URL", "http://119.29.173.89:8888").rstrip("/")
+API = f"{BASE}/api"
+PHONE = os.environ.get("PHONE", "17279698608")
+CODE = os.environ.get("CODE", "123456")
+SSE_TIMEOUT_SEC = float(os.environ.get("SSE_TIMEOUT_SEC", "300"))
+
+PASS = FAIL = 0
+
+
+def record(case: str, ok: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if ok:
+        PASS += 1
+        icon = "✅"
+    else:
+        FAIL += 1
+        icon = "❌"
+    line = f"{icon} {case}"
+    if detail:
+        line += f" — {detail[:220]}"
+    print(line)
+
+
+def http(m: str, p: str, b: dict | None = None, t: str | None = None) -> Any:
+    h = {"Content-Type": "application/json", "Accept": "application/json"}
+    if t:
+        h["Authorization"] = f"Bearer {t}"
+    r = Request(f"{API}{p}", data=None if b is None else json.dumps(b).encode(), headers=h, method=m)
+    with urlopen(r, timeout=120) as resp:
+        return json.loads(resp.read())
+
+
+def sse_collect(t: str, sid: str, msg: str, tid: str, *, timeout: float = 300) -> tuple[list[dict], str, set[str], str]:
+    body: dict[str, Any] = {"sessionId": sid, "message": msg, "threadId": tid}
+    h = {
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+        "Authorization": f"Bearer {t}",
+        "Idempotency-Key": f"ik_{uuid.uuid4().hex}",
+    }
+    r = Request(f"{API}/agent/chat/conversation", data=json.dumps(body).encode(), headers=h, method="POST")
+    events: list[dict] = []
+    types: set[str] = set()
+    parts: list[str] = []
+    end = time.time() + timeout
+    exit_reason = "timeout"
+    with urlopen(r, timeout=timeout) as resp:
+        buf = ""
+        try:
+            while time.time() < end:
+                try:
+                    chunk = resp.read(4096)
+                except IncompleteRead as exc:
+                    if exc.partial:
+                        buf += exc.partial.decode(errors="replace")
+                    exit_reason = "eof"
+                    break
+                if not chunk:
+                    exit_reason = "eof"
+                    break
+                buf += chunk.decode(errors="replace")
+                while "\n\n" in buf:
+                    block, buf = buf.split("\n\n", 1)
+                    for line in block.splitlines():
+                        if not line.startswith("data:"):
+                            continue
+                        pl = line[5:].strip()
+                        if pl == "[DONE]":
+                            return events, "".join(parts), types, "done_marker"
+                        try:
+                            ev = json.loads(pl)
+                        except json.JSONDecodeError:
+                            continue
+                        events.append(ev)
+                        et = str(ev.get("type") or "")
+                        types.add(et)
+                        if et == "text_delta":
+                            parts.append(str((ev.get("data") or {}).get("text") or ""))
+                        if et == "done":
+                            return events, "".join(parts), types, "done"
+                        if et == "error":
+                            return events, "".join(parts), types, "error"
+        except IncompleteRead:
+            exit_reason = "eof"
+    return events, "".join(parts), types, exit_reason
+
+
+def thread_state(tok: str, tid: str) -> dict[str, Any]:
+    return http("GET", f"/agent/thread-state?threadId={quote(tid, safe='')}", t=tok).get("data") or {}
+
+
+def image_nodes(tok: str, sid: str) -> list[dict[str, Any]]:
+    sess = http("GET", f"/sessions/{sid}", t=tok)["data"]
+    canvas = sess.get("canvasData") or {}
+    return [n for n in (canvas.get("nodes") or []) if n.get("type") == "image"]
+
+
+def main() -> int:
+    print("=== Prod smoke: atomic_regenerate two-turn (create → regen) ===")
+    print(f"BASE={BASE}\n")
+
+    try:
+        http("POST", "/auth/send-code", {"phone": PHONE})
+    except Exception:
+        pass
+    try:
+        tok = http("POST", "/auth/login", {"phone": PHONE, "code": CODE})["data"]["token"]
+        record("Login", True)
+    except Exception as exc:  # noqa: BLE001
+        record("Login", False, str(exc))
+        return 1
+
+    rt = http("GET", "/agent/runtime-health", t=tok)
+    record("Runtime health", bool((rt.get("data") or {}).get("ok")))
+
+    sid = http("POST", "/sessions", {"title": f"regen-{int(time.time())}"}, t=tok)["data"]["id"]
+    tid = f"regen_{uuid.uuid4().hex[:8]}"
+    record("Create session", True, f"sid={sid} tid={tid}")
+
+    # Turn 1: atomic create
+    _, text1, types1, exit1 = sse_collect(
+        tok, sid, "帮我生成一个模特人物图", tid, timeout=SSE_TIMEOUT_SEC
+    )
+    atomic_ok = "原子创作" in text1 and "image 节点" in text1
+    not_campaign = "await_confirm" not in types1 and "拟定拆解约" not in text1[:200]
+    record("Turn1 atomic path", atomic_ok and not_campaign, text1[:120])
+
+    nodes1 = image_nodes(tok, sid)
+    node_count1 = len(nodes1)
+    first_node_id = str((nodes1[0] if nodes1 else {}).get("id") or "")
+    data1 = ((nodes1[0] if nodes1 else {}).get("data") or {})
+    has_output = bool(data1.get("generationRecordId") or data1.get("url"))
+    gen_ok = "生成完成" in text1 or has_output
+    record(
+        "Turn1 node created + gen",
+        node_count1 >= 1 and gen_ok and "error" not in types1,
+        f"exit={exit1} nodes={node_count1} rec={data1.get('generationRecordId')}",
+    )
+
+    ts1 = thread_state(tok, tid)
+    record(
+        "Turn1 not stuck at plan gate",
+        "await_confirm" not in (ts1.get("nextNodes") or []) and ts1.get("phase") not in ("await_confirm",),
+        f"phase={ts1.get('phase')}",
+    )
+
+    # Turn 2: regenerate on same thread
+    _, text2, types2, exit2 = sse_collect(tok, sid, "再试一次", tid, timeout=SSE_TIMEOUT_SEC)
+
+    nodes2 = image_nodes(tok, sid)
+    node_count2 = len(nodes2)
+    same_count = node_count2 == node_count1
+    record(
+        "Turn2 node count unchanged",
+        same_count,
+        f"before={node_count1} after={node_count2} first_id={first_node_id}",
+    )
+
+    regen_text_ok = "重新生成" in text2 or "生成完成" in text2
+    not_plan_gate = (
+        "await_confirm" not in types2
+        and "拟定拆解约" not in text2[:200]
+        and "interrupt" not in types2
+    )
+    record(
+        "Turn2 regen path (no plan gate)",
+        regen_text_ok and not_plan_gate and "error" not in types2,
+        f"exit={exit2} text={text2[:120]}",
+    )
+
+    ts2 = thread_state(tok, tid)
+    record(
+        "Turn2 not stuck at plan gate",
+        "await_confirm" not in (ts2.get("nextNodes") or []) and ts2.get("phase") not in ("await_confirm",),
+        f"phase={ts2.get('phase')}",
+    )
+
+    print(f"\n=== Summary PASS={PASS} FAIL={FAIL} ===")
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/superpowers/plans/2026-08-04-atomic-regenerate.md
+++ b/docs/superpowers/plans/2026-08-04-atomic-regenerate.md
@@ -1,0 +1,594 @@
+# L1-03 atomic_regenerate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users say「再试一次」on the same thread after an atomic_create run and re-run Studio generation on the existing `atomic_node_id`, skipping parse/create.
+
+**Architecture:** Extend intake routing with `atomic_regenerate_intent()` gated on checkpoint-persisted `atomic_node_id` + `atomic_spec`. New `prepare_atomic_regenerate` node resets error fields and routes to existing `run_atomic_gen`. Video/audio skip confirm on regenerate (user utterance = explicit consent). No new subgraph; one edge from intake into atomic gate tail.
+
+**Tech Stack:** LangGraph (Python 3.11+), pytest (`services/agent-runtime`), existing Nest internal `run_*_generation` Harness, deploy smoke scripts.
+
+**Spec:** `.trae/documents/loop-engineering-product-spec.md` §3.4 LC-5 V2, `.trae/documents/atomic-studio-intent-product-spec.md` §2.2.3
+
+## Global Constraints
+
+- Branch from `main`: `feature/atomic-regenerate` — **never push to main directly**.
+- Pre-commit validation: `cd services/agent-runtime && python -m pytest tests/test_atomic*.py tests/test_atomic_regenerate*.py -v` and `pnpm build` before PR.
+- `atomic_create_intent`（新建资产句）**优先于** regenerate；有 `focus_node_id` + `single_node_gen_intent` 仍走 P3。
+- Regenerate **不得**新建画布节点（`add_nodes_batch` 调用次数不变）。
+- Regenerate **不得**经过 `parse_atomic_intent` / `create_atomic_node` / `await_atomic_confirm`。
+- 同 thread 无 `atomic_node_id` 时说「再试一次」→ 不进入 regenerate（走 chat）。
+- `max_auto_retries()` 内建 retry **不在本 PR**；本 PR 仅用户显式 Adjust 回路。
+- Commit per task; squash merge PR.
+
+## File map
+
+| File | Role |
+| --- | --- |
+| `services/agent-runtime/app/graph/atomic_intent.py` | `atomic_regenerate_intent()` |
+| `services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml` | Regenerate hints + route priority |
+| `services/agent-runtime/app/graph/nodes/intake.py` | Detect regenerate from checkpoint state |
+| `services/agent-runtime/app/graph/nodes/prepare_atomic_regenerate.py` | **NEW** — validate + reset + AIMessage |
+| `services/agent-runtime/app/graph/builder.py` | `route_after_intake` → `prepare_atomic_regenerate` |
+| `services/agent-runtime/app/graph/subgraphs/atomic_create_gate.py` | Register prepare node + edge → `run_atomic_gen` |
+| `services/agent-runtime/app/graph/state.py` | Extend `flow_mode` Literal |
+| `services/agent-runtime/tests/test_atomic_regenerate_intent.py` | **NEW** — intent unit tests |
+| `services/agent-runtime/tests/test_atomic_regenerate_flow.py` | **NEW** — intake + graph path tests |
+| `deploy/prod-atomic-regenerate-verify.py` | **NEW** — prod two-turn smoke |
+| `.trae/documents/loop-engineering-product-spec.md` | Mark LC-5 V2 implemented |
+
+---
+
+### Task 1: Regenerate intent classifier
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/atomic_intent.py`
+- Modify: `services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml`
+- Create: `services/agent-runtime/tests/test_atomic_regenerate_intent.py`
+
+**Interfaces:**
+- Produces: `atomic_regenerate_intent(text: str) -> bool`
+- Produces: module constant `ATOMIC_REGENERATE_HINTS: tuple[str, ...]`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# services/agent-runtime/tests/test_atomic_regenerate_intent.py
+from app.graph.atomic_intent import (
+    atomic_create_intent,
+    atomic_regenerate_intent,
+)
+
+
+def test_atomic_regenerate_positive():
+    assert atomic_regenerate_intent("再试一次")
+    assert atomic_regenerate_intent("重试")
+    assert atomic_regenerate_intent("重新生成")
+    assert atomic_regenerate_intent("再来一次")
+
+
+def test_atomic_regenerate_not_new_create():
+    assert not atomic_regenerate_intent("帮我生成一个模特人物图")
+    assert atomic_create_intent("帮我生成一个模特人物图")
+
+
+def test_atomic_regenerate_not_campaign():
+    assert not atomic_regenerate_intent("帮我做一套天猫蓝牙耳机详情页营销方案")
+
+
+def test_atomic_regenerate_not_confirm_gate_reply():
+    assert not atomic_regenerate_intent("确认生成")
+    assert not atomic_regenerate_intent("取消")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/agent-runtime && python -m pytest tests/test_atomic_regenerate_intent.py -v`  
+Expected: FAIL with `ImportError` or `AttributeError: atomic_regenerate_intent`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `intent-taxonomy.yaml` append:
+
+```yaml
+atomic_regenerate_hints:
+  - 再试一次
+  - 再试
+  - 重试
+  - 重新生成
+  - 再来一次
+  - 再生成一次
+  - 再跑一遍
+```
+
+In `atomic_intent.py`:
+
+```python
+ATOMIC_REGENERATE_HINTS = tuple(_TAXONOMY.get("atomic_regenerate_hints") or (
+    "再试一次",
+    "再试",
+    "重试",
+    "重新生成",
+    "再来一次",
+    "再生成一次",
+    "再跑一遍",
+))
+
+
+def atomic_regenerate_intent(text: str) -> bool:
+    """True when user wants to re-run gen on existing atomic_node_id."""
+    t = (text or "").strip()
+    if not t:
+        return False
+    if _is_campaign_override(t):
+        return False
+    if atomic_create_intent(t):
+        return False
+    lowered = t.lower()
+    if any(h in lowered or h in t for h in ATOMIC_REGENERATE_HINTS):
+        return True
+    return lowered in ("retry", "again")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd services/agent-runtime && python -m pytest tests/test_atomic_regenerate_intent.py -v`  
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/agent-runtime/app/graph/atomic_intent.py \
+  services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml \
+  services/agent-runtime/tests/test_atomic_regenerate_intent.py
+git commit -m "feat(agent): add atomic_regenerate intent classifier"
+```
+
+---
+
+### Task 2: Intake routing with checkpoint gate
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/state.py`
+- Modify: `services/agent-runtime/app/graph/nodes/intake.py`
+- Modify: `services/agent-runtime/tests/test_atomic_create_intent.py` (add one case)
+
+**Interfaces:**
+- Consumes: `atomic_regenerate_intent(text: str) -> bool` from Task 1
+- Produces: intake sets `flow_mode: "atomic_regenerate"` when checkpoint has `atomic_node_id` + `atomic_spec` and text matches
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_atomic_create_intent.py`:
+
+```python
+from app.graph.atomic_intent import atomic_regenerate_intent
+from app.graph.nodes.intake import make_intake_node
+from langchain_core.messages import HumanMessage
+import pytest
+from pathlib import Path
+
+
+@pytest.mark.asyncio
+async def test_intake_atomic_regenerate_when_prior_node(tmp_path: Path):
+    skills = Path(__file__).resolve().parents[1] / "skills"
+    intake = make_intake_node(skills)
+    out = await intake({
+        "messages": [HumanMessage(content="再试一次")],
+        "atomic_node_id": "node-abc",
+        "atomic_spec": {"target_type": "image", "title": "模特图", "prompt": "模特人物图"},
+    })
+    assert out["flow_mode"] == "atomic_regenerate"
+    assert atomic_regenerate_intent("再试一次")
+
+
+@pytest.mark.asyncio
+async def test_intake_regenerate_without_prior_node_falls_through(tmp_path: Path):
+    skills = Path(__file__).resolve().parents[1] / "skills"
+    intake = make_intake_node(skills)
+    out = await intake({
+        "messages": [HumanMessage(content="再试一次")],
+    })
+    assert out.get("flow_mode") != "atomic_regenerate"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/agent-runtime && python -m pytest tests/test_atomic_create_intent.py::test_intake_atomic_regenerate_when_prior_node -v`  
+Expected: FAIL (`flow_mode` is `"campaign"` or `"atomic_create"` not `"atomic_regenerate"`)
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `state.py` extend flow_mode:
+
+```python
+flow_mode: Literal["campaign", "single_node", "atomic_create", "atomic_regenerate"] | None
+```
+
+In `intake.py` import `atomic_regenerate_intent` and after single_node block, before atomic_create:
+
+```python
+        elif (
+            atomic_regenerate_intent(text)
+            and str(state.get("atomic_node_id") or "").strip()
+            and isinstance(state.get("atomic_spec"), dict)
+        ):
+            mode = "create"
+            proposed_brief = None
+            flow_mode = "atomic_regenerate"
+            skill_id = None
+        elif is_atomic:
+            ...
+```
+
+And in `resolved_flow`:
+
+```python
+        resolved_flow = (
+            flow_mode
+            if is_single_node or is_atomic or flow_mode == "atomic_regenerate"
+            else "campaign"
+        )
+```
+
+Initialize `flow_mode = "campaign"` at top of intake to avoid UnboundLocalError on chat path.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd services/agent-runtime && python -m pytest tests/test_atomic_create_intent.py::test_intake_atomic_regenerate_when_prior_node tests/test_atomic_create_intent.py::test_intake_regenerate_without_prior_node_falls_through -v`  
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/agent-runtime/app/graph/state.py \
+  services/agent-runtime/app/graph/nodes/intake.py \
+  services/agent-runtime/tests/test_atomic_create_intent.py
+git commit -m "feat(agent): route atomic_regenerate from intake when checkpoint has node"
+```
+
+---
+
+### Task 3: prepare_atomic_regenerate node
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/nodes/prepare_atomic_regenerate.py`
+- Modify: `services/agent-runtime/app/graph/subgraphs/atomic_create_gate.py`
+- Modify: `services/agent-runtime/app/graph/builder.py`
+
+**Interfaces:**
+- Consumes: state keys `atomic_node_id: str`, `atomic_spec: dict`
+- Produces: `make_prepare_atomic_regenerate_node(*, nest: Any) -> Callable` returning async node that emits:
+  ```python
+  {
+      "phase": "atomic_create",
+      "last_error": None,
+      "atomic_record_id": None,
+      "user_decision": "none",
+      "messages": [AIMessage(content=f"正在重新生成「{title}」…")],
+  }
+  ```
+- Produces: `route_after_intake` maps `flow_mode=="atomic_regenerate"` → `"prepare_atomic_regenerate"`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_atomic_regenerate_flow.py`:
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.graph.builder import route_after_intake
+from app.graph.nodes.prepare_atomic_regenerate import make_prepare_atomic_regenerate_node
+from app.graph.nodes.run_atomic_gen import make_run_atomic_gen_node
+
+
+class FakeNest:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Any]] = []
+
+    async def get_node(self, node_id: str) -> dict[str, Any]:
+        self.calls.append(("get_node", node_id))
+        return {"id": node_id, "type": "image", "title": "模特图"}
+
+    async def run_image_generation(self, node_id: str) -> dict[str, Any]:
+        self.calls.append(("run_image_generation", node_id))
+        return {"status": "completed", "generationRecordId": "rec-regen-1"}
+
+
+def test_route_after_intake_regenerate():
+    assert route_after_intake({"flow_mode": "atomic_regenerate"}) == "prepare_atomic_regenerate"
+
+
+@pytest.mark.asyncio
+async def test_prepare_then_regenerate_skips_create():
+    nest = FakeNest()
+    spec = {"target_type": "image", "title": "模特图", "prompt": "模特人物图", "confirm_gate": False}
+    state = {"atomic_node_id": "node-abc", "atomic_spec": spec, "last_error": "tool_timeout"}
+
+    prep = make_prepare_atomic_regenerate_node(nest=nest)
+    prepped = await prep(state)
+    assert prepped["last_error"] is None
+    assert "重新生成" in prepped["messages"][0].content
+
+    run = make_run_atomic_gen_node(nest=nest)
+    done = await run({**state, **prepped})
+    assert done["phase"] == "done"
+    assert not any(c[0] == "add_nodes_batch" for c in nest.calls)
+    assert ("run_image_generation", "node-abc") in nest.calls
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/agent-runtime && python -m pytest tests/test_atomic_regenerate_flow.py -v`  
+Expected: FAIL (`prepare_atomic_regenerate` / route not found)
+
+- [ ] **Step 3: Write minimal implementation**
+
+`prepare_atomic_regenerate.py`:
+
+```python
+"""L1-03: re-run atomic gen on existing canvas node (skip parse/create)."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from langchain_core.messages import AIMessage
+
+
+def make_prepare_atomic_regenerate_node(*, nest: Any) -> Callable:
+    async def prepare_atomic_regenerate(state: dict) -> dict:
+        node_id = str(state.get("atomic_node_id") or "").strip()
+        spec = state.get("atomic_spec") or {}
+        title = str(spec.get("title") or spec.get("target_type") or "节点")
+
+        if not node_id:
+            return {
+                "phase": "error",
+                "last_error": "missing atomic_node_id",
+                "messages": [AIMessage(content="没有可重新生成的节点，请先描述要创作的内容。")],
+            }
+
+        get_node = getattr(nest, "get_node", None)
+        if get_node is not None:
+            try:
+                node = await get_node(node_id)
+                if not isinstance(node, dict) or not str(node.get("id") or node_id).strip():
+                    return {
+                        "phase": "error",
+                        "last_error": "atomic node missing",
+                        "messages": [AIMessage(content="画布节点已不存在，请重新描述要生成的内容。")],
+                    }
+            except Exception as exc:  # noqa: BLE001
+                return {
+                    "phase": "error",
+                    "last_error": str(exc),
+                    "messages": [AIMessage(content=f"读取节点失败：{exc}")],
+                }
+
+        return {
+            "phase": "atomic_create",
+            "flow_mode": "atomic_regenerate",
+            "last_error": None,
+            "atomic_record_id": None,
+            "user_decision": "none",
+            "messages": [AIMessage(content=f"正在重新生成「{title}」…")],
+        }
+
+    return prepare_atomic_regenerate
+```
+
+In `atomic_create_gate.py`:
+
+```python
+from app.graph.nodes.prepare_atomic_regenerate import make_prepare_atomic_regenerate_node
+
+def register_atomic_create_gate(graph: StateGraph, *, nest: Any) -> None:
+    graph.add_node("prepare_atomic_regenerate", make_prepare_atomic_regenerate_node(nest=nest))
+    ...
+    graph.add_edge("prepare_atomic_regenerate", "run_atomic_gen")
+```
+
+In `builder.py`:
+
+```python
+def route_after_intake(state: AgentRuntimeState) -> str:
+    if state.get("flow_mode") == "atomic_regenerate":
+        return "prepare_atomic_regenerate"
+    if state.get("flow_mode") == "single_node":
+        ...
+```
+
+And add to conditional_edges map:
+
+```python
+        {
+            "prepare_atomic_regenerate": "prepare_atomic_regenerate",
+            "prepare_single_gen": "prepare_single_gen",
+            ...
+        },
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd services/agent-runtime && python -m pytest tests/test_atomic_regenerate_flow.py -v`  
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/agent-runtime/app/graph/nodes/prepare_atomic_regenerate.py \
+  services/agent-runtime/app/graph/subgraphs/atomic_create_gate.py \
+  services/agent-runtime/app/graph/builder.py \
+  services/agent-runtime/tests/test_atomic_regenerate_flow.py
+git commit -m "feat(agent): prepare_atomic_regenerate skips parse/create"
+```
+
+---
+
+### Task 4: Video/audio regenerate + subgraph regression
+
+**Files:**
+- Modify: `services/agent-runtime/tests/test_atomic_regenerate_flow.py`
+- Modify: `services/agent-runtime/tests/test_atomic_create_subgraph.py`
+
+**Interfaces:**
+- Consumes: existing `run_atomic_gen` + confirm_gate spec fields
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test_atomic_regenerate_flow.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_video_regenerate_skips_confirm_gate():
+    class VideoNest(FakeNest):
+        async def run_video_generation(self, node_id: str) -> dict[str, Any]:
+            self.calls.append(("run_video_generation", node_id))
+            return {"status": "completed", "url": "https://cdn/v2.mp4"}
+
+    nest = VideoNest()
+    spec = {
+        "target_type": "video",
+        "title": "产品视频",
+        "prompt": "15秒展示",
+        "confirm_gate": True,
+    }
+    prep = make_prepare_atomic_regenerate_node(nest=nest)
+    prepped = await prep({"atomic_node_id": "vid-1", "atomic_spec": spec})
+    run = make_run_atomic_gen_node(nest=nest)
+    done = await run({**prepped, "atomic_node_id": "vid-1", "atomic_spec": spec})
+    assert done["phase"] == "done"
+    assert ("run_video_generation", "vid-1") in nest.calls
+    assert not any(c[0] == "add_nodes_batch" for c in nest.calls)
+```
+
+- [ ] **Step 2: Run test — expect PASS without code change**
+
+Run: `cd services/agent-runtime && python -m pytest tests/test_atomic_regenerate_flow.py::test_video_regenerate_skips_confirm_gate -v`  
+Expected: PASS (documents contract; fix only if fail)
+
+- [ ] **Step 3: Run full atomic test suite**
+
+Run: `cd services/agent-runtime && python -m pytest tests/test_atomic*.py -v`  
+Expected: all PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add services/agent-runtime/tests/test_atomic_regenerate_flow.py
+git commit -m "test(agent): video/audio atomic_regenerate skips confirm gate"
+```
+
+---
+
+### Task 5: Production smoke — two-turn regenerate
+
+**Files:**
+- Create: `deploy/prod-atomic-regenerate-verify.py`
+- Modify: `deploy/prod-p4-full-regression.py` (optional append as Phase C2)
+
+**Interfaces:**
+- Consumes: prod API `POST /api/agent/chat/conversation` with same `threadId`
+
+- [ ] **Step 1: Write deploy script**
+
+```python
+#!/usr/bin/env python3
+"""Prod smoke: atomic_create turn 1 → forced fail mock not available — use image regen path.
+
+Turn 1: 帮我生成一个模特人物图  → node created + gen ok
+Turn 2: 再试一次               → same thread, no second node, gen called again
+
+Reuse SSE helpers from prod-atomic-studio-verify.py.
+Assert: session node count for title stable; second SSE has「重新生成」or completed again.
+"""
+```
+
+Implementation notes for engineer:
+- Copy `http`, `sse_collect`, auth helpers from `deploy/prod-atomic-studio-verify.py`
+- Use fixed `thread_id = f"regen_{uuid.uuid4().hex[:8]}"`
+- After turn 1: `GET /api/agent/sessions/{id}` → capture node count + first node id
+- Turn 2 message: `再试一次`
+- PASS if: node count unchanged; SSE assistant text contains `重新生成` or `生成完成`; no new plan/confirm gate events
+
+- [ ] **Step 2: Run locally against prod (optional)**
+
+Run: `python3 deploy/prod-atomic-regenerate-verify.py`  
+Expected: all checks PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deploy/prod-atomic-regenerate-verify.py
+git commit -m "test(deploy): prod atomic_regenerate two-turn smoke"
+```
+
+---
+
+### Task 6: Spec sync + PR
+
+**Files:**
+- Modify: `.trae/documents/loop-engineering-product-spec.md`
+- Modify: `.trae/documents/atomic-studio-intent-product-spec.md`
+
+- [ ] **Step 1: Update LC-5 V2 status**
+
+In `loop-engineering-product-spec.md` §3.4 change:
+
+```markdown
+**V2（未实现）**：`atomic_regenerate` ...
+```
+
+to:
+
+```markdown
+**V2（L1-03 ✅）**：`atomic_regenerate` — 同 thread「再试一次」+ checkpoint 有 `atomic_node_id` → `prepare_atomic_regenerate` → `run_atomic_gen`
+```
+
+In `atomic-studio-intent-product-spec.md` §2.2.3 append implementation note + link to this plan.
+
+- [ ] **Step 2: Final validation**
+
+Run: `cd services/agent-runtime && python -m pytest tests/test_atomic*.py -v`  
+Run: `pnpm build`
+
+- [ ] **Step 3: Push + PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --base main --title "feat(agent): L1-03 atomic_regenerate loop" --body "$(cat <<'EOF'
+## Summary
+- Add `atomic_regenerate_intent` and intake routing when checkpoint retains `atomic_node_id`
+- New `prepare_atomic_regenerate` node skips parse/create and re-runs Harness gen
+- Prod two-turn smoke script
+
+## Test plan
+- [x] pytest tests/test_atomic*.py
+- [ ] pnpm build
+- [ ] deploy/prod-atomic-regenerate-verify.py
+- [ ] deploy/prod-p4-full-regression.py
+
+EOF
+)"
+```
+
+---
+
+## Self-Review (spec coverage)
+
+| Spec requirement | Task |
+| --- | --- |
+| LC-5 V2 skip parse/create | Task 3 |
+| Same thread + atomic_node_id gate | Task 2 |
+| L-P5 single round per turn | Task 3 (`run_atomic_gen` once) |
+| P3 focus priority | Task 2 (single_node checked first) |
+| New create not hijacked | Task 1 (`atomic_create_intent` excludes regenerate) |
+| L-A5 atomic done termination | Task 3 reuses `run_atomic_gen` |
+| Prod verification | Task 5 |
+
+No placeholders remain. Types consistent: `flow_mode="atomic_regenerate"` used in intake, builder, prepare node.

--- a/services/agent-runtime/app/graph/atomic_intent.py
+++ b/services/agent-runtime/app/graph/atomic_intent.py
@@ -75,6 +75,16 @@ ATOMIC_CONFIRM_KEYWORDS = tuple(_TAXONOMY.get("atomic_confirm_keywords") or (
 
 ATOMIC_CANCEL_KEYWORDS = ("取消", "不要了", "算了", "放弃")
 
+ATOMIC_REGENERATE_HINTS = tuple(_TAXONOMY.get("atomic_regenerate_hints") or (
+    "再试一次",
+    "再试",
+    "重试",
+    "重新生成",
+    "再来一次",
+    "再生成一次",
+    "再跑一遍",
+))
+
 # Full-campaign phrases — atomic keyword substrings (e.g. 「图」in「出图」) must not hijack.
 CAMPAIGN_OVERRIDE_PHRASES = (
     "营销方案",
@@ -117,6 +127,21 @@ def atomic_create_intent(text: str) -> bool:
     if any(h in lowered for h in IMAGE_KEYWORDS):
         return True
     return False
+
+
+def atomic_regenerate_intent(text: str) -> bool:
+    """True when user wants to re-run gen on existing atomic_node_id."""
+    t = (text or "").strip()
+    if not t:
+        return False
+    if _is_campaign_override(t):
+        return False
+    if atomic_create_intent(t):
+        return False
+    lowered = t.lower()
+    if any(h in lowered or h in t for h in ATOMIC_REGENERATE_HINTS):
+        return True
+    return lowered in ("retry", "again")
 
 
 def resolve_intake_route(

--- a/services/agent-runtime/app/graph/builder.py
+++ b/services/agent-runtime/app/graph/builder.py
@@ -21,6 +21,8 @@ from app.graph.subgraphs.topo_gate import register_topo_gate
 
 
 def route_after_intake(state: AgentRuntimeState) -> str:
+    if state.get("flow_mode") == "atomic_regenerate":
+        return "prepare_atomic_regenerate"
     if state.get("flow_mode") == "single_node":
         return "prepare_single_gen"
     if state.get("flow_mode") == "atomic_create":
@@ -66,6 +68,7 @@ def build_agent_graph(
         "intake",
         route_after_intake,
         {
+            "prepare_atomic_regenerate": "prepare_atomic_regenerate",
             "prepare_single_gen": "prepare_single_gen",
             "parse_atomic_intent": "parse_atomic_intent",
             "decide_plan_mode": "decide_plan_mode",

--- a/services/agent-runtime/app/graph/nodes/intake.py
+++ b/services/agent-runtime/app/graph/nodes/intake.py
@@ -51,6 +51,11 @@ def make_intake_node(skills_dir: Path) -> Callable:
             flow_mode = "single_node"
             if not skill_id and "enterprise-marketing-campaign" in by_id:
                 skill_id = "enterprise-marketing-campaign"
+        elif is_atomic:
+            mode = "create"
+            proposed_brief = None
+            flow_mode = "atomic_create"
+            skill_id = None
         elif (
             atomic_regenerate_intent(text)
             and str(state.get("atomic_node_id") or "").strip()
@@ -59,11 +64,6 @@ def make_intake_node(skills_dir: Path) -> Callable:
             mode = "create"
             proposed_brief = None
             flow_mode = "atomic_regenerate"
-            skill_id = None
-        elif is_atomic:
-            mode = "create"
-            proposed_brief = None
-            flow_mode = "atomic_create"
             skill_id = None
         elif is_modify:
             mode = "modify"

--- a/services/agent-runtime/app/graph/nodes/intake.py
+++ b/services/agent-runtime/app/graph/nodes/intake.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable
 
-from app.graph.atomic_intent import resolve_intake_route
+from app.graph.atomic_intent import atomic_regenerate_intent, resolve_intake_route
 from app.graph.intent import marketing_intent, modify_intent, single_node_gen_intent  # re-export for tests
 from app.graph.state import BRIEF_RESET_PREFIX
 from app.skills.loader import discover_skills
@@ -25,6 +25,7 @@ def make_intake_node(skills_dir: Path) -> Callable:
         requested = str(state.get("requested_skill_id") or "").strip()
         by_id = {e.skill_id: e for e in entries}
         skill_id: str | None = None
+        flow_mode = "campaign"
         if requested and requested in by_id:
             skill_id = requested
         elif marketing_intent(text):
@@ -50,6 +51,15 @@ def make_intake_node(skills_dir: Path) -> Callable:
             flow_mode = "single_node"
             if not skill_id and "enterprise-marketing-campaign" in by_id:
                 skill_id = "enterprise-marketing-campaign"
+        elif (
+            atomic_regenerate_intent(text)
+            and str(state.get("atomic_node_id") or "").strip()
+            and isinstance(state.get("atomic_spec"), dict)
+        ):
+            mode = "create"
+            proposed_brief = None
+            flow_mode = "atomic_regenerate"
+            skill_id = None
         elif is_atomic:
             mode = "create"
             proposed_brief = None
@@ -67,11 +77,10 @@ def make_intake_node(skills_dir: Path) -> Callable:
         else:
             mode = "create"
             proposed_brief = None
-            flow_mode = "campaign"
 
         resolved_flow = (
             flow_mode
-            if is_single_node or is_atomic
+            if is_single_node or is_atomic or flow_mode == "atomic_regenerate"
             else "campaign"
         )
 

--- a/services/agent-runtime/app/graph/nodes/prepare_atomic_regenerate.py
+++ b/services/agent-runtime/app/graph/nodes/prepare_atomic_regenerate.py
@@ -1,0 +1,49 @@
+"""L1-03: re-run atomic gen on existing canvas node (skip parse/create)."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from langchain_core.messages import AIMessage
+
+
+def make_prepare_atomic_regenerate_node(*, nest: Any) -> Callable:
+    async def prepare_atomic_regenerate(state: dict) -> dict:
+        node_id = str(state.get("atomic_node_id") or "").strip()
+        spec = state.get("atomic_spec") or {}
+        title = str(spec.get("title") or spec.get("target_type") or "节点")
+
+        if not node_id:
+            return {
+                "phase": "error",
+                "last_error": "missing atomic_node_id",
+                "messages": [AIMessage(content="没有可重新生成的节点，请先描述要创作的内容。")],
+            }
+
+        get_node = getattr(nest, "get_node", None)
+        if get_node is not None:
+            try:
+                node = await get_node(node_id)
+                if not isinstance(node, dict) or not str(node.get("id") or node_id).strip():
+                    return {
+                        "phase": "error",
+                        "last_error": "atomic node missing",
+                        "messages": [AIMessage(content="画布节点已不存在，请重新描述要生成的内容。")],
+                    }
+            except Exception as exc:  # noqa: BLE001
+                return {
+                    "phase": "error",
+                    "last_error": str(exc),
+                    "messages": [AIMessage(content=f"读取节点失败：{exc}")],
+                }
+
+        return {
+            "phase": "atomic_create",
+            "flow_mode": "atomic_regenerate",
+            "last_error": None,
+            "atomic_record_id": None,
+            "user_decision": "none",
+            "messages": [AIMessage(content=f"正在重新生成「{title}」…")],
+        }
+
+    return prepare_atomic_regenerate

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -97,7 +97,7 @@ class AgentRuntimeState(TypedDict, total=False):
     session_id: str
     user_id: str
     prompt_version: str | None  # W19: active skill prompt template version
-    flow_mode: Literal["campaign", "single_node", "atomic_create"] | None  # W28/W29/P4
+    flow_mode: Literal["campaign", "single_node", "atomic_create", "atomic_regenerate"] | None  # W28/W29/P4
     focus_node_id: str | None  # W28: canvas node for single-node gen
     atomic_spec: dict | None  # P4: parsed atomic create intent
     atomic_node_id: str | None  # P4: created canvas node id

--- a/services/agent-runtime/app/graph/subgraphs/atomic_create_gate.py
+++ b/services/agent-runtime/app/graph/subgraphs/atomic_create_gate.py
@@ -9,6 +9,7 @@ from langgraph.graph import END, StateGraph
 from app.graph.nodes.atomic_create_node import make_create_atomic_node
 from app.graph.nodes.atomic_parse import make_parse_atomic_intent_node
 from app.graph.nodes.await_atomic_confirm import make_await_atomic_confirm_node
+from app.graph.nodes.prepare_atomic_regenerate import make_prepare_atomic_regenerate_node
 from app.graph.nodes.run_atomic_gen import make_run_atomic_gen_node
 from app.graph.state import AgentRuntimeState
 
@@ -34,6 +35,7 @@ def route_after_atomic_confirm(state: AgentRuntimeState) -> str:
 def register_atomic_create_gate(graph: StateGraph, *, nest: Any) -> None:
     graph.add_node("parse_atomic_intent", make_parse_atomic_intent_node(nest=nest))
     graph.add_node("create_atomic_node", make_create_atomic_node(nest=nest))
+    graph.add_node("prepare_atomic_regenerate", make_prepare_atomic_regenerate_node(nest=nest))
     graph.add_node("await_atomic_confirm", make_await_atomic_confirm_node())
     graph.add_node("run_atomic_gen", make_run_atomic_gen_node(nest=nest))
 
@@ -60,4 +62,5 @@ def register_atomic_create_gate(graph: StateGraph, *, nest: Any) -> None:
             "end": END,
         },
     )
+    graph.add_edge("prepare_atomic_regenerate", "run_atomic_gen")
     graph.add_edge("run_atomic_gen", "done")

--- a/services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml
+++ b/services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml
@@ -94,3 +94,12 @@ atomic_confirm_keywords:
   - 确认生成
   - 开始生成
   - 确认
+
+atomic_regenerate_hints:
+  - 再试一次
+  - 再试
+  - 重试
+  - 重新生成
+  - 再来一次
+  - 再生成一次
+  - 再跑一遍

--- a/services/agent-runtime/tests/test_atomic_create_intent.py
+++ b/services/agent-runtime/tests/test_atomic_create_intent.py
@@ -7,12 +7,16 @@ from pathlib import Path
 import pytest
 import yaml
 
+from langchain_core.messages import HumanMessage
+
 from app.graph.atomic_intent import (
     atomic_create_intent,
+    atomic_regenerate_intent,
     build_atomic_spec,
     parse_atomic_target_type,
     resolve_intake_route,
 )
+from app.graph.nodes.intake import make_intake_node
 
 EVAL_PATH = Path(__file__).resolve().parents[1] / "skills" / "atomic-create" / "eval-intent-set.yaml"
 
@@ -54,3 +58,26 @@ def test_d1_storyboard_is_text_not_prompt():
 def test_atomic_create_intent_negative_campaign():
     assert not atomic_create_intent("帮我做一套天猫蓝牙耳机详情页营销方案")
     assert atomic_create_intent("帮我生成一个模特人物图")
+
+
+@pytest.mark.asyncio
+async def test_intake_atomic_regenerate_when_prior_node(tmp_path: Path):
+    skills = Path(__file__).resolve().parents[1] / "skills"
+    intake = make_intake_node(skills)
+    out = await intake({
+        "messages": [HumanMessage(content="再试一次")],
+        "atomic_node_id": "node-abc",
+        "atomic_spec": {"target_type": "image", "title": "模特图", "prompt": "模特人物图"},
+    })
+    assert out["flow_mode"] == "atomic_regenerate"
+    assert atomic_regenerate_intent("再试一次")
+
+
+@pytest.mark.asyncio
+async def test_intake_regenerate_without_prior_node_falls_through(tmp_path: Path):
+    skills = Path(__file__).resolve().parents[1] / "skills"
+    intake = make_intake_node(skills)
+    out = await intake({
+        "messages": [HumanMessage(content="再试一次")],
+    })
+    assert out.get("flow_mode") != "atomic_regenerate"

--- a/services/agent-runtime/tests/test_atomic_create_intent.py
+++ b/services/agent-runtime/tests/test_atomic_create_intent.py
@@ -74,6 +74,19 @@ async def test_intake_atomic_regenerate_when_prior_node(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_intake_atomic_create_wins_over_regenerate_with_prior_node(tmp_path: Path):
+    skills = Path(__file__).resolve().parents[1] / "skills"
+    intake = make_intake_node(skills)
+    out = await intake({
+        "messages": [HumanMessage(content="帮我生成一个模特人物图")],
+        "atomic_node_id": "node-abc",
+        "atomic_spec": {"target_type": "image", "title": "模特图", "prompt": "模特人物图"},
+    })
+    assert out["flow_mode"] == "atomic_create"
+    assert out["flow_mode"] != "atomic_regenerate"
+
+
+@pytest.mark.asyncio
 async def test_intake_regenerate_without_prior_node_falls_through(tmp_path: Path):
     skills = Path(__file__).resolve().parents[1] / "skills"
     intake = make_intake_node(skills)

--- a/services/agent-runtime/tests/test_atomic_regenerate_flow.py
+++ b/services/agent-runtime/tests/test_atomic_regenerate_flow.py
@@ -65,3 +65,26 @@ async def test_video_regenerate_skips_confirm_gate():
     assert done["phase"] == "done"
     assert ("run_video_generation", "vid-1") in nest.calls
     assert not any(c[0] == "add_nodes_batch" for c in nest.calls)
+
+
+@pytest.mark.asyncio
+async def test_audio_regenerate_skips_confirm_gate():
+    class AudioNest(FakeNest):
+        async def run_audio_generation(self, node_id: str) -> dict[str, Any]:
+            self.calls.append(("run_audio_generation", node_id))
+            return {"status": "completed", "url": "https://cdn/v2.mp3"}
+
+    nest = AudioNest()
+    spec = {
+        "target_type": "audio",
+        "title": "产品配音",
+        "prompt": "15秒旁白",
+        "confirm_gate": True,
+    }
+    prep = make_prepare_atomic_regenerate_node(nest=nest)
+    prepped = await prep({"atomic_node_id": "aud-1", "atomic_spec": spec})
+    run = make_run_atomic_gen_node(nest=nest)
+    done = await run({**prepped, "atomic_node_id": "aud-1", "atomic_spec": spec})
+    assert done["phase"] == "done"
+    assert ("run_audio_generation", "aud-1") in nest.calls
+    assert not any(c[0] == "add_nodes_batch" for c in nest.calls)

--- a/services/agent-runtime/tests/test_atomic_regenerate_flow.py
+++ b/services/agent-runtime/tests/test_atomic_regenerate_flow.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.graph.builder import route_after_intake
+from app.graph.nodes.prepare_atomic_regenerate import make_prepare_atomic_regenerate_node
+from app.graph.nodes.run_atomic_gen import make_run_atomic_gen_node
+
+
+class FakeNest:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Any]] = []
+
+    async def get_node(self, node_id: str) -> dict[str, Any]:
+        self.calls.append(("get_node", node_id))
+        return {"id": node_id, "type": "image", "title": "模特图"}
+
+    async def run_image_generation(self, node_id: str) -> dict[str, Any]:
+        self.calls.append(("run_image_generation", node_id))
+        return {"status": "completed", "generationRecordId": "rec-regen-1"}
+
+
+def test_route_after_intake_regenerate():
+    assert route_after_intake({"flow_mode": "atomic_regenerate"}) == "prepare_atomic_regenerate"
+
+
+@pytest.mark.asyncio
+async def test_prepare_then_regenerate_skips_create():
+    nest = FakeNest()
+    spec = {"target_type": "image", "title": "模特图", "prompt": "模特人物图", "confirm_gate": False}
+    state = {"atomic_node_id": "node-abc", "atomic_spec": spec, "last_error": "tool_timeout"}
+
+    prep = make_prepare_atomic_regenerate_node(nest=nest)
+    prepped = await prep(state)
+    assert prepped["last_error"] is None
+    assert "重新生成" in prepped["messages"][0].content
+
+    run = make_run_atomic_gen_node(nest=nest)
+    done = await run({**state, **prepped})
+    assert done["phase"] == "done"
+    assert not any(c[0] == "add_nodes_batch" for c in nest.calls)
+    assert ("run_image_generation", "node-abc") in nest.calls

--- a/services/agent-runtime/tests/test_atomic_regenerate_flow.py
+++ b/services/agent-runtime/tests/test_atomic_regenerate_flow.py
@@ -42,3 +42,26 @@ async def test_prepare_then_regenerate_skips_create():
     assert done["phase"] == "done"
     assert not any(c[0] == "add_nodes_batch" for c in nest.calls)
     assert ("run_image_generation", "node-abc") in nest.calls
+
+
+@pytest.mark.asyncio
+async def test_video_regenerate_skips_confirm_gate():
+    class VideoNest(FakeNest):
+        async def run_video_generation(self, node_id: str) -> dict[str, Any]:
+            self.calls.append(("run_video_generation", node_id))
+            return {"status": "completed", "url": "https://cdn/v2.mp4"}
+
+    nest = VideoNest()
+    spec = {
+        "target_type": "video",
+        "title": "产品视频",
+        "prompt": "15秒展示",
+        "confirm_gate": True,
+    }
+    prep = make_prepare_atomic_regenerate_node(nest=nest)
+    prepped = await prep({"atomic_node_id": "vid-1", "atomic_spec": spec})
+    run = make_run_atomic_gen_node(nest=nest)
+    done = await run({**prepped, "atomic_node_id": "vid-1", "atomic_spec": spec})
+    assert done["phase"] == "done"
+    assert ("run_video_generation", "vid-1") in nest.calls
+    assert not any(c[0] == "add_nodes_batch" for c in nest.calls)

--- a/services/agent-runtime/tests/test_atomic_regenerate_intent.py
+++ b/services/agent-runtime/tests/test_atomic_regenerate_intent.py
@@ -1,0 +1,25 @@
+from app.graph.atomic_intent import (
+    atomic_create_intent,
+    atomic_regenerate_intent,
+)
+
+
+def test_atomic_regenerate_positive():
+    assert atomic_regenerate_intent("再试一次")
+    assert atomic_regenerate_intent("重试")
+    assert atomic_regenerate_intent("重新生成")
+    assert atomic_regenerate_intent("再来一次")
+
+
+def test_atomic_regenerate_not_new_create():
+    assert not atomic_regenerate_intent("帮我生成一个模特人物图")
+    assert atomic_create_intent("帮我生成一个模特人物图")
+
+
+def test_atomic_regenerate_not_campaign():
+    assert not atomic_regenerate_intent("帮我做一套天猫蓝牙耳机详情页营销方案")
+
+
+def test_atomic_regenerate_not_confirm_gate_reply():
+    assert not atomic_regenerate_intent("确认生成")
+    assert not atomic_regenerate_intent("取消")


### PR DESCRIPTION
## Summary
- Add `atomic_regenerate_intent` and intake routing when checkpoint retains `atomic_node_id`
- New `prepare_atomic_regenerate` node skips parse/create and re-runs Harness gen
- Prod two-turn smoke script

## Test plan
- [x] pytest tests/test_atomic*.py
- [x] pnpm build
- [ ] deploy/prod-atomic-regenerate-verify.py
- [ ] deploy/prod-p4-full-regression.py


Made with [Cursor](https://cursor.com)