### PR TITLE
feat: prompt table render and commercial storyboard UX (P0-P2)

### DIFF
--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -922,7 +922,13 @@ export class AgentCanvasToolsService {
     sessionId: string
     userId: string
     nodeId: string
-  }): Promise<{ status: string; generationRecordId?: string; actions: CanvasAction[] }> {
+  }): Promise<{
+    status: string
+    generationRecordId?: string
+    actions: CanvasAction[]
+    promptMode?: string | null
+    completionSummary?: string
+  }> {
     const { canvas } = await this.loadOwnedSession(input.sessionId, input.userId)
     const node = canvas.nodes.find((n) => n.id === input.nodeId)
     if (!node) throw new NotFoundException('节点不存在')

--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -2,6 +2,7 @@ import { ConflictException, ForbiddenException, Inject, Injectable, NotFoundExce
 import { applyCanvasActions } from '@lnkpi/agent'
 import {
   resolveNodeRefs,
+  summarizePromptCompletion,
   type CanvasAction,
   type CanvasData,
   type CanvasNode,
@@ -968,7 +969,14 @@ export class AgentCanvasToolsService {
       ]
       await this.persist(input.sessionId, finishActions)
       allActions.push(...finishActions)
-      return { status: 'completed', generationRecordId: recordId, actions: allActions }
+      const completionSummary = summarizePromptCompletion(parsed.mode, parsed.content)
+      return {
+        status: 'completed',
+        generationRecordId: recordId,
+        actions: allActions,
+        promptMode: parsed.mode,
+        completionSummary: completionSummary ?? undefined,
+      }
     } catch (err) {
       if (err instanceof ForbiddenException || err instanceof NotFoundException) throw err
       const errorMessage = err instanceof Error ? err.message : '提示词生成失败'

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,10 @@
   "dependencies": {
     "@lnkpi/shared": "workspace:*",
     "@tiptap/extension-placeholder": "^3.28.0",
+    "@tiptap/extension-table": "^3.28.0",
+    "@tiptap/extension-table-cell": "^3.28.0",
+    "@tiptap/extension-table-header": "^3.28.0",
+    "@tiptap/extension-table-row": "^3.28.0",
     "@tiptap/extension-typography": "^3.28.0",
     "@tiptap/starter-kit": "^3.28.0",
     "@tiptap/vue-3": "^3.28.0",

--- a/apps/web/src/components/canvas/CanvasNodePrompt.vue
+++ b/apps/web/src/components/canvas/CanvasNodePrompt.vue
@@ -5,25 +5,33 @@ import NeoBaseNode from '@/components/canvas/NeoBaseNode.vue'
 import PromptMarkdownEditor from '@/components/canvas/PromptMarkdownEditor.vue'
 import { CANVAS_NODE_PATCH_KEY } from '@/composables/canvasNodeActions'
 import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
+import { buildPromptNodeCardPreview } from '@lnkpi/shared'
 
 const props = defineProps<{
   selected?: boolean
-  data: { prompt?: string; content?: string; label?: string; status?: string; errorMessage?: string }
+  data: {
+    prompt?: string
+    content?: string
+    label?: string
+    status?: string
+    errorMessage?: string
+    promptMode?: string
+  }
 }>()
 
 const nodeId = useNodeId()
 const { updateNodeData } = useVueFlow()
-// 同 CanvasNodeText:受控模式下必须走页面级 patch 才能持久化并让下游引用可见。
 const patchCanvasNode = inject(CANVAS_NODE_PATCH_KEY, null)
 
 const editorOpen = ref(false)
 const draft = ref('')
 
-const preview = computed(() => {
-  const c = String(props.data.content ?? '').trim()
-  if (c) return c.length > 180 ? `${c.slice(0, 180)}…` : c
-  return ''
-})
+const preview = computed(() =>
+  buildPromptNodeCardPreview({
+    content: String(props.data.content ?? ''),
+    promptMode: props.data.promptMode,
+  }),
+)
 
 const isError = computed(
   () => props.data.status === NODE_GENERATION_STATUS.error || props.data.status === 'error',

--- a/apps/web/src/components/canvas/PromptMarkdownEditor.css
+++ b/apps/web/src/components/canvas/PromptMarkdownEditor.css
@@ -13,8 +13,8 @@
 .prompt-md-modal {
   display: flex;
   flex-direction: column;
-  width: min(920px, 100%);
-  max-height: min(85vh, 720px);
+  width: min(1100px, 100%);
+  max-height: min(88vh, 780px);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 16px;
   background: #1a1a1e;
@@ -155,6 +155,38 @@
 
 .prompt-md-editor .tiptap em {
   font-style: italic;
+}
+
+.prompt-md-editor .tiptap table {
+  width: 100%;
+  margin: 0.75em 0;
+  border-collapse: collapse;
+  table-layout: auto;
+  font-size: 12px;
+}
+
+.prompt-md-editor .tiptap th,
+.prompt-md-editor .tiptap td {
+  min-width: 72px;
+  padding: 6px 8px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  vertical-align: top;
+  text-align: left;
+}
+
+.prompt-md-editor .tiptap th {
+  background: rgba(255, 255, 255, 0.06);
+  font-weight: 650;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.prompt-md-editor .tiptap td {
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.prompt-md-editor .tiptap .tableWrapper {
+  overflow-x: auto;
+  margin: 0.5em 0;
 }
 
 .prompt-md-btn-secondary {

--- a/apps/web/src/components/canvas/PromptMarkdownEditor.vue
+++ b/apps/web/src/components/canvas/PromptMarkdownEditor.vue
@@ -4,6 +4,10 @@ import { EditorContent, Editor } from '@tiptap/vue-3'
 import StarterKit from '@tiptap/starter-kit'
 import Placeholder from '@tiptap/extension-placeholder'
 import Typography from '@tiptap/extension-typography'
+import { Table } from '@tiptap/extension-table'
+import { TableRow } from '@tiptap/extension-table-row'
+import { TableCell } from '@tiptap/extension-table-cell'
+import { TableHeader } from '@tiptap/extension-table-header'
 import { Markdown } from 'tiptap-markdown'
 import type { MarkdownStorage } from 'tiptap-markdown'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
@@ -46,8 +50,12 @@ function ensureEditor() {
     extensions: [
       StarterKit,
       Typography,
+      Table.configure({ resizable: false }),
+      TableRow,
+      TableHeader,
+      TableCell,
       Placeholder.configure({ placeholder: '输入或生成提示词内容...' }),
-      Markdown.configure({ html: false }),
+      Markdown.configure({ html: false, transformPastedText: true, transformCopiedText: true }),
     ],
     content: props.modelValue || '',
     onUpdate: () => scheduleSave(),

--- a/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
@@ -16,15 +16,13 @@ import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
 import { useModelProviderSettings } from '@/composables/useModelProviderSettings'
 import { resolveGenerationModel } from '@/constants/studioModels'
 import { isNodeGenerating } from '@/constants/dockStudio'
+import {
+  PROMPT_MODE_LABELS,
+  buildPromptNodeCardPreview,
+  countMarkdownTableDataRows,
+} from '@lnkpi/shared'
 
-const MODE_LABELS: Record<string, string> = {
-  image_prompt_multi_style: '多风格绘画提示词',
-  character_turnaround: '人物三视图',
-  storyboard: '分镜提示词',
-  script: '剧本',
-  copywriting: '文案/旁白',
-  generic: '通用创作',
-}
+const MODE_LABELS = PROMPT_MODE_LABELS
 
 const { getConfig } = useModelProviderSettings()
 
@@ -57,6 +55,20 @@ const promptModeLabel = computed(() => {
   const mode = promptMode.value
   return mode ? (MODE_LABELS[mode] ?? mode) : ''
 })
+
+const generatedContent = computed(() => String(props.node.data?.content ?? '').trim())
+const generatedPreview = computed(() =>
+  buildPromptNodeCardPreview({
+    content: generatedContent.value,
+    promptMode: promptMode.value,
+    maxChars: 360,
+  }),
+)
+const tableRowCount = computed(() =>
+  promptMode.value === 'commercial_storyboard'
+    ? countMarkdownTableDataRows(generatedContent.value)
+    : 0,
+)
 
 const textRefs = computed(() => (props.refs ?? []).filter((ref) => ref.mediaType === 'text'))
 
@@ -145,6 +157,22 @@ function onRefRemove(ref: NodeRef) {
       @update:model-value="onPromptInput"
       @submit="onGenerate"
     />
+
+    <section
+      v-if="generatedContent"
+      class="mx-3 mb-2 rounded-xl border border-white/10 bg-white/[0.03] p-3"
+    >
+      <div class="mb-2 flex items-center justify-between gap-2">
+        <span class="text-[10px] font-medium text-fuchsia-300/90">
+          {{ promptModeLabel || '生成结果' }}
+        </span>
+        <span v-if="tableRowCount" class="text-[10px] text-white/45">
+          含 {{ tableRowCount }} 镜表格
+        </span>
+      </div>
+      <pre class="max-h-36 overflow-auto whitespace-pre-wrap text-left text-[11px] leading-relaxed text-white/75">{{ generatedPreview }}</pre>
+      <p class="mt-2 text-[10px] text-white/35">双击画布节点可打开表格编辑器查看完整分镜表</p>
+    </section>
 
     <div class="bottom-toolbar-actions flex-wrap">
       <UniversalModelSelector

--- a/packages/agent/src/prompt-modes/generate.test.ts
+++ b/packages/agent/src/prompt-modes/generate.test.ts
@@ -39,4 +39,24 @@ describe('generatePromptContent with key', () => {
       generatePromptContent('test', 'generic', { apiKey: 'test-key' }),
     ).rejects.toThrow(/LLM 返回空内容/)
   })
+
+  it('retries commercial_storyboard once when validation fails', async () => {
+    const valid = `## 1. 商业策略上下文\nx\n## 2. 规则映射摘要\nx\n## 3. 分镜执行脚本\n| 序号 | 时长(秒) | 景别与视角 | 画面内容 | 镜头运动 | 营销文案(旁白/大字) | 声音设计 | 剪辑节奏 |\n| 1 | 0-3 | 中景+平视 | 手指点击，居中，冷蓝 | 固定 | 无 | 无 | 硬切 |\n| 2 | 3-6 | 特写+平视 | 屏幕亮，居中，冷蓝 | 固定 | 无 | 无 | 硬切 |\n| 3 | 6-9 | 近景+平视 | 离盘，居中，冷蓝 | 固定 | 无 | 无 | 硬切 |\n| 4 | 9-12 | 微距+平视 | 雷达，居中，冷蓝 | 固定 | 无 | 无 | 硬切 |\n| 5 | 12-15 | 全景+平视 | 转弯，居中，冷蓝 | 固定 | 无 | 无 | 硬切 |\n| 6 | 15-18 | 中景+平视 | 后排，居中，暖 | 固定 | 无 | 无 | 硬切 |\n| 7 | 18-21 | 特写+平视 | 上扬，居中，暖 | 固定 | 无 | 无 | 硬切 |\n| 8 | 21-24 | 特写+平视 | Logo，居中，黑金 | 固定 | 无 | 无 | 硬切 |\n## 4. 质量校验锁\n- [x] 开头3秒验证：ok\n- [x] 产品露出验证：ok\n- [x] 文字可读性验证：ok\n- [x] 声音独占验证：ok\n- [x] 物理可行性验证：ok`
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ choices: [{ message: { content: '只有散文，没有表格' } }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ choices: [{ message: { content: valid } }] }),
+      })
+    vi.stubGlobal('fetch', fetchMock)
+    const { content } = await generatePromptContent('问界M9 30秒商业分镜', 'commercial_storyboard', {
+      apiKey: 'test-key',
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(content).toContain('分镜执行脚本')
+  })
 })

--- a/packages/agent/src/prompt-modes/generate.ts
+++ b/packages/agent/src/prompt-modes/generate.ts
@@ -1,6 +1,35 @@
 import { getPromptMode } from './registry'
 import type { PromptModeId } from './types'
 import { classifyPromptMode } from './classify'
+import { validateCommercialStoryboardOutput } from './modes/commercial-storyboard-validate'
+
+const MODE_TEMPERATURE: Partial<Record<PromptModeId, number>> = {
+  commercial_storyboard: 0.35,
+}
+
+async function callChat(
+  messages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }>,
+  opts: { apiKey: string; baseUrl: string; model: string; temperature: number },
+): Promise<string> {
+  const res = await fetch(`${opts.baseUrl}/chat/completions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${opts.apiKey}` },
+    body: JSON.stringify({
+      model: opts.model,
+      temperature: opts.temperature,
+      messages,
+    }),
+  })
+  if (!res.ok) {
+    throw new Error(`LLM 请求失败: ${res.status} ${res.statusText}`)
+  }
+  const json = (await res.json()) as { choices: Array<{ message: { content: string } }> }
+  const content = json.choices[0]?.message?.content?.trim()
+  if (!content) {
+    throw new Error('LLM 返回空内容')
+  }
+  return content
+}
 
 export async function generatePromptContent(
   prompt: string,
@@ -15,6 +44,8 @@ export async function generatePromptContent(
   }
 
   const baseUrl = (opts?.baseUrl ?? process.env.OPENAI_BASE_URL ?? 'https://api.openai.com/v1').replace(/\/$/, '')
+  const model = opts?.model ?? process.env.OPENAI_CHAT_MODEL ?? 'gpt-4o'
+  const temperature = MODE_TEMPERATURE[mode] ?? 0.8
   const fewShots = def.fewShots ?? [def.fewShot]
   const messages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }> = [
     { role: 'system', content: def.system },
@@ -25,23 +56,26 @@ export async function generatePromptContent(
   }
   messages.push({ role: 'user', content: `请基于以下需求生成：\n\n${prompt}` })
 
-  const res = await fetch(`${baseUrl}/chat/completions`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
-    body: JSON.stringify({
-      model: opts?.model ?? process.env.OPENAI_CHAT_MODEL ?? 'gpt-4o',
-      temperature: 0.8,
-      messages,
-    }),
-  })
-  if (!res.ok) {
-    throw new Error(`LLM 请求失败: ${res.status} ${res.statusText}`)
+  let content = await callChat(messages, { apiKey: key, baseUrl, model, temperature })
+
+  if (mode === 'commercial_storyboard') {
+    const validation = validateCommercialStoryboardOutput(content)
+    if (!validation.ok) {
+      messages.push({ role: 'assistant', content })
+      messages.push({
+        role: 'user',
+        content:
+          `输出未通过质量校验，请严格修正后重新输出完整四节+表格+校验锁：\n${validation.issues.map((i) => `- ${i}`).join('\n')}`,
+      })
+      content = await callChat(messages, {
+        apiKey: key,
+        baseUrl,
+        model,
+        temperature: 0.2,
+      })
+    }
   }
-  const json = (await res.json()) as { choices: Array<{ message: { content: string } }> }
-  const content = json.choices[0]?.message?.content?.trim()
-  if (!content) {
-    throw new Error('LLM 返回空内容')
-  }
+
   return { mode, content }
 }
 

--- a/packages/agent/src/prompt-modes/modes/commercial-storyboard-validate.test.ts
+++ b/packages/agent/src/prompt-modes/modes/commercial-storyboard-validate.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { validateCommercialStoryboardOutput } from './commercial-storyboard-validate'
+
+describe('validateCommercialStoryboardOutput', () => {
+  it('passes well-formed commercial storyboard', () => {
+    const content = `## 1. 商业策略上下文
+- 品类：智能汽车
+
+## 2. 规则映射摘要
+- 视觉语法：低角度仰拍
+
+## 3. 分镜执行脚本
+
+| 序号 | 时长(秒) | 景别与视角 | 画面内容 | 镜头运动 | 营销文案(旁白/大字) | 声音设计 | 剪辑节奏 |
+| 1 | 0-3 | 中景+平视 | 手指点击按钮，居中构图，冷蓝硬调 | 固定 | 大字：交给它 | 触控声 | 硬切 |
+| 2 | 3-6 | 特写+俯视45° | 屏幕点亮，居中构图，冷蓝硬调 | 微推 | 无 | 叮 | 硬切 |
+| 3 | 6-9 | 近景+平视 | 双手离盘，居中构图，冷蓝硬调 | 固定 | 无 | 环境音 | 硬切 |
+| 4 | 9-12 | 微距+平视 | 雷达点亮，居中构图，冷蓝硬调 | 固定 | 无 | 脉冲 | 硬切 |
+| 5 | 12-15 | 全景+低角度仰拍 | 车辆转弯，居中构图，黑金硬调 | 跟拍 | 无 | 风声 | 硬切 |
+| 6 | 15-18 | 中景+平视 | 后排观影，居中构图，暖调 | 横移 | 无 | 环绕 | 叠化 |
+| 7 | 18-21 | 特写+平视 | 嘴角上扬15度，居中构图，暖调 | 微推 | 无 | 风声 | 叠化 |
+| 8 | 21-24 | 特写+低角度仰拍 | Logo发光，居中构图，黑金硬调 | 固定 | AITO | 混响 | 硬切 |
+
+## 4. 质量校验锁
+- [x] 开头3秒验证：已建立冲突
+- [x] 产品露出验证：前30%已出现
+- [x] 文字可读性验证：通过
+- [x] 声音独占验证：通过
+- [x] 物理可行性验证：通过`
+
+    const result = validateCommercialStoryboardOutput(content)
+    expect(result.ok).toBe(true)
+    expect(result.issues).toEqual([])
+  })
+
+  it('fails when sections missing', () => {
+    const result = validateCommercialStoryboardOutput('只有一段散文')
+    expect(result.ok).toBe(false)
+    expect(result.issues.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/agent/src/prompt-modes/modes/commercial-storyboard-validate.ts
+++ b/packages/agent/src/prompt-modes/modes/commercial-storyboard-validate.ts
@@ -1,0 +1,37 @@
+import { countMarkdownTableDataRows } from '@lnkpi/shared'
+
+const REQUIRED_SECTIONS = [
+  '## 1. 商业策略上下文',
+  '## 2. 规则映射摘要',
+  '## 3. 分镜执行脚本',
+  '## 4. 质量校验锁',
+]
+
+const EMOTION_WORDS = ['开心', '美丽', '震撼', '惊艳', '氛围感拉满', '非常感动']
+
+export function validateCommercialStoryboardOutput(content: string): {
+  ok: boolean
+  issues: string[]
+} {
+  const issues: string[] = []
+  const text = content.trim()
+
+  for (const section of REQUIRED_SECTIONS) {
+    if (!text.includes(section)) issues.push(`缺少「${section.replace('## ', '')}」`)
+  }
+
+  if (!text.includes('| 序号 |')) issues.push('缺少分镜 Markdown 表格表头')
+
+  const rows = countMarkdownTableDataRows(text)
+  if (rows < 6) issues.push(`分镜表格行数不足（${rows}，30秒建议≥8镜）`)
+
+  if (!text.includes('- [x]') && !text.includes('- [X]')) {
+    issues.push('质量校验锁未逐条勾选 [x]')
+  }
+
+  for (const word of EMOTION_WORDS) {
+    if (text.includes(word)) issues.push(`含禁用情绪词「${word}」`)
+  }
+
+  return { ok: issues.length === 0, issues }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,6 +11,7 @@ export * from './providerChannels'
 export * from './generationDiagnostics'
 export * from './agentContract'
 export * from './agentIntent'
+export * from './promptContent'
 
 export type GenerationType = 'text' | 'image' | 'video'
 

--- a/packages/shared/src/promptContent.test.ts
+++ b/packages/shared/src/promptContent.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildPromptNodeCardPreview,
+  countMarkdownTableDataRows,
+  summarizePromptCompletion,
+} from './promptContent'
+
+describe('promptContent', () => {
+  const table = `| 序号 | 时长(秒) | 景别与视角 |
+| :---: | :---: | :--- |
+| 1 | 0-4 | 中景+平视 |
+| 2 | 4-8 | 特写+俯视45° |`
+
+  it('counts markdown table rows', () => {
+    expect(countMarkdownTableDataRows(table)).toBe(2)
+  })
+
+  it('summarizes commercial storyboard completion', () => {
+    const summary = summarizePromptCompletion(
+      'commercial_storyboard',
+      `## 3. 分镜执行脚本\n${table}`,
+    )
+    expect(summary).toContain('2 镜商业分镜表')
+  })
+
+  it('builds commercial card preview with shot count', () => {
+    const preview = buildPromptNodeCardPreview({
+      content: `## 1. 商业策略上下文\n${table}`,
+      promptMode: 'commercial_storyboard',
+    })
+    expect(preview).toContain('2 镜表格')
+    expect(preview).not.toContain('| 1 |')
+  })
+})

--- a/packages/shared/src/promptContent.ts
+++ b/packages/shared/src/promptContent.ts
@@ -1,0 +1,86 @@
+/** Shared helpers for prompt node content preview and completion summaries. */
+
+export const PROMPT_MODE_LABELS: Record<string, string> = {
+  image_prompt_multi_style: '多风格绘画提示词',
+  character_turnaround: '人物三视图',
+  storyboard: '分镜提示词',
+  commercial_storyboard: '商业品牌分镜',
+  script: '剧本',
+  copywriting: '文案/旁白',
+  generic: '通用创作',
+}
+
+export function promptModeLabel(mode: string | null | undefined): string {
+  if (!mode) return ''
+  return PROMPT_MODE_LABELS[mode] ?? mode
+}
+
+/** Count GFM table data rows (excludes header and separator). */
+export function countMarkdownTableDataRows(content: string): number {
+  return content.split('\n').filter((line) => {
+    const t = line.trim()
+    if (!t.startsWith('|')) return false
+    if (t.includes('序号') && t.includes('时长')) return false
+    if (/^\|[\s:|-]+\|$/.test(t)) return false
+    const cells = t.split('|').filter((c) => c.trim())
+    return cells.length >= 3
+  }).length
+}
+
+export function countStoryboardMirrorSections(content: string): number {
+  return (content.match(/###\s*镜\s*\d+/g) ?? []).length
+}
+
+export function summarizePromptCompletion(
+  mode: string | null | undefined,
+  content: string,
+): string | null {
+  const text = content.trim()
+  if (!text) return null
+
+  if (mode === 'commercial_storyboard') {
+    const shots = countMarkdownTableDataRows(text)
+    if (shots > 0) {
+      return `已生成 ${shots} 镜商业分镜表（含策略层与校验锁），双击节点可查看完整表格。`
+    }
+    if (text.includes('分镜执行脚本')) {
+      return '已生成商业分镜结构化文稿，双击节点查看完整内容。'
+    }
+  }
+
+  if (mode === 'storyboard') {
+    const mirrors = countStoryboardMirrorSections(text)
+    if (mirrors > 0) {
+      return `已生成 ${mirrors} 镜分镜提示词，双击节点查看。`
+    }
+  }
+
+  return null
+}
+
+export function buildPromptNodeCardPreview(input: {
+  content: string
+  promptMode?: string | null
+  maxChars?: number
+}): string {
+  const text = input.content.trim()
+  if (!text) return ''
+  const max = input.maxChars ?? 180
+  const mode = input.promptMode ?? ''
+
+  if (mode === 'commercial_storyboard') {
+    const shots = countMarkdownTableDataRows(text)
+    if (shots > 0) {
+      return `商业品牌分镜 · ${shots} 镜表格\n双击查看策略层、分镜表与校验锁`
+    }
+  }
+
+  if (mode === 'storyboard') {
+    const mirrors = countStoryboardMirrorSections(text)
+    if (mirrors > 0) {
+      return `分镜提示词 · ${mirrors} 镜\n双击查看完整内容`
+    }
+  }
+
+  return text.length > max ? `${text.slice(0, max)}…` : text
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,18 @@ importers:
       '@tiptap/extension-placeholder':
         specifier: ^3.28.0
         version: 3.28.0(@tiptap/extensions@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))
+      '@tiptap/extension-table':
+        specifier: ^3.28.0
+        version: 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
+      '@tiptap/extension-table-cell':
+        specifier: ^3.28.0
+        version: 3.28.0(@tiptap/extension-table@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))
+      '@tiptap/extension-table-header':
+        specifier: ^3.28.0
+        version: 3.28.0(@tiptap/extension-table@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))
+      '@tiptap/extension-table-row':
+        specifier: ^3.28.0
+        version: 3.28.0(@tiptap/extension-table@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))
       '@tiptap/extension-typography':
         specifier: ^3.28.0
         version: 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))
@@ -1116,6 +1128,27 @@ packages:
     resolution: {integrity: sha512-VVj2ZZU9QYqiHLcjqMqRYvuHSsokj/AgUl+6TzLrKjlWwyZ18D4H2vkyI0g70iVTKnUpZ3sEy8WA/rqjgBjqBg==}
     peerDependencies:
       '@tiptap/core': 3.28.0
+
+  '@tiptap/extension-table-cell@3.28.0':
+    resolution: {integrity: sha512-/p4c79YkZpAcytvhMqCJ73KKllG4CxkqHvgnkzySR7TEl+Shpt1pdFhaTW3Zm3ExLDNVBlWj8i0+EZ1cAmaZJA==}
+    peerDependencies:
+      '@tiptap/extension-table': 3.28.0
+
+  '@tiptap/extension-table-header@3.28.0':
+    resolution: {integrity: sha512-wMHWAZn+JzRCR2+peIGG195DRO8YHee/OpNuN1FK2FyLE/3qjRNfJumN2k8Sj6/ad41yoHp3I738ZW6oWwFgKw==}
+    peerDependencies:
+      '@tiptap/extension-table': 3.28.0
+
+  '@tiptap/extension-table-row@3.28.0':
+    resolution: {integrity: sha512-rWxgoHhFlwGcy6Q2uPhoHBZLNd6MO6J5anDhp85+NwZ8f8XPaX+y6+DlGiMsYXTCmQhZRchgSwX8eKxeIszyFg==}
+    peerDependencies:
+      '@tiptap/extension-table': 3.28.0
+
+  '@tiptap/extension-table@3.28.0':
+    resolution: {integrity: sha512-SX2Uwn/bFyrqjbBo2Hg9wfLT/ofByHm4f80BuG0h5/m89Ve78CgtaK2lGz9jHZRM7rKTG6eqel+PUZQUwcSzOg==}
+    peerDependencies:
+      '@tiptap/core': 3.28.0
+      '@tiptap/pm': 3.28.0
 
   '@tiptap/extension-text@3.28.0':
     resolution: {integrity: sha512-Jqp1LgfY1mnp4TQHoy+vnHyfn6qnnAM6nHgGwbY5zA8b/Xf1Etll6pziTx9p1J1qcfAgSrnjOyAmA++H7VQqww==}
@@ -3729,6 +3762,23 @@ snapshots:
   '@tiptap/extension-strike@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))':
     dependencies:
       '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-table-cell@3.28.0(@tiptap/extension-table@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))':
+    dependencies:
+      '@tiptap/extension-table': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-table-header@3.28.0(@tiptap/extension-table@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))':
+    dependencies:
+      '@tiptap/extension-table': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-table-row@3.28.0(@tiptap/extension-table@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))':
+    dependencies:
+      '@tiptap/extension-table': 3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)
+
+  '@tiptap/extension-table@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0)':
+    dependencies:
+      '@tiptap/core': 3.28.0(@tiptap/pm@3.28.0)
+      '@tiptap/pm': 3.28.0
 
   '@tiptap/extension-text@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))':
     dependencies:

--- a/services/agent-runtime/app/graph/nodes/run_atomic_gen.py
+++ b/services/agent-runtime/app/graph/nodes/run_atomic_gen.py
@@ -51,6 +51,7 @@ def make_run_atomic_gen_node(*, nest: Any) -> Callable:
         completed: list[str] = []
         failed: list[str] = []
         last_record_id: str | None = None
+        last_completion_summary: str | None = None
         last_error: str | None = None
 
         for item in items:
@@ -79,6 +80,9 @@ def make_run_atomic_gen_node(*, nest: Any) -> Callable:
             if record_id:
                 last_record_id = record_id
 
+            if isinstance(result, dict) and result.get("completionSummary"):
+                last_completion_summary = str(result["completionSummary"])
+
             if _is_success(result):
                 completed.append(title)
             else:
@@ -91,7 +95,9 @@ def make_run_atomic_gen_node(*, nest: Any) -> Callable:
                 msg = f"「{completed[0]}」生成完成。"
             else:
                 msg = f"已完成 {len(completed)} 张：{'、'.join(completed)}。"
-            if last_record_id:
+            if last_completion_summary:
+                msg += last_completion_summary
+            elif last_record_id:
                 msg += f"（record: {last_record_id}）"
             return {
                 "phase": "done",

--- a/services/agent-runtime/tests/test_run_atomic_gen_summary.py
+++ b/services/agent-runtime/tests/test_run_atomic_gen_summary.py
@@ -1,0 +1,42 @@
+"""Tests for run_atomic_gen completion summary."""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from app.graph.nodes.run_atomic_gen import make_run_atomic_gen_node
+
+
+class PromptNest:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    async def run_prompt_generation(self, node_id: str) -> dict:
+        self.calls.append(("run_prompt_generation", node_id))
+        return {
+            "status": "completed",
+            "generationRecordId": "rec-prompt-1",
+            "completionSummary": "已生成 8 镜商业分镜表（含策略层与校验锁），双击节点可查看完整表格。",
+        }
+
+
+@pytest.mark.asyncio
+async def test_prompt_completion_summary_appended_to_chat_message():
+    nest = PromptNest()
+    run = make_run_atomic_gen_node(nest=nest)
+    out = await run(
+        {
+            "atomic_node_id": "prompt-1",
+            "atomic_spec": {
+                "target_type": "prompt",
+                "title": "问界M9 30秒商业分镜提示词",
+                "prompt": "问界M9 30秒商业分镜提示词",
+            },
+        }
+    )
+    assert out["phase"] == "done"
+    msg = out["messages"][0]
+    assert isinstance(msg, AIMessage)
+    assert "8 镜商业分镜表" in msg.content
+    assert "record:" not in msg.content


### PR DESCRIPTION
## Summary
- **表格渲染**：PromptMarkdownEditor 接入 TipTap Table 四件套 + 表格 CSS，GFM 分镜表可正常渲染
- **P0**：Prompt Dock 展示生成结果摘要；节点卡片对商业分镜显示「N 镜表格，双击查看」
- **P1**：`commercial_storyboard` 模式标签；低温 0.35 + 输出校验失败自动重试一次
- **P2**：atomic prompt 完成后聊天追加「已生成 N 镜商业分镜表…」摘要

## Test plan
- [x] `pnpm --filter @lnkpi/shared test`
- [x] `pnpm --filter @lnkpi/agent test`
- [x] `pnpm --filter @lnkpi/web build`
- [x] `pnpm --filter @lnkpi/server exec vitest run src/agent/agent-canvas-tools.service.test.ts`
- [x] `pytest services/agent-runtime/tests/test_run_atomic_gen_summary.py`
- [ ] 合并后生产复测商业分镜路径 + 双击节点查看表格


Made with [Cursor](https://cursor.com)