### PR TITLE
fix(agent): Phase 5 atomic variant parse prompts

### DIFF
--- a/services/agent-runtime/app/graph/atomic_parse_llm.py
+++ b/services/agent-runtime/app/graph/atomic_parse_llm.py
@@ -37,6 +37,7 @@ _PARSE_SYSTEM = """你是 Atomic Studio 意图解析器。根据用户一句话�
 - multi：用户要多张/多项时 structure=multi，items 逐条拆分 prompt/title
 - 营销方案/14节点/全链路 → confidence<0.7，clarify_question 建议走 Campaign
 - 意图不清（如仅「帮我生成」）→ confidence<0.7 并给出 clarify_question
+- 「再生成一张/按刚才风格/重新生成」→ 非首轮 create parse；confidence<0.5，clarify 引导同会话 regenerate/变体（勿判 Campaign）
 """
 
 

--- a/services/agent-runtime/skills/atomic-create/assets/few-shots.yaml
+++ b/services/agent-runtime/skills/atomic-create/assets/few-shots.yaml
@@ -32,6 +32,12 @@ nodes:
     - user: 重新生成一张
       assistant: |
         {"structure":"single","items":[],"confidence":0.20,"reason":"regenerate 非 create parse","clarify_question":"若要重新生成已有节点，请在同一会话中直接说「再试一次」。"}
+    - user: 按刚才那个风格再生成一张
+      assistant: |
+        {"structure":"single","items":[],"confidence":0.18,"reason":"variant/regenerate 需 checkpoint","clarify_question":"请在同一会话中先完成一张图，再说「按刚才那个风格再生成一张」以新建变体节点。"}
+    - user: 重新生成一张，背景改成白色
+      assistant: |
+        {"structure":"single","items":[],"confidence":0.18,"reason":"variant adjust 需 checkpoint","clarify_question":"请在同一会话中先有一张图，再说「重新生成一张，背景改成白色」。"}
     - user: 帮我做一套天猫蓝牙耳机详情页营销方案
       assistant: |
         {"structure":"single","items":[],"confidence":0.25,"reason":"Campaign 全链路","clarify_question":"这像完整营销方案，是否改用 Campaign 全链路？若只要单张图请说明。"}


### PR DESCRIPTION
## Summary
- **Prompt**：`atomic_parse_llm` 系统规则 + few-shots 覆盖「按刚才风格再生成一张」等变体/regenerate 短语
- 避免 LLM parse 误走 Campaign clarify（checkpoint 快捷路径不可用时的兜底）

## Test plan
- [x] 现有 atomic parse 测试通过
- [ ] 与 Phase 2 合并后：无 checkpoint 变体短语应得到 regenerate 引导 clarify


Made with [Cursor](https://cursor.com)