### PR TITLE
feat(agent): Phase 3 atomic context, deixis, and adjust regenerate

### DIFF
--- a/services/agent-runtime/app/graph/atomic_context.py
+++ b/services/agent-runtime/app/graph/atomic_context.py
@@ -1,0 +1,70 @@
+"""Phase 3: compact context for atomic parse (canvas + recent dialogue)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.graph.atomic_parse_util import canvas_summary_nodes, format_canvas_context_line
+
+_MAX_CONTEXT_CHARS = 500
+
+
+def _message_role(msg: Any) -> str | None:
+    role = getattr(msg, "type", None)
+    if role:
+        return str(role)
+    if isinstance(msg, dict):
+        return str(msg.get("role") or "")
+    return None
+
+
+def _message_content(msg: Any) -> str:
+    content = getattr(msg, "content", None)
+    if content is None and isinstance(msg, dict):
+        content = msg.get("content")
+    return str(content or "").strip()
+
+
+def summarize_recent_turns(messages: list[Any] | None, *, max_turns: int = 2) -> str:
+    """Compact summary of the last N user→assistant turns."""
+    turns: list[str] = []
+    pending_user: str | None = None
+    for msg in messages or []:
+        role = _message_role(msg)
+        content = _message_content(msg)
+        if not content:
+            continue
+        if role in ("human", "user"):
+            pending_user = content[:80] + ("…" if len(content) > 80 else "")
+        elif role in ("ai", "assistant") and pending_user:
+            ai_short = content[:100].replace("\n", " ")
+            if len(content) > 100:
+                ai_short += "…"
+            turns.append(f"用户:{pending_user}→助手:{ai_short}")
+            pending_user = None
+    if not turns:
+        return ""
+    return "；".join(turns[-max_turns:])
+
+
+def build_atomic_parse_context(
+    state: dict[str, Any],
+    *,
+    canvas_summary: dict[str, Any] | None = None,
+    max_chars: int = _MAX_CONTEXT_CHARS,
+) -> str:
+    """Canvas one-liner + last 2 dialogue turns for hybrid parse."""
+    parts: list[str] = []
+    nodes = canvas_summary_nodes(canvas_summary)
+    canvas_line = format_canvas_context_line(nodes)
+    if canvas_line:
+        parts.append(canvas_line)
+    history = summarize_recent_turns(state.get("messages") or [])
+    if history:
+        parts.append(f"近期对话:{history}")
+    if not parts:
+        return ""
+    ctx = " | ".join(parts)
+    if len(ctx) <= max_chars:
+        return ctx
+    return ctx[: max_chars - 1] + "…"

--- a/services/agent-runtime/app/graph/atomic_intent.py
+++ b/services/agent-runtime/app/graph/atomic_intent.py
@@ -108,9 +108,63 @@ def _matches_regenerate_hints(text: str) -> bool:
         return True
     if "重新生成" in t:
         return True
-    if any(p in t for p in ("再生成一次", "再生成一遍", "再跑一次")):
+    if any(p in t for p in ("再生成一次", "再生成一遍", "再跑一次", "再生成一张")):
         return True
     return lowered in ("retry", "again")
+
+
+_REGENERATE_STRIP_PHRASES = (
+    "重新生成一张",
+    "重新生成",
+    "再生成一张",
+    "再生成一次",
+    "再生成一遍",
+    "再跑一次",
+    "再来一次",
+    "再试一次",
+    "再试",
+    "重试",
+)
+
+
+def detect_regenerate_adjust(text: str) -> str | None:
+    """Extract prompt-adjustment tail from regenerate utterance (L1-04)."""
+    t = (text or "").strip()
+    if not t or not _matches_regenerate_hints(t):
+        return None
+    remainder = t
+    for phrase in sorted(_REGENERATE_STRIP_PHRASES, key=len, reverse=True):
+        remainder = remainder.replace(phrase, "")
+    remainder = remainder.strip("，,、。；; \t")
+    if len(remainder) >= 2:
+        return remainder
+    return None
+
+
+def apply_regenerate_adjust(
+    spec: dict[str, Any],
+    adjust: str | None,
+    *,
+    parse_context: str | None = None,
+) -> dict[str, Any]:
+    """Merge adjust phrase (and optional style context) into atomic_spec.prompt."""
+    if not adjust:
+        return dict(spec)
+    out = dict(spec)
+    base = str(out.get("prompt") or "").strip()
+    adj = adjust.strip()
+    if any(h in adj for h in ("同样风格", "刚才那个风格", "按刚才", "跟刚才一样")):
+        from app.graph.atomic_parse_util import style_seed_from_context
+
+        style_seed = style_seed_from_context(parse_context)
+        if style_seed:
+            merged = f"{style_seed}；{base}" if base else style_seed
+            out["prompt"] = merged
+            return out
+    if adj in base:
+        return out
+    out["prompt"] = f"{base}；{adj}" if base else adj
+    return out
 
 
 def _has_prompt_explicit(text: str) -> bool:

--- a/services/agent-runtime/app/graph/atomic_parse_util.py
+++ b/services/agent-runtime/app/graph/atomic_parse_util.py
@@ -12,7 +12,20 @@ import yaml
 from app.graph.few_shot import load_few_shots
 from app.graph.atomic_intent import build_atomic_spec, confirm_gate_for_type, parse_atomic_target_type
 
-_DEICTIC_HINTS = ("这个", "这张", "该", "主图", "当前", "刚才")
+_DEICTIC_HINTS = (
+    "这个",
+    "这张",
+    "那个",
+    "那张",
+    "该",
+    "主图",
+    "当前",
+    "刚才",
+    "同样风格",
+    "同样",
+    "上一张",
+)
+_STYLE_INHERIT_HINTS = ("同样风格", "刚才那个风格", "按刚才", "跟刚才一样", "一样风格")
 
 _STRIP_PREFIXES = (
     "帮我生成一个",
@@ -82,6 +95,21 @@ def dedupe_atomic_title(title: str, nodes: list[dict[str, Any]]) -> str:
         if candidate not in existing:
             return candidate
     return f"{base} ({len(nodes) + 1})"
+
+
+def style_seed_from_context(parse_context: str | None) -> str | None:
+    """Pull prior user topic from compact dialogue summary for style inheritance."""
+    ctx = (parse_context or "").strip()
+    if not ctx or "近期对话:" not in ctx:
+        return None
+    tail = ctx.split("近期对话:", 1)[1]
+    for chunk in tail.split("；"):
+        if "用户:" not in chunk:
+            continue
+        user_part = chunk.split("用户:", 1)[1].split("→助手:", 1)[0].strip()
+        if user_part and len(user_part) >= 4:
+            return user_part[:80]
+    return None
 
 
 def resolve_focus_seed(utterance: str, focus_node_id: str | None, nodes: list[dict[str, Any]]) -> str | None:
@@ -226,6 +254,7 @@ def build_atomic_spec_enriched(
     *,
     canvas_summary: dict[str, Any] | None = None,
     focus_node_id: str | None = None,
+    parse_context: str | None = None,
 ) -> dict[str, Any]:
     """Keyword routing + prompt/title cleanup + canvas context (P4-04/05)."""
     nodes = canvas_summary_nodes(canvas_summary)
@@ -241,6 +270,11 @@ def build_atomic_spec_enriched(
         elif len(prompt) <= 8:
             prompt = focus_seed
 
+    if any(h in utterance for h in _STYLE_INHERIT_HINTS):
+        style_seed = style_seed_from_context(parse_context)
+        if style_seed and style_seed not in (prompt or ""):
+            prompt = f"{style_seed}；{prompt}" if prompt else style_seed
+
     if prompt:
         base["prompt"] = prompt
         if len(prompt) <= 28:
@@ -248,7 +282,10 @@ def build_atomic_spec_enriched(
 
     if nodes:
         base["title"] = dedupe_atomic_title(str(base.get("title") or ""), nodes)
-        base["canvas_context"] = format_canvas_context_line(nodes)
+
+    ctx_line = parse_context or (format_canvas_context_line(nodes) if nodes else None)
+    if ctx_line:
+        base["canvas_context"] = ctx_line
 
     return base
 
@@ -311,6 +348,7 @@ def rule_parse_atomic(
     *,
     canvas_summary: dict[str, Any] | None = None,
     focus_node_id: str | None = None,
+    parse_context: str | None = None,
 ) -> tuple[list[dict[str, Any]], float]:
     """Rule-based parse returning items + confidence."""
     multi_items = build_atomic_items_enriched(
@@ -324,6 +362,7 @@ def rule_parse_atomic(
         utterance,
         canvas_summary=canvas_summary,
         focus_node_id=focus_node_id,
+        parse_context=parse_context,
     )
     return [spec], rule_parse_confidence(utterance, spec, None)
 

--- a/services/agent-runtime/app/graph/builder.py
+++ b/services/agent-runtime/app/graph/builder.py
@@ -10,9 +10,10 @@ from langgraph.graph import END, START, StateGraph
 
 from app.graph.nodes.chat import make_chat_node
 from app.graph.nodes.done import make_done_node
-from app.graph.nodes.intake import make_intake_node
+from app.graph.nodes.intake import make_intake_node, latest_user_text
 from app.graph.nodes.split import make_split_node
 from app.graph.state import AgentRuntimeState
+from app.graph.atomic_intent import detect_regenerate_adjust
 from app.graph.subgraphs.atomic_create_gate import register_atomic_create_gate
 from app.graph.subgraphs.confirm_gate import register_confirm_gate
 from app.graph.subgraphs.copy_gate import register_copy_gate
@@ -22,6 +23,9 @@ from app.graph.subgraphs.topo_gate import register_topo_gate
 
 def route_after_intake(state: AgentRuntimeState) -> str:
     if state.get("flow_mode") == "atomic_regenerate":
+        text = latest_user_text(state.get("messages") or [])
+        if detect_regenerate_adjust(text):
+            return "adjust_atomic_regenerate"
         return "prepare_atomic_regenerate"
     if state.get("flow_mode") == "single_node":
         return "prepare_single_gen"
@@ -68,6 +72,7 @@ def build_agent_graph(
         "intake",
         route_after_intake,
         {
+            "adjust_atomic_regenerate": "adjust_atomic_regenerate",
             "prepare_atomic_regenerate": "prepare_atomic_regenerate",
             "prepare_single_gen": "prepare_single_gen",
             "parse_atomic_intent": "parse_atomic_intent",

--- a/services/agent-runtime/app/graph/nodes/adjust_atomic_regenerate.py
+++ b/services/agent-runtime/app/graph/nodes/adjust_atomic_regenerate.py
@@ -1,0 +1,76 @@
+"""Phase 3 L1-04: regenerate with prompt adjustment before re-gen."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from langchain_core.messages import AIMessage
+
+from app.graph.atomic_context import build_atomic_parse_context
+from app.graph.atomic_intent import apply_regenerate_adjust, detect_regenerate_adjust
+
+
+def _latest_user_text(messages: list[Any]) -> str:
+    for msg in reversed(messages or []):
+        role = getattr(msg, "type", None) or (msg.get("role") if isinstance(msg, dict) else None)
+        content = getattr(msg, "content", None) or (msg.get("content") if isinstance(msg, dict) else "")
+        if role in ("human", "user") and content:
+            return str(content)
+    return ""
+
+
+def make_adjust_atomic_regenerate_node(*, nest: Any) -> Callable:
+    async def adjust_atomic_regenerate(state: dict) -> dict:
+        node_id = str(state.get("atomic_node_id") or "").strip()
+        spec = state.get("atomic_spec") or {}
+        text = _latest_user_text(state.get("messages") or [])
+        adjust = detect_regenerate_adjust(text)
+        title = str(spec.get("title") or spec.get("target_type") or "节点")
+
+        if not node_id:
+            return {
+                "phase": "error",
+                "last_error": "missing atomic_node_id",
+                "messages": [AIMessage(content="没有可重新生成的节点，请先描述要创作的内容。")],
+            }
+
+        canvas_summary = None
+        get_summary = getattr(nest, "get_canvas_summary", None)
+        if get_summary is not None:
+            try:
+                canvas_summary = await get_summary()
+            except Exception:  # noqa: BLE001
+                canvas_summary = None
+
+        parse_ctx = build_atomic_parse_context(state, canvas_summary=canvas_summary)
+        updated_spec = apply_regenerate_adjust(spec, adjust, parse_context=parse_ctx or None)
+
+        get_node = getattr(nest, "get_node", None)
+        if get_node is not None:
+            try:
+                node = await get_node(node_id)
+                if not isinstance(node, dict) or not str(node.get("id") or node_id).strip():
+                    return {
+                        "phase": "error",
+                        "last_error": "atomic node missing",
+                        "messages": [AIMessage(content="画布节点已不存在，请重新描述要生成的内容。")],
+                    }
+            except Exception as exc:  # noqa: BLE001
+                return {
+                    "phase": "error",
+                    "last_error": str(exc),
+                    "messages": [AIMessage(content=f"读取节点失败：{exc}")],
+                }
+
+        detail = f"（{adjust}）" if adjust else ""
+        return {
+            "phase": "atomic_create",
+            "flow_mode": "atomic_regenerate",
+            "atomic_spec": updated_spec,
+            "last_error": None,
+            "atomic_record_id": None,
+            "user_decision": "none",
+            "messages": [AIMessage(content=f"正在按新要求重新生成「{title}」{detail}…")],
+        }
+
+    return adjust_atomic_regenerate

