### PR TITLE
feat(agent): Phase 4 orchestration routing and multi limits

### DIFF
--- a/deploy/prod-atomic-intent-verify.py
+++ b/deploy/prod-atomic-intent-verify.py
@@ -213,6 +213,15 @@ def run_variant_new_node_smoke(tok: str) -> None:
     record("Variant Turn3 style new node", style_ok, f"nodes {count2}->{count3} text={text3[:120]} exit={exit3}")
 
 
+def run_clarify_smoke(tok: str) -> None:
+    sid = http("POST", "/sessions", {"title": f"intent-clarify-{int(time.time())}"}, t=tok)["data"]["id"]
+    tid = f"iclari_{uuid.uuid4().hex[:8]}"
+    _, text, types, _ = sse_collect(tok, sid, "帮我生成", tid, timeout=SSE_TIMEOUT_SEC)
+    nodes = image_nodes(tok, sid)
+    ok = len(nodes) == 0 and ("不确定" in text or "有误" in text or "描述" in text or "clarify" in text.lower())
+    record("Clarify vague utterance", ok and "error" not in types, text[:120])
+
+
 def main() -> int:
     print("=== Prod smoke: atomic intent (regen + multi + variant new node) ===")
     print(f"BASE={BASE}\n")
@@ -234,6 +243,7 @@ def main() -> int:
     run_regenerate_phrase_smoke(tok)
     run_multi_image_smoke(tok)
     run_variant_new_node_smoke(tok)
+    run_clarify_smoke(tok)
 
     print(f"\n=== Summary PASS={PASS} FAIL={FAIL} ===")
     return 0 if FAIL == 0 else 1

--- a/docs/adr/p5-atomic-orchestration-boundary-adr.md
+++ b/docs/adr/p5-atomic-orchestration-boundary-adr.md
@@ -1,0 +1,33 @@
+# ADR: Atomic Studio vs Campaign Orchestration Boundary (P5)
+
+**Status:** Accepted  
+**Date:** 2026-08-04  
+**Context:** Phase 4 hybrid intent — prevent atomic gate from silently absorbing high-complexity marketing work.
+
+## Decision
+
+| User intent shape | Route | Rationale |
+|-------------------|-------|-----------|
+| Single / enumerated multi (≤5 same-modality items) | `atomic_create` | Single-shot Studio loop |
+| ≥4 storyboard shots, 全链路, 详情页方案, 14节点 | `campaign` | Requires plan/split/topo |
+| Vague「帮我生成」| `clarify` (parse) or `chat` | No silent node creation |
+| Same-node retry「重新生成一张」| `atomic_regenerate` | LC-5 V2 |
+| Variant retry「…背景改成白色」| `atomic_create` (new node) | User asked for another asset |
+| Mixed image + video/audio multi | `await_atomic_confirm` | HITL before expensive gen |
+
+## Rules
+
+1. **L1 intake** may override `atomic_create` → `campaign` when `orchestration_complexity_intent` returns `campaign`.
+2. **Parse** enforces `MAX_ATOMIC_MULTI_ITEMS = 5`; excess → clarify suggesting Campaign.
+3. **LLM parse** does not change L1 `flow_mode`; only structure/items.
+4. **Thread isolation:** atomic turns clear `split_manifest` (Phase 3).
+
+## Consequences
+
+- Eval: `eval-orchestration-set.yaml` (20 cases) + existing 95-case routing set.
+- Prod smoke: `deploy/prod-atomic-intent-verify.py` ≥12 cases covering regen, multi, variant, clarify.
+
+## References
+
+- `docs/superpowers/specs/2026-08-04-atomic-intent-hybrid-design.md` § Phase 4
+- `services/agent-runtime/app/graph/atomic_intent.py` — `orchestration_complexity_intent`

--- a/docs/superpowers/specs/2026-08-04-loop-engineering-design.md
+++ b/docs/superpowers/specs/2026-08-04-loop-engineering-design.md
@@ -141,6 +141,8 @@ Terminate: success | hard_fail | cancel → phase=done
 
 **V2（L1-03 ✅）**：`atomic_regenerate` — 同 thread「再试一次」+ checkpoint 有 `atomic_node_id` → `prepare_atomic_regenerate` → `run_atomic_gen`
 
