### PR TITLE
fix(agent): Phase 3 atomic context thread contract (rebased)

### DIFF
--- a/apps/server/src/agent/agent-runtime.client.ts
+++ b/apps/server/src/agent/agent-runtime.client.ts
@@ -22,6 +22,11 @@ export interface RuntimeThreadState {
   nextNodes: string[]
   interrupted: boolean
   finished: boolean
+  hasAtomicCheckpoint?: boolean
+  atomicNodeId?: string | null
+  atomicTargetType?: string | null
+  atomicTitle?: string | null
+  flowMode?: string | null
 }
 
 export interface RuntimeThreadTimelineEntry {

--- a/apps/server/src/agent/agent.service.ts
+++ b/apps/server/src/agent/agent.service.ts
@@ -178,6 +178,11 @@ export class AgentService {
     nextNodes: string[]
     interrupted: boolean
     finished: boolean
+    hasAtomicCheckpoint?: boolean
+    atomicNodeId?: string | null
+    atomicTargetType?: string | null
+    atomicTitle?: string | null
+    flowMode?: string | null
   } | null> {
     const runtimeUrl = process.env.AGENT_RUNTIME_URL?.trim()
     if (!runtimeUrl || !threadId.trim()) return null

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -108,6 +108,8 @@ const reconnecting = ref(false)
 const recoveredPhaseHint = ref<string | null>(null)
 /** P0-06: authoritative gate from SSE interrupt or thread-state reconnect */
 const interruptGate = ref<AgentInterruptPayload | null>(null)
+/** LangGraph checkpoint: same thread can regenerate/variant on prior atomic node */
+const hasAtomicCheckpoint = ref(false)
 
 const agentStream = useAgentStream({
   onStale: () => {
@@ -275,7 +277,30 @@ function newAgentSession() {
   agent.clear()
   input.value = ''
   taskProgress.value = emptyTaskProgress()
+  interruptGate.value = null
+  hasAtomicCheckpoint.value = false
+  recoveredPhaseHint.value = null
   agentThreadId.value = createAgentThreadId(props.sessionId)
+  ElMessage.info('已新建对话：重新生成/变体需要在新对话里先完成首次创作。')
+}
+
+async function refreshThreadCheckpoint() {
+  try {
+    const token = localStorage.getItem('token')
+    const res = await fetch(
+      apiUrl(`/api/agent/thread-state?threadId=${encodeURIComponent(agentThreadId.value)}`),
+      { headers: { Authorization: `Bearer ${token}` } },
+    )
+    const json = (await res.json()) as {
+      data?: { hasAtomicCheckpoint?: boolean; interrupted?: boolean; phase?: string | null }
+    }
+    hasAtomicCheckpoint.value = Boolean(json.data?.hasAtomicCheckpoint)
+    if (json.data?.interrupted) {
+      interruptGate.value = interruptPayloadFromThreadState(json.data)
+    }
+  } catch {
+    // ignore — checkpoint hint is best-effort
+  }
 }
 
 async function loadHistory() {
@@ -463,6 +488,7 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
     }
     agent.finishStreaming()
     await reconcileLatestAssistant()
+    await refreshThreadCheckpoint()
     const actions = agent.flushActions()
     if (actions.length) emit('canvasActions', actions)
     // 始终回拉：Runtime 已写 Session.canvasData；本地 save 不得用旧节点覆盖
@@ -495,9 +521,11 @@ async function reconnectStream() {
         interrupted?: boolean
         finished?: boolean
         nextNodes?: string[]
+        hasAtomicCheckpoint?: boolean
       } | null
     }
     const phase = json.data?.phase ?? null
+    hasAtomicCheckpoint.value = Boolean(json.data?.hasAtomicCheckpoint)
     interruptGate.value = interruptPayloadFromThreadState(json.data)
 
     if (agent.isStreaming) {

--- a/services/agent-runtime/app/graph/atomic_context.py
+++ b/services/agent-runtime/app/graph/atomic_context.py
@@ -55,6 +55,12 @@ def build_atomic_parse_context(
 ) -> str:
     """Canvas one-liner + last 2 dialogue turns for hybrid parse."""
     parts: list[str] = []
+    prior = state.get("atomic_spec")
+    if isinstance(prior, dict):
+        title = str(prior.get("title") or "").strip()
+        target = str(prior.get("target_type") or "").strip()
+        if title:
+            parts.append(f"上轮原子:{target or 'image'}:{title[:32]}")
     nodes = canvas_summary_nodes(canvas_summary)
     canvas_line = format_canvas_context_line(nodes)
     if canvas_line:

--- a/services/agent-runtime/tests/test_atomic_context.py
+++ b/services/agent-runtime/tests/test_atomic_context.py
@@ -49,3 +49,14 @@ def test_build_atomic_parse_context_includes_canvas_and_history():
     assert "画布" in ctx
     assert "主图" in ctx
     assert "近期对话" in ctx
+
+
+def test_build_atomic_parse_context_includes_prior_atomic_spec():
+    ctx = build_atomic_parse_context(
+        {
+            "messages": [],
+            "atomic_spec": {"target_type": "image", "title": "模特人物图", "prompt": "模特"},
+        },
+        canvas_summary={"nodes": []},
+    )
+    assert "上轮原子:image:模特人物图" in ctx

--- a/services/agent-runtime/tests/test_checkpoint_observability.py
+++ b/services/agent-runtime/tests/test_checkpoint_observability.py
@@ -32,3 +32,9 @@ def test_checkpoint_diagnostics_shape():
     assert diag["atomicTitle"] == "模特人物图"
     assert diag["flowMode"] == "atomic_create"
     assert diag["phase"] == "done"
+
+
+def test_checkpoint_diagnostics_exposes_has_flag():
+    diag = checkpoint_diagnostics({"atomic_node_id": "n1", "atomic_spec": {"target_type": "text"}})
+    assert diag["hasAtomicCheckpoint"] is True
+    assert diag["atomicNodeId"] == "n1"


### PR DESCRIPTION
## Summary
Rebased on main after #131 + #132 merge. Replaces #133.

- thread-state API 返回 `hasAtomicCheckpoint` 等字段
- `build_atomic_parse_context` 注入上轮 `atomic_spec`
- 前端 refresh checkpoint / 新建对话提示

## Test plan
- [x] pytest atomic_context + checkpoint_observability
- [ ] 浏览器 thread-state 验证


Made with [Cursor](https://cursor.com)