--- a/services/agent-runtime/app/graph/nodes/atomic_parse.py
+++ b/services/agent-runtime/app/graph/nodes/atomic_parse.py
@@ -7,6 +7,7 @@ from typing import Any, Callable
 from langchain_core.messages import AIMessage
 
 from app.graph.atomic_parse_llm import llm_parse_atomic_intent
+from app.graph.atomic_context import build_atomic_parse_context
 from app.graph.atomic_parse_schema import (
     CLARIFY_THRESHOLD,
     RULE_FAST_PATH_THRESHOLD,
@@ -46,12 +47,14 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
                     canvas_summary = None
 
         focus_node_id = state.get("focus_node_id")
+        parse_ctx = build_atomic_parse_context(state, canvas_summary=canvas_summary)
         rule_items, rule_conf = rule_parse_atomic(
             text,
             canvas_summary=canvas_summary,
             focus_node_id=focus_node_id,
+            parse_context=parse_ctx or None,
         )
-        canvas_ctx = rule_items[0].get("canvas_context") if rule_items else None
+        canvas_ctx = parse_ctx or (rule_items[0].get("canvas_context") if rule_items else None)
 
         outcome = None
         if rule_conf >= RULE_FAST_PATH_THRESHOLD:

--- a/services/agent-runtime/app/graph/nodes/intake.py
+++ b/services/agent-runtime/app/graph/nodes/intake.py
@@ -9,7 +9,7 @@ from app.graph.state import BRIEF_RESET_PREFIX
 from app.skills.loader import discover_skills
 
 
-def _latest_user_text(messages: list[Any]) -> str:
+def latest_user_text(messages: list[Any]) -> str:
     for msg in reversed(messages or []):
         role = getattr(msg, "type", None) or (msg.get("role") if isinstance(msg, dict) else None)
         content = getattr(msg, "content", None) or (msg.get("content") if isinstance(msg, dict) else "")
@@ -20,7 +20,7 @@ def _latest_user_text(messages: list[Any]) -> str:
 
 def make_intake_node(skills_dir: Path) -> Callable:
     async def intake(state: dict) -> dict:
-        text = _latest_user_text(state.get("messages") or [])
+        text = latest_user_text(state.get("messages") or [])
         entries = discover_skills(skills_dir)
         requested = str(state.get("requested_skill_id") or "").strip()
         by_id = {e.skill_id: e for e in entries}
@@ -93,6 +93,9 @@ def make_intake_node(skills_dir: Path) -> Callable:
             "mode": mode,
             "flow_mode": resolved_flow,
         }
