### PR TITLE
fix(agent): Phase 2 atomic LangGraph loop closure

### DIFF
--- a/services/agent-runtime/app/graph/atomic_intent.py
+++ b/services/agent-runtime/app/graph/atomic_intent.py
@@ -274,6 +274,11 @@ def atomic_create_intent(text: str) -> bool:
     return False
 
 
+def regenerate_phrase_intent(text: str) -> bool:
+    """True when utterance looks like regenerate/variant retry phrasing."""
+    return _matches_regenerate_hints(text)
+
+
 def atomic_regenerate_intent(text: str) -> bool:
     """True when user wants to re-run gen on existing atomic_node_id."""
     t = (text or "").strip()

--- a/services/agent-runtime/app/graph/atomic_parse_schema.py
+++ b/services/agent-runtime/app/graph/atomic_parse_schema.py
@@ -184,7 +184,6 @@ def parse_outcome_to_state(outcome: ParseOutcome, *, canvas_context: str | None 
             "flow_mode": "atomic_create",
             "parse_confidence": outcome["confidence"],
             "clarify_question": outcome["clarify_question"],
-            "messages": [AIMessage(content=outcome["clarify_question"])],
         }
 
     items = outcome["items"]

--- a/services/agent-runtime/app/graph/builder.py
+++ b/services/agent-runtime/app/graph/builder.py
@@ -21,6 +21,8 @@ from app.graph.subgraphs.topo_gate import register_topo_gate
 
 
 def route_after_intake(state: AgentRuntimeState) -> str:
+    if state.get("phase") == "clarify" and state.get("clarify_question"):
+        return "clarify_atomic_intent"
     if state.get("flow_mode") == "atomic_regenerate":
         return "prepare_atomic_regenerate"
     if state.get("flow_mode") == "single_node":
@@ -71,6 +73,7 @@ def build_agent_graph(
             "prepare_atomic_regenerate": "prepare_atomic_regenerate",
             "prepare_single_gen": "prepare_single_gen",
             "parse_atomic_intent": "parse_atomic_intent",
+            "clarify_atomic_intent": "clarify_atomic_intent",
             "decide_plan_mode": "decide_plan_mode",
             "chat": "chat",
         },

--- a/services/agent-runtime/app/graph/nodes/done.py
+++ b/services/agent-runtime/app/graph/nodes/done.py
@@ -10,6 +10,10 @@ from app.graph.gen_progress_read import load_gen_progress, parse_gen_progress_re
 
 def make_done_node(*, nest: Any = None) -> Callable:
     async def done(state: dict) -> dict:
+        flow_mode = state.get("flow_mode")
+        if flow_mode in ("atomic_create", "atomic_regenerate"):
+            return {"phase": "done", "messages": []}
+
         thread_id = str(state.get("thread_id") or "")
         progress = await load_gen_progress(nest, thread_id) if state.get("gen_progress_id") else None
 

--- a/services/agent-runtime/app/graph/nodes/intake.py
+++ b/services/agent-runtime/app/graph/nodes/intake.py
@@ -7,11 +7,18 @@ from app.graph.atomic_intent import (
     atomic_regenerate_intent,
     is_regenerate_new_variant,
     orchestration_complexity_intent,
+    regenerate_phrase_intent,
     resolve_intake_route,
 )
 from app.graph.intent import marketing_intent, modify_intent, single_node_gen_intent  # re-export for tests
 from app.graph.state import BRIEF_RESET_PREFIX
 from app.skills.loader import discover_skills
+
+REGENERATE_NO_CHECKPOINT_CLARIFY = (
+    "当前对话还没有可重新生成的画布节点。"
+    "请先在同一会话里完成首次创作（例如「帮我生成一张蓝牙耳机主图」），"
+    "再说「重新生成一张」或「按刚才那个风格再生成一张」。"
+)
 
 
 def latest_user_text(messages: list[Any]) -> str:
@@ -54,6 +61,7 @@ def make_intake_node(skills_dir: Path) -> Callable:
             and isinstance(state.get("atomic_spec"), dict)
         )
         is_variant_create = has_atomic_checkpoint and is_regenerate_new_variant(text)
+        needs_regen_clarify = not has_atomic_checkpoint and regenerate_phrase_intent(text)
         orch = orchestration_complexity_intent(text)
         if orch == "campaign" and (is_atomic or is_variant_create):
             is_atomic = False
@@ -70,6 +78,11 @@ def make_intake_node(skills_dir: Path) -> Callable:
             mode = "create"
             proposed_brief = None
             flow_mode = "atomic_regenerate"
+            skill_id = None
+        elif needs_regen_clarify:
+            mode = "create"
+            proposed_brief = None
+            flow_mode = "atomic_create"
             skill_id = None
         elif is_atomic or is_variant_create:
             mode = "create"
@@ -93,7 +106,11 @@ def make_intake_node(skills_dir: Path) -> Callable:
 
         resolved_flow = (
             flow_mode
-            if is_single_node or is_atomic or is_variant_create or flow_mode == "atomic_regenerate"
+            if is_single_node
+            or is_atomic
+            or is_variant_create
+            or flow_mode == "atomic_regenerate"
+            or needs_regen_clarify
             else "campaign"
         )
 
@@ -109,6 +126,9 @@ def make_intake_node(skills_dir: Path) -> Callable:
         if resolved_flow in ("atomic_create", "atomic_regenerate"):
             out["split_manifest"] = []
             out["skill_id"] = None