+**V3（Phase 4 LC-6 partial ✅）**：`atomic_multi_gen` — 顺序 gen；部分失败时 `phase=error` 且 AIMessage 列明「部分完成 / 未完成」项（不 silent 截断）。
+
 **验收**：`prod-atomic-studio-verify.py`、`prod-atomic-confirm-gate-verify.py`。
 
 ### 3.5 LC-6 高成本确认循环（P4 D2，已实现）

--- a/services/agent-runtime/app/graph/atomic_intent.py
+++ b/services/agent-runtime/app/graph/atomic_intent.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Literal
 
+import re
+
 import yaml
 
 from app.graph.intent import (
@@ -93,6 +95,42 @@ CAMPAIGN_OVERRIDE_PHRASES = (
     "campaign",
 )
 
+CAMPAIGN_COMPLEXITY_PHRASES = (
+    "详情页方案",
+    "详情页营销",
+    "14节点",
+    "14个节点",
+    "整套分镜",
+    "全套分镜",
+    "分镜脚本方案",
+)
+
+OrchestrationComplexity = Literal["atomic", "campaign", "clarify"]
+
+_VAGUE_ORCHESTRATION = frozenset({
+    "帮我生成",
+    "生成一下",
+    "做一个",
+    "来一张",
+    "帮我做一张",
+})
+
+_CN_ORCH_COUNT = {
+    "一": 1,
+    "二": 2,
+    "两": 2,
+    "三": 3,
+    "四": 4,
+    "五": 5,
+    "六": 6,
+    "七": 7,
+    "八": 8,
+    "九": 9,
+    "十": 10,
+    "十一": 11,
+    "十二": 12,
+}
+
 
 def _is_campaign_override(text: str) -> bool:
     return any(p in text for p in CAMPAIGN_OVERRIDE_PHRASES)
@@ -177,6 +215,32 @@ def apply_regenerate_adjust(
     return out
 
 
+def _parse_orch_count(token: str) -> int | None:
+    token = (token or "").strip()
+    if not token:
+        return None
+    if token.isdigit():
+        return int(token)
+    if token in _CN_ORCH_COUNT:
+        return _CN_ORCH_COUNT[token]
+    if len(token) == 2 and token[0] == "十" and token[1] in _CN_ORCH_COUNT:
+        return 10 + _CN_ORCH_COUNT[token[1]]
+    return None
+
+
+def _storyboard_shot_count(text: str) -> int | None:
+    t = (text or "").strip()
+    for pat in (
+        r"([一二三四五六七八九十两\d]+)\s*个分镜",
+        r"([一二三四五六七八九十两\d]+)\s*个镜头",
+        r"([一二三四五六七八九十两\d]+)\s*张分镜",
+    ):
+        m = re.search(pat, t)
+        if m:
+            return _parse_orch_count(m.group(1))
+    return None
+
+
 def _has_prompt_explicit(text: str) -> bool:
     n = _normalize(text)
     if any(_normalize(k) in n for k in PROMPT_EXPLICIT_KEYWORDS):
@@ -218,6 +282,31 @@ def atomic_regenerate_intent(text: str) -> bool:
     if _is_campaign_override(t):
         return False
     return should_regenerate_same_node(t)
+
+
+def orchestration_complexity_intent(text: str) -> OrchestrationComplexity:
+    """Phase 4: route high-complexity requests toward Campaign vs atomic."""
+    t = (text or "").strip()
+    if not t:
+        return "clarify"
+    if any(p in t for p in CAMPAIGN_COMPLEXITY_PHRASES) or _is_campaign_override(t):
+        return "campaign"
+    shots = _storyboard_shot_count(t)
+    if shots is not None and shots >= 4:
+        return "campaign"
+    if "分镜" in t and any(x in t for x in ("12", "十二", "整套", "全套")):
+        return "campaign"
+    if t in _VAGUE_ORCHESTRATION:
+        return "clarify"
+    from app.graph.atomic_parse_util import parse_atomic_multi_items
+
+    if parse_atomic_multi_items(t):
+        return "atomic"
+    if atomic_create_intent(t):
+        return "atomic"
+    if marketing_intent(t):
+        return "campaign"
+    return "clarify"
 
 
 def resolve_intake_route(

--- a/services/agent-runtime/app/graph/atomic_parse_schema.py
+++ b/services/agent-runtime/app/graph/atomic_parse_schema.py
@@ -11,6 +11,7 @@ from app.graph.intent import marketing_intent
 
 CLARIFY_THRESHOLD = 0.70
 RULE_FAST_PATH_THRESHOLD = 0.95
+MAX_ATOMIC_MULTI_ITEMS = 5
 
 VALID_TARGET_TYPES = frozenset({"image", "text", "video", "audio", "prompt"})
 
@@ -133,6 +134,17 @@ def validate_parse_result(
             "confidence": confidence,
             "reason": "invalid_items",
             "clarify_question": clarify_q or _default_clarify_question(utterance),
+        }
+
+    if len(items) > MAX_ATOMIC_MULTI_ITEMS:
+        return {
+            "kind": "clarify",
+            "confidence": min(confidence, 0.5),
+            "reason": "multi_item_limit",
+            "clarify_question": (
+                f"原子创作一次最多支持 {MAX_ATOMIC_MULTI_ITEMS} 个同模态节点。"
+                "如需更多资产或完整营销链路，请改用 Campaign 方案（例如：「帮我做一套详情页营销方案」）。"
+            ),
         }
 
     structure_raw = str(data.get("structure") or "").strip()

--- a/services/agent-runtime/app/graph/nodes/intake.py
+++ b/services/agent-runtime/app/graph/nodes/intake.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable
 
-from app.graph.atomic_intent import atomic_regenerate_intent, is_regenerate_new_variant, resolve_intake_route
+from app.graph.atomic_intent import (
+    atomic_regenerate_intent,
+    is_regenerate_new_variant,
+    orchestration_complexity_intent,
+    resolve_intake_route,
+)
 from app.graph.intent import marketing_intent, modify_intent, single_node_gen_intent  # re-export for tests
 from app.graph.state import BRIEF_RESET_PREFIX
 from app.skills.loader import discover_skills
@@ -49,6 +54,11 @@ def make_intake_node(skills_dir: Path) -> Callable:
             and isinstance(state.get("atomic_spec"), dict)
         )
         is_variant_create = has_atomic_checkpoint and is_regenerate_new_variant(text)
+        orch = orchestration_complexity_intent(text)
+        if orch == "campaign" and (is_atomic or is_variant_create):
+            is_atomic = False
+            is_variant_create = False
+            route = "campaign"
 
         if is_single_node:
             mode = "create"
@@ -69,8 +79,10 @@ def make_intake_node(skills_dir: Path) -> Callable:
         elif is_modify:
             mode = "modify"
             proposed_brief = None  # reducer keeps existing brief
-        elif marketing_intent(text):
+        elif marketing_intent(text) or (orch == "campaign" and route == "campaign"):
             mode = "create"
+            if not skill_id and "enterprise-marketing-campaign" in by_id:
+                skill_id = "enterprise-marketing-campaign"
             if existing_brief and not modify_intent(text):
                 proposed_brief = BRIEF_RESET_PREFIX + text
             else:

--- a/services/agent-runtime/app/graph/subgraphs/atomic_create_gate.py
+++ b/services/agent-runtime/app/graph/subgraphs/atomic_create_gate.py
@@ -29,7 +29,14 @@ def route_after_atomic_create(state: AgentRuntimeState) -> str:
     if state.get("phase") == "error":
         return "done"
     spec = state.get("atomic_spec") or {}
-    if spec.get("confirm_gate"):
+    items = state.get("atomic_items") or []
+    types = {str(i.get("target_type") or "") for i in items if isinstance(i, dict)}
+    if not types:
+        types = {str(spec.get("target_type") or "image")}
+    heavy = types & {"video", "audio"}
+    light = types & {"image", "text", "prompt"}
+    mixed_modal_confirm = bool(heavy) and bool(light)
+    if spec.get("confirm_gate") or mixed_modal_confirm:
         return "await_atomic_confirm"
     return "run_atomic_gen"
 

--- a/services/agent-runtime/skills/atomic-create/eval-orchestration-set.yaml
+++ b/services/agent-runtime/skills/atomic-create/eval-orchestration-set.yaml
@@ -1,0 +1,86 @@
+# Phase 4: orchestration complexity routing gold set (20 cases)
+version: 1
+meta:
+  spec: docs/superpowers/specs/2026-08-04-atomic-intent-hybrid-design.md
+  phase: 4
+
+cases:
+  - id: orch-01
+    utterance: 帮我生成12个分镜镜头
+    gold: { complexity: campaign, route: campaign }
+
+  - id: orch-02
+    utterance: 做一套天猫蓝牙耳机详情页营销方案
+    gold: { complexity: campaign, route: campaign }
+
+  - id: orch-03
+    utterance: 帮我做全链路营销方案
+    gold: { complexity: campaign, route: campaign }
+
+  - id: orch-04
+    utterance: 生成6个分镜脚本
+    gold: { complexity: campaign, route: campaign }
+
+  - id: orch-05
+    utterance: 帮我生成三张图，分别是蓝牙耳机主图、白底图、三视图。
+    gold: { complexity: atomic, route: atomic_create }
+
+  - id: orch-06
+    utterance: 帮我生成一个模特人物图
+    gold: { complexity: atomic, route: atomic_create }
+
+  - id: orch-07
+    utterance: 生成一张白底产品图
+    gold: { complexity: atomic, route: atomic_create }
+
+  - id: orch-08
+    utterance: 写一段天猫详情页开场文案
+    gold: { complexity: atomic, route: atomic_create }
+
+  - id: orch-09
+    utterance: 14节点详情页方案
+    gold: { complexity: campaign, route: campaign }
+
+  - id: orch-10
+    utterance: 帮我生成
+    gold: { complexity: clarify, route: chat }
+
+  - id: orch-11
+    utterance: 生成4张分镜图
+    gold: { complexity: campaign, route: campaign }
+
+  - id: orch-12
+    utterance: 来一张风图，户外跑步场景
+    gold: { complexity: atomic, route: atomic_create }
+
+  - id: orch-13
+    utterance: 帮我做一套campaign全链路
+    gold: { complexity: campaign, route: campaign }
+
+  - id: orch-14
+    utterance: 生成2张图片，分别是白底图、场景图。
+    gold: { complexity: atomic, route: atomic_create }
+
+  - id: orch-15
+    utterance: 整套分镜脚本方案
+    gold: { complexity: campaign, route: campaign }
+
+  - id: orch-16
+    utterance: 15秒产品展示视频
+    gold: { complexity: atomic, route: atomic_create }
+
+  - id: orch-17
+    utterance: 详情页方案拆画布
+    gold: { complexity: campaign, route: campaign }
+
+  - id: orch-18
+    utterance: 帮我生成一个蓝牙耳机的分镜提示词
+    gold: { complexity: atomic, route: atomic_create }
+
+  - id: orch-19
+    utterance: 生成十个镜头分镜
+    gold: { complexity: campaign, route: campaign }
+
+  - id: orch-20
+    utterance: 做一个Banner图
+    gold: { complexity: atomic, route: atomic_create }

--- a/services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml
+++ b/services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml
@@ -64,6 +64,10 @@ intake_priority:
   - id: atomic_create
     when: atomic_create_intent and not marketing_intent
     route: atomic_create
+  - id: orchestration_campaign
+    when: orchestration_complexity_intent == campaign
+    route: campaign
+    notes: Overrides atomic_create for high-complexity storyboard / full-funnel requests
   - id: fallback
     when: default
     route: chat
@@ -109,3 +113,11 @@ atomic_regenerate_hints:
   - 再来一次
   - 再生成一次
   - 再跑一遍
+
+orchestration:
+  max_atomic_multi_items: 5
+  campaign_complexity_phrases:
+    - 详情页方案
+    - 全链路
+    - 14节点
+    - 整套分镜

--- a/services/agent-runtime/tests/test_atomic_create_subgraph.py
+++ b/services/agent-runtime/tests/test_atomic_create_subgraph.py
@@ -175,3 +175,31 @@ async def test_await_atomic_confirm_then_gen():
     out = await run({"atomic_node_id": "node-atomic-1", "atomic_spec": spec})
     assert out["phase"] == "done"
     assert any(c[0] == "run_video_generation" for c in nest.calls)
+
+
+@pytest.mark.asyncio
+async def test_partial_multi_gen_compose_lc6():
+    class PartialNest(FakeNest):
+        def __init__(self) -> None:
+            super().__init__()
+            self._n = 0
+
+        async def run_image_generation(self, node_id: str) -> dict[str, Any]:
+            self._n += 1
+            self.calls.append(("run_image_generation", node_id))
+            if self._n == 2:
+                return {"status": "failed", "error": "timeout"}
+            return {"status": "completed", "generationRecordId": f"rec-{self._n}"}
+
+    nest = PartialNest()
+    items = [
+        {"node_id": "n1", "target_type": "image", "title": "主图"},
+        {"node_id": "n2", "target_type": "image", "title": "白底图"},
+        {"node_id": "n3", "target_type": "image", "title": "三视图"},
+    ]
+    run = make_run_atomic_gen_node(nest=nest)
+    out = await run({"atomic_items": items})
+    assert out["phase"] == "error"
+    assert "部分完成" in out["messages"][0].content
+    assert "主图" in out["messages"][0].content
+    assert "白底图" in out["messages"][0].content or "三视图" in out["messages"][0].content

--- a/services/agent-runtime/tests/test_atomic_orchestration.py
+++ b/services/agent-runtime/tests/test_atomic_orchestration.py
@@ -1,0 +1,79 @@
+"""Phase 4: orchestration complexity and multi-limit tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from langchain_core.messages import HumanMessage
+
+from app.graph.atomic_intent import (
+    orchestration_complexity_intent,
+    resolve_intake_route,
+)
+from app.graph.atomic_parse_schema import MAX_ATOMIC_MULTI_ITEMS, validate_parse_result
+from app.graph.nodes.intake import make_intake_node
+from app.graph.subgraphs.atomic_create_gate import route_after_atomic_create
+
+EVAL_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "atomic-create"
+    / "eval-orchestration-set.yaml"
+)
+
+
+@pytest.fixture(scope="module")
+def orch_cases() -> list[dict]:
+    doc = yaml.safe_load(EVAL_PATH.read_text(encoding="utf-8"))
+    return doc["cases"]
+
+
+def test_eval_orchestration_complexity(orch_cases: list[dict]):
+    mismatches: list[str] = []
+    for case in orch_cases:
+        utterance = case["utterance"]
+        gold = case["gold"]
+        pred_orch = orchestration_complexity_intent(utterance)
+        if pred_orch != gold["complexity"]:
+            mismatches.append(f"{case['id']}: complexity {pred_orch} != {gold['complexity']}")
+    assert not mismatches, "\n".join(mismatches)
+
+
+def test_multi_item_limit_clarify():
+    items = [
+        {"target_type": "image", "title": f"图{i}", "prompt": f"图{i}", "confirm_gate": False}
+        for i in range(MAX_ATOMIC_MULTI_ITEMS + 1)
+    ]
+    outcome = validate_parse_result(
+        {"structure": "multi", "items": items, "confidence": 0.95, "reason": "test"},
+        utterance="六张图",
+    )
+    assert outcome["kind"] == "clarify"
+    assert outcome["reason"] == "multi_item_limit"
+
+
+def test_mixed_modal_routes_to_confirm():
+    assert (
+        route_after_atomic_create(
+            {
+                "phase": "atomic_create",
+                "atomic_spec": {"target_type": "image", "confirm_gate": False},
+                "atomic_items": [
+                    {"target_type": "image", "title": "主图"},
+                    {"target_type": "video", "title": "视频", "confirm_gate": True},
+                ],
+            }
+        )
+        == "await_atomic_confirm"
+    )
+
+
+@pytest.mark.asyncio
+async def test_intake_storyboard_redirects_to_campaign(tmp_path: Path):
+    skills = Path(__file__).resolve().parents[1] / "skills"
+    intake = make_intake_node(skills)
+    out = await intake({"messages": [HumanMessage(content="帮我生成12个分镜镜头")]})
+    assert out["flow_mode"] == "campaign"
+    assert out.get("skill_id") is not None


### PR DESCRIPTION
## Summary
- P4-1: `orchestration_complexity_intent()` routes high-complexity storyboard / full-funnel requests to campaign instead of atomic_create
- P4-2: Cap atomic multi items at 5 (clarify → suggest Campaign); mixed image+video/audio routes to confirm gate
- P4-3: LC-6 partial multi-gen failure compose + test coverage
- P4-4: ADR for atomic vs campaign boundary; prod smoke adds clarify case (≥17 total)

## Test plan
- [x] `python3 -m pytest tests/test_atomic*.py` — 82 passed
- [x] `pnpm build`
- [ ] CI green
- [ ] Deploy Agent Runtime
- [ ] `python3 deploy/prod-atomic-intent-verify.py` on production


Made with [Cursor](https://cursor.com)