+        if resolved_flow in ("atomic_create", "atomic_regenerate"):
+            out["split_manifest"] = []
+            out["skill_id"] = None
         if focus_node_id:
             out["focus_node_id"] = focus_node_id
         if proposed_brief is not None:

--- a/services/agent-runtime/app/graph/subgraphs/atomic_create_gate.py
+++ b/services/agent-runtime/app/graph/subgraphs/atomic_create_gate.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from langgraph.graph import END, StateGraph
 
+from app.graph.nodes.adjust_atomic_regenerate import make_adjust_atomic_regenerate_node
 from app.graph.nodes.atomic_create_node import make_create_atomic_node
 from app.graph.nodes.atomic_parse import make_parse_atomic_intent_node
 from app.graph.nodes.await_atomic_confirm import make_await_atomic_confirm_node
@@ -50,6 +51,7 @@ def register_atomic_create_gate(graph: StateGraph, *, nest: Any, llm: Any | None
     graph.add_node("clarify_atomic_intent", make_clarify_atomic_intent_node())
     graph.add_node("create_atomic_node", make_create_atomic_node(nest=nest))
     graph.add_node("prepare_atomic_regenerate", make_prepare_atomic_regenerate_node(nest=nest))
+    graph.add_node("adjust_atomic_regenerate", make_adjust_atomic_regenerate_node(nest=nest))
     graph.add_node("await_atomic_confirm", make_await_atomic_confirm_node())
     graph.add_node("run_atomic_gen", make_run_atomic_gen_node(nest=nest))
 
@@ -82,4 +84,5 @@ def register_atomic_create_gate(graph: StateGraph, *, nest: Any, llm: Any | None
         },
     )
     graph.add_edge("prepare_atomic_regenerate", "run_atomic_gen")
