### PR TITLE
fix(agent): variant regenerate creates new node, not same-node retry

### DIFF
--- a/deploy/prod-atomic-intent-verify.py
+++ b/deploy/prod-atomic-intent-verify.py
@@ -4,6 +4,8 @@
 Cases:
   A) create →「重新生成一张」→ same node count, regen path
   B) multi-image enumerated → 3 nodes on canvas
+  C) create →「重新生成一张，背景改成白色」→ new node (count +1)
+  D) create →「按刚才那个风格再生成一张」→ new node (count +1)
 
 Reuse SSE helpers from prod-atomic-regenerate-verify.py.
 """
@@ -173,8 +175,46 @@ def run_multi_image_smoke(tok: str) -> None:
     record("Multi expected titles", title_hit >= 2, f"titles={list(titles)[:6]}")
 
 
+def run_variant_new_node_smoke(tok: str) -> None:
+    sid = http("POST", "/sessions", {"title": f"intent-variant-{int(time.time())}"}, t=tok)["data"]["id"]
+    tid = f"ivariant_{uuid.uuid4().hex[:8]}"
+    record("Variant session", True, f"sid={sid}")
+
+    _, text1, types1, exit1 = sse_collect(
+        tok, sid, "帮我生成一个模特人物图", tid, timeout=SSE_TIMEOUT_SEC
+    )
+    record("Variant Turn1 atomic", "原子创作" in text1 and "error" not in types1, text1[:100])
+
+    count1 = len(image_nodes(tok, sid))
+    record("Variant Turn1 one node", count1 >= 1, f"nodes={count1} exit={exit1}")
+
+    _, text2, types2, exit2 = sse_collect(
+        tok, sid, "重新生成一张，背景改成白色", tid, timeout=SSE_TIMEOUT_SEC
+    )
+    count2 = len(image_nodes(tok, sid))
+    adjust_ok = (
+        count2 > count1
+        and ("已创建" in text2 or "image 节点" in text2 or "生成完成" in text2)
+        and "await_confirm" not in types2
+        and "error" not in types2
+    )
+    record("Variant Turn2 adjust new node", adjust_ok, f"nodes {count1}->{count2} text={text2[:120]} exit={exit2}")
+
+    _, text3, types3, exit3 = sse_collect(
+        tok, sid, "按刚才那个风格再生成一张", tid, timeout=SSE_TIMEOUT_SEC
+    )
+    count3 = len(image_nodes(tok, sid))
+    style_ok = (
+        count3 > count2
+        and ("已创建" in text3 or "image 节点" in text3 or "生成完成" in text3)
+        and "await_confirm" not in types3
+        and "error" not in types3
+    )
+    record("Variant Turn3 style new node", style_ok, f"nodes {count2}->{count3} text={text3[:120]} exit={exit3}")
+
+
 def main() -> int:
-    print("=== Prod smoke: Phase 1 atomic intent (regen phrase + multi-image) ===")
+    print("=== Prod smoke: atomic intent (regen + multi + variant new node) ===")
     print(f"BASE={BASE}\n")
 
     try:
@@ -193,6 +233,7 @@ def main() -> int:
 
     run_regenerate_phrase_smoke(tok)
     run_multi_image_smoke(tok)
+    run_variant_new_node_smoke(tok)
 
     print(f"\n=== Summary PASS={PASS} FAIL={FAIL} ===")
     return 0 if FAIL == 0 else 1

--- a/services/agent-runtime/app/graph/atomic_intent.py
+++ b/services/agent-runtime/app/graph/atomic_intent.py
@@ -141,6 +141,16 @@ def detect_regenerate_adjust(text: str) -> str | None:
     return None
 
 
+def is_regenerate_new_variant(text: str) -> bool:
+    """True when user wants another node (variant), not retry on the same node."""
+    return _matches_regenerate_hints(text) and detect_regenerate_adjust(text) is not None
+
+
+def should_regenerate_same_node(text: str) -> bool:
+    """Same-node retry only when regenerate phrasing has no variant/adjust tail."""
+    return _matches_regenerate_hints(text) and not is_regenerate_new_variant(text)
+
+
 def apply_regenerate_adjust(
     spec: dict[str, Any],
     adjust: str | None,
@@ -207,7 +217,7 @@ def atomic_regenerate_intent(text: str) -> bool:
         return False
     if _is_campaign_override(t):
         return False
-    return _matches_regenerate_hints(t)
+    return should_regenerate_same_node(t)
 
 
 def resolve_intake_route(

--- a/services/agent-runtime/app/graph/atomic_parse_util.py
+++ b/services/agent-runtime/app/graph/atomic_parse_util.py
@@ -10,7 +10,13 @@ from typing import Any
 import yaml
 
 from app.graph.few_shot import load_few_shots
-from app.graph.atomic_intent import build_atomic_spec, confirm_gate_for_type, parse_atomic_target_type
+from app.graph.atomic_intent import (
+    apply_regenerate_adjust,
+    build_atomic_spec,
+    confirm_gate_for_type,
+    detect_regenerate_adjust,
+    parse_atomic_target_type,
+)
 
 _DEICTIC_HINTS = (
     "这个",
@@ -234,6 +240,27 @@ def build_atomic_items_enriched(
             seen_titles.add(title)
         enriched.append(copy)
     return enriched
+
+
+def build_variant_spec_from_checkpoint(
+    utterance: str,
+    prior_spec: dict[str, Any],
+    *,
+    canvas_summary: dict[str, Any] | None = None,
+    parse_context: str | None = None,
+) -> dict[str, Any]:
+    """Derive a new-node atomic spec from checkpoint + variant/adjust utterance."""
+    adjust = detect_regenerate_adjust(utterance)
+    spec = apply_regenerate_adjust(prior_spec, adjust, parse_context=parse_context)
+    nodes = canvas_summary_nodes(canvas_summary)
+    title = str(spec.get("title") or spec.get("prompt") or "节点").strip()
+    if nodes and title:
+        spec["title"] = dedupe_atomic_title(title, nodes)
+    if parse_context:
+        spec["canvas_context"] = parse_context
+    elif nodes:
+        spec["canvas_context"] = format_canvas_context_line(nodes)
+    return spec
 
 
 def extract_atomic_prompt(utterance: str) -> str:

--- a/services/agent-runtime/app/graph/builder.py
+++ b/services/agent-runtime/app/graph/builder.py
@@ -10,10 +10,9 @@ from langgraph.graph import END, START, StateGraph
 
 from app.graph.nodes.chat import make_chat_node
 from app.graph.nodes.done import make_done_node
-from app.graph.nodes.intake import make_intake_node, latest_user_text
+from app.graph.nodes.intake import make_intake_node
 from app.graph.nodes.split import make_split_node
 from app.graph.state import AgentRuntimeState
-from app.graph.atomic_intent import detect_regenerate_adjust
 from app.graph.subgraphs.atomic_create_gate import register_atomic_create_gate
 from app.graph.subgraphs.confirm_gate import register_confirm_gate
 from app.graph.subgraphs.copy_gate import register_copy_gate
@@ -23,9 +22,6 @@ from app.graph.subgraphs.topo_gate import register_topo_gate
 
 def route_after_intake(state: AgentRuntimeState) -> str:
     if state.get("flow_mode") == "atomic_regenerate":
-        text = latest_user_text(state.get("messages") or [])
-        if detect_regenerate_adjust(text):
-            return "adjust_atomic_regenerate"
         return "prepare_atomic_regenerate"
     if state.get("flow_mode") == "single_node":
         return "prepare_single_gen"
@@ -72,7 +68,6 @@ def build_agent_graph(
         "intake",
         route_after_intake,
         {
-            "adjust_atomic_regenerate": "adjust_atomic_regenerate",
             "prepare_atomic_regenerate": "prepare_atomic_regenerate",
             "prepare_single_gen": "prepare_single_gen",
             "parse_atomic_intent": "parse_atomic_intent",

--- a/services/agent-runtime/app/graph/nodes/atomic_parse.py
+++ b/services/agent-runtime/app/graph/nodes/atomic_parse.py
@@ -15,7 +15,12 @@ from app.graph.atomic_parse_schema import (
     parse_outcome_to_state,
     validate_parse_result,
 )
-from app.graph.atomic_parse_util import load_atomic_parse_few_shots, rule_parse_atomic
+from app.graph.atomic_parse_util import (
+    build_variant_spec_from_checkpoint,
+    load_atomic_parse_few_shots,
+    rule_parse_atomic,
+)
+from app.graph.atomic_intent import is_regenerate_new_variant
 
 
 def _latest_user_text(messages: list[Any]) -> str:
@@ -48,6 +53,26 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
 
         focus_node_id = state.get("focus_node_id")
         parse_ctx = build_atomic_parse_context(state, canvas_summary=canvas_summary)
+
+        prior_spec = state.get("atomic_spec")
+        if (
+            is_regenerate_new_variant(text)
+            and isinstance(prior_spec, dict)
+            and str(state.get("atomic_node_id") or "").strip()
+        ):
+            variant_spec = build_variant_spec_from_checkpoint(
+                text,
+                prior_spec,
+                canvas_summary=canvas_summary,
+                parse_context=parse_ctx or None,
+            )
+            outcome = outcome_from_rule_items(
+                [variant_spec],
+                confidence=0.96,
+                reason="variant_new_node_from_checkpoint",
+            )
+            return parse_outcome_to_state(outcome, canvas_context=parse_ctx)
+
         rule_items, rule_conf = rule_parse_atomic(
             text,
             canvas_summary=canvas_summary,

--- a/services/agent-runtime/app/graph/nodes/intake.py
+++ b/services/agent-runtime/app/graph/nodes/intake.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable
 
-from app.graph.atomic_intent import atomic_regenerate_intent, resolve_intake_route
+from app.graph.atomic_intent import atomic_regenerate_intent, is_regenerate_new_variant, resolve_intake_route
 from app.graph.intent import marketing_intent, modify_intent, single_node_gen_intent  # re-export for tests
 from app.graph.state import BRIEF_RESET_PREFIX
 from app.skills.loader import discover_skills
@@ -48,6 +48,7 @@ def make_intake_node(skills_dir: Path) -> Callable:
             bool(str(state.get("atomic_node_id") or "").strip())
             and isinstance(state.get("atomic_spec"), dict)
         )
+        is_variant_create = has_atomic_checkpoint and is_regenerate_new_variant(text)
 
         if is_single_node:
             mode = "create"
@@ -60,7 +61,7 @@ def make_intake_node(skills_dir: Path) -> Callable:
             proposed_brief = None
             flow_mode = "atomic_regenerate"
             skill_id = None
-        elif is_atomic:
+        elif is_atomic or is_variant_create:
             mode = "create"
             proposed_brief = None
             flow_mode = "atomic_create"
@@ -80,7 +81,7 @@ def make_intake_node(skills_dir: Path) -> Callable:
 
         resolved_flow = (
             flow_mode
-            if is_single_node or is_atomic or flow_mode == "atomic_regenerate"
+            if is_single_node or is_atomic or is_variant_create or flow_mode == "atomic_regenerate"
             else "campaign"
         )
 

--- a/services/agent-runtime/skills/atomic-create/eval-intent-regression.yaml
+++ b/services/agent-runtime/skills/atomic-create/eval-intent-regression.yaml
@@ -44,6 +44,32 @@ cases:
       flow_mode: atomic_create
     notes: explicit new create wins over regenerate when user asks for new asset
 
+  - id: reg-04
+    utterance: 重新生成一张，背景改成白色
+    checkpoint:
+      atomic_node_id: node-abc
+      atomic_spec:
+        target_type: image
+        title: 模特图
+        prompt: 模特人物图
+        confirm_gate: false
+    gold:
+      flow_mode: atomic_create
+    notes: variant/adjust creates new node, not same-node regenerate
+
+  - id: reg-05
+    utterance: 按刚才那个风格再生成一张
+    checkpoint:
+      atomic_node_id: node-abc
+      atomic_spec:
+        target_type: image
+        title: 模特图
+        prompt: 模特人物图
+        confirm_gate: false
+    gold:
+      flow_mode: atomic_create
+    notes: style variant creates new node
+
   # --- regenerate without checkpoint ---
   - id: reg-neg-01
     utterance: 再试一次

--- a/services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml
+++ b/services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml
@@ -60,7 +60,7 @@ intake_priority:
   - id: atomic_regenerate
     when: atomic_node_id and atomic_spec and atomic_regenerate_intent
     route: atomic_regenerate
-    notes: Requires checkpoint in thread state; see eval-intent-regression.yaml
+    notes: Same-node retry only (no variant/adjust tail). Variant phrases route to atomic_create.
   - id: atomic_create
     when: atomic_create_intent and not marketing_intent
     route: atomic_create

--- a/services/agent-runtime/tests/test_atomic_parse_util.py
+++ b/services/agent-runtime/tests/test_atomic_parse_util.py
@@ -88,6 +88,33 @@ def test_build_atomic_spec_style_inherit_from_context():
     assert "赛博朋克耳机主图" in spec["prompt"]
 
 
+def test_build_variant_spec_dedupes_title_for_new_node():
+    from app.graph.atomic_parse_util import build_variant_spec_from_checkpoint
+
+    prior = {"target_type": "image", "title": "模特图", "prompt": "模特人物图", "confirm_gate": False}
+    summary = {"nodes": [{"id": "node-abc", "type": "image", "title": "模特图"}]}
+    spec = build_variant_spec_from_checkpoint(
+        "重新生成一张，背景改成白色",
+        prior,
+        canvas_summary=summary,
+    )
+    assert spec["title"] == "模特图 (2)"
+    assert "背景改成白色" in spec["prompt"]
+
+
+def test_build_variant_spec_style_from_context():
+    from app.graph.atomic_parse_util import build_variant_spec_from_checkpoint
+
+    prior = {"target_type": "image", "title": "模特图", "prompt": "模特人物图", "confirm_gate": False}
+    ctx = "近期对话:用户:赛博朋克耳机主图→助手:已创建"
+    spec = build_variant_spec_from_checkpoint(
+        "按刚才那个风格再生成一张",
+        prior,
+        parse_context=ctx,
+    )
+    assert "赛博朋克耳机主图" in spec["prompt"]
+
+
 def test_format_canvas_context_line():
     line = format_canvas_context_line(
         [

--- a/services/agent-runtime/tests/test_atomic_thread_isolation.py
+++ b/services/agent-runtime/tests/test_atomic_thread_isolation.py
@@ -1,20 +1,31 @@
-"""Phase 3: adjust regenerate and thread isolation tests."""
+"""Phase 3: variant regenerate → new node; same-node retry unchanged."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
 import pytest
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import HumanMessage
 
 from app.graph.atomic_intent import (
-    apply_regenerate_adjust,
+    atomic_regenerate_intent,
     detect_regenerate_adjust,
+    is_regenerate_new_variant,
 )
 from app.graph.builder import route_after_intake
