### PR TITLE
fix(agent): Phase 3 atomic context thread contract

### DIFF
--- a/apps/server/src/agent/agent-runtime.client.ts
+++ b/apps/server/src/agent/agent-runtime.client.ts
@@ -22,6 +22,11 @@ export interface RuntimeThreadState {
   nextNodes: string[]
   interrupted: boolean
   finished: boolean
+  hasAtomicCheckpoint?: boolean
+  atomicNodeId?: string | null
+  atomicTargetType?: string | null
+  atomicTitle?: string | null
+  flowMode?: string | null
 }
 
 export interface RuntimeThreadTimelineEntry {

--- a/apps/server/src/agent/agent.service.ts
+++ b/apps/server/src/agent/agent.service.ts
@@ -178,6 +178,11 @@ export class AgentService {
     nextNodes: string[]
     interrupted: boolean
     finished: boolean
+    hasAtomicCheckpoint?: boolean
+    atomicNodeId?: string | null
+    atomicTargetType?: string | null
+    atomicTitle?: string | null
+    flowMode?: string | null
   } | null> {
     const runtimeUrl = process.env.AGENT_RUNTIME_URL?.trim()
     if (!runtimeUrl || !threadId.trim()) return null

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -108,6 +108,8 @@ const reconnecting = ref(false)
 const recoveredPhaseHint = ref<string | null>(null)
 /** P0-06: authoritative gate from SSE interrupt or thread-state reconnect */
 const interruptGate = ref<AgentInterruptPayload | null>(null)
+/** LangGraph checkpoint: same thread can regenerate/variant on prior atomic node */
+const hasAtomicCheckpoint = ref(false)
 
 const agentStream = useAgentStream({
   onStale: () => {
@@ -275,7 +277,30 @@ function newAgentSession() {
   agent.clear()
   input.value = ''
   taskProgress.value = emptyTaskProgress()
+  interruptGate.value = null
+  hasAtomicCheckpoint.value = false
+  recoveredPhaseHint.value = null
   agentThreadId.value = createAgentThreadId(props.sessionId)
+  ElMessage.info('已新建对话：重新生成/变体需要在新对话里先完成首次创作。')
+}
+
+async function refreshThreadCheckpoint() {
+  try {
+    const token = localStorage.getItem('token')
+    const res = await fetch(
+      apiUrl(`/api/agent/thread-state?threadId=${encodeURIComponent(agentThreadId.value)}`),
+      { headers: { Authorization: `Bearer ${token}` } },
+    )
+    const json = (await res.json()) as {
+      data?: { hasAtomicCheckpoint?: boolean; interrupted?: boolean; phase?: string | null }
+    }
+    hasAtomicCheckpoint.value = Boolean(json.data?.hasAtomicCheckpoint)
+    if (json.data?.interrupted) {
+      interruptGate.value = interruptPayloadFromThreadState(json.data)
+    }
+  } catch {
+    // ignore — checkpoint hint is best-effort
+  }
 }
 
 async function loadHistory() {
@@ -463,6 +488,7 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
     }
     agent.finishStreaming()
     await reconcileLatestAssistant()
+    await refreshThreadCheckpoint()
     const actions = agent.flushActions()
     if (actions.length) emit('canvasActions', actions)
     // 始终回拉：Runtime 已写 Session.canvasData；本地 save 不得用旧节点覆盖
@@ -495,9 +521,11 @@ async function reconnectStream() {
         interrupted?: boolean
         finished?: boolean
         nextNodes?: string[]
+        hasAtomicCheckpoint?: boolean
       } | null
     }
     const phase = json.data?.phase ?? null
+    hasAtomicCheckpoint.value = Boolean(json.data?.hasAtomicCheckpoint)
     interruptGate.value = interruptPayloadFromThreadState(json.data)
 
     if (agent.isStreaming) {

--- a/services/agent-runtime/app/checkpoint_observability.py
+++ b/services/agent-runtime/app/checkpoint_observability.py
@@ -1,0 +1,31 @@
+"""Diagnostic helpers for LangGraph checkpoint / atomic context observability."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def has_atomic_checkpoint(vals: dict[str, Any] | None) -> bool:
+    if not isinstance(vals, dict):
+        return False
+    return bool(str(vals.get("atomic_node_id") or "").strip()) and isinstance(
+        vals.get("atomic_spec"), dict
+    )
+
+
+def checkpoint_diagnostics(vals: dict[str, Any] | None) -> dict[str, Any]:
+    """Compact snapshot for logs and thread-state API (no full atomic_spec payload)."""
+    if not isinstance(vals, dict):
+        vals = {}
+    node_id = str(vals.get("atomic_node_id") or "").strip() or None
+    spec = vals.get("atomic_spec") if isinstance(vals.get("atomic_spec"), dict) else None
+    title = str(spec.get("title") or "")[:40] if spec else None
+    target = str(spec.get("target_type") or "") if spec else None
+    return {
+        "hasAtomicCheckpoint": has_atomic_checkpoint(vals),
+        "atomicNodeId": node_id,
+        "atomicTargetType": target or None,
+        "atomicTitle": title or None,
+        "flowMode": vals.get("flow_mode"),
+        "phase": vals.get("phase"),
+    }

--- a/services/agent-runtime/app/graph/atomic_context.py
+++ b/services/agent-runtime/app/graph/atomic_context.py
@@ -55,6 +55,12 @@ def build_atomic_parse_context(
 ) -> str:
     """Canvas one-liner + last 2 dialogue turns for hybrid parse."""
     parts: list[str] = []
+    prior = state.get("atomic_spec")
+    if isinstance(prior, dict):
+        title = str(prior.get("title") or "").strip()
+        target = str(prior.get("target_type") or "").strip()
+        if title:
+            parts.append(f"上轮原子:{target or 'image'}:{title[:32]}")
     nodes = canvas_summary_nodes(canvas_summary)
     canvas_line = format_canvas_context_line(nodes)
     if canvas_line:

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -14,6 +14,7 @@ from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 from pydantic import BaseModel
 
+from app.checkpoint_observability import checkpoint_diagnostics
 from app.config import settings
 from app.errors import AgentToolError, error_to_sse_payload, from_exception
 from app.graph.builder import build_agent_graph
@@ -472,12 +473,14 @@ async def get_thread_state(
     next_nodes = [str(n) for n in (getattr(snap, "next", None) or [])]
     phase = vals.get("phase")
     phase_str = str(phase) if phase is not None else None
+    diag = checkpoint_diagnostics(vals)
     return {
         "threadId": thread_id,
         "phase": phase_str,
         "nextNodes": next_nodes,
         "interrupted": bool(next_nodes),
         "finished": phase_str == "done" or (not next_nodes and bool(vals)),
+        **diag,
     }
 
 

--- a/services/agent-runtime/tests/test_atomic_context.py
+++ b/services/agent-runtime/tests/test_atomic_context.py
@@ -49,3 +49,14 @@ def test_build_atomic_parse_context_includes_canvas_and_history():
     assert "画布" in ctx
     assert "主图" in ctx
     assert "近期对话" in ctx
+
+
+def test_build_atomic_parse_context_includes_prior_atomic_spec():
+    ctx = build_atomic_parse_context(
+        {
+            "messages": [],
+            "atomic_spec": {"target_type": "image", "title": "模特人物图", "prompt": "模特"},
+        },
+        canvas_summary={"nodes": []},
+    )
+    assert "上轮原子:image:模特人物图" in ctx

--- a/services/agent-runtime/tests/test_checkpoint_observability.py
+++ b/services/agent-runtime/tests/test_checkpoint_observability.py
@@ -1,0 +1,18 @@
+"""Tests for checkpoint observability helpers."""
+
+from app.checkpoint_observability import checkpoint_diagnostics, has_atomic_checkpoint
+
+
+def test_has_atomic_checkpoint_true():
+    assert has_atomic_checkpoint(
+        {
+            "atomic_node_id": "node-1",
+            "atomic_spec": {"target_type": "image", "title": "主图"},
+        }
+    )
+
+
+def test_checkpoint_diagnostics_exposes_has_flag():
+    diag = checkpoint_diagnostics({"atomic_node_id": "n1", "atomic_spec": {"target_type": "text"}})
+    assert diag["hasAtomicCheckpoint"] is True
+    assert diag["atomicNodeId"] == "n1"


### PR DESCRIPTION
## Summary
- thread-state API 返回 `hasAtomicCheckpoint` / `atomicNodeId` 等诊断字段（Context 层契约）
- `build_atomic_parse_context` 注入上轮 `atomic_spec`，支撑变体「按刚才风格」解析
- 前端：每轮结束后 refresh checkpoint；新建对话清 interrupt + 提示会丢失 regenerate 上下文

## Test plan
- [x] `pytest tests/test_atomic_context.py tests/test_checkpoint_observability.py`
- [ ] 浏览器：首轮 atomic 完成后 thread-state 应显示 `hasAtomicCheckpoint=true`


Made with [Cursor](https://cursor.com)