+    graph.add_edge("adjust_atomic_regenerate", "run_atomic_gen")
     graph.add_edge("run_atomic_gen", "done")

--- a/services/agent-runtime/skills/atomic-create/eval-intent-set.yaml
+++ b/services/agent-runtime/skills/atomic-create/eval-intent-set.yaml
@@ -425,3 +425,78 @@ cases:
     utterance: 来一段场景氛围视频
     focus_node_id: null
     gold: { route: atomic_create, target_type: video, confirm_gate: true }
+
+  - id: p3-deix-01
+    utterance: 多模式扩写这个主图 prompt
+    focus_node_id: hero-001
+    gold: { route: atomic_create, target_type: prompt, confirm_gate: false }
+
+  - id: p3-deix-02
+    utterance: 用提示词模式扩写这个白底图
+    focus_node_id: white-001
+    gold: { route: atomic_create, target_type: prompt, confirm_gate: false }
+
+  - id: p3-deix-03
+    utterance: 帮我生成一张这个产品的场景图
+    focus_node_id: prod-001
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  - id: p3-deix-04
+    utterance: 只生成这张白底版
+    focus_node_id: node-img-1
+    gold: { route: single_node, target_type: image, confirm_gate: false }
+
+  - id: p3-deix-05
+    utterance: 同样风格帮我生成一张主图
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  - id: p3-deix-06
+    utterance: 按刚才那个风格生成一张海报
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  - id: p3-deix-07
+    utterance: 跟刚才一样再来一张白底图
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  - id: p3-deix-08
+    utterance: 扩写该节点的 prompt
+    focus_node_id: node-prompt-1
+    gold: { route: atomic_create, target_type: prompt, confirm_gate: false }
+
+  - id: p3-deix-09
+    utterance: 重新生成这张
+    focus_node_id: node-img-1
+    gold: { route: single_node, target_type: image, confirm_gate: false }
+
+  - id: p3-deix-10
+    utterance: 帮我生成一张当前主图的变体
+    focus_node_id: hero-001
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  - id: p3-deix-11
+    utterance: 主图、白底和三视图各来一张
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  - id: p3-deix-12
+    utterance: 再来一张那个风格的场景图
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  - id: p3-deix-13
+    utterance: 生成一张上一张图的横版
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  - id: p3-deix-14
+    utterance: 用同样风格写一段开场文案
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: text, confirm_gate: false }
+
+  - id: p3-deix-15
+    utterance: 帮我做一张该产品的三视图
+    focus_node_id: prod-001
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }

