### PR TITLE
fix(agent): preserve turnaround pipeline in parse schema

### DIFF
--- a/services/agent-runtime/app/graph/atomic_parse_schema.py
+++ b/services/agent-runtime/app/graph/atomic_parse_schema.py
@@ -16,11 +16,14 @@ MAX_ATOMIC_MULTI_ITEMS = 5
 VALID_TARGET_TYPES = frozenset({"image", "text", "video", "audio", "prompt"})
 
 
-class AtomicParseItem(TypedDict):
+class AtomicParseItem(TypedDict, total=False):
     target_type: str
     title: str
     prompt: str
     confirm_gate: bool
+    pipeline: str
+    imageAspect: str
+    resolutionBump: bool
 
 
 class AtomicParseSuccess(TypedDict):
@@ -52,12 +55,19 @@ def _normalize_item(raw: dict[str, Any]) -> AtomicParseItem | None:
     confirm = raw.get("confirm_gate")
     if confirm is None:
         confirm = confirm_gate_for_type(target)  # type: ignore[arg-type]
-    return {
+    item: dict[str, Any] = {
         "target_type": target,
         "title": title,
         "prompt": prompt,
         "confirm_gate": bool(confirm),
     }
+    if raw.get("pipeline"):
+        item["pipeline"] = str(raw["pipeline"])
+    if raw.get("imageAspect"):
+        item["imageAspect"] = str(raw["imageAspect"])
+    if raw.get("resolutionBump") is not None:
+        item["resolutionBump"] = bool(raw["resolutionBump"])
+    return item  # type: ignore[return-value]
 
 
 def _default_clarify_question(utterance: str) -> str:

--- a/services/agent-runtime/tests/test_atomic_parse_schema.py
+++ b/services/agent-runtime/tests/test_atomic_parse_schema.py
@@ -63,6 +63,31 @@ def test_validate_video_confirm_gate_default():
     assert out["items"][0]["confirm_gate"] is True
 
 
+def test_validate_preserves_turnaround_pipeline_fields():
+    out = validate_parse_result(
+        {
+            "items": [
+                {
+                    "target_type": "image",
+                    "prompt": "山海经吞金兽的三视图，CG风格",
+                    "title": "山海经吞金兽的三视图，CG风格",
+                    "confirm_gate": False,
+                    "pipeline": "turnaround_image",
+                    "imageAspect": "2:1",
+                    "resolutionBump": True,
+                }
+            ],
+            "confidence": 0.96,
+        },
+        utterance="山海经吞金兽的三视图，CG风格",
+    )
+    assert out["kind"] == "success"
+    item = out["items"][0]
+    assert item.get("pipeline") == "turnaround_image"
+    assert item.get("imageAspect") == "2:1"
+    assert item.get("resolutionBump") is True
+
+
 def test_validate_campaign_override_clarify():
     out = validate_parse_result(
         {"confidence": 0.9, "items": [{"target_type": "image", "prompt": "x", "title": "x"}]},


### PR DESCRIPTION
## Summary
- Keep pipeline/imageAspect/resolutionBump through validate_parse_result

## Test plan
- [x] pytest test_atomic_parse_schema.py
- [ ] prod turnaround smoke after deploy

Made with [Cursor](https://cursor.com)