### PR TITLE
docs: atomic intent hybrid phase 1-4 spec and plan

### DIFF
--- a/docs/superpowers/plans/2026-08-04-atomic-intent-hybrid-phases.md
+++ b/docs/superpowers/plans/2026-08-04-atomic-intent-hybrid-phases.md
@@ -1,0 +1,399 @@
+# Atomic Intent Hybrid — Phase 1–4 实施方案
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan phase-by-phase. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 将 atomic Studio 意图识别从关键词子串升级为 Hybrid 四层模型（路由 / 结构 / 模态 / 抽取），分四阶段交付可测增量。
+
+**Architecture:** Phase 1 纯规则+评测闭环；Phase 2 在 `parse_atomic_intent` 引入 LLM JSON fallback + clarify；Phase 3 注入 context/指代/adjust regenerate；Phase 4 编排复杂度分流 + Loop multi 上限与部分失败 compose。L1 路由始终由 Graph intake 决定，LLM 不直接改 flow_mode。
+
+**Tech Stack:** LangGraph (Python 3.11+), pytest, YAML eval sets, Nest Harness (`add_nodes_batch`, `run_*_generation`), optional LLM via existing agent-runtime LLM client.
+
+**Spec:** [2026-08-04-atomic-intent-hybrid-design.md](../specs/2026-08-04-atomic-intent-hybrid-design.md)
+
+## Global Constraints
+
+- Branch per phase from `main`: `feature/atomic-intent-p{N}-...` — **never push to main directly**.
+- Pre-PR: `cd services/agent-runtime && python -m pytest tests/test_atomic*.py -v` 全绿；涉及 TS 时 `pnpm build`。
+- Squash merge；合并后 `deploy-agent-runtime.yml` 自动部署 CVM。
+- L1 路由：`atomic_regenerate` 需 checkpoint（`atomic_node_id` + `atomic_spec`）；无 checkpoint 的 regenerate 短语 → chat/clarify，不建节点。
+- LLM 仅允许在 `parse_atomic_intent` 节点调用（Phase 2+）；temperature ≤ 0.2；失败回退规则 parse。
+- eval 集只增不删 gold；生产 bug 先入 `eval-intent-regression.yaml` 再修代码。
+- Commit per task；每 Phase 独立 PR。
+
+## File map（跨 Phase）
+
+| File | Phase | Role |
+| --- | --- | --- |
+| `app/graph/atomic_intent.py` | 1–3 | L1 路由、hint 互斥、复杂度分类（4） |
+| `app/graph/atomic_parse_util.py` | 1–3 | L2–L4 规则 parse、multi split、context |
+| `app/graph/atomic_parse_llm.py` | 2 | **NEW** LLM structured parse + validator |
+| `app/graph/nodes/intake.py` | 1 | checkpoint 优先 regenerate |
+| `app/graph/nodes/atomic_parse.py` | 1–2 | hybrid parse 编排 |
+| `app/graph/nodes/atomic_create_node.py` | 1 | multi `add_nodes_batch` |
+| `app/graph/nodes/run_atomic_gen.py` | 1, 4 | multi gen + 部分失败 compose |
+| `app/graph/nodes/clarify_atomic_intent.py` | 2 | **NEW** 低置信追问 |
+| `app/graph/nodes/adjust_atomic_regenerate.py` | 3 | **NEW** regenerate + prompt 微调 |
+| `app/graph/subgraphs/atomic_create_gate.py` | 2–3 | 注册 clarify/adjust 边 |
+| `app/graph/state.py` | 1–2 | `atomic_items`, `parse_confidence` |
+| `skills/atomic-create/intent-taxonomy.yaml` | 1–4 | hints、priority、multi cap |
+| `skills/atomic-create/eval-intent-set.yaml` | 1–4 | gold 集 |
+| `skills/atomic-create/eval-intent-regression.yaml` | 1 | **NEW** 生产 bug 集 |
+| `skills/atomic-create/assets/few-shots.yaml` | 2 | parse LLM few-shots |
+| `tests/test_atomic_*` | 1–4 | 单测 + eval |
+| `deploy/prod-atomic-intent-verify.py` | 1, 4 | 生产 smoke |
+
+---
+
+# Phase 1 — 规则层加固与评测闭环
+
+**PR 标题建议:** `fix(agent): atomic intent phase1 — hint mutual exclusion, multi-image, eval`
+
+**预计：** 2–3 天 | **依赖：** 无
+
+---
+
+### Task P1-1: Hint 互斥与 regenerate 路由
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/atomic_intent.py`
+- Modify: `services/agent-runtime/app/graph/nodes/intake.py`
+- Modify: `services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml`
+- Create: `services/agent-runtime/tests/test_atomic_regenerate_intent.py`（若不存在则扩写）
+
+**Interfaces:**
+- Produces: `_matches_regenerate_hints(text) -> bool`
+- Produces: `atomic_create_intent` 遇 regenerate 短语返回 False
+- Produces: intake `has_atomic_checkpoint and atomic_regenerate_intent` **先于** `is_atomic`
+
+- [ ] **Step 1: 写失败测试**
+
+```python
+def test_regenerate_phrase_not_create():
+    assert not atomic_create_intent("重新生成一张")
+    assert atomic_regenerate_intent("重新生成一张")
+
+@pytest.mark.asyncio
+async def test_intake_regenerate_before_create_with_checkpoint():
+    out = await intake({
+        "messages": [HumanMessage(content="重新生成一张")],
+        "atomic_node_id": "n1",
+        "atomic_spec": {"target_type": "image", "prompt": "模特人物图", "title": "模特图"},
+    })
+    assert out["flow_mode"] == "atomic_regenerate"
+```
+
+- [ ] **Step 2:** 实现 `_matches_regenerate_hints`；更新 taxonomy `intake_priority` 增加 regenerate 条目
+- [ ] **Step 3:** `pytest tests/test_atomic_regenerate_intent.py tests/test_atomic_create_intent.py -v`
+- [ ] **Step 4:** Commit `fix(agent): mutual-exclude regenerate hints from atomic create`
+
+---
+
+### Task P1-2: Multi-image 结构解析（规则）
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/atomic_parse_util.py`
+- Modify: `services/agent-runtime/app/graph/nodes/atomic_parse.py`
+- Modify: `services/agent-runtime/tests/test_atomic_parse_util.py`
+
+**Interfaces:**
+- Produces: `parse_atomic_multi_items(utterance) -> list[dict] | None`
+- Produces: `build_atomic_items_enriched(...) -> list[dict] | None`
+- Consumes: `parse_atomic_target_type` 必须为 image
+
+- [ ] **Step 1: 写失败测试**
+
+```python
+def test_parse_three_images_enumerated():
+    u = "帮我生成三张图，分别是蓝牙耳机主图、白底图、三视图。"
+    items = parse_atomic_multi_items(u)
+    assert items and len(items) == 3
+    assert [i["prompt"] for i in items] == ["蓝牙耳机主图", "白底图", "三视图"]
+```
+
+- [ ] **Step 2:** 实现 N张图 + 分别是/分别为/包括/冒号列表 解析；count 与 items 长度校验
+- [ ] **Step 3:** `atomic_parse` 有 multi 时写 `atomic_items` + 汇总 AIMessage
+- [ ] **Step 4:** Commit `feat(agent): parse enumerated multi-image atomic requests`
+
+---
+
+### Task P1-3: Multi create + multi gen
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/nodes/atomic_create_node.py`
+- Modify: `services/agent-runtime/app/graph/nodes/run_atomic_gen.py`
+- Modify: `services/agent-runtime/app/graph/state.py`
+- Modify: `services/agent-runtime/tests/test_atomic_create_subgraph.py`
+
+- [ ] **Step 1: 写失败测试** — 3 items → `add_nodes_batch` len=3 → `run_image_generation` ×3
+- [ ] **Step 2:** create 回填每项 `node_id`；gen 顺序执行并汇总 AIMessage
+- [ ] **Step 3:** `pytest tests/test_atomic_create_subgraph.py -v`
+- [ ] **Step 4:** Commit `feat(agent): batch atomic create and sequential gen`
+
+---
+
+### Task P1-4: 扩展 eval 集 + regression 文件
+
+**Files:**
+- Modify: `services/agent-runtime/skills/atomic-create/eval-intent-set.yaml`（50 句）
+- Create: `services/agent-runtime/skills/atomic-create/eval-intent-regression.yaml`
+- Modify: `services/agent-runtime/tests/test_atomic_create_intent_eval.py`
+
+**新增 gold case 类别（至少各 3 句）：**
+- regenerate（需 mock checkpoint 测 route _fn，或在 intake 集成测测）
+- multi-image 枚举
+- 子串陷阱（重新生成/确认生成/生成一张）
+- campaign 边界
+
+- [ ] **Step 1:** 添 case 先红
+- [ ] **Step 2:** 代码通过后全绿
+- [ ] **Step 3:** Commit `test(agent): expand atomic intent eval to 50 cases`
+
+---
+
+### Task P1-5: Prod smoke
+
+**Files:**
+- Create: `deploy/prod-atomic-intent-verify.py`（或扩展现有 regenerate verify）
+
+- [ ] **Step 1:** Turn1 模特图 → Turn2「重新生成一张」→ 同 prompt
+- [ ] **Step 2:** 三图枚举 → 侧栏含 3 节点完成文案
+- [ ] **Step 3:** Commit + PR + CI + squash merge + 验证 deploy-agent-runtime
+
+**Phase 1 完成标准：** 规格 P1-R1~R7 全部满足；prod smoke PASS。
+
+---
+
+# Phase 2 — LLM Structured Parse
+
+**PR 标题建议:** `feat(agent): atomic intent phase2 — hybrid LLM parse and clarify`
+
+**预计：** 4–5 天 | **依赖：** Phase 1 merged
+
+---
+
+### Task P2-1: Parse result schema 与 validator
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/atomic_parse_schema.py`
+- Create: `services/agent-runtime/tests/test_atomic_parse_schema.py`
+
+**Interfaces:**
+- Produces: `AtomicParseResult` TypedDict
+- Produces: `validate_parse_result(data: dict) -> AtomicParseResult | ClarifyResult`
+- Produces: `merge_rule_and_llm(rule_items, llm_items) -> AtomicParseResult`
+
+- [ ] **Step 1:** JSON schema 单测（缺字段、非法 target_type、items 空）
+- [ ] **Step 2:** marketing override post-check
+- [ ] **Step 3:** Commit `feat(agent): atomic parse result schema and validator`
+
+---
+
+### Task P2-2: LLM parse 节点
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/atomic_parse_llm.py`
+- Modify: `services/agent-runtime/skills/atomic-create/assets/few-shots.yaml`（≥20 对）
+- Modify: `services/agent-runtime/app/graph/nodes/atomic_parse.py`
+
+**Interfaces:**
+- Produces: `async def llm_parse_atomic_intent(utterance, canvas_context, few_shots) -> dict`
+- Consumes: 现有 LLM client（对齐 plan/revise 节点调用方式）
+
+- [ ] **Step 1:** Mock LLM 测试 — 返回合法 JSON → items 正确
+- [ ] **Step 2:** 实现 prompt 模板（system + schema + few-shots + user）
+- [ ] **Step 3:** `parse_atomic_intent`：规则高置信 → 跳过 LLM；否则 fallback
+- [ ] **Step 4:** LLM 异常 → 回退 `build_atomic_spec_enriched`
+- [ ] **Step 5:** Commit `feat(agent): LLM fallback for atomic parse`
+
+---
+
+### Task P2-3: Clarify 路径
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/nodes/clarify_atomic_intent.py`
+- Modify: `services/agent-runtime/app/graph/subgraphs/atomic_create_gate.py`
+
+- [ ] **Step 1:** confidence < 0.70 → `clarify_atomic_intent` → AIMessage 追问 → `done`（无 add_nodes）
+- [ ] **Step 2:** 集成测：歧义句「生成一下」→ 无 nest batch 调用
+- [ ] **Step 3:** Commit `feat(agent): clarify on low-confidence atomic parse`
+
+---
+
+### Task P2-4: Eval 80 句 + 误判率脚本
+
+**Files:**
+- Modify: `eval-intent-set.yaml`（80 句）
+- Create: `services/agent-runtime/scripts/eval_atomic_intent_report.py`
+
+- [ ] **Step 1:** 报告输出 route/target_type 混淆矩阵
+- [ ] **Step 2:** CI 门槛 ≥95%（LLM 测试用 recorded fixtures / mock）
+- [ ] **Step 3:** Commit + PR
+
+**Phase 2 完成标准：** P2-R1~R7；clarify E2E；eval ≥95%。
+
+---
+
+# Phase 3 — 上下文感知与指代消解
+
+**PR 标题建议:** `feat(agent): atomic intent phase3 — context, deixis, adjust regenerate`
+
+**预计：** 5 天 | **依赖：** Phase 2 merged
+
+---
+
+### Task P3-1: Context 组装
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/atomic_context.py`
+- Modify: `services/agent-runtime/app/graph/atomic_parse_llm.py`
+- Modify: `services/agent-runtime/app/graph/atomic_parse_util.py`
+
+**Interfaces:**
+- Produces: `build_atomic_parse_context(state) -> str`（canvas 一行 + 最近 2 轮摘要）
+
+- [ ] **Step 1:** 单测 context 格式与长度上限（≤500 字）
+- [ ] **Step 2:** 注入 rule parse 与 LLM parse
+- [ ] **Step 3:** Commit
+
+---
+
+### Task P3-2: 指代与 focus seed 增强
+
+**Files:**
+- Modify: `atomic_parse_util.py` — 扩展 `_DEICTIC_HINTS`、focus seed 逻辑
+- Modify: `eval-intent-set.yaml` — +15 指代句
+
+- [ ] **Step 1:** 「按刚才那个风格」+ history 摘要 → prompt 含风格继承（LLM 或规则 seed）
+- [ ] **Step 2:** 「多模式扩写这个主图 prompt」+ focus → 已有用例保持 pass
+- [ ] **Step 3:** Commit
+
+---
+
+### Task P3-3: Adjust regenerate（L1-04）
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/nodes/adjust_atomic_regenerate.py`
+- Modify: `atomic_intent.py` — `detect_regenerate_adjust(text) -> str | None`
+- Modify: `builder.py` / `atomic_create_gate.py` — regenerate 含 adjust 时走 adjust 节点
+
+- [ ] **Step 1:** 「重新生成一张，背景改成白色」→ 更新 spec.prompt 再 gen
+- [ ] **Step 2:** 纯 regenerate 仍走 `prepare_atomic_regenerate`
+- [ ] **Step 3:** Commit
+
+---
+
+### Task P3-4: Thread 污染防护
+
+**Files:**
+- Modify: `app/graph/nodes/intake.py` 或 checkpoint hydrate 逻辑
+- Create: `tests/test_atomic_thread_isolation.py`
+
+- [ ] **Step 1:** atomic_create/regenerate turn 不读取 `plan_draft`/`split_manifest` 做路由
+- [ ] **Step 2:** Campaign 混合画布复测用例
+- [ ] **Step 3:** Commit + PR
+
+**Phase 3 完成标准：** P3-R1~R6；指代集 100% pass；thread 隔离 PASS。
+
+---
+
+# Phase 4 — Loop 扩展与编排分流
+
+**PR 标题建议:** `feat(agent): atomic intent phase4 — orchestration routing and multi limits`
+
+**预计：** 5–7 天 | **依赖：** Phase 3 merged
+
+---
+
+### Task P4-1: 编排复杂度分类
+
+**Files:**
+- Modify: `atomic_intent.py` — `orchestration_complexity_intent(text) -> Literal["atomic","campaign","clarify"]`
+- Modify: `intake.py` — 高复杂度 → campaign 或 clarify suggest
+- Modify: `intent-taxonomy.yaml`
+
+- [ ] **Step 1:** 「12 个分镜镜头」→ campaign；「三张图分别是…」→ atomic
+- [ ] **Step 2:** eval 分流集 20 句
+- [ ] **Step 3:** Commit
+
+---
+
+### Task P4-2: Multi 上限与混合模态 confirm
+
+**Files:**
+- Modify: `atomic_parse_schema.py` — items > 5 → clarify
+- Modify: `atomic_create_gate.py` — multi 含 video/audio → `await_atomic_confirm`
+
+- [ ] **Step 1:** 6 图请求 → 侧栏 suggest 改用 Campaign
+- [ ] **Step 2:** 2 图 + 1 视频 → 确认门
+- [ ] **Step 3:** Commit
+
+---
+
+### Task P4-3: Loop LC-6 部分失败 compose
+
+**Files:**
+- Modify: `run_atomic_gen.py` — 部分成功/失败 AIMessage（已有雏形则扩展）
+- Modify: `docs/superpowers/specs/2026-08-04-loop-engineering-design.md` — 标记 LC-6
+
+- [ ] **Step 1:** 3 gen 中 1 fail → phase=error 但 messages 列明已完成项
+- [ ] **Step 2:** Commit
+
+---
+
+### Task P4-4: ADR + 全量 prod smoke
+
+**Files:**
+- Create: `docs/adr/p5-atomic-orchestration-boundary-adr.md`
+- Modify: `deploy/prod-atomic-intent-verify.py` — ≥12 case
+
+- [ ] **Step 1:** 文档化 atomic vs campaign 边界
+- [ ] **Step 2:** 生产 12 case 全 PASS
+- [ ] **Step 3:** PR + merge
+
+**Phase 4 完成标准：** P4-R1~R6 全部满足。
+
+---
+
+## 执行顺序与 PR 策略
+
+| Phase | 分支示例 | 合并前提 |
+|-------|----------|----------|
+| 1 | `fix/atomic-intent-p1-rules` | eval 50 全绿 + smoke |
+| 2 | `feature/atomic-intent-p2-llm` | eval 80 ≥95% + clarify E2E |
+| 3 | `feature/atomic-intent-p3-context` | 指代集 100% + thread 隔离 |
+| 4 | `feature/atomic-intent-p4-orchestration` | 分流集 100% + smoke 12 |
+
+**不建议**把 Phase 1–4 挤在一个 PR：规则/LLM/上下文/分流耦合过高，review 与回滚成本大。
+
+---
+
+## 与当前本地分支的关系
+
+`fix/atomic-regenerate-phrase` 上的改动 ≈ **Phase 1 的部分实现**（P1-1~P1-3）。建议：
+
+1. 重命名/拆 PR 为 `fix/atomic-intent-p1-rules`
+2. 补全 P1-4 eval + P1-5 smoke 后再合并
+3. Phase 2 从 main 新分支开始
+
+---
+
+## Self-Review（规格覆盖）
+
+| 规格需求 | 本计划 Task |
+|----------|-------------|
+| P1-R1~R7 | P1-1 ~ P1-5 |
+| P2-R1~R7 | P2-1 ~ P2-4 |
+| P3-R1~R6 | P3-1 ~ P3-4 |
+| P4-R1~R6 | P4-1 ~ P4-4 |
+
+无 TBD 占位；每 Phase 有独立验收与 PR 边界。
+
+---
+
+**Plan complete.** 规格：`docs/superpowers/specs/2026-08-04-atomic-intent-hybrid-design.md`  
+**Two execution options:**
+
+1. **Subagent-Driven（推荐）** — 按 Phase 派发子 agent，Phase 内按 Task 迭代  
+2. **Inline Execution** — 本会话从 Phase 1 Task P1-4（补 eval）开始连续实施
+
+如需我先 **补全 Phase 1 剩余 eval/smoke 并提 PR**，或 **开 Phase 2 分支写 LLM parse 骨架**，直接说即可。