--- a/services/agent-runtime/tests/test_atomic_context.py
+++ b/services/agent-runtime/tests/test_atomic_context.py
@@ -1,0 +1,51 @@
+"""Phase 3: atomic parse context assembly tests."""
+
+from __future__ import annotations
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from app.graph.atomic_context import build_atomic_parse_context, summarize_recent_turns
+
+
+def test_summarize_recent_turns_last_two():
+    messages = [
+        HumanMessage(content="帮我生成模特图"),
+        AIMessage(content="已创建 image 节点"),
+        HumanMessage(content="重新生成一张"),
+        AIMessage(content="正在重新生成"),
+        HumanMessage(content="背景改成白色"),
+        AIMessage(content="完成"),
+    ]
+    summary = summarize_recent_turns(messages, max_turns=2)
+    assert "重新生成一张" in summary
+    assert "背景改成白色" in summary
+    assert "帮我生成模特图" not in summary
+
+
+def test_build_atomic_parse_context_respects_max_length():
+    long_user = "A" * 400
+    messages = [
+        HumanMessage(content=long_user),
+        AIMessage(content="ok"),
+        HumanMessage(content="B" * 400),
+        AIMessage(content="ok2"),
+    ]
+    ctx = build_atomic_parse_context({"messages": messages}, max_chars=500)
+    assert len(ctx) <= 500
+    assert ctx.endswith("…") or len(ctx) <= 500
+
+
+def test_build_atomic_parse_context_includes_canvas_and_history():
+    summary = {
+        "nodes": [
+            {"id": "n1", "type": "image", "title": "主图"},
+        ]
+    }
+    messages = [
+        HumanMessage(content="帮我生成主图"),
+        AIMessage(content="主图已创建"),
+    ]
+    ctx = build_atomic_parse_context({"messages": messages}, canvas_summary=summary)
+    assert "画布" in ctx
+    assert "主图" in ctx
+    assert "近期对话" in ctx