-from app.graph.nodes.adjust_atomic_regenerate import make_adjust_atomic_regenerate_node
+from app.graph.nodes.atomic_create_node import make_create_atomic_node
+from app.graph.nodes.atomic_parse import make_parse_atomic_intent_node
 from app.graph.nodes.intake import make_intake_node
 from app.graph.nodes.run_atomic_gen import make_run_atomic_gen_node
+
+
+def test_variant_phrases_are_not_same_node_regenerate():
+    assert is_regenerate_new_variant("重新生成一张，背景改成白色")
+    assert is_regenerate_new_variant("按刚才那个风格再生成一张")
+    assert not is_regenerate_new_variant("重新生成一张")
+    assert not is_regenerate_new_variant("再试一次")
+    assert not atomic_regenerate_intent("重新生成一张，背景改成白色")
+    assert atomic_regenerate_intent("重新生成一张")
 
 
 def test_detect_regenerate_adjust_with_tail():
@@ -22,73 +33,82 @@ def test_detect_regenerate_adjust_with_tail():
     assert detect_regenerate_adjust("按刚才那个风格再生成一张") == "按刚才那个风格"
 
 
-def test_detect_regenerate_adjust_pure_regenerate_none():
-    assert detect_regenerate_adjust("重新生成一张") is None
-    assert detect_regenerate_adjust("再试一次") is None
-
-
-def test_apply_regenerate_adjust_merges_prompt():
-    spec = {"target_type": "image", "prompt": "模特人物图", "title": "模特图"}
-    out = apply_regenerate_adjust(spec, "背景改成白色")
-    assert "模特人物图" in out["prompt"]
-    assert "背景改成白色" in out["prompt"]
-
-
-def test_apply_regenerate_adjust_style_from_context():
-    spec = {"target_type": "image", "prompt": "模特人物图", "title": "模特图"}
-    ctx = "近期对话:用户:赛博朋克耳机主图→助手:已创建"
-    out = apply_regenerate_adjust(spec, "按刚才那个风格", parse_context=ctx)
-    assert "赛博朋克耳机主图" in out["prompt"]
-
-
-def test_route_after_intake_adjust_vs_prepare():
+def test_route_after_intake_pure_regenerate_only():
     assert route_after_intake({"flow_mode": "atomic_regenerate", "messages": []}) == "prepare_atomic_regenerate"
