### PR TITLE
feat(agent): turnaround image pipeline with expand-then-generate

### DIFF
--- a/apps/server/src/agent/agent-canvas-tools.controller.ts
+++ b/apps/server/src/agent/agent-canvas-tools.controller.ts
@@ -58,6 +58,14 @@ class BatchNodeItemDto {
 
   @IsOptional()
   position?: { x: number; y: number }
+
+  @IsOptional()
+  @IsString()
+  pipeline?: string
+
+  @IsOptional()
+  @IsString()
+  imageAspect?: string
 }
 
 class AddNodesBatchDto {

--- a/apps/server/src/agent/agent-canvas-tools.service.test.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.test.ts
@@ -20,6 +20,7 @@ describe('AgentCanvasToolsService', () => {
   const generateText = vi.fn()
   const generatePrompt = vi.fn()
   const generateAudio = vi.fn()
+  const expandPromptContent = vi.fn()
   const getGeneration = vi.fn()
 
   const defaultPrefs = {
@@ -79,6 +80,10 @@ describe('AgentCanvasToolsService', () => {
       status: 'completed',
       metadata: JSON.stringify({ mode: 'image_prompt_multi_style', content: '扩写后的 prompt...' }),
     })
+    expandPromptContent.mockResolvedValue({
+      mode: 'character_turnaround',
+      content: '画面分为四格布局…近景特写…正面全身…侧面全身…背面全身…纯白背景',
+    })
     generateAudio.mockResolvedValue({
       id: 'gen-a1',
       status: 'completed',
@@ -116,7 +121,7 @@ describe('AgentCanvasToolsService', () => {
         },
         {
           provide: StudioService,
-          useValue: { generateImage, generateVideo, generateText, generatePrompt, generateAudio, getGeneration },
+          useValue: { generateImage, generateVideo, generateText, generatePrompt, generateAudio, getGeneration, expandPromptContent },
         },
       ],
     }).compile()
@@ -487,6 +492,50 @@ describe('AgentCanvasToolsService', () => {
       1,
       { sessionId: 's1', nodeId: 'img-1' },
     )
+  })
+
+  it('runImageGeneration turnaround pipeline expands prompt and uses 2:1', async () => {
+    canvas = {
+      nodes: [
+        {
+          id: 'img-turn',
+          type: 'image',
+          position: { x: 0, y: 0 },
+          data: {
+            prompt: '山海经吞金兽的三视图，CG风格',
+            status: 'draft',
+            pipeline: 'turnaround_image',
+            imageAspect: '2:1',
+            imageResolution: '1K',
+          },
+        },
+      ],
+      edges: [],
+    }
+    await svc.runImageGeneration({
+      sessionId: 's1',
+      userId: 'u1',
+      nodeId: 'img-turn',
+    })
+    expect(expandPromptContent).toHaveBeenCalledWith(
+      'u1',
+      '山海经吞金兽的三视图，CG风格',
+      'platform::user-default-text',
+    )
+    expect(generateImage).toHaveBeenCalledWith(
+      'u1',
+      expect.stringContaining('四格布局'),
+      'platform::user-default-image',
+      '2:1',
+      [],
+      undefined,
+      '2K',
+      2,
+      { sessionId: 's1', nodeId: 'img-turn' },
+    )
+    expect(canvas.nodes[0].data.expandedPrompt).toContain('四格布局')
+    expect(canvas.nodes[0].data.promptMode).toBe('character_turnaround')
+    expect(canvas.nodes[0].data.imageResolution).toBe('2K')
   })
 
   it('addNodesBatch stamps account defaults onto image/video/text/audio skeletons', async () => {

--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -306,6 +306,8 @@ export class AgentCanvasToolsService {
       targetType: NodeType | string
       prompt?: string
       position?: { x: number; y: number }
+      pipeline?: string
+      imageAspect?: string
     }>
     stage?: boolean
   }): Promise<{ nodes: Array<{ key: string; nodeId: string }>; actions: CanvasAction[] }> {
@@ -326,19 +328,22 @@ export class AgentCanvasToolsService {
           y: 80 + Math.floor((baseIndex + i) / 4) * GRID_Y,
         }
       const defaults = modalityDefaults(nodeType, prefs)
+      const nodeData: Record<string, unknown> = {
+        title: item.title,
+        manifestKey: item.key,
+        prompt: item.prompt ?? '',
+        status: 'draft',
+        ...defaults,
+      }
+      if (item.pipeline) nodeData.pipeline = item.pipeline
+      if (item.imageAspect) nodeData.imageAspect = item.imageAspect
       actions.push({
         type: 'add_node',
         payload: {
           id: nodeId,
           nodeType,
           position,
-          data: {
-            title: item.title,
-            manifestKey: item.key,
-            prompt: item.prompt ?? '',
-            status: 'draft',
-            ...defaults,
-          },
+          data: nodeData,
         },
       })
       mapping.push({ key: item.key, nodeId })
@@ -547,8 +552,10 @@ export class AgentCanvasToolsService {
 
     const prefs = await this.loadAccountGenPrefs(input.userId)
     const refs = toStudioRefs(node, current)
-    const aspectRatio = pickString(node.data?.imageAspect, prefs.defaultImageAspect || '16:9')
-    const resolution = pickString(
+    const pipeline = String(node.data?.pipeline ?? '').trim()
+    let imagePrompt = prompt
+    let aspectRatio = pickString(node.data?.imageAspect, prefs.defaultImageAspect || '16:9')
+    let resolution = pickString(
       node.data?.imageResolution,
       prefs.defaultImageResolution || '1K',
     )
@@ -557,9 +564,43 @@ export class AgentCanvasToolsService {
     )
     const model = pickString(node.data?.imageModel, prefs.defaultImageModel) || undefined
 
+    if (pipeline === 'turnaround_image') {
+      const textModel = pickString(node.data?.textModel, prefs.defaultTextModel) || undefined
+      const expanded = await this.studio.expandPromptContent(input.userId, prompt, textModel)
+      imagePrompt = expanded.content
+      aspectRatio = '2:1'
+      const userResolution = pickString(
+        node.data?.imageResolution,
+        prefs.defaultImageResolution || '1K',
+      )
+      const bumpedResolution = userResolution === '1K' ? '2K' : userResolution
+      if (bumpedResolution !== userResolution) {
+        resolution = bumpedResolution
+      }
+      const expandActions: CanvasAction[] = [
+        {
+          type: 'update_node',
+          payload: {
+            id: input.nodeId,
+            data: {
+              expandedPrompt: expanded.content,
+              content: expanded.content,
+              promptMode: expanded.mode,
+              pipeline,
+              imageAspect: aspectRatio,
+              imageResolution: resolution,
+              ...(bumpedResolution !== userResolution ? { resolutionBump: true } : {}),
+            },
+          },
+        },
+      ]
+      await this.persist(input.sessionId, expandActions)
+      allActions.push(...expandActions)
+    }
+
     const record = await this.studio.generateImage(
       input.userId,
-      prompt,
+      imagePrompt,
       model,
       aspectRatio,
       refs,

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -528,6 +528,30 @@ export class StudioService {
     }
   }
 
+  /** Expand user prompt via prompt-modes (no separate charge; used by turnaround image pipeline). */
+  async expandPromptContent(
+    userId: string,
+    prompt: string,
+    model?: string,
+  ): Promise<{ mode: string; content: string }> {
+    const trimmed = prompt?.trim()
+    if (!trimmed) throw new BadRequestException('prompt 不能为空')
+    const resolved = await this.resolver.resolveForGeneration(userId, model, 'text')
+    const { modelKey: resolvedKey, entry } = resolveModelKey('text', resolved.modelName)
+    const gatewayModelId =
+      resolved.source === 'user' ? resolved.modelName : entry.gatewayModelId
+    const opts = userProviderOpts(resolved)
+    if (resolved.source === 'user' && !resolved.credentials.apiKey) {
+      throw new Error('missing api key')
+    }
+    const { mode, content } = await generatePromptFromUserInput(trimmed, {
+      model: gatewayModelId,
+      apiKey: opts?.apiKey ?? process.env.OPENAI_API_KEY,
+      baseUrl: opts?.baseUrl ?? process.env.OPENAI_BASE_URL,
+    })
+    return { mode, content }
+  }
+
   async getGeneration(userId: string, id: string) {
     const record = await this.prisma.generationRecord.findFirst({
       where: { id, userId },

--- a/deploy/prod-atomic-studio-verify.py
+++ b/deploy/prod-atomic-studio-verify.py
@@ -38,6 +38,8 @@ CASES: list[tuple[str, str, str]] = [
     ("prompt", "帮我对「蓝牙耳机」做 prompt 扩写，出图用", "prompt"),
 ]
 
+TURNAROUND_UTTERANCE = "山海经吞金兽的三视图，CG风格"
+
 
 def record(case: str, ok: bool, detail: str = "") -> None:
     global PASS, FAIL
@@ -163,6 +165,60 @@ def verify_modality(tok: str, label: str, utterance: str, node_type: str) -> Non
     )
 
 
+def verify_turnaround_pipeline(tok: str) -> None:
+    sid = http("POST", "/sessions", {"title": f"P4-turnaround-{int(time.time())}"}, t=tok)["data"]["id"]
+    tid = f"{sid}:{uuid.uuid4()}"
+    _, text, types, exit_reason = sse_collect(
+        tok, sid, TURNAROUND_UTTERANCE, tid, timeout=SSE_TIMEOUT_SEC
+    )
+
+    record(
+        "turnaround atomic path",
+        "image 节点" in text and "2:1" in text,
+        text[:160],
+    )
+    record(
+        "turnaround light hint",
+        "角色设定图" in text or "非账户默认" in text or "非默认" in text,
+        text[:160],
+    )
+
+    node = latest_node(tok, sid, "image")
+    data = (node or {}).get("data") or {}
+    expanded = str(data.get("expandedPrompt") or data.get("content") or "")
+    record(
+        "turnaround expandedPrompt",
+        "四格" in expanded,
+        expanded[:120],
+    )
+    record(
+        "turnaround promptMode",
+        data.get("promptMode") == "character_turnaround",
+        str(data.get("promptMode")),
+    )
+
+    rec_id = data.get("generationRecordId")
+    aspect_ok = False
+    if rec_id:
+        rec = http("GET", f"/studio/generations/{rec_id}", t=tok).get("data") or {}
+        try:
+            meta = json.loads(rec.get("metadata") or "{}")
+        except json.JSONDecodeError:
+            meta = {}
+        aspect_ok = meta.get("aspectRatio") == "2:1"
+        prompt_used = str(rec.get("prompt") or "")
+        record(
+            "turnaround image prompt not raw utterance",
+            "四格" in prompt_used,
+            prompt_used[:100],
+        )
+    record(
+        "turnaround aspect 2:1",
+        aspect_ok,
+        f"rec={rec_id} exit={exit_reason}",
+    )
+
+
 def main() -> int:
     print("=== P4 atomic_create production smoke verify (image/text/prompt) ===")
     print(f"BASE={BASE}\n")
@@ -183,6 +239,8 @@ def main() -> int:
 
     for label, utterance, node_type in CASES:
         verify_modality(tok, label, utterance, node_type)
+
+    verify_turnaround_pipeline(tok)
 
     print(f"\n=== Summary PASS={PASS} FAIL={FAIL} ===")
     return 0 if FAIL == 0 else 1

--- a/docs/superpowers/plans/2026-08-05-turnaround-image-pipeline.md
+++ b/docs/superpowers/plans/2026-08-05-turnaround-image-pipeline.md
@@ -1,0 +1,122 @@
+# 角色设定图（多视图）智能二段式出图 — P0 实现计划
+
+> **For agentic workers:** 使用 superpowers:subagent-driven-development 或 superpowers:executing-plans 按 Task 执行。  
+> **Spec:** [2026-08-05-turnaround-image-pipeline-design.md](../specs/2026-08-05-turnaround-image-pipeline-design.md)
+
+**Goal:** 用户说「三视图/四视图/角色设定图」（无「提示词」）时，单 image 节点内完成 character_turnaround 扩写 + 2:1 出图。
+
+**Architecture:** agent-runtime 识别 `pipeline=turnaround_image` 写入 atomic_spec；server `startImageGeneration` 检测 pipeline → `generatePromptFromUserInput` → `generateImage(expandedPrompt, 2:1)` → 节点写入 expandedPrompt + url。
+
+**Tech Stack:** Python 3.11 (agent-runtime pytest), NestJS (`apps/server`), `@lnkpi/agent` prompt-modes, deploy smoke.
+
+## Global Constraints
+
+- Branch from `main`: `feature/turnaround-image-pipeline` — **禁止直推 main**
+- 本地验证：`pnpm build` + `pytest services/agent-runtime/tests/test_atomic_create_intent*.py` + server 相关 test
+- 含「提示词」utterance **不得**进入 turnaround_pipeline
+- 普通 image 直出路径 **零回归**
+- Squash merge + 生产 smoke
+
+## File map
+
+| File | Role |
+|------|------|
+| `services/agent-runtime/app/graph/atomic_intent.py` | `is_turnaround_image_intent()`, `build_atomic_spec()` pipeline |
+| `services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml` | pipeline + triggers |
+| `services/agent-runtime/skills/atomic-create/eval-intent-set.yaml` | 新增 case |
+| `services/agent-runtime/tests/test_atomic_create_intent.py` | 路由单测 |
+| `apps/server/src/agent/agent-canvas-tools.service.ts` | 二段式出图 |
+| `apps/server/src/agent/agent-canvas-tools.service.test.ts` | server 单测 |
+| `packages/agent/src/prompt-modes/modes/character-turnaround.ts` | 非人物/神兽 system 补充 |
+| `deploy/prod-atomic-studio-verify.py` | 生产 smoke case |
+
+---
+
+### Task 1: Turnaround intent + atomic_spec pipeline
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/atomic_intent.py`
+- Modify: `services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml`
+- Modify: `services/agent-runtime/tests/test_atomic_create_intent.py`
+
+**Acceptance:**
+- [ ] `is_turnaround_image_intent("山海经吞金兽的三视图，CG风格")` → True
+- [ ] `is_turnaround_image_intent("…三视图的提示词")` → False
+- [ ] `build_atomic_spec(...)` 返回 `target_type=image`, `pipeline=turnaround_image`
+- [ ] `parse_atomic_target_type` 仍为 `image`（非 prompt）
+
+---
+
+### Task 2: Eval set + taxonomy sync
+
+**Files:**
+- Modify: `services/agent-runtime/skills/atomic-create/eval-intent-set.yaml`
+- Modify: `services/agent-runtime/skills/atomic-create/assets/few-shots.yaml`（可选）
+- Modify: `services/agent-runtime/app/graph/atomic_parse_llm.py`（LLM parse 规则一行）
+
+**Acceptance:**
+- [ ] 新增 case：`山海经吞金兽的三视图，CG风格` → image + pipeline
+- [ ] eval 全绿
+
+---
+
+### Task 3: Server 二段式出图
+
+**Files:**
+- Modify: `apps/server/src/agent/agent-canvas-tools.service.ts`
+- Modify: `apps/server/src/agent/agent-canvas-tools.service.test.ts`
+
+**Logic sketch:**
+
+```typescript
+// startImageGeneration
+const pipeline = node.data?.pipeline ?? specFromAtomic
+if (pipeline === 'turnaround_image') {
+  const { mode, content } = await generatePromptFromUserInput(prompt, opts)
+  expandedPrompt = content
+  aspectRatio = '2:1'
+  imagePrompt = content
+}
+// persist expandedPrompt + promptMode on node before generateImage
+```
+
+**Acceptance:**
+- [ ] turnaround 路径调用 `generatePromptFromUserInput`
+- [ ] `generateImage` 使用扩写 content，非原句
+- [ ] aspectRatio 为 2:1
+- [ ] 节点 data 含 `expandedPrompt`, `promptMode=character_turnaround`, `pipeline=turnaround_image`
+- [ ] 单测 mock 验证调用顺序
+
+---
+
+### Task 4: character_turnaround 非人物支持
+
+**Files:**
+- Modify: `packages/agent/src/prompt-modes/modes/character-turnaround.ts`
+- Sync: `services/agent-runtime/app/tools/prompt_templates.py`（若 system 片段 duplicated）
+
+**Acceptance:**
+- [ ] system 明确：角色可为人物、神兽、机甲、生物、道具
+- [ ] 图类型占位符示例含非人类 case
+
+---
+
+### Task 5: Deploy smoke + 生产复测
+
+**Files:**
+- Modify: `deploy/prod-atomic-studio-verify.py`
+
+**Acceptance:**
+- [ ] 新增 case：`山海经吞金兽的三视图，CG风格`
+- [ ] 断言 image 节点 + expandedPrompt 含「四格」
+- [ ] aspectRatio ≠ 16:9
+- [ ] 生产 PASS
+
+---
+
+### Task 6: PR + CI + merge
+
+- [ ] `pnpm build`
+- [ ] pytest + server test 全绿
+- [ ] PR body 引用 spec §七 AC-T
+- [ ] Squash merge → 等待 deploy → 跑 smoke

--- a/docs/superpowers/specs/2026-08-03-atomic-studio-intent-design.md
+++ b/docs/superpowers/specs/2026-08-03-atomic-studio-intent-design.md
@@ -1,7 +1,7 @@
 # Atomic Studio Intent — 意图驱动画布原子创作（设计）
 
-> 状态：**P4 已交付**（2026-08-04）；**L1-03 atomic_regenerate ✅**（PR #122）  
-> 日期：2026-08-03（v1.1）；2026-08-04（L1-03 修订）  
+> 状态：**P4 已交付**（2026-08-04）；**L1-03 atomic_regenerate ✅**（PR #122）；**多视图二段式出图** → [2026-08-05-turnaround-image-pipeline-design.md](./2026-08-05-turnaround-image-pipeline-design.md)  
+> 日期：2026-08-03（v1.1）；2026-08-04（L1-03 修订）；2026-08-05（turnaround pipeline 规格）  
 > 前置：[2026-07-26-graph-engineering-design.md](./2026-07-26-graph-engineering-design.md)、P3 单节点快速生成（#113）、Phase B/C（#114）  
 > Loop 层：[2026-08-04-loop-engineering-design.md](./2026-08-04-loop-engineering-design.md)
 

--- a/docs/superpowers/specs/2026-08-05-turnaround-image-pipeline-design.md
+++ b/docs/superpowers/specs/2026-08-05-turnaround-image-pipeline-design.md
@@ -1,0 +1,326 @@
+# 角色设定图（多视图）智能二段式出图 — 产品与设计规格
+
+> **状态**：P0 开发中  
+> **日期**：2026-08-05  
+> **关联**：[2026-08-03-atomic-studio-intent-design.md](./2026-08-03-atomic-studio-intent-design.md)、[2026-07-17-prompt-node-intent-templates-design.md](./2026-07-17-prompt-node-intent-templates-design.md)、PR #139（凡含「提示词」→ prompt 节点）
+
+| 字段 | 值 |
+|------|-----|
+| 文档版本 | v1.0 |
+| 文档定位 | 多视图 utterance 的产品行为、路由、验收标准 |
+| 实现计划 | [2026-08-05-turnaround-image-pipeline.md](../plans/2026-08-05-turnaround-image-pipeline.md) |
+
+### 已确认决策（2026-08-05）
+
+| # | 决策 | 说明 |
+|---|------|------|
+| **T1** | 多视图类 utterance **走智能二段式闭环** | 内部：character_turnaround 扩写 → 出图；对用户：**一步完成** |
+| **T2** | 用户仍见 **单 image 节点** | 扩写结果写入节点字段，不在画布默认展示 prompt 子节点（P2 可选双节点） |
+| **T3** | 含「提示词」的多视图句 **仍走 prompt-only** | 与 PR #139 一致：用户明确要文案时不自动出图 |
+| **T4** | 多视图出图画幅 **2:1** | 禁止默认 16:9 宽屏单图 |
+| **T5** | **轻提示**说明未用账户默认画幅 | 侧栏一句，无确认门、无弹窗 |
+| **T6** | 分辨率沿用账户档位；**1K 软抬 2K** | 四格每格更清晰；轻提示中说明 |
+| **T7** | 节点写入 `imageAspect` / `imageResolution` 实际值 | 便于重试与排查 |
+
+---
+
+## 一、问题陈述
+
+### 1.1 现状（2026-08-05 生产实证）
+
+用户输入「山海经吞金兽的三视图，CG风格」时：
+
+| 现象 | 根因 |
+|------|------|
+| 系统回复「已创建 **image** 节点」 | utterance 无「提示词」→ `parse_atomic_target_type` → `image` |
+| 未按四格模版出图 | image 路径原句直传 `generateImage`，未调用 `character_turnaround` |
+| 非白底、非近景+正/侧/背 | 无模版约束；模型自由理解「三视图」为 3 格 |
+| record `aspectRatio: 16:9`, `1024×576` | 默认宽屏单图，不适合四格拼图 |
+
+生产 record 样例：`cmsfeo2pl02fhl901g8w2p6sw`（type=image, prompt=用户原句）。
+
+### 1.2 用户预期
+
+> 说「三视图 / 四视图 / 角色设定图」→ 直接得到**标准四格角色设定参考图**（白底、同一角色、面部近景 + 正/侧/背全身），**无需**说「提示词」、**无需**手动复制 prompt。
+
+### 1.3 与现有能力的关系
+
+| 路径 | 触发 | 现状 | 本规格 |
+|------|------|------|--------|
+| prompt-only | 含「提示词」 | prompt 节点 + `run_prompt_generation` | **不变** |
+| image-direct | 普通主图/海报 | 原句直出 | **不变** |
+| **turnaround_pipeline** | 多视图词且无「提示词」 | ❌ 等同 image-direct | **新增** |
+
+`character_turnaround` 模版已存在于 `packages/agent` + `services/agent-runtime/app/tools/prompt_templates.py`，本规格将其**接入 image 出图链路**。
+
+---
+
+## 二、产品目标
+
+| ID | 目标 |
+|----|------|
+| **G1** | 多视图类 utterance 自动走「模版扩写 → 出图」闭环 |
+| **G2** | 用户感知为**一步完成**（单 image 节点 + 最终图） |
+| **G3** | 扩写结果可追溯、可编辑、可重试（P1 UI） |
+| **G4** | 非人物角色（神兽、机甲、道具等）同样适用 |
+
+### 非目标（P0）
+
+- 画布默认展示 prompt 子节点（留给 P2 power user 模式）
+- 改动普通海报/主图的 image 直出路径
+- 保证 100% 模型服从四格构图（v1 以 prompt 质量 + 画幅为主；构图失败 P2 加重试）
+
+---
+
+## 三、用户故事
+
+> **作为**创作者，**当**我说「山海经吞金兽的三视图，CG 风格」，**我希望**系统直接给我一张四格角色设定参考图（白底、同一角色、近景 + 正/侧/背），**而不需要**我先说「提示词」或自己把 prompt 复制到 image 节点。
+
+**对外命名建议**：侧栏/节点文案优先使用「**角色设定图（四格）**」，减少「三视图 vs 四格」语义冲突（模版为近景 + 正/侧/背 = 4 格）。
+
+---
+
+## 四、路由规则（AC-R）
+
+### 4.1 路由表
+
+| ID | 用户说法示例 | 路由 | 节点类型 | 是否出图 |
+|----|-------------|------|---------|---------|
+| **R1** | 山海经吞金兽的三视图，CG 风格 | `turnaround_pipeline` | image | ✅ 自动 |
+| **R2** | 年轻女性模特四视图 | turnaround_pipeline | image | ✅ |
+| **R3** | 角色设定图 / turnaround / 模特定妆图 | turnaround_pipeline | image | ✅ |
+| **R4** | …三视图的**提示词** | `prompt_only` | prompt | ❌ 仅文本 |
+| **R5** | 生成一张产品主图 | `image_direct` | image | ✅ 直出 |
+| **R6** | 分镜提示词 | prompt_only | prompt | ❌ |
+
+### 4.2 触发词（与 `packages/agent/src/prompt-modes/classify.ts` heuristic 对齐）
+
+```
+三视图|四视图|多视图|turnaround|角色设定|模特定妆|正侧背|模特图|
+q版|q萌|chibi|二头身|洛丽塔|lolita|婚纱|战术|军事|牛仔|皮克斯|绘本|水彩
+```
+
+**判定逻辑**：
+
+1. 若 utterance **含「提示词」** → `prompt_only`（PR #139，优先级最高）
+2. 否则若命中上述触发词 → `turnaround_pipeline`
+3. 否则 → 现有 `parse_atomic_target_type` 逻辑（image/text/video/…）
+
+### 4.3 taxonomy 扩展（`intent-taxonomy.yaml`）
+
+新增 `pipelines.turnaround_image`：
+
+```yaml
+turnaround_image:
+  description: 多视图类 utterance 内部扩写 character_turnaround 后出图
+  target_type: image
+  prompt_mode: character_turnaround
+  aspect_ratio: "2:1"
+  studio_sequence:
+    - run_prompt_expansion   # 内部，非独立 prompt 节点
+    - run_image_generation
+```
+
+---
+
+## 五、系统行为（AC-B）
+
+### 5.1 内部二段式（对用户不可见）
+
+```
+utterance
+  → [B1] is_turnaround_image_intent(utterance) == true
+  → [B2] classifyPromptMode → character_turnaround
+  → [B3] generatePromptContent → 四格结构化中文 prompt（单段）
+  → [B4] generateImage(expandedPrompt, aspectRatio=2:1)
+  → [B5] 写入 image 节点（url + 元数据）
+```
+
+### 5.2 image 节点字段
+
+| 字段 | 含义 | 写入时机 |
+|------|------|---------|
+| `prompt` | 用户原话 | 建节点时 |
+| `expandedPrompt` 或 `content` | LLM 扩写后的完整生图 prompt | 出图前 |
+| `promptMode` | `character_turnaround` | 扩写后 |
+| `pipeline` | `turnaround_image` | 建节点/出图时（便于排查） |
+| `url` | 最终图片 | 出图完成 |
+| `generationRecordId` | 出图 record | 出图完成 |
+
+约定：
+
+- **`prompt` 始终保留用户原句**，禁止用扩写结果覆盖。
+- 下游 image 生成 **必须使用 `expandedPrompt`**，不得使用原句。
+- 与 prompt 节点一致：`content` 有则优先用于展示扩写结果（P1 UI 折叠区）。
+
+### 5.3 画幅规则（AC-B3）
+
+| 条件 | aspectRatio | size 策略 |
+|------|-------------|-----------|
+| `pipeline=turnaround_image` | **2:1** | 长边 = 分辨率档位（见 §5.3.1） |
+| `image_direct` | 用户/账户默认（通常 16:9） | 不变 |
+
+**轻提示（T5）**：当账户默认画幅 ≠ 2:1 时，侧栏追加一句：
+
+> 四格设定图已使用 **2:1** 画幅（非您的默认 {defaultAspect}）。
+
+不弹窗、不二次确认。
+
+#### 5.3.1 分辨率（T6）
+
+| 账户默认档位 | turnaround 实际档位 | 2:1 像素（长边） |
+|-------------|-------------------|-----------------|
+| 1K | **2K（软抬）** | 2048×1024 |
+| 2K | 2K | 2048×1024 |
+| 4K | 4K | 4096×2048 |
+
+**轻提示（T6 补充）**：当 1K 软抬 2K 时追加：
+
+> 为保证四格清晰度，已按 **2K** 输出（高于您的默认 1K）。
+
+节点 `data.imageResolution` 写入**实际使用值**（T7）。
+
+### 5.4 用户可见回复文案（AC-B4）
+
+```
+原子创作：image 节点 — {title}
+已按角色设定图模版扩写并出图；四格横排使用 2:1 画幅（非默认 {defaultAspect}）。
+「{title}」生成完成。（record: xxx）
+```
+
+若 1K 软抬 2K，合并为一句：
+
+```
+…；画幅 2:1，分辨率 2K（四格清晰度优化，高于默认 1K）。
+```
+
+P1 可选：节点标签 `2:1 · 设定图`，hover 说明专用比例。
+
+### 5.5 扩写 content 质量要求（AC-B5）
+
+扩写结果须满足（与 `character-turnaround.ts` system 一致）：
+
+- [ ] 含「画面分为四格布局」
+- [ ] 第一格：近景 / 面部特写
+- [ ] 第二～四格：正面 / 侧面 / 背面全身
+- [ ] 背景默认「纯白背景」（赛博朋克 / 3D 等预设除外）
+- [ ] 同一角色、同一服装发型，禁止每格换人
+- [ ] 支持非人物（神兽、机甲、道具等）— system prompt 须 explicit 支持
+
+### 5.6 失败降级（AC-B6）
+
+| 场景 | 行为 |
+|------|------|
+| 扩写失败 | 节点 `status=error`；文案「提示词扩写失败，请重试或简化描述」 |
+| 扩写成功、出图失败 | 保留 `expandedPrompt`；支持同节点重试出图（regenerate） |
+| 出图完成但构图不像四格 | v1 接受；P2 提供「编辑提示词并重试」 |
+
+---
+
+## 六、实现落点（研发指引）
+
+| 层 | 文件 | 改动 |
+|----|------|------|
+| **agent-runtime** | `app/graph/atomic_intent.py` | `is_turnaround_image_intent()`；`build_atomic_spec()` 增加 `pipeline: turnaround_image` |
+| **agent-runtime** | `skills/atomic-create/intent-taxonomy.yaml` | 触发词 + pipeline 定义 |
+| **agent-runtime** | `eval-intent-set.yaml` / tests | 新增 R1–R3 case |
+| **apps/server** | `agent-canvas-tools.service.ts` | `startImageGeneration`：若 pipeline → 先 `generatePromptFromUserInput` → 再 `generateImage` |
+| **packages/agent** | `modes/character-turnaround.ts` | system 补充非人物/神兽支持 |
+| **deploy** | `prod-atomic-studio-verify.py` | 新增 turnaround smoke case |
+
+**推荐主实现点**：`apps/server` 的 `startImageGeneration`（或抽取 `runTurnaroundImageGeneration`），避免 agent-runtime 编排两次 nest 调用的复杂度。
+
+**agent-runtime 职责**：仅负责识别 pipeline 并将 `pipeline` 写入 `atomic_spec` / 节点 data；不在 Python 侧重复扩写逻辑。
+
+---
+
+## 七、验收用例（AC-T）
+
+### T1 核心回归（生产 bug case）
+
+**输入**：`山海经吞金兽的三视图，CG风格`
+
+**期望**：
+
+- [ ] 创建 **image** 节点（非 prompt）
+- [ ] `record.type = image`
+- [ ] 节点含 `expandedPrompt`，含四格描述 + 白底
+- [ ] `aspectRatio` ≠ 16:9（应为 2:1 或 4:1）
+- [ ] 侧栏回复含「角色设定图模版」或等价表述
+- [ ] 传给 image API 的 prompt ≠ 用户原句
+
+### T2 纯提示词路径不变
+
+**输入**：`年轻女性模特三视图的提示词`
+
+**期望**：
+
+- [ ] prompt 节点
+- [ ] **不**自动出图
+
+### T3 普通出图不变
+
+**输入**：`帮我生成一张蓝牙耳机主图`
+
+**期望**：
+
+- [ ] image 直出，无扩写步骤
+- [ ] 无 `pipeline=turnaround_image`
+
+### T4 非人物
+
+**输入**：`赛博朋克机甲 turnaround，3D 渲染`
+
+**期望**：
+
+- [ ] turnaround_pipeline
+- [ ] expandedPrompt 描述机甲，非强行套人类模特预设
+
+### T5 自动化
+
+- [ ] `test_atomic_create_intent.py`：turnaround utterance → `target_type=image` + `pipeline=turnaround_image`
+- [ ] `test_atomic_create_intent.py`：含「提示词」→ 仍为 prompt，无 pipeline
+- [ ] 生产 smoke：`deploy/prod-atomic-studio-verify.py` 新增 case PASS
+
+---
+
+## 八、分期
+
+| 阶段 | 范围 | 交付 |
+|------|------|------|
+| **P0** | R1–R3 路由 + 二段式出图 + 2:1 画幅 + 节点存 expandedPrompt | 修复当前生产 bug |
+| **P1** | UI 折叠「查看/编辑提示词」+ 仅重试出图 | 可控性与可调试 |
+| **P2** | 可选双节点（prompt → image 可见链）；「仅要提示词不出图」快捷说法 | Power user |
+
+**P0 PR 范围**：本规格 §四～§七 + 实现计划 Task 1–5。
+
+---
+
+## 九、成功指标
+
+| 指标 | 目标 |
+|------|------|
+| 多视图类 utterance 走原句直出 image 的比例 | **0%**（P0 上线后） |
+| 生产 smoke turnaround case | **PASS** |
+| 用户需说「提示词」才能得到四格模版 | **否** |
+| expandedPrompt 含四格结构关键词率 | **≥95%**（eval / 抽样） |
+
+---
+
+## 附录 A：与 PR #139 路由的关系
+
+| utterance | PR #139 | 本规格 |
+|-----------|---------|--------|
+| 分镜**提示词** | prompt | prompt（不变） |
+| 三视图**提示词** | prompt | prompt（不变） |
+| 三视图（无提示词） | image 直出 ❌ | **turnaround_pipeline** ✅ |
+| 产品主图 | image 直出 | 不变 |
+
+## 附录 B：相关代码索引
+
+- 模版：`packages/agent/src/prompt-modes/modes/character-turnaround.ts`
+- 预设：`packages/agent/src/prompt-modes/modes/character-turnaround-presets.ts`
+- 分类：`packages/agent/src/prompt-modes/classify.ts`
+- 生成：`packages/agent/src/prompt-modes/generate.ts`
+- 路由：`services/agent-runtime/app/graph/atomic_intent.py`
+- 出图：`apps/server/src/agent/agent-canvas-tools.service.ts` → `startImageGeneration`

--- a/packages/agent/src/prompt-modes/modes/character-turnaround.ts
+++ b/packages/agent/src/prompt-modes/modes/character-turnaround.ts
@@ -37,6 +37,8 @@ export const characterTurnaroundMode: PromptModeDefinition = {
     '用户要人物三视图/模特图/角色设定图/多视图/模特定妆图/Q版/Q萌/chibi/洛丽塔/婚纱/战术/牛仔/皮克斯/绘本插画/turnaround/正侧背/四视图，强调同一角色一致性、四格拼图出图',
   system: `你是角色设定与 AI 绘画提示词专家。根据用户短需求，输出一份**可直接用于 AI 生图的单段中文提示词**（连贯段落，非 Markdown 分节、非中英对照）。
 
+主角可以是人物、神兽、机甲、生物、道具或拟人角色；勿将非人类需求强行改写为真人模特。
+
 严格按以下骨架填充，将 {占位符} 替换为具体内容：
 
 ${CHARACTER_TURNAROUND_TEMPLATE}

--- a/services/agent-runtime/app/graph/atomic_intent.py
+++ b/services/agent-runtime/app/graph/atomic_intent.py
@@ -67,6 +67,15 @@ AUDIO_KEYWORDS = ("配音", "旁白", "音频", "语音")
 # Avoid bare 「图」— it matches campaign phrases like 「确认出图」.
 IMAGE_KEYWORDS = ("海报", "banner", "视觉", "主图", "白底", "场景图", "产品图", "人物图", "风图")
 
+TURNAROUND_IMAGE_PATTERN = re.compile(
+    r"三视图|四视图|多视图|turnaround|角色设定|模特定妆|正侧背|模特图|"
+    r"q版|q萌|chibi|二头身|洛丽塔|lolita|婚纱|战术|军事|牛仔|皮克斯|绘本|水彩",
+    re.IGNORECASE,
+)
+
+TURNAROUND_PIPELINE = "turnaround_image"
+TURNAROUND_ASPECT_RATIO = "2:1"
+
 ATOMIC_CONFIRM_KEYWORDS = tuple(_TAXONOMY.get("atomic_confirm_keywords") or (
     "确认生成",
     "开始生成",
@@ -239,6 +248,22 @@ def _storyboard_shot_count(text: str) -> int | None:
     return None
 
 
+def is_turnaround_image_intent(text: str) -> bool:
+    """True when user wants multi-view character sheet as image (not prompt-only)."""
+    t = (text or "").strip()
+    if not t or _has_prompt_explicit(t):
+        return False
+    return bool(TURNAROUND_IMAGE_PATTERN.search(t))
+
+
+def turnaround_pipeline_user_note() -> str:
+    """Light UX copy when auto-switching aspect for turnaround pipeline."""
+    return (
+        "已按角色设定图模版扩写并出图；"
+        f"四格横排使用 {TURNAROUND_ASPECT_RATIO} 画幅（非账户默认比例）。"
+    )
+
+
 def _has_prompt_explicit(text: str) -> bool:
     n = _normalize(text)
     if any(_normalize(k) in n for k in PROMPT_EXPLICIT_KEYWORDS):
@@ -366,12 +391,17 @@ def build_atomic_spec(text: str) -> dict[str, Any]:
     utterance = (text or "").strip()
     target_type = parse_atomic_target_type(utterance)
     title = utterance[:24] + ("…" if len(utterance) > 24 else "")
-    return {
+    spec: dict[str, Any] = {
         "target_type": target_type,
         "prompt": utterance,
         "title": title or target_type,
         "confirm_gate": confirm_gate_for_type(target_type),
     }
+    if is_turnaround_image_intent(utterance):
+        spec["pipeline"] = TURNAROUND_PIPELINE
+        spec["imageAspect"] = TURNAROUND_ASPECT_RATIO
+        spec["resolutionBump"] = True
+    return spec
 
 
 AtomicConfirmDecision = Literal["none", "confirm", "cancel"]

--- a/services/agent-runtime/app/graph/atomic_parse_llm.py
+++ b/services/agent-runtime/app/graph/atomic_parse_llm.py
@@ -34,7 +34,7 @@ _PARSE_SYSTEM = """你是 Atomic Studio 意图解析器。根据用户一句话�
 - D1：「脚本/广告词/文案/口播稿」→ target_type=text（不含「提示词」字样）
 - D2：video/audio → confirm_gate=true
 - 凡含「提示词」→ target_type=prompt（含分镜提示词、三视图提示词、提示词模式扩写等）
-- 「生成一张三视图/三视图各来一张」且无「提示词」→ target_type=image（直接出图）
+- 「生成一张三视图/三视图各来一张」且无「提示词」→ target_type=image，pipeline=turnaround_image（内部扩写后出图，非原句直出）
 - multi：用户要多张/多项时 structure=multi，items 逐条拆分 prompt/title
 - 营销方案/14节点/全链路 → confidence<0.7，clarify_question 建议走 Campaign
 - 意图不清（如仅「帮我生成」）→ confidence<0.7 并给出 clarify_question

--- a/services/agent-runtime/app/graph/atomic_parse_schema.py
+++ b/services/agent-runtime/app/graph/atomic_parse_schema.py
@@ -6,7 +6,7 @@ from typing import Any, Literal, TypedDict
 
 from langchain_core.messages import AIMessage
 
-from app.graph.atomic_intent import confirm_gate_for_type, _is_campaign_override
+from app.graph.atomic_intent import confirm_gate_for_type, _is_campaign_override, turnaround_pipeline_user_note
 from app.graph.intent import marketing_intent
 
 CLARIFY_THRESHOLD = 0.70
@@ -199,6 +199,8 @@ def parse_outcome_to_state(outcome: ParseOutcome, *, canvas_context: str | None 
         gate = "需确认" if spec["confirm_gate"] else "直达"
         ctx_note = f" [{canvas_context}]" if canvas_context else ""
         msg = f"原子创作：{target} 节点（{gate}）— {spec['title']}{ctx_note}"
+        if spec.get("pipeline") == "turnaround_image":
+            msg += turnaround_pipeline_user_note()
         return {
             "phase": "atomic_parse",
             "flow_mode": "atomic_create",

--- a/services/agent-runtime/app/graph/nodes/atomic_create_node.py
+++ b/services/agent-runtime/app/graph/nodes/atomic_create_node.py
@@ -19,6 +19,16 @@ def _atomic_batch_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "title": title,
                 "targetType": target_type,
                 "prompt": prompt,
+                **(
+                    {"pipeline": item["pipeline"]}
+                    if item.get("pipeline")
+                    else {}
+                ),
+                **(
+                    {"imageAspect": item["imageAspect"]}
+                    if item.get("imageAspect")
+                    else {}
+                ),
             }
         )
     return batch
@@ -78,6 +88,10 @@ def make_create_atomic_node(*, nest: Any) -> Callable:
             msg = f"已创建 {target_type} 节点，准备生产。"
         else:
             msg = f"已创建 {count} 个 {target_type} 节点，准备生产。"
+        if str(first.get("pipeline") or "") == "turnaround_image":
+            from app.graph.atomic_intent import turnaround_pipeline_user_note
+
+            msg += turnaround_pipeline_user_note()
 
         return {
             "phase": "atomic_create",

--- a/services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml
+++ b/services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml
@@ -129,3 +129,25 @@ orchestration:
     - 全链路
     - 14节点
     - 整套分镜
+
+pipelines:
+  turnaround_image:
+    description: 多视图 utterance 内部 character_turnaround 扩写后出图
+    target_type: image
+    prompt_mode: character_turnaround
+    aspect_ratio: "2:1"
+    resolution_bump_from_1k: true
+    trigger_pattern: 三视图|四视图|多视图|turnaround|角色设定|模特定妆|正侧背|模特图
+
+turnaround_image_keywords:
+  - 三视图
+  - 四视图
+  - 多视图
+  - turnaround
+  - 角色设定
+  - 模特定妆
+  - 正侧背
+  - 模特图
+  - q版
+  - chibi
+  - 模特定妆图

--- a/services/agent-runtime/tests/test_atomic_create_intent.py
+++ b/services/agent-runtime/tests/test_atomic_create_intent.py
@@ -13,6 +13,7 @@ from app.graph.atomic_intent import (
     atomic_create_intent,
     atomic_regenerate_intent,
     build_atomic_spec,
+    is_turnaround_image_intent,
     parse_atomic_target_type,
     resolve_intake_route,
 )
@@ -67,6 +68,24 @@ def test_turnaround_prompt_phrase_routes_to_prompt_node():
 def test_turnaround_image_without_prompt_word_stays_image():
     assert parse_atomic_target_type("帮我做一张该产品的三视图") == "image"
     assert parse_atomic_target_type("生成一张三视图，蓝牙耳机") == "image"
+
+
+def test_turnaround_pipeline_spec_for_direct_image_request():
+    utterance = "山海经吞金兽的三视图，CG风格"
+    assert is_turnaround_image_intent(utterance)
+    spec = build_atomic_spec(utterance)
+    assert spec["target_type"] == "image"
+    assert spec.get("pipeline") == "turnaround_image"
+    assert spec.get("imageAspect") == "2:1"
+    assert spec.get("resolutionBump") is True
+
+
+def test_turnaround_prompt_with_hint_word_not_pipeline():
+    utterance = "年轻女性模特三视图的提示词"
+    assert not is_turnaround_image_intent(utterance)
+    spec = build_atomic_spec(utterance)
+    assert spec["target_type"] == "prompt"
+    assert "pipeline" not in spec
 
 
 def test_atomic_create_intent_negative_campaign():


### PR DESCRIPTION
## Summary
- 多视图 utterance（无「提示词」）走 `turnaround_image` pipeline：内部 character_turnaround 扩写 → 2:1 出图
- 1K 账户默认软抬 2K；侧栏轻提示说明非默认画幅/分辨率
- 规格文档：`docs/superpowers/specs/2026-08-05-turnaround-image-pipeline-design.md`

## Test plan
- [x] pnpm build
- [x] pytest test_atomic_create_intent*.py (18 passed)
- [x] vitest agent-canvas-tools.service.test.ts (30 passed)
- [ ] CI green
- [ ] 生产 prod-atomic-studio-verify turnaround case


Made with [Cursor](https://cursor.com)