--- a/services/agent-runtime/tests/test_atomic_create_intent_eval.py
+++ b/services/agent-runtime/tests/test_atomic_create_intent_eval.py
@@ -24,9 +24,9 @@ def taxonomy_doc() -> dict:
     return yaml.safe_load(TAXONOMY_PATH.read_text(encoding="utf-8"))
 
 
-def test_eval_set_has_80_cases(eval_doc: dict):
+def test_eval_set_has_95_cases(eval_doc: dict):
     cases = eval_doc.get("cases") or []
-    assert len(cases) == 80
+    assert len(cases) == 95
     ids = [c["id"] for c in cases]
     assert len(ids) == len(set(ids)), "duplicate case ids"
 

--- a/services/agent-runtime/tests/test_atomic_parse_util.py
+++ b/services/agent-runtime/tests/test_atomic_parse_util.py
@@ -79,6 +79,15 @@ def test_build_atomic_spec_focus_seed_for_prompt_expand():
     assert "主图" in spec["prompt"]
 
 
+def test_build_atomic_spec_style_inherit_from_context():
+    messages_ctx = "近期对话:用户:赛博朋克耳机主图→助手:已创建"
+    spec = build_atomic_spec_enriched(
+        "同样风格帮我生成一张主图",
+        parse_context=messages_ctx,
+    )
+    assert "赛博朋克耳机主图" in spec["prompt"]
+
+
 def test_format_canvas_context_line():
     line = format_canvas_context_line(
         [

--- a/services/agent-runtime/tests/test_atomic_regenerate_flow.py
+++ b/services/agent-runtime/tests/test_atomic_regenerate_flow.py
@@ -23,7 +23,7 @@ class FakeNest:
 
 
 def test_route_after_intake_regenerate():
-    assert route_after_intake({"flow_mode": "atomic_regenerate"}) == "prepare_atomic_regenerate"
+    assert route_after_intake({"flow_mode": "atomic_regenerate", "messages": []}) == "prepare_atomic_regenerate"
 
 
 @pytest.mark.asyncio

--- a/services/agent-runtime/tests/test_atomic_thread_isolation.py
+++ b/services/agent-runtime/tests/test_atomic_thread_isolation.py
@@ -1,0 +1,125 @@
+"""Phase 3: adjust regenerate and thread isolation tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from app.graph.atomic_intent import (
+    apply_regenerate_adjust,
+    detect_regenerate_adjust,
+)
+from app.graph.builder import route_after_intake
+from app.graph.nodes.adjust_atomic_regenerate import make_adjust_atomic_regenerate_node
+from app.graph.nodes.intake import make_intake_node
+from app.graph.nodes.run_atomic_gen import make_run_atomic_gen_node
+
+
+def test_detect_regenerate_adjust_with_tail():
+    assert detect_regenerate_adjust("重新生成一张，背景改成白色") == "背景改成白色"
+    assert detect_regenerate_adjust("按刚才那个风格再生成一张") == "按刚才那个风格"
+
+
+def test_detect_regenerate_adjust_pure_regenerate_none():
+    assert detect_regenerate_adjust("重新生成一张") is None
+    assert detect_regenerate_adjust("再试一次") is None
+
+
+def test_apply_regenerate_adjust_merges_prompt():
+    spec = {"target_type": "image", "prompt": "模特人物图", "title": "模特图"}
+    out = apply_regenerate_adjust(spec, "背景改成白色")
+    assert "模特人物图" in out["prompt"]
+    assert "背景改成白色" in out["prompt"]
+
+
+def test_apply_regenerate_adjust_style_from_context():
+    spec = {"target_type": "image", "prompt": "模特人物图", "title": "模特图"}
+    ctx = "近期对话:用户:赛博朋克耳机主图→助手:已创建"
+    out = apply_regenerate_adjust(spec, "按刚才那个风格", parse_context=ctx)
+    assert "赛博朋克耳机主图" in out["prompt"]
+
+
+def test_route_after_intake_adjust_vs_prepare():
+    assert route_after_intake({"flow_mode": "atomic_regenerate", "messages": []}) == "prepare_atomic_regenerate"
+    assert (
+        route_after_intake(
+            {
+                "flow_mode": "atomic_regenerate",
+                "messages": [HumanMessage(content="重新生成一张，背景改成白色")],
+            }
+        )
+        == "adjust_atomic_regenerate"
+    )
+
+
+class FakeNest:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    async def get_node(self, node_id: str) -> dict:
+        self.calls.append(("get_node", node_id))
+        return {"id": node_id, "type": "image", "title": "模特图"}
+
+    async def get_canvas_summary(self) -> dict:
+        return {"nodes": []}
+
+    async def run_image_generation(self, node_id: str) -> dict:
+        self.calls.append(("run_image_generation", node_id))
+        return {"status": "completed", "generationRecordId": "rec-adj-1"}
+
+
+@pytest.mark.asyncio
+async def test_adjust_regenerate_updates_prompt_before_gen():
+    nest = FakeNest()
+    spec = {"target_type": "image", "title": "模特图", "prompt": "模特人物图", "confirm_gate": False}
+    adjust_node = make_adjust_atomic_regenerate_node(nest=nest)
+    out = await adjust_node(
+        {
+            "atomic_node_id": "node-abc",
+            "atomic_spec": spec,
+            "messages": [HumanMessage(content="重新生成一张，背景改成白色")],
+        }
+    )
+    assert "背景改成白色" in out["atomic_spec"]["prompt"]
+    assert "按新要求" in out["messages"][0].content
+
+    run = make_run_atomic_gen_node(nest=nest)
+    done = await run({**out, "atomic_node_id": "node-abc"})
+    assert done["phase"] == "done"
+    assert ("run_image_generation", "node-abc") in nest.calls
+
+
+@pytest.mark.asyncio
+async def test_intake_atomic_clears_campaign_split_manifest(tmp_path: Path):
+    skills = Path(__file__).resolve().parents[1] / "skills"
+    intake = make_intake_node(skills)
+    out = await intake(
+        {
+            "messages": [HumanMessage(content="帮我生成一个模特人物图")],
+            "plan_draft": "14 节点营销方案",
+            "split_manifest": [{"key": "hero", "title": "主图", "target_type": "image"}],
+            "user_brief": "天猫蓝牙耳机详情页",
+        }
+    )
+    assert out["flow_mode"] == "atomic_create"
+    assert out["split_manifest"] == []
+    assert out.get("skill_id") is None
+
+
+@pytest.mark.asyncio
+async def test_intake_regenerate_on_mixed_canvas(tmp_path: Path):
+    skills = Path(__file__).resolve().parents[1] / "skills"
+    intake = make_intake_node(skills)
+    out = await intake(
+        {
+            "messages": [HumanMessage(content="重新生成一张")],
+            "atomic_node_id": "node-abc",
+            "atomic_spec": {"target_type": "image", "title": "模特图", "prompt": "模特人物图"},
+            "plan_draft": "campaign plan",
+            "split_manifest": [{"key": "hero", "title": "主图"}],
+        }
+    )
+    assert out["flow_mode"] == "atomic_regenerate"
+    assert out["split_manifest"] == []


### PR DESCRIPTION
## Summary
- 新增 `atomic_context.py`：画布摘要 + 最近 2 轮对话注入 hybrid parse（≤500 字）
- 扩展指代消解（这个/同样风格/按刚才等）与风格继承；regenerate 支持 adjust 短语（如「背景改成白色」）
- atomic turn 清空 `split_manifest`，避免 Campaign 混合画布 thread 污染
- eval 集 +15 指代句，共 95 条，路由准确率 100%

## Test plan
- [x] `cd services/agent-runtime && python3 -m pytest tests/test_atomic*.py -v` — 76/76 PASS
- [x] `python3 scripts/eval_atomic_intent_report.py` — 95/95 (100%)
- [x] 生产浏览器用户路径 A–D 复测 PASS（clarify / 单图 / regenerate / 三图）


Made with [Cursor](https://cursor.com)