--- a/docs/superpowers/specs/2026-08-04-atomic-intent-hybrid-design.md
+++ b/docs/superpowers/specs/2026-08-04-atomic-intent-hybrid-design.md
@@ -1,0 +1,315 @@
+# Atomic Intent Hybrid — 分阶段需求规格（Phase 1–4）
+
+> 状态：**Draft**（2026-08-04）  
+> 日期：2026-08-04  
+> 前置：[2026-08-03-atomic-studio-intent-design.md](./2026-08-03-atomic-studio-intent-design.md)（P4）、[2026-08-04-loop-engineering-design.md](./2026-08-04-loop-engineering-design.md)（L1）  
+> 实施计划：[2026-08-04-atomic-intent-hybrid-phases.md](../plans/2026-08-04-atomic-intent-hybrid-phases.md)
+
+| 字段 | 值 |
+|------|-----|
+| 文档版本 | v1.0 |
+| 创建日期 | 2026-08-04 |
+| 文档定位 | 原子 Studio 意图识别从「关键词子串」升级为「Hybrid 分层识别」的产品与技术规格 |
+| 动机 | 生产复测暴露：regenerate/create 子串冲突、多图请求单节点、变体句式覆盖不足 |
+
+---
+
+## 一、问题陈述
+
+### 1.1 现状（P4 + L1-03 已交付）
+
+| 组件 | 实现方式 | 局限 |
+|------|----------|------|
+| **intake 路由** | `marketing_intent` / `single_node_gen_intent` / `atomic_create_intent` / `atomic_regenerate_intent` 关键词 | 子串互斥（如「生成一张」⊂「重新生成一张」）；`resolve_intake_route` 不感知 checkpoint |
+| **parse** | `build_atomic_spec_enriched` 规则 + prefix strip | 无 LLM；多 item 仅靠硬编码正则；整句作 prompt |
+| **create/gen** | 单 `atomic_spec` + 单 `atomic_node_id` | 一次请求只能 1 节点 1 次生成（除非临时 patch `atomic_items`） |
+| **评测** | `eval-intent-set.yaml` 30 句 | 无 regenerate / multi-image / 子串陷阱 gold case |
+
+### 1.2 用户期望
+
+用户在 Agent 侧栏用**自然语言变体**描述需求时，系统应：
+
+1. **正确选路**：Campaign / P3 单节点 / atomic 新建 / atomic 重生成 / chat
+2. **正确结构**：单条 vs 多条资产（如 3 张不同用途的图）
+3. **正确模态**：image / text / video / audio / prompt（含 D1/D2）
+4. **正确 payload**：每条资产有独立 `title` + `prompt`，而非整句原文
+5. **低置信澄清**：歧义时追问，不擅自建节点或走错链路
+
+### 1.3 非目标（四阶段整体）
+
+- 替代 Campaign 14 节点营销全链路
+- 在 atomic_create 内实现 12+ 节点分镜编排（属 Phase 4 Loop/Campaign 扩展）
+- ReAct 无限工具循环
+- 前端 Studio 大改
+
+---
+
+## 二、目标架构：四层意图模型
+
+将「意图识别」拆为四个**正交维度**，每层独立评测、独立演进：
+
+```
+用户输入 + checkpoint + 画布摘要 + 近期 history
+        │
+        ▼
+┌───────────────────────────────────────────────────┐
+│ L1 路由层 (flow_mode)                              │
+│ campaign | single_node | atomic_regenerate         │
+│          | atomic_create | chat                    │
+└───────────────────────────────────────────────────┘
+        │ atomic_create / regenerate
+        ▼
+┌───────────────────────────────────────────────────┐
+│ L2 结构层 (structure)                              │
+│ single | multi (items[])                           │
+└───────────────────────────────────────────────────┘
+        ▼
+┌───────────────────────────────────────────────────┐
+│ L3 模态层 (target_type)                            │
+│ image | text | video | audio | prompt              │
+└───────────────────────────────────────────────────┘
+        ▼
+┌───────────────────────────────────────────────────┐
+│ L4 抽取层 (title, prompt per item)                 │
+└───────────────────────────────────────────────────┘
+```
+
+### 2.1 L1 路由优先级（有 checkpoint 时 regenerate 优先）
+
+| 优先级 | 条件 | `flow_mode` |
+|--------|------|-------------|
+| 1 | `marketing_intent` 且非纯原子句 | `campaign` |
+| 2 | `focus_node_id` + `single_node_gen_intent` + 非 modify | `single_node` |
+| 3 | **有** `atomic_node_id` + `atomic_spec` + regenerate 意图 | `atomic_regenerate` |
+| 4 | atomic 新建意图 | `atomic_create` |
+| 5 | else | `chat` |
+
+> **决策 I-1**：L1 以**规则高置信 fast path + checkpoint 门控**为主；Phase 2 起 LLM 仅辅助 L2–L4，不直接决定 flow_mode（避免 Graph 双栈）。
+
+### 2.2 数据契约增量
+
+```python
+# Phase 1 起：multi 为一等公民
+atomic_items: list[AtomicCreateSpec] | None  # 每项含 target_type, title, prompt, confirm_gate
+# create 后每项附加 node_id
+
+class AtomicParseResult(TypedDict):
+    flow_mode: Literal["atomic_create", "atomic_regenerate", "clarify"]
+    structure: Literal["single", "multi"]
+    items: list[AtomicCreateSpec]
+    confidence: float  # Phase 2+
+    reason: str        # Phase 2+，日志/调试
+    clarify_question: str | None  # Phase 2+，confidence < 阈值时
+```
+
+### 2.3 Hybrid 执行策略
+
+| 置信度 | 行为 |
+|--------|------|
+| 规则 ≥ 0.95 | 跳过 LLM，直接输出 |
+| 0.70 ≤ 规则 < 0.95 | LLM 校验/补全（Phase 2） |
+| LLM ≥ 0.70 | 采纳 LLM 结构化结果 |
+| < 0.70 | `clarify` — 侧栏追问，**不**建节点（Phase 2） |
+
+---
+
+## 三、Phase 1 — 规则层加固与评测闭环
+
+### 3.1 目标
+
+在不引入 LLM 的前提下，消除**已知生产 bug 类**，建立可回归的 gold 评测集，为多图提供**有限但可靠**的结构解析。
+
+### 3.2 需求
+
+| ID | 需求 | 验收 |
+|----|------|------|
+| P1-R1 | regenerate hint 与 create hint **互斥表**；create 遇 regenerate 短语提前 false | 「重新生成一张」→ regenerate，非 create |
+| P1-R2 | intake：**有 checkpoint 时 regenerate 优先于 create** | 同上 + 「再试一次」 |
+| P1-R3 | `atomic_regenerate_intent` 不再被 create 子串误杀 | 子串陷阱用例全 pass |
+| P1-R4 | multi-image：**N张图 + 枚举**（分别是/分别为/包括/冒号列表）→ `atomic_items` | 三图用例 → 3 节点 3 次 gen |
+| P1-R5 | `create_atomic_node` / `run_atomic_gen` 支持 `atomic_items` 批量 | batch add + 顺序 gen |
+| P1-R6 | 扩展 `eval-intent-set.yaml` 至 **≥50 句**，含 regenerate/multi/陷阱 | CI 100% gold pass |
+| P1-R7 | 更新 `intent-taxonomy.yaml` intake_priority 含 regenerate 路由 | taxonomy 与代码一致 |
+
+### 3.3 明确不做（Phase 1）
+
+- LLM parse
+- 「主图、白底、三视图各一张」无数量词句式
+- 跨模态 multi（如 1 图 + 1 文案同句）
+
+### 3.4 验收门槛
+
+- `pytest tests/test_atomic*.py` 全绿
+- eval 集新增 case **100% pass**
+- prod smoke：regenerate 两回合 + 三图枚举各 PASS
+
+---
+
+## 四、Phase 2 — LLM Structured Parse（Hybrid 兜底）
+
+### 4.1 目标
+
+规则无法覆盖的自然语言变体，由**轻量 LLM + JSON Schema + few-shot** 结构化解析；低置信时**澄清**而非误判。
+
+### 4.2 需求
+
+| ID | 需求 | 验收 |
+|----|------|------|
+| P2-R1 | `parse_atomic_intent` 节点：**规则 fast path → LLM fallback** | 规则命中零 LLM 调用（可测 mock） |
+| P2-R2 | LLM 输出强制 schema：`structure`, `items[]`, `confidence`, `reason` | schema 校验失败 → clarify |
+| P2-R3 | few-shots 扩至 **≥20 对**（含 multi/regenerate 负例/变体） | few-shot 加载测试 pass |
+| P2-R4 | `confidence < 0.70` → `phase=clarify`，AIMessage 追问，**interrupt 或 done 无副作用** | 歧义句不建节点 |
+| P2-R5 | post-validator：marketing 词 override → 拒绝 atomic；items 数量与数量词一致性检查 | 营销方案句不走 atomic |
+| P2-R6 | eval 集扩至 **≥80 句** + **变体生成脚本**（同义改写 smoke） | CI 误判率 < 5% |
+| P2-R7 | 可观测：日志记录 `confidence` + `reason`（prompt 脱敏前 80 字） | 结构化 log 字段 |
+
+### 4.3 LLM 调用约束（G-NEW-2）
+
+- **仅** `parse_atomic_intent` 节点可调用 LLM
+- 输入：`user utterance` + `canvas_context` 一行摘要 + 模态枚举
+- 输出：JSON only，temperature ≤ 0.2
+- 超时/失败：**回退**规则 parse，不 crash graph
+
+### 4.4 明确不做（Phase 2）
+
+- 多轮 Critic-Refiner
+- LLM 决定 intake flow_mode
+- 自动连边/拓扑
+
+### 4.5 验收门槛
+
+- 80 句 eval **≥95%** route + target_type 正确
+- LLM fallback 延迟 P95 < 3s（生产 agent-runtime）
+- clarify 路径 E2E：用户收到追问且无 canvas 副作用
+
+---
+
+## 五、Phase 3 — 上下文感知与指代消解
+
+### 5.1 目标
+
+利用 **checkpoint、画布摘要、focus 节点、近期对话**，解析指代与风格继承，减少「重复建同名节点」和「丢失上文语义」。
+
+### 5.2 需求
+
+| ID | 需求 | 验收 |
+|----|------|------|
+| P3-R1 | parse context 块：`canvas_summary`（已有）+ **最近 2 轮 human/ai 摘要** | context 注入单测 |
+| P3-R2 | 指代词（这个/这张/该/刚才/同样风格）+ `focus_node_id` → seed prompt/title | 「扩写这个主图 prompt」用例 |
+| P3-R3 | regenerate 时可带 **adjust 短语**（「换个风格」「背景改成白色」）→ 更新 `atomic_spec.prompt` 再 gen | L1-04 adjust 扩展 |
+| P3-R4 | dedupe：`atomic_items` 每项独立 dedupe title（已有 P4-05 逻辑扩展） | 画布已有「主图」→ 「主图 (2)」 |
+| P3-R5 | multi-image **无「分别是」**变体由 LLM 解析（依赖 P2） | 「主图、白底和三视图各来一张」→ 3 items |
+| P3-R6 | thread 污染防护：atomic turn 不加载 Campaign `plan_draft` / `split_manifest` | Campaign 混合画布复测 PASS |
+
+### 5.3 明确不做（Phase 3）
+
+- 完整 canvas JSON 进 context
+- 跨 session 长期记忆
+
+### 5.4 验收门槛
+
+- 指代用例集 **≥15 句，100% pass**
+- Campaign + atomic 同 thread 两回合无 plan 泄漏
+- prod：「按刚才那个风格再生成一张」PASS
+
+---
+
+## 六、Phase 4 — Loop 扩展与复杂编排分流
+
+### 6.1 目标
+
+**大于 atomic 能力边界**的请求（多分镜批量、拓扑依赖、营销全案）**显式分流**到 Campaign 或专用 Loop Skill，而非在 atomic_create 内堆逻辑。
+
+### 6.2 需求
+
+| ID | 需求 | 验收 |
+|----|------|------|
+| P4-R1 | **编排复杂度分类器**（规则+LLM）：节点数 ≥4 或含「分镜 N 个镜头」「全链路」「详情页方案」→ suggest Campaign | 12 张分镜句 → campaign 或 clarify |
+| P4-R2 | atomic multi 上限：**≤5 个同模态 item**；超出 → clarify 或 suggest Campaign | 6 图请求不 silent 截断 |
+| P4-R3 | Loop LC-6：**atomic_multi_gen** — items 顺序 gen + 部分失败 compose（继承 L-P3 retry 语义） | 3 图 1 失败 → 部分成功文案 |
+| P4-R4 | 可选 **atomic_batch_confirm**：multi + video/audio 混合时统一确认门 | 混合模态 HITL |
+| P4-R5 | 与 Campaign split 边界文档化 + eval case | ADR 更新 |
+| P4-R6 | prod smoke：`deploy/prod-atomic-intent-verify.py` 覆盖 Phase 1–3 回归 + Phase 4 分流 | 脚本 ≥12 case |
+
+### 6.3 分流决策表
+
+| 用户表达 | 推荐路径 |
+|----------|----------|
+| 1–5 张明确枚举图 | `atomic_create` multi |
+| 6+ 张 / 分镜 12 镜头 / 详情页 14 节点 | `campaign` |
+| 选中节点 +「快速生成这张」 | `single_node` (P3) |
+| 同 thread 再试 | `atomic_regenerate` |
+| 意图不明 | `clarify` → chat |
+
+### 6.4 验收门槛
+
+- 编排分流 eval **≥20 句，100%** 正确 route
+- multi 部分失败 E2E 有明确侧栏反馈
+- 无「atomic 路径 silent 建 1 节点糊弄 multi 请求」回归
+
+---
+
+## 七、评测与 CI 策略（跨 Phase）
+
+### 7.1 资产
+
+| 资产 | Phase 1 | Phase 2 | Phase 3 | Phase 4 |
+|------|---------|---------|---------|---------|
+| `eval-intent-set.yaml` | 50 | 80 | 95 | 110+ |
+| `eval-intent-regression.yaml` | 生产 bug 反哺 | +LLM 变体 | +指代 | +分流 |
+| `deploy/prod-atomic-intent-verify.py` | 基础 smoke | +clarify | +指代 | +分流 |
+
+### 7.2 CI 门槛演进
+
+| Phase | pytest | eval gold | 误判率 |
+|-------|--------|-----------|--------|
+| 1 | atomic* 全绿 | 100% | — |
+| 2 | + parse LLM mock | ≥95% | <5% |
+| 3 | + context | ≥95% | <3% |
+| 4 | + orchestration | ≥95% | <3% |
+
+### 7.3 生产 bug 反哺流程
+
+1. 用户反馈 utterance + 期望行为
+2. 加入 `eval-intent-regression.yaml`（先红后绿）
+3. 修复 + PR + prod smoke
+4. 关闭跟踪项
+
+---
+
+## 八、风险与缓解
+
+| 风险 | 缓解 |
+|------|------|
+| 规则与 LLM 结论冲突 | post-validator；冲突 → clarify |
+| LLM 延迟 | fast path 覆盖高频 30 句；异步不阻塞 intake |
+| thread 污染 | atomic 路径不 hydrate campaign state |
+| multi 部分失败 UX | compose 汇总；节点级 error 态 |
+| 范围蔓延 | Phase 4 强制分流，atomic multi cap=5 |
+
+---
+
+## 九、阶段依赖
+
+```
+Phase 1（规则+评测+multi 基础）
+    ↓
+Phase 2（LLM hybrid + clarify）
+    ↓
+Phase 3（context + 指代 + adjust regenerate）
+    ↓
+Phase 4（编排分流 + Loop multi + 上限）
+```
+
+每 Phase **独立可交付**：完成后生产可测，不依赖下一 Phase 上线。
+
+---
+
+## 十、关联文档更新清单
+
+| Phase | 需更新 |
+|-------|--------|
+| 1 | `intent-taxonomy.yaml`, `eval-intent-set.yaml`, P4 spec §1.3 非目标脚注 |
+| 2 | P4 spec §2.4 parse LLM, few-shots.yaml, ADR-003 |
+| 3 | Loop spec LC-4 adjust, P4 spec §2.3 context |
+| 4 | Loop spec LC-6, ADR 编排边界, deploy smoke |


### PR DESCRIPTION
## Summary
- Add requirements spec for Hybrid atomic intent recognition (Phase 1–4): four-layer model, acceptance criteria, data contracts
- Add phased implementation plan with tasks, file map, PR strategy, and eval/smoke gates

## Test plan
- [x] Markdown only — no runtime changes
- [ ] Reviewer confirms Phase boundaries and acceptance gates align with production bugs


Made with [Cursor](https://cursor.com)