-    assert (
-        route_after_intake(
-            {
-                "flow_mode": "atomic_regenerate",
-                "messages": [HumanMessage(content="重新生成一张，背景改成白色")],
-            }
-        )
-        == "adjust_atomic_regenerate"
-    )
 
 
 class FakeNest:
     def __init__(self) -> None:
-        self.calls: list[tuple[str, str]] = []
-
-    async def get_node(self, node_id: str) -> dict:
-        self.calls.append(("get_node", node_id))
-        return {"id": node_id, "type": "image", "title": "模特图"}
+        self.calls: list[tuple[str, object]] = []
 
     async def get_canvas_summary(self) -> dict:
-        return {"nodes": []}
+        return {
+            "nodes": [
+                {"id": "node-abc", "type": "image", "title": "模特图"},
+            ]
+        }
+
+    async def add_nodes_batch(self, batch: list[dict]) -> dict:
+        self.calls.append(("add_nodes_batch", batch))
+        return {
+            "nodes": [
+                {"key": batch[0]["key"], "nodeId": "node-new-1"},
+            ]
+        }
 
     async def run_image_generation(self, node_id: str) -> dict:
         self.calls.append(("run_image_generation", node_id))
-        return {"status": "completed", "generationRecordId": "rec-adj-1"}
+        return {"status": "completed", "generationRecordId": "rec-new-1"}
 
 
 @pytest.mark.asyncio