+        if needs_regen_clarify:
+            out["phase"] = "clarify"
+            out["clarify_question"] = REGENERATE_NO_CHECKPOINT_CLARIFY
         if focus_node_id:
             out["focus_node_id"] = focus_node_id
         if proposed_brief is not None:

--- a/services/agent-runtime/app/graph/subgraphs/atomic_create_gate.py
+++ b/services/agent-runtime/app/graph/subgraphs/atomic_create_gate.py
@@ -71,7 +71,7 @@ def register_atomic_create_gate(graph: StateGraph, *, nest: Any, llm: Any | None
             "done": "done",
         },
     )
-    graph.add_edge("clarify_atomic_intent", "done")
+    graph.add_edge("clarify_atomic_intent", END)
     graph.add_conditional_edges(
         "create_atomic_node",
         route_after_atomic_create,
@@ -92,4 +92,4 @@ def register_atomic_create_gate(graph: StateGraph, *, nest: Any, llm: Any | None
     )
     graph.add_edge("prepare_atomic_regenerate", "run_atomic_gen")
     graph.add_edge("adjust_atomic_regenerate", "run_atomic_gen")
-    graph.add_edge("run_atomic_gen", "done")
+    graph.add_edge("run_atomic_gen", END)

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -584,6 +584,7 @@ async def stream_run_events(
         }
 
     async def run_graph() -> None:
+        last_text_delta: str | None = None
         try:
             async for update in graph.astream(input_state, config, stream_mode="updates"):
                 if not isinstance(update, dict):
@@ -615,7 +616,11 @@ async def stream_run_events(
                                 msg.get("role") if isinstance(msg, dict) else None
                             )
                             if msg_type in ("ai", "assistant") or isinstance(msg, AIMessage):
-                                await emit({"type": "text_delta", "data": {"text": str(content)}})
+                                text = str(content)
+                                if text == last_text_delta:
+                                    continue
+                                last_text_delta = text
+                                await emit({"type": "text_delta", "data": {"text": text}})
             post = await graph.aget_state(config)
             post_next = [str(n) for n in (getattr(post, "next", None) or [])]
             post_vals = getattr(post, "values", None) or {}

--- a/services/agent-runtime/tests/test_atomic_create_intent.py
+++ b/services/agent-runtime/tests/test_atomic_create_intent.py
@@ -106,4 +106,7 @@ async def test_intake_regenerate_without_prior_node_falls_through(tmp_path: Path
     out = await intake({
         "messages": [HumanMessage(content="再试一次")],
     })
+    assert out.get("flow_mode") == "atomic_create"
+    assert out.get("phase") == "clarify"
+    assert out.get("clarify_question")
     assert out.get("flow_mode") != "atomic_regenerate"

--- a/services/agent-runtime/tests/test_atomic_regenerate_clarify.py
+++ b/services/agent-runtime/tests/test_atomic_regenerate_clarify.py
@@ -1,0 +1,36 @@
+"""Phase 2: intake routes regenerate phrases without checkpoint to clarify."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from app.graph.builder import route_after_intake
+from app.graph.nodes.intake import make_intake_node
+
+
+@pytest.mark.asyncio
+async def test_intake_variant_phrase_without_checkpoint_clarifies():
+    skills = Path(__file__).resolve().parents[1] / "skills"
+    intake = make_intake_node(skills)
+    out = await intake({"messages": [HumanMessage(content="按刚才那个风格再生成一张")]})
+    assert out["phase"] == "clarify"
+    assert route_after_intake(out) == "clarify_atomic_intent"
+
+
+@pytest.mark.asyncio
+async def test_parse_clarify_state_has_no_duplicate_message():
+    from app.graph.atomic_parse_schema import parse_outcome_to_state
+
+    state = parse_outcome_to_state(
+        {
+            "kind": "clarify",
+            "confidence": 0.2,
+            "reason": "vague",
+            "clarify_question": "请补充要生成的内容。",
+        }
+    )
+    assert state["phase"] == "clarify"
+    assert "messages" not in state

--- a/services/agent-runtime/tests/test_done.py
+++ b/services/agent-runtime/tests/test_done.py
@@ -49,3 +49,11 @@ async def test_done_without_progress_uses_last_error():
     done = make_done_node()
     out = await done({"phase": "done", "last_error": "出图编排失败：cycle"})
     assert "出图编排失败" in out["messages"][0].content
+
+
+@pytest.mark.asyncio
+async def test_done_skips_campaign_fallback_for_atomic_flow():
+    done = make_done_node()
+    out = await done({"phase": "done", "flow_mode": "atomic_create"})
+    assert out["phase"] == "done"
+    assert out["messages"] == []


### PR DESCRIPTION
## Summary
- **Loop/Graph**：无 checkpoint 的 regenerate/变体短语 → `clarify_atomic_intent`，不再落 `chat`
- **LangGraph**：`run_atomic_gen` / `clarify_atomic_intent` 直接 `END`，避免 Campaign `done` 追加「无可汇总出图」
- **SSE**：连续相同 `text_delta` 去重；parse clarify 不再预 emit 消息（由 clarify 节点单点产出）
- **done 节点**：atomic flow 兜底跳过 Campaign 关账文案

## Test plan
- [x] `pytest tests/test_atomic_regenerate_clarify.py tests/test_done.py tests/test_atomic_create_subgraph.py`
- [ ] 浏览器同会话：首轮建图 →「重新生成一张」应走 atomic_regenerate（需 Phase 1 checkpoint 正常）


Made with [Cursor](https://cursor.com)