### PR TITLE
fix(agent): turnaround utterances enter atomic_create

### DIFF
--- a/services/agent-runtime/app/graph/atomic_intent.py
+++ b/services/agent-runtime/app/graph/atomic_intent.py
@@ -287,6 +287,8 @@ def atomic_create_intent(text: str) -> bool:
         return False
     if _is_campaign_override(text):
         return False
+    if is_turnaround_image_intent(text):
+        return True
     if _has_prompt_explicit(text):
         return True
     if any(h in lowered for h in ATOMIC_CREATE_HINTS):

--- a/services/agent-runtime/tests/test_atomic_create_intent.py
+++ b/services/agent-runtime/tests/test_atomic_create_intent.py
@@ -73,6 +73,7 @@ def test_turnaround_image_without_prompt_word_stays_image():
 def test_turnaround_pipeline_spec_for_direct_image_request():
     utterance = "山海经吞金兽的三视图，CG风格"
     assert is_turnaround_image_intent(utterance)
+    assert atomic_create_intent(utterance)
     spec = build_atomic_spec(utterance)
     assert spec["target_type"] == "image"
     assert spec.get("pipeline") == "turnaround_image"


### PR DESCRIPTION
## Summary
- `is_turnaround_image_intent` → `atomic_create_intent` True

## Test plan
- [x] pytest test_atomic_create_intent.py
- [ ] prod turnaround smoke after deploy

Made with [Cursor](https://cursor.com)