-async def test_adjust_regenerate_updates_prompt_before_gen():
+async def test_intake_variant_routes_to_atomic_create(tmp_path: Path):
+    skills = Path(__file__).resolve().parents[1] / "skills"
+    intake = make_intake_node(skills)
+    checkpoint = {
+        "atomic_node_id": "node-abc",
+        "atomic_spec": {
+            "target_type": "image",
+            "title": "模特图",
+            "prompt": "模特人物图",
+            "confirm_gate": False,
+        },
+    }
+    for utterance in ("重新生成一张，背景改成白色", "按刚才那个风格再生成一张"):
+        out = await intake({**checkpoint, "messages": [HumanMessage(content=utterance)]})
+        assert out["flow_mode"] == "atomic_create", utterance
+
+
+@pytest.mark.asyncio
+async def test_variant_create_adds_new_node_not_regenerate_old():
     nest = FakeNest()
-    spec = {"target_type": "image", "title": "模特图", "prompt": "模特人物图", "confirm_gate": False}
-    adjust_node = make_adjust_atomic_regenerate_node(nest=nest)
-    out = await adjust_node(
+    prior = {
+        "target_type": "image",
+        "title": "模特图",
+        "prompt": "模特人物图",
+        "confirm_gate": False,
+    }
+    parse = make_parse_atomic_intent_node(nest=nest, llm=None)
+    parsed = await parse(
         {
-            "atomic_node_id": "node-abc",
-            "atomic_spec": spec,
             "messages": [HumanMessage(content="重新生成一张，背景改成白色")],
+            "atomic_node_id": "node-abc",
+            "atomic_spec": prior,
         }
     )
-    assert "背景改成白色" in out["atomic_spec"]["prompt"]
-    assert "按新要求" in out["messages"][0].content
+    assert "背景改成白色" in parsed["atomic_spec"]["prompt"]
+    assert parsed["atomic_spec"]["title"] == "模特图 (2)"
+
+    create = make_create_atomic_node(nest=nest)
+    created = await create(parsed)
+    assert created["atomic_node_id"] == "node-new-1"
+    assert any(c[0] == "add_nodes_batch" for c in nest.calls)
 
     run = make_run_atomic_gen_node(nest=nest)
-    done = await run({**out, "atomic_node_id": "node-abc"})
+    done = await run({**created, **parsed})
     assert done["phase"] == "done"
-    assert ("run_image_generation", "node-abc") in nest.calls
+    assert ("run_image_generation", "node-new-1") in nest.calls
+    assert not any(c == ("run_image_generation", "node-abc") for c in nest.calls)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- 带变体/adjust 的 regenerate 句（如「背景改成白色」「按刚才那个风格再生成一张」）改走 `atomic_create` 新建节点
- 纯重试句（「重新生成一张」「再试一次」）仍走 `atomic_regenerate`，节点数不变
- 扩展 prod smoke：variant Turn2/Turn3 验证节点数递增

## Test plan
- [x] `python3 -m pytest tests/test_atomic*.py` — 77/77 PASS
- [ ] CI green
- [ ] `python3 deploy/prod-atomic-intent-verify.py` 生产 smoke（合并部署后）


Made with [Cursor](https://cursor.com)