### PR TITLE
fix(agent): Phase 1 atomic checkpoint observability

### DIFF
--- a/services/agent-runtime/app/checkpoint_observability.py
+++ b/services/agent-runtime/app/checkpoint_observability.py
@@ -1,0 +1,31 @@
+"""Diagnostic helpers for LangGraph checkpoint / atomic context observability."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def has_atomic_checkpoint(vals: dict[str, Any] | None) -> bool:
+    if not isinstance(vals, dict):
+        return False
+    return bool(str(vals.get("atomic_node_id") or "").strip()) and isinstance(
+        vals.get("atomic_spec"), dict
+    )
+
+
+def checkpoint_diagnostics(vals: dict[str, Any] | None) -> dict[str, Any]:
+    """Compact snapshot for logs and thread-state API (no full atomic_spec payload)."""
+    if not isinstance(vals, dict):
+        vals = {}
+    node_id = str(vals.get("atomic_node_id") or "").strip() or None
+    spec = vals.get("atomic_spec") if isinstance(vals.get("atomic_spec"), dict) else None
+    title = str(spec.get("title") or "")[:40] if spec else None
+    target = str(spec.get("target_type") or "") if spec else None
+    return {
+        "hasAtomicCheckpoint": has_atomic_checkpoint(vals),
+        "atomicNodeId": node_id,
+        "atomicTargetType": target or None,
+        "atomicTitle": title or None,
+        "flowMode": vals.get("flow_mode"),
+        "phase": vals.get("phase"),
+    }

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 import uuid
 from pathlib import Path
@@ -14,6 +15,7 @@ from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 from pydantic import BaseModel
 
+from app.checkpoint_observability import checkpoint_diagnostics
 from app.config import settings
 from app.errors import AgentToolError, error_to_sse_payload, from_exception
 from app.graph.builder import build_agent_graph
@@ -29,6 +31,8 @@ from app.graph.nodes.intake import modify_intent
 from app.tools.nest_client import NestCanvasClient
 
 EmitFn = Callable[[dict[str, Any]], Awaitable[None]]
+
+logger = logging.getLogger(__name__)
 
 
 async def _init_checkpointer() -> AsyncSqliteSaver:
@@ -472,12 +476,14 @@ async def get_thread_state(
     next_nodes = [str(n) for n in (getattr(snap, "next", None) or [])]
     phase = vals.get("phase")
     phase_str = str(phase) if phase is not None else None
+    diag = checkpoint_diagnostics(vals)
     return {
         "threadId": thread_id,
         "phase": phase_str,
         "nextNodes": next_nodes,
         "interrupted": bool(next_nodes),
         "finished": phase_str == "done" or (not next_nodes and bool(vals)),
+        **diag,
     }
 
 
@@ -558,6 +564,14 @@ async def stream_run_events(
     # W5: 检查是否从 interrupt_before 恢复
     snap = await graph.aget_state(config)
     next_nodes = getattr(snap, "next", None) or []
+    pre_vals = getattr(snap, "values", None) or {}
+    logger.info(
+        "agent_turn_start thread_id=%s session_id=%s resume=%s checkpoint=%s",
+        thread_id,
+        req.session_id,
+        bool(next_nodes),
+        checkpoint_diagnostics(pre_vals),
+    )
     assistant_save_after = 0
 
     if next_nodes:
@@ -619,6 +633,13 @@ async def stream_run_events(
             post = await graph.aget_state(config)
             post_next = [str(n) for n in (getattr(post, "next", None) or [])]
             post_vals = getattr(post, "values", None) or {}
+            logger.info(
+                "agent_turn_end thread_id=%s session_id=%s checkpoint=%s next=%s",
+                thread_id,
+                req.session_id,
+                checkpoint_diagnostics(post_vals),
+                post_next,
+            )
             if post_next:
                 phase = post_vals.get("phase")
                 await emit(

--- a/services/agent-runtime/tests/test_checkpoint_observability.py
+++ b/services/agent-runtime/tests/test_checkpoint_observability.py
@@ -1,0 +1,34 @@
+"""Tests for checkpoint observability helpers."""
+
+from app.checkpoint_observability import checkpoint_diagnostics, has_atomic_checkpoint
+
+
+def test_has_atomic_checkpoint_false_when_empty():
+    assert not has_atomic_checkpoint({})
+    assert not has_atomic_checkpoint({"atomic_node_id": "n1"})
+
+
+def test_has_atomic_checkpoint_true():
+    assert has_atomic_checkpoint(
+        {
+            "atomic_node_id": "node-1",
+            "atomic_spec": {"target_type": "image", "title": "主图"},
+        }
+    )
+
+
+def test_checkpoint_diagnostics_shape():
+    diag = checkpoint_diagnostics(
+        {
+            "atomic_node_id": "node-abc",
+            "atomic_spec": {"target_type": "image", "title": "模特人物图"},
+            "flow_mode": "atomic_create",
+            "phase": "done",
+        }
+    )
+    assert diag["hasAtomicCheckpoint"] is True
+    assert diag["atomicNodeId"] == "node-abc"
+    assert diag["atomicTargetType"] == "image"
+    assert diag["atomicTitle"] == "模特人物图"
+    assert diag["flowMode"] == "atomic_create"
+    assert diag["phase"] == "done"

--- a/services/agent-runtime/tests/test_thread_state.py
+++ b/services/agent-runtime/tests/test_thread_state.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import pytest
+from langchain_core.messages import HumanMessage
 from langgraph.checkpoint.memory import MemorySaver
 
+from app.graph.builder import build_agent_graph
 from app.runs import get_thread_state
 
 
@@ -16,3 +18,34 @@ async def test_get_thread_state_empty_thread():
     assert state["phase"] is None
     assert state["nextNodes"] == []
     assert state["interrupted"] is False
+    assert state["hasAtomicCheckpoint"] is False
+    assert state["atomicNodeId"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_thread_state_includes_atomic_checkpoint(tmp_path):
+    cp = MemorySaver()
+    graph = build_agent_graph(
+        nest=type("_N", (), {"close": lambda self: None})(),
+        llm=None,
+        skills_dir=__import__("pathlib").Path(__file__).resolve().parents[1] / "skills",
+        checkpointer=cp,
+    )
+    config = {"configurable": {"thread_id": "t-atomic-diag"}}
+    await graph.ainvoke(
+        {
+            "messages": [HumanMessage(content="帮我生成一个模特人物图")],
+            "atomic_node_id": "node-x",
+            "atomic_spec": {"target_type": "image", "title": "模特图", "prompt": "模特"},
+            "flow_mode": "atomic_create",
+            "phase": "done",
+            "thread_id": "t-atomic-diag",
+            "session_id": "s1",
+            "user_id": "u1",
+        },
+        config,
+    )
+    state = await get_thread_state("t-atomic-diag", checkpointer=cp)
+    assert state["hasAtomicCheckpoint"] is True
+    assert state["atomicNodeId"] == "node-x"
+    assert state["atomicTargetType"] == "image"


### PR DESCRIPTION
## Summary
- 新增 `checkpoint_diagnostics`  helper，统一抽取 `hasAtomicCheckpoint` / `atomicNodeId` / `flowMode` 等字段
- `stream_run_events` 在每轮开始/结束打 structured log，便于对比 browser 多轮 thread 与 checkpoint 是否一致
- `GET /v1/threads/{id}/state` 响应扩展上述诊断字段，供前端 reconnect 与 prod smoke 断言

## Test plan
- [x] `pytest tests/test_checkpoint_observability.py tests/test_thread_state.py`
- [ ] 合并后 prod：同一 thread 两轮 regenerate 时在 runtime log 中可见 `hasAtomicCheckpoint=true`


Made with [Cursor](https://cursor.com)