### PR TITLE
feat: intent planning guard (Phase B) — route plan/write vs generate

### DIFF
--- a/deploy/prod-atomic-studio-verify.py
+++ b/deploy/prod-atomic-studio-verify.py
@@ -252,6 +252,28 @@ def verify_turnaround_pipeline(tok: str) -> None:
     )
 
 
+PLANNING_UTTERANCE = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+
+
+def verify_planning_guard(tok: str) -> None:
+    sid = http("POST", "/sessions", {"title": f"P4-planning-{int(time.time())}"}, t=tok)["data"]["id"]
+    tid = f"{sid}:{uuid.uuid4()}"
+    _, text, _types, exit_reason = sse_collect(
+        tok, sid, PLANNING_UTTERANCE, tid, timeout=SSE_TIMEOUT_SEC
+    )
+    not_image_direct = "image 节点（直达）" not in text or "方案" in text or "确认" in text
+    record(
+        "planning guard not image direct",
+        not_image_direct,
+        text[:160],
+    )
+    record(
+        "planning guard campaign or clarify",
+        "方案" in text or "拟定拆解" in text or "请确认" in text or "1）" in text,
+        text[:120],
+    )
+
+
 def verify_photoreal_turnaround_deai(tok: str) -> None:
     sid = http("POST", "/sessions", {"title": f"P4-photoreal-{int(time.time())}"}, t=tok)["data"]["id"]
     tid = f"{sid}:{uuid.uuid4()}"
@@ -301,6 +323,7 @@ def main() -> int:
         verify_modality(tok, label, utterance, node_type)
 
     verify_turnaround_pipeline(tok)
+    verify_planning_guard(tok)
     verify_photoreal_turnaround_deai(tok)
 
     print(f"\n=== Summary PASS={PASS} FAIL={FAIL} ===")

--- a/docs/superpowers/plans/2026-08-05-intent-llm-structured-parse.md
+++ b/docs/superpowers/plans/2026-08-05-intent-llm-structured-parse.md
@@ -1,0 +1,239 @@
+# Intent LLM Structured Parse Implementation Plan (Phase C)
+
+> **For agentic workers:** 本计划 **依赖 Phase B 完成并过 Gate** 后方可执行。  
+> REQUIRED SUB-SKILL: superpowers:executing-plans 或 subagent-driven-development
+
+**Goal:** 将 atomic/campaign 意图识别主路径从 keyword+rule 升级为 LLM 结构化 parse（Action×Scope×Modality×Extract），保留 B 的 planning_guard 作为 guardrail。
+
+**Architecture:** LLM 输出 `IntentParseResult` JSON → planning_guard.validate → validate_parse_result → create|clarify；feature flag 灰度；rule parse 作 fallback。
+
+**Tech Stack:** Python 3.11, LangGraph, OpenAI/DeepSeek JSON mode, pytest, YAML eval
+
+**Prerequisite Gate (must all pass before Task C0):**
+- [ ] Phase B merged to main
+- [ ] `eval-planning-guard-set.yaml` 25/25 PASS
+- [ ] prod planning smoke 2 weeks green
+- [ ] See [2026-08-05-intent-llm-structured-parse-design.md §8.4](../specs/2026-08-05-intent-llm-structured-parse-design.md)
+
+## Global Constraints
+
+- `INTENT_LLM_PARSE` default **false** until C4
+- planning_guard **never removed** — only role changes to validator
+- `CLARIFY_THRESHOLD = 0.70` unchanged
+- LLM timeout 8s → fallback `rule_parse_atomic`
+- Zero regression on B eval sets + existing eval-intent-set
+
+---
+
+## File Map (Phase C)
+
+| File | Action |
+|------|--------|
+| `app/graph/intent_parse_schema.py` | Create |
+| `app/graph/intent_parse_llm.py` | Create |
+| `app/graph/clarify_reply.py` | Create |
+| `app/graph/planning_guard.py` | Extend `validate_llm_parse` |
+| `app/graph/nodes/atomic_parse.py` | LLM-first + shadow |
+| `app/config.py` | Add flags |
+| `packages/agent/src/prompt-modes/taxonomy.yaml` | Create (shared w/ runtime) |
+| `skills/atomic-create/eval-intent-llm-set.yaml` | Create (80 cases) |
+| `tests/test_intent_llm_parse.py` | Create |
+| `tests/test_intent_llm_parse_eval.py` | Create |
+| `tests/test_clarify_reply.py` | Create |
+| `deploy/prod-atomic-intent-shadow-verify.py` | Create |
+
+---
+
+## Milestone C0: Schema + LLM Parse Core
+
+### Task C0-1: IntentParseResult schema
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/intent_parse_schema.py`
+- Create: `services/agent-runtime/tests/test_intent_parse_schema.py`
+
+- [ ] Define `IntentParseResult`, `IntentParseItem` TypedDicts (per design §3.1)
+- [ ] Implement `parse_llm_json(raw: str) -> IntentParseResult | None`
+- [ ] Implement `intent_result_to_parse_outcome(result, utterance) -> ParseOutcome`
+- [ ] Tests: valid JSON, missing fields, invalid target_type, confidence clamp
+
+### Task C0-2: LLM parse module
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/intent_parse_llm.py`
+- Modify: `skills/atomic-create/few-shots.yaml` — add `parse_intent_structured` section
+
+- [ ] `_STRUCTURED_PARSE_SYSTEM` with action/scope/route rules (design §3.2)
+- [ ] `async def llm_parse_intent(utterance, *, canvas_summary, dialogue, checkpoint) -> IntentParseResult`
+- [ ] JSON mode + 1 retry on parse error
+- [ ] Unit test with mocked LLM response (planning utterance → route=campaign)
+
+### Task C0-3: Config flags
+
+**Files:**
+- Modify: `services/agent-runtime/app/config.py`
+
+```python
+intent_llm_parse: bool = False
+intent_llm_parse_shadow: bool = False
+```
+
+---
+
+## Milestone C1: Shadow Mode + Eval 80 Cases
+
+### Task C1-1: eval-intent-llm-set.yaml
+
+**Files:**
+- Create: `services/agent-runtime/skills/atomic-create/eval-intent-llm-set.yaml`
+
+Categories (80 total):
+- `llm-plan-campaign` (15)
+- `llm-generate-image` (15)
+- `llm-write-text` (10)
+- `llm-expand-prompt` (10)
+- `llm-multi-image` (10)
+- `llm-adversarial` (10)
+- `llm-clarify-expected` (10)
+
+Include user original case as `llm-001`.
+
+### Task C1-2: Eval runner + shadow diff
+
+**Files:**
+- Create: `services/agent-runtime/tests/test_intent_llm_parse_eval.py`
+- Modify: `services/agent-runtime/app/graph/nodes/atomic_parse.py`
+
+- [ ] Shadow: run both `llm_parse_intent` and `rule_parse_atomic`, log diff if disagree
+- [ ] Eval asserts LLM outcome matches gold when `INTENT_LLM_PARSE=1`
+- [ ] Agreement report script for CI artifact
+
+**Gate:** agreement ≥ 90% on eval-intent-llm-set before C2.
+
+---
+
+## Milestone C2: Guardrail + Clarify 续聊
+
+### Task C2-1: validate_llm_parse in planning_guard
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/planning_guard.py`
+
+```python
+def validate_llm_parse(result: IntentParseResult, utterance: str) -> ParseOutcome | None:
+    """Return clarify outcome if guard conflicts; None if OK to proceed."""
+```
+
+- [ ] action=generate + has_planning_image_conflict → clarify
+- [ ] items with image when action=plan → clarify
+- [ ] Tests in `test_planning_guard.py`
+
+### Task C2-2: Clarify reply classifier
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/clarify_reply.py`
+- Create: `services/agent-runtime/tests/test_clarify_reply.py`
+- Modify: `services/agent-runtime/app/graph/nodes/atomic_parse.py`
+
+- [ ] `classify_clarify_reply(original, question, reply, checkpoint)`
+- [ ] Map `1/2/3` and natural language variants
+- [ ] Graph: if `phase=clarify` and new user msg → try classify_clarify_reply first
+
+---
+
+## Milestone C3: prompt_mode L3 统一
+
+### Task C3-1: Shared taxonomy
+
+**Files:**
+- Create: `packages/agent/src/prompt-modes/taxonomy.yaml`
+- Create: `services/agent-runtime/app/tools/prompt_mode_taxonomy.py` (loader)
+
+- [ ] Mirror `classify.ts` heuristics as yaml patterns
+- [ ] Runtime `resolve_prompt_mode(utterance) -> str | None`
+- [ ] LLM parse prompt references same taxonomy ids
+
+### Task C3-2: Wire prompt_mode into items
+
+- [ ] `IntentParseItem.prompt_mode` → `atomic_spec.promptMode` in create
+- [ ] Tests: commercial_storyboard utterance → prompt/text + correct mode
+
+---
+
+## Milestone C4: LLM Primary + Fast Path 收缩
+
+### Task C4-1: atomic_parse LLM-first
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/nodes/atomic_parse.py`
+
+```python
+if settings.intent_llm_parse:
+    result = await llm_parse_intent(...)
+    guard = validate_llm_parse(result, utterance)
+    if guard: return guard
+    return intent_result_to_parse_outcome(result, utterance)
+# fallback
+return rule_path(...)
+```
+
+- [ ] Timeout → rule fallback
+- [ ] Remove blanket `_STRONG_SIGNAL_KEYWORDS` fast path when flag ON
+
+### Task C4-2: Prod smoke + flag rollout
+
+**Files:**
+- Create: `deploy/prod-atomic-intent-shadow-verify.py`
+- Modify: `deploy/prod-p4-full-regression.py` (optional include)
+
+- [ ] Shadow verify on prod weekly
+- [ ] Document rollout: shadow 1 week → 10% → 100%
+
+**Gate:** C4 requires C1 agreement ≥ 90%, C2 clarify tests PASS, zero B regression.
+
+---
+
+## Milestone C5: Observability
+
+### Task C5-1: Logging + metrics
+
+- [ ] Log fields: `intent_parse_source=llm|rule`, `action`, `route`, `confidence`, `guard_triggered`
+- [ ] Optional: nest endpoint for badcase collection
+
+---
+
+## B → C Handoff Checklist
+
+| # | Item | Owner |
+|---|------|-------|
+| 1 | B PR merged | — |
+| 2 | B eval 25/25 | — |
+| 3 | B prod smoke 2 weeks | — |
+| 4 | C0 schema + LLM module | — |
+| 5 | C1 shadow agreement ≥ 90% | — |
+| 6 | C2 clarify 续聊 | — |
+| 7 | C3 prompt_mode unified | — |
+| 8 | C4 flag default ON | — |
+
+---
+
+## Self-Review
+
+| Design § | Plan Task |
+|----------|-----------|
+| §3 Schema | C0-1 |
+| §6 LLM spec | C0-2 |
+| §4 Fast path | C4-1 |
+| §5 Clarify 续聊 | C2-2 |
+| §7 Guardrail | C2-1 |
+| §8 Eval | C1-1, C1-2 |
+| §9 Files | File Map |
+| §11 Acceptance | Gates throughout |
+
+---
+
+**Status:** Draft — execute only after Phase B plan complete.
+
+**Related:**
+- Phase B spec: [2026-08-05-intent-planning-guard-design.md](../specs/2026-08-05-intent-planning-guard-design.md)
+- Phase B plan: [2026-08-05-intent-planning-guard.md](./2026-08-05-intent-planning-guard.md)

--- a/docs/superpowers/plans/2026-08-05-intent-planning-guard.md
+++ b/docs/superpowers/plans/2026-08-05-intent-planning-guard.md
@@ -1,0 +1,481 @@
+# Intent Planning Guard Implementation Plan (Phase B)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Roadmap:** 本计划为 **Phase B**。Phase C（LLM 结构化 parse）见 [2026-08-05-intent-llm-structured-parse.md](./2026-08-05-intent-llm-structured-parse.md)，**B 过 Gate 后方可启动 C**。
+
+**Goal:** 防止「主图/详情页/构图方案」等 planning 型 utterance 误走 image 直出；通过 Planning Guard + Clarify + Eval 系统性提升 Action 理解。
+
+**Architecture:** 新增 `planning_guard.py` 提供 action/planning 检测与 confidence cap；扩展 `orchestration_complexity_intent` 将 planning+详情页路由至 campaign；`validate_parse_result` 与 `rule_parse_confidence` 在冲突时强制 clarify；新增 25 case eval gold set。
+
+**Tech Stack:** Python 3.11, pytest, YAML eval sets, LangGraph agent-runtime
+
+**Design spec:** [2026-08-05-intent-planning-guard-design.md](../specs/2026-08-05-intent-planning-guard-design.md)（含 B→C 总览）
+
+## Global Constraints
+
+- `CLARIFY_THRESHOLD = 0.70`（不变）
+- `RULE_FAST_PATH_THRESHOLD = 0.95`（不变）
+- planning conflict 时 confidence cap ≤ **0.65**
+- 明确「生成一张/来一张」类 utterance 不得回归
+- 中文 clarify 文案
+- 本阶段不改 TS promptMode / Nest Studio 生产层
+
+---
+
+## File Map
+
+| File | Responsibility |
+|------|----------------|
+| `services/agent-runtime/app/graph/planning_guard.py` | **Create** — action/planning detection, confidence cap, clarify templates |
+| `services/agent-runtime/tests/test_planning_guard.py` | **Create** — unit tests |
+| `services/agent-runtime/app/graph/atomic_intent.py` | **Modify** — extend orchestration campaign phrases |
+| `services/agent-runtime/app/graph/atomic_parse_util.py` | **Modify** — cap rule confidence via planning_guard |
+| `services/agent-runtime/app/graph/atomic_parse_schema.py` | **Modify** — planning conflict → clarify in validate |
+| `services/agent-runtime/app/graph/atomic_parse_llm.py` | **Modify** — system prompt action/scope hints |
+| `services/agent-runtime/skills/atomic-create/eval-planning-guard-set.yaml` | **Create** — 25 gold cases |
+| `services/agent-runtime/tests/test_planning_guard_eval.py` | **Create** — eval runner |
+| `services/agent-runtime/skills/atomic-create/eval-orchestration-set.yaml` | **Modify** — +5 cases |
+| `services/agent-runtime/skills/atomic-create/eval-intent-set.yaml` | **Modify** — +3 cases |
+| `deploy/prod-atomic-studio-verify.py` | **Modify** — optional planning smoke (Task 6) |
+
+---
+
+### Task 1: Planning Guard 核心模块
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/planning_guard.py`
+- Create: `services/agent-runtime/tests/test_planning_guard.py`
+
+**Interfaces:**
+- Produces: `detect_action`, `is_planning_intent`, `is_explicit_generation_intent`, `has_planning_image_conflict`, `planning_guard_confidence_cap`, `planning_clarify_question`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# services/agent-runtime/tests/test_planning_guard.py
+from app.graph.planning_guard import (
+    detect_action,
+    has_planning_image_conflict,
+    is_explicit_generation_intent,
+    is_planning_intent,
+    planning_clarify_question,
+    planning_guard_confidence_cap,
+)
+
+
+def test_design_detail_page_planning_conflict():
+    u = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    assert is_planning_intent(u)
+    assert has_planning_image_conflict(u)
+    assert not is_explicit_generation_intent(u)
+
+
+def test_generate_single_hero_not_planning_conflict():
+    u = "生成一张蓝牙耳机主图"
+    assert is_explicit_generation_intent(u)
+    assert not has_planning_image_conflict(u)
+
+
+def test_confidence_cap_on_conflict():
+    u = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    assert planning_guard_confidence_cap(u, 0.96) <= 0.65
+
+
+def test_clarify_question_nonempty():
+    q = planning_clarify_question("主图详情页构图方案")
+    assert "1" in q and "2" in q and "Campaign" in q or "方案" in q
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/agent-runtime && python3 -m pytest tests/test_planning_guard.py -v`  
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement planning_guard.py**
+
+```python
+# services/agent-runtime/app/graph/planning_guard.py
+"""Planning Guard — distinguish plan/design vs generate/create utterances."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+ActionKind = Literal["plan", "write", "generate", "expand", "unknown"]
+
+PLANNING_VERBS = (
+    "视觉方案",
+    "视觉策划",
+    "构图方案",
+    "构图",
+    "策划",
+    "规划",
+    "结构",
+    "框架",
+    "思路",
+    "布局",
+    "模块",
+    "方案",
+    "设计",
+)
+
+GENERATION_PATTERNS = (
+    r"生成一张",
+    r"生成一个",
+    r"来一张",
+    r"做一张",
+    r"出一张",
+    r"直接生成",
+    r"帮我生成一张",
+    r"帮我做一张",
+    r"帮我生成一个",
+)
+
+WRITE_VERBS = ("写", "撰写", "起草", "输出文案")
+
+EXPAND_MARKERS = ("提示词", "prompt", "扩写")
+
+PLANNING_CONFIDENCE_CAP = 0.65
+
+
+def detect_action(text: str) -> ActionKind:
+    t = (text or "").strip()
+    if not t:
+        return "unknown"
+    if any(m in t for m in EXPAND_MARKERS):
+        return "expand"
+    if is_explicit_generation_intent(t):
+        return "generate"
+    if any(v in t for v in WRITE_VERBS):
+        return "write"
+    if is_planning_intent(t):
+        return "plan"
+    return "unknown"
+
+
+def is_planning_intent(text: str) -> bool:
+    t = (text or "").strip()
+    if not t:
+        return False
+    if any(v in t for v in PLANNING_VERBS):
+        return True
+    if "详情页" in t and any(x in t for x in ("构图", "方案", "结构", "布局", "模块")):
+        return True
+    return False
+
+
+def is_explicit_generation_intent(text: str) -> bool:
+    t = (text or "").strip()
+    if not t:
+        return False
+    for pat in GENERATION_PATTERNS:
+        if re.search(pat, t):
+            return True
+    # 「设计一张海报」→ generate
+    if re.search(r"设计一[张个]", t):
+        return True
+    return False
+
+
+def has_planning_image_conflict(text: str) -> bool:
+    """True when planning semantics + ecommerce asset nouns without explicit generation."""
+    t = (text or "").strip()
+    if not t or is_explicit_generation_intent(t):
+        return False
+    if not is_planning_intent(t):
+        return False
+    asset_hit = any(k in t for k in ("主图", "详情页", "白底", "场景图", "banner", "Banner"))
+    return asset_hit
+
+
+def planning_guard_confidence_cap(text: str, base_conf: float) -> float:
+    if has_planning_image_conflict(text):
+        return min(base_conf, PLANNING_CONFIDENCE_CAP)
+    if is_planning_intent(text) and not is_explicit_generation_intent(text):
+        return min(base_conf, PLANNING_CONFIDENCE_CAP)
+    return base_conf
+
+
+def planning_clarify_question(utterance: str) -> str:
+    snippet = (utterance or "").strip()[:32]
+    return (
+        f"您提到「{snippet}…」涉及主图/详情页与构图方案。请确认：\n"
+        "1）单张主图直接出图；\n"
+        "2）完整详情页 Campaign 方案（多节点：主图/白底/场景等）；\n"
+        "3）只要文字版构图策划（不出图）。\n"
+        "回复 1 / 2 / 3，或补充具体需求。"
+    )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd services/agent-runtime && python3 -m pytest tests/test_planning_guard.py -v`  
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/agent-runtime/app/graph/planning_guard.py services/agent-runtime/tests/test_planning_guard.py
+git commit -m "feat(agent): add planning_guard for plan vs generate intent"
+```
+
+---
+
+### Task 2: Orchestration — planning → campaign
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/atomic_intent.py`
+- Modify: `services/agent-runtime/tests/test_atomic_create_intent.py` (or existing orchestration tests)
+
+**Interfaces:**
+- Consumes: `planning_guard.is_planning_intent`, `has_planning_image_conflict`, `is_explicit_generation_intent`
+- Produces: extended `orchestration_complexity_intent` returning `campaign` for planning+详情页 patterns
+
+- [ ] **Step 1: Write failing test**
+
+```python
+def test_orchestration_design_detail_page_is_campaign():
+    from app.graph.atomic_intent import orchestration_complexity_intent
+    u = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    assert orchestration_complexity_intent(u) == "campaign"
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+- [ ] **Step 3: Extend atomic_intent.py**
+
+In `orchestration_complexity_intent`, after existing campaign phrase checks, add:
+
+```python
+from app.graph.planning_guard import has_planning_image_conflict, is_planning_intent
+
+# inside orchestration_complexity_intent, early in function:
+if has_planning_image_conflict(t):
+    return "campaign"
+if "详情页" in t and is_planning_intent(t):
+    return "campaign"
+```
+
+Also extend `CAMPAIGN_COMPLEXITY_PHRASES`:
+
+```python
+CAMPAIGN_COMPLEXITY_PHRASES = (
+    ...
+    "详情页构图",
+    "详情页的构图",
+    "构图方案",
+    "视觉方案",
+)
+```
+
+- [ ] **Step 4: Run orchestration + planning tests — PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(agent): route planning+详情页 utterances to campaign orchestration"
+```
+
+---
+
+### Task 3: Rule confidence cap + validate clarify
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/atomic_parse_util.py` (`rule_parse_confidence`)
+- Modify: `services/agent-runtime/app/graph/atomic_parse_schema.py` (`validate_parse_result`)
+- Test: `services/agent-runtime/tests/test_atomic_parse_schema.py` (create if missing)
+
+- [ ] **Step 1: Write failing test**
+
+```python
+def test_rule_confidence_capped_for_planning_conflict():
+    from app.graph.atomic_parse_util import rule_parse_confidence
+    u = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    spec = {"target_type": "image", "prompt": u}
+    assert rule_parse_confidence(u, spec, None) <= 0.65
+
+
+def test_validate_parse_planning_conflict_clarifies():
+    from app.graph.atomic_parse_schema import validate_parse_result
+    u = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    out = validate_parse_result(
+        {"items": [{"target_type": "image", "prompt": u, "title": "x"}], "confidence": 0.96},
+        utterance=u,
+    )
+    assert out["kind"] == "clarify"
+    assert "1" in out["clarify_question"]
+```
+
+- [ ] **Step 2: Implement cap in rule_parse_confidence**
+
+```python
+from app.graph.planning_guard import planning_guard_confidence_cap
+
+# at end of rule_parse_confidence, before return:
+return planning_guard_confidence_cap(t, computed_conf)
+```
+
+- [ ] **Step 3: Implement validate_parse_result guard**
+
+At top of `validate_parse_result`, after invalid payload check:
+
+```python
+from app.graph.planning_guard import has_planning_image_conflict, planning_clarify_question
+
+if has_planning_image_conflict(utterance):
+    return {
+        "kind": "clarify",
+        "confidence": 0.0,
+        "reason": "planning_image_conflict",
+        "clarify_question": planning_clarify_question(utterance),
+    }
+```
+
+- [ ] **Step 4: Run tests — PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(agent): planning guard caps rule confidence and triggers clarify"
+```
+
+---
+
+### Task 4: LLM parse prompt + parse_atomic_target_type 微调
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/atomic_parse_llm.py`
+- Modify: `services/agent-runtime/app/graph/atomic_intent.py` (`parse_atomic_target_type`)
+
+- [ ] **Step 1: Add to `_PARSE_SYSTEM` in atomic_parse_llm.py**
+
+```
+- 「设计/构图方案/详情页策划」且无「生成一张/来一张」→ needs_clarify 或 target_type=text，confidence<0.7
+- 「主图+详情页+方案」→ 建议 Campaign，勿直接 image
+- 明确「生成一张主图」→ image，confidence≥0.9
+```
+
+- [ ] **Step 2: In parse_atomic_target_type, before IMAGE_KEYWORDS check**
+
+```python
+from app.graph.planning_guard import is_planning_intent, is_explicit_generation_intent
+
+if is_planning_intent(t) and not is_explicit_generation_intent(t):
+    if any(k in t for k in TEXT_DEFAULT_KEYWORDS) or "构图" in t or "方案" in t:
+        return "text"
+```
+
+- [ ] **Step 3: Run full atomic intent tests — PASS, no regression on img-01..06**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(agent): LLM parse and target_type respect planning intent"
+```
+
+---
+
+### Task 5: Eval gold sets
+
+**Files:**
+- Create: `services/agent-runtime/skills/atomic-create/eval-planning-guard-set.yaml`
+- Create: `services/agent-runtime/tests/test_planning_guard_eval.py`
+- Modify: `eval-orchestration-set.yaml`, `eval-intent-set.yaml`
+
+- [ ] **Step 1: Create eval-planning-guard-set.yaml** (25 cases per spec §5.1)
+
+Minimum required cases:
+
+```yaml
+- id: pg-01
+  utterance: 请你帮我设计一个蓝牙耳机主图，详情页的构图方案
+  gold: { route: campaign, allow_clarify: true, forbid_target: image }
+
+- id: pg-ctrl-01
+  utterance: 生成一张蓝牙耳机主图
+  gold: { route: atomic_create, target_type: image, min_confidence: 0.90 }
+```
+
+- [ ] **Step 2: Implement test_planning_guard_eval.py**
+
+Mirror `test_orchestration_intent_eval.py` pattern: for each case assert `resolve_intake_route`, `orchestration_complexity_intent`, and/or `validate_parse_result` outcome.
+
+- [ ] **Step 3: Add to eval-intent-set.yaml**
+
+```yaml
+- id: plan-01
+  utterance: 请你帮我设计一个蓝牙耳机主图，详情页的构图方案
+  focus_node_id: null
+  gold: { route: campaign, target_type: null }
+  notes: planning guard — must not image fast path
+```
+
+- [ ] **Step 4: Run all eval tests — 100% pass, zero regression**
+
+Run:
+```bash
+cd services/agent-runtime && python3 -m pytest tests/test_planning_guard_eval.py tests/test_atomic_create_intent_eval.py tests/test_orchestration_intent_eval.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "test(agent): add planning guard eval gold set (25 cases)"
+```
+
+---
+
+### Task 6: Production smoke (optional)
+
+**Files:**
+- Modify: `deploy/prod-atomic-studio-verify.py`
+
+- [ ] **Step 1: Add verify_planning_guard function**
+
+```python
+PLANNING_UTTERANCE = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+
+def verify_planning_guard(tok: str) -> None:
+    sid = http("POST", "/sessions", {"title": f"P4-planning-{int(time.time())}"}, t=tok)["data"]["id"]
+    tid = f"{sid}:{uuid.uuid4()}"
+    _, text, types, exit_reason = sse_collect(tok, sid, PLANNING_UTTERANCE, tid, timeout=SSE_TIMEOUT_SEC)
+    not_image_atomic = "image 节点（直达）" not in text or "确认" in text or "方案" in text
+    record("planning guard not image direct", not_image_atomic, text[:160])
+```
+
+- [ ] **Step 2: Run locally against prod after deploy**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "test(deploy): prod smoke for planning guard utterance"
+```
+
+---
+
+## Self-Review (spec coverage)
+
+| Spec § | Task |
+|--------|------|
+| Planning Guard 模块 | Task 1 |
+| orchestration → campaign | Task 2 |
+| confidence cap + clarify | Task 3 |
+| LLM parse hints | Task 4 |
+| Eval 25 cases | Task 5 |
+| prod smoke | Task 6 |
+| 「生成一张主图」不回归 | Task 5 control cases + existing eval |
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-08-05-intent-planning-guard.md`.
+
+**Phase C**（后续）：[2026-08-05-intent-llm-structured-parse-design.md](../specs/2026-08-05-intent-llm-structured-parse-design.md) + [plan](../plans/2026-08-05-intent-llm-structured-parse.md)
+
+**Two execution options (Phase B only):**
+
+1. **Subagent-Driven (recommended)** — 按 Task 1→6 分派 subagent，每 task 后 review  
+2. **Inline Execution** — 本会话内用 executing-plans 批量实现，checkpoint Review
+
+你选哪种？确认后我即可开始 Task 1。

--- a/docs/superpowers/specs/2026-08-05-intent-llm-structured-parse-design.md
+++ b/docs/superpowers/specs/2026-08-05-intent-llm-structured-parse-design.md
@@ -1,0 +1,368 @@
+# Intent LLM Structured Parse — 设计规格（Phase C）
+
+> 状态：**Draft**（2026-08-05，B 未交付前为设计态）  
+> 前置：**必须先完成** [2026-08-05-intent-planning-guard-design.md](./2026-08-05-intent-planning-guard-design.md)（Phase B）  
+> Phase B 计划：[2026-08-05-intent-planning-guard.md](../plans/2026-08-05-intent-planning-guard.md)  
+> Phase C 计划：[2026-08-05-intent-llm-structured-parse.md](../plans/2026-08-05-intent-llm-structured-parse.md)
+
+| 字段 | 值 |
+|------|-----|
+| 文档版本 | v1.0 |
+| 定位 | 从「关键词 + hybrid 规则」升级为 **LLM 结构化意图理解** |
+| 原则 | LLM 主判、规则 guardrail；B 的 Planning Guard **永不删除** |
+
+---
+
+## 一、动机与 B→C 边界
+
+### 1.1 B 方案遗留上限
+
+| 局限 | 表现 |
+|------|------|
+| 词表维护 | 新说法「视觉脚本」「页面结构稿」需人工加词 |
+| 子串冲突 | 「设计一张」vs「设计方案」靠 regex 边界 |
+| 多意图句 | 「写文案并生成主图」只能单模态或 clarify |
+| promptMode 脱节 | `classifyPromptMode` 只在 Nest 生产层，路由层不知 commercial/turnaround |
+| 跨语言/口语 | 「帮我整一个详情页的感觉」规则难以覆盖 |
+
+### 1.2 C 方案目标
+
+用户任意自然语言 utterance → **单次 LLM 结构化 parse** → 输出可执行的 `route + items[]`，置信不足或 guard 冲突 → **Clarify**。
+
+### 1.3 非目标（C 阶段）
+
+- 不实现 ReAct 多轮工具循环
+- 不替代 Campaign 14 节点编排引擎
+- 不做前端 Clarify 卡片 UI（仍 SSE 文本）
+- 不在 C 第一阶段改 Vercel 前端 classify
+
+---
+
+## 二、目标架构
+
+### 2.1 解析流水线（C 主路径）
+
+```mermaid
+flowchart TD
+  A[utterance + canvas_summary + history + checkpoint] --> B[LLM structured parse]
+  B --> C{JSON schema valid?}
+  C -->|否| D[clarify: parse failed]
+  C -->|是| E[planning_guard.validate]
+  E -->|conflict| F[clarify or override]
+  E -->|ok| G[validate_parse_result]
+  G -->|confidence < 0.70| H[clarify_atomic_intent]
+  G -->|ok| I[create / campaign intake]
+```
+
+### 2.2 与 B 的关系
+
+| 组件 | B 角色 | C 角色 |
+|------|--------|--------|
+| `planning_guard.py` | 决策者（cap confidence、campaign override） | **校验器**（否决 LLM 明显违规 parse） |
+| `rule_parse_atomic` | 主路径 fast path | **降级 fallback**（LLM 超时/失败） |
+| `atomic_parse_llm.py` | 低置信时才调用 | **默认首调** |
+| `classifyPromptMode` (TS) | 生产层 | **L3 路由层同步调用**（通过 runtime bridge） |
+
+### 2.3 四层意图模型（C 完整实现）
+
+```
+用户输入 + checkpoint + 画布摘要 + 近期 history
+        │
+        ▼
+┌───────────────────────────────────────────────────┐
+│ L0 Action    plan | write | generate | expand      │
+│              | regenerate | confirm | cancel       │
+└───────────────────────────────────────────────────┘
+        ▼
+┌───────────────────────────────────────────────────┐
+│ L1 Route     campaign | atomic_create |            │
+│              atomic_regenerate | single_node | chat│
+└───────────────────────────────────────────────────┘
+        ▼
+┌───────────────────────────────────────────────────┐
+│ L2 Structure single | multi                       │
+└───────────────────────────────────────────────────┘
+        ▼
+┌───────────────────────────────────────────────────┐
+│ L3 Modality  image | text | video | audio | prompt│
+│              + prompt_mode (optional)              │
+└───────────────────────────────────────────────────┘
+        ▼
+┌───────────────────────────────────────────────────┐
+│ L4 Extract   per-item title, prompt, pipeline      │
+└───────────────────────────────────────────────────┘
+```
+
+---
+
+## 三、LLM Parse JSON Schema
+
+### 3.1 顶层结构
+
+```typescript
+interface IntentParseResult {
+  action: 'plan' | 'write' | 'generate' | 'expand' | 'regenerate' | 'unknown'
+  scope: 'atomic' | 'campaign' | 'unknown'
+  route: 'campaign' | 'atomic_create' | 'atomic_regenerate' | 'single_node' | 'chat'
+  structure: 'single' | 'multi'
+  items: IntentParseItem[]
+  confidence: number          // 0.0–1.0
+  needs_clarify: boolean
+  clarify_question: string | null
+  reason: string              // 简短中文理由，便于日志
+}
+
+interface IntentParseItem {
+  target_type: 'image' | 'text' | 'video' | 'audio' | 'prompt'
+  title: string               // ≤24 字节点标题
+  prompt: string              // 生图/扩写/文案正文
+  confirm_gate?: boolean
+  prompt_mode?: string        // e.g. character_turnaround, commercial_storyboard
+  pipeline?: string           // e.g. turnaround_image
+  imageAspect?: string
+}
+```
+
+### 3.2 映射规则（LLM system prompt 硬约束）
+
+| action | scope | 典型 route | items |
+|--------|-------|------------|-------|
+| plan | campaign | campaign | [] 或 placeholder（由 Campaign 填充） |
+| plan | atomic | atomic_create | text（构图策划 Markdown） |
+| write | atomic | atomic_create | text |
+| expand | atomic | atomic_create | prompt + prompt_mode |
+| generate | atomic | atomic_create | image/text/video/audio |
+| generate | atomic | atomic_create | multi image items |
+| regenerate | — | atomic_regenerate | 沿用 checkpoint |
+| unknown | — | chat 或 clarify | needs_clarify=true |
+
+**硬约束（与 planning_guard 一致）**：
+- `action=plan` 且 utterance 含「详情页/主图+方案」→ **禁止** `target_type=image` 单 item 直出
+- `action=generate` 且含「生成一张/来一张」→ 允许 image，`confidence≥0.85`
+- video/audio → `confirm_gate=true`
+- multi items > 5 → `needs_clarify=true`，建议 campaign
+
+### 3.3 prompt_mode 与 packages/agent 对齐
+
+| prompt_mode | 触发 utterance 示例 | target_type |
+|-------------|-------------------|-------------|
+| `character_turnaround` | 三视图/模特定妆/turnaround | image + pipeline |
+| `commercial_storyboard` | 商业分镜/问界/AITO/15秒30秒 | prompt 或 text |
+| `storyboard` | 分镜提示词（非商业） | prompt |
+| `vision_text` | 视觉方案/构图策划 | text |
+| `generic` | 默认 | prompt |
+
+C 阶段在 runtime 增加 `resolve_prompt_mode(utterance) -> str | None`，与 TS `classifyPromptMode` **同规则**（可 codegen 或共享 yaml taxonomy）。
+
+---
+
+## 四、Rule Fast Path 收缩策略
+
+### 4.1 C 上线后保留 fast path 的条件（全部满足）
+
+1. `INTENT_LLM_PARSE=0`（flag 关闭，纯 B）或 LLM 超时 fallback
+2. LLM 失败降级：调用现有 `rule_parse_atomic`
+3. **可选**保留的「白名单 fast path」（eval 对照组 100% PASS）：
+   - 「生成一张*」「来一张*」+ image
+   - 「写*文案/脚本/广告词」+ text
+   - 「重新生成一张」+ checkpoint regenerate
+
+### 4.2 取消 fast path 的场景
+
+- 含 planning 动词
+- 含 ≥2 种模态关键词
+- 含 marketing + image 双命中
+- confidence 由 LLM 给出且 guard 无冲突 → **不再调用** `rule_parse_confidence`
+
+### 4.3 Feature Flag
+
+```python
+# app/config.py
+intent_llm_parse: bool = Field(default=False, alias="INTENT_LLM_PARSE")
+intent_llm_parse_shadow: bool = Field(default=False, alias="INTENT_LLM_PARSE_SHADOW")
+```
+
+| 模式 | 行为 |
+|------|------|
+| `0/0` | 纯 B |
+| `1/0` | LLM 主路径，规则 fallback |
+| `1/1` | Shadow：LLM 与 rule 并行，日志 diff，用户仍走 rule（灰度验证） |
+
+---
+
+## 五、Clarify 续聊（C 新增）
+
+### 5.1 场景
+
+B 阶段 clarify 后用户回复「1」「2」「3」或自然语言续答，C 需解析续路由。
+
+### 5.2 `classify_clarify_reply`
+
+```python
+def classify_clarify_reply(
+    original_utterance: str,
+    clarify_question: str,
+    user_reply: str,
+    *,
+    checkpoint: dict | None,
+) -> IntentParseResult | Literal["none"]:
+    ...
+```
+
+| 用户回复 | 映射 |
+|----------|------|
+| `1` / 「单张主图」 | action=generate, items=[{image}] |
+| `2` / 「完整方案」 | route=campaign |
+| `3` / 「文字策划」 | action=write, items=[{text, prompt_mode=vision_text}] |
+| 新 utterance | 重新 full parse |
+
+### 5.3 Graph 状态
+
+```python
+clarify_context: {
+  "original_utterance": str,
+  "clarify_question": str,
+  "clarify_kind": "planning_image_conflict" | "campaign_vs_atomic" | ...
+}
+```
+
+`atomic_parse` 节点检测 `phase=clarify` + 新 user message → 优先 `classify_clarify_reply`。
+
+---
+
+## 六、LLM 调用规格
+
+### 6.1 模型与参数
+
+| 参数 | 值 | 理由 |
+|------|-----|------|
+| model | 与现有 atomic parse 一致（如 gpt-4o-mini / deepseek） | 成本 |
+| temperature | 0.1 | 结构化输出稳定性 |
+| response_format | JSON object | schema 约束 |
+| timeout | 8s | 超时 fallback rule |
+| max_retries | 1 | 格式错误重试 |
+
+### 6.2 Context 注入
+
+```json
+{
+  "utterance": "...",
+  "canvas_summary": "画布 3 节点（image×2, text×1）；已有：主图、白底图",
+  "recent_dialogue": "用户:...→助手:...",
+  "checkpoint": { "atomic_node_id": "...", "target_type": "image" },
+  "focus_node_id": null
+}
+```
+
+### 6.3 Few-shot
+
+扩展 `skills/atomic-create/few-shots.yaml` → `parse_intent_structured` 段，≥15 对，覆盖：
+- planning → campaign
+- planning → text
+- generate → image
+- expand → prompt + prompt_mode
+- multi image
+- clarify 触发
+
+---
+
+## 七、Guardrail 层（B 遗产，C 必留）
+
+LLM parse 后 **必须**过：
+
+```python
+def validate_llm_parse(result: IntentParseResult, utterance: str) -> ParseOutcome:
+    # 1. planning_guard: action=generate 但 has_planning_image_conflict → clarify
+    # 2. schema: items 非空或 route=campaign
+    # 3. validate_parse_result: confidence threshold
+    # 4. cross-check: LLM route=campaign 但 orchestration=atomic → 以 LLM 为准并 log
+```
+
+**永不信任 LLM 单点**：guard 冲突 → clarify，不 silent override 为用户不可见行为。
+
+---
+
+## 八、评测（Eval）
+
+### 8.1 数据集扩展
+
+| 文件 | cases | 说明 |
+|------|-------|------|
+| `eval-planning-guard-set.yaml` | 25 | B 交付，C 回归 |
+| `eval-intent-llm-set.yaml` | **80+** | C 主集：口语/adversarial/多意图 |
+| `eval-intent-regression.yaml` | 持续追加 | 生产 badcase |
+
+### 8.2 Adversarial 类别（C 必测）
+
+- 子串陷阱：「重新生成一张」「确认出图」
+- 资产名无动词：「蓝牙耳机主图」
+- 多意图：「写文案并生成主图」
+- 口语：「整一个详情页的感觉」
+- 英文混排：「hero image + detail page layout」
+
+### 8.3 Shadow 模式指标
+
+- **Agreement rate**：LLM vs rule 一致率 ≥ 90% 方可切主路径
+- **Latency p95**：parse ≤ 3s（含 LLM）
+- **Clarify rate**：5–15%（过低=冒进，过高=体验差）
+
+### 8.4 启动 C 的前置条件（Gate）
+
+- [ ] B：`eval-planning-guard-set` 25/25 PASS
+- [ ] B：prod planning smoke 2 周无 FAIL
+- [ ] B：planning 误路由人工抽检 < 5%
+- [ ] C shadow：`eval-intent-llm-set` agreement ≥ 90%
+- [ ] C shadow：latency p95 ≤ 3s
+
+---
+
+## 九、文件改动清单（C）
+
+| 文件 | 改动 |
+|------|------|
+| `app/graph/intent_parse_schema.py` | **Create** — IntentParseResult TypedDict + validator |
+| `app/graph/intent_parse_llm.py` | **Create** — 主 LLM parse（或扩展现有 atomic_parse_llm） |
+| `app/graph/nodes/atomic_parse.py` | LLM-first 分支 + shadow + fallback |
+| `app/graph/clarify_reply.py` | **Create** — 1/2/3 续聊解析 |
+| `app/graph/planning_guard.py` | 增加 `validate_llm_parse()` |
+| `app/config.py` | INTENT_LLM_PARSE flags |
+| `packages/agent/src/prompt-modes/taxonomy.yaml` | **Create** — prompt_mode 与 route 共享词表 |
+| `skills/atomic-create/eval-intent-llm-set.yaml` | **Create** |
+| `tests/test_intent_llm_parse_eval.py` | **Create** |
+| `deploy/prod-atomic-intent-shadow-verify.py` | **Create** — shadow diff 报表 |
+
+---
+
+## 十、风险与缓解
+
+| 风险 | 缓解 |
+|------|------|
+| LLM 延迟增加 | fallback rule；cache 同 utterance（session 内） |
+| LLM 成本 | mini model；fast path 白名单保留 |
+| JSON 格式错误 | response_format + 1 retry + fallback |
+| LLM 幻觉 route | planning_guard + eval adversarial |
+| 回退困难 | feature flag 一键切 B |
+
+---
+
+## 十一、验收标准（C）
+
+1. `INTENT_LLM_PARSE=1` 时，「请你帮我设计一个蓝牙耳机主图，详情页的构图方案」→ campaign 或 clarify，**零** image 直出
+2. 「生成一张蓝牙耳机主图」→ atomic image，p95 延迟 ≤ B + 2s
+3. `eval-intent-llm-set` ≥ 95% PASS（80 cases）
+4. B eval sets **零回归**
+5. clarify 回复「2」→ campaign 链路可继续
+6. shadow 报告 agreement ≥ 90% 才允许默认开启 flag
+
+---
+
+## 十二、里程碑
+
+| 里程碑 | 内容 | 依赖 |
+|--------|------|------|
+| **C0** | Schema + LLM prompt + unit tests | B merged |
+| **C1** | Shadow mode + eval-intent-llm-set 80 cases | C0 |
+| **C2** | Guardrail validate + clarify 续聊 | C1 |
+| **C3** | prompt_mode L3 统一 | C1 |
+| **C4** | Flag 默认 ON + 收缩 fast path | C1–C3 PASS |
+| **C5** | prod shadow verify + 2 周观察 | C4 |

--- a/docs/superpowers/specs/2026-08-05-intent-planning-guard-design.md
+++ b/docs/superpowers/specs/2026-08-05-intent-planning-guard-design.md
@@ -1,0 +1,285 @@
+# Intent Understanding Evolution — 设计规格（B → C 路线图）
+
+> 状态：**Draft**（2026-08-05）  
+> 前置：[2026-08-04-atomic-intent-hybrid-design.md](./2026-08-04-atomic-intent-hybrid-design.md)、[2026-08-03-atomic-studio-intent-design.md](./2026-08-03-atomic-studio-intent-design.md)  
+> **Phase B 计划**：[2026-08-05-intent-planning-guard.md](../plans/2026-08-05-intent-planning-guard.md)  
+> **Phase C 规格**：[2026-08-05-intent-llm-structured-parse-design.md](./2026-08-05-intent-llm-structured-parse-design.md)  
+> **Phase C 计划**：[2026-08-05-intent-llm-structured-parse.md](../plans/2026-08-05-intent-llm-structured-parse.md)
+
+| 字段 | 值 |
+|------|-----|
+| 文档版本 | v1.1 |
+| 动机 | 「蓝牙耳机主图，详情页的构图方案」因「主图」子串误走 image 直出 |
+| 路线 | **先 B 再 C**：B = Planning Guard + Clarify + Eval；C = LLM 结构化意图理解 |
+
+---
+
+## 一、问题陈述
+
+### 1.1 根因
+
+| 现象 | 机制 |
+|------|------|
+| 「主图」触发 image | `IMAGE_KEYWORDS` + `parse_atomic_target_type` 默认 image |
+| Campaign 未生效 | `resolve_intake_route` 中 `atomic_create_intent` **优先于** `marketing_intent` |
+| 「构图方案」无规则 | 不在 `TEXT_DEFAULT_KEYWORDS` / `CAMPAIGN_COMPLEXITY_PHRASES` |
+| LLM 被 bypass | 「主图」∈ `_STRONG_SIGNAL_KEYWORDS` → `rule_parse_confidence=0.96` |
+
+### 1.2 核心矛盾
+
+系统将 **资产名词**（主图、Banner、详情页）等同于 **动作意图**（生成一张 / 设计方案 / 写策划）。
+
+### 1.3 非目标（Phase B）
+
+- 不在 B 阶段做全 LLM 路由（去掉 rule fast path）→ **见 Phase C spec**
+- 不新增前端 Clarify UI 组件（复用现有 `clarify_atomic_intent` SSE 文案）
+- 不改造 Campaign 14 节点拓扑逻辑
+
+---
+
+## 〇、四阶段改造总览（B → C）
+
+从「关键词路由」到「意图理解」分 **四层**，B/C 分工如下：
+
+| 层 | 名称 | Phase B | Phase C |
+|----|------|---------|---------|
+| **L0** | Action 理解 | 规则：`planning_guard.detect_action` | LLM 结构化 `action` 字段 |
+| **L1** | 路由 (flow_mode) | orchestration override + 现有 keyword intake | LLM `route` + planning_guard 兜底 |
+| **L2** | 结构 (single/multi) | 规则 multi parse + LLM 辅助 | LLM `structure` + `items[]` |
+| **L3** | 模态 (target_type) | keyword + planning cap | LLM `target_type` per item |
+| **L4** | 抽取 (title/prompt) | prefix strip + enrich | LLM per-item 抽取 |
+| **横切** | Clarify + Eval | ✅ 25 case gold set | 100+ case + 续聊解析 |
+
+```mermaid
+flowchart LR
+  subgraph B["Phase B（当前）"]
+    B1[关键词 + Planning Guard]
+    B2[Clarify 兜底]
+    B3[Eval 25 cases]
+  end
+  subgraph C["Phase C（后续）"]
+    C1[LLM Structured Parse]
+    C2[缩小 rule fast path]
+    C3[promptMode 与 L1 统一]
+  end
+  B --> C
+```
+
+**B 交付门槛 → 启动 C 的前置条件**（详见 C spec §8）：
+1. `eval-planning-guard-set` 25/25 PASS 且零回归
+2. prod planning smoke 稳定 2 周
+3. clarify 模板 A/B 可量化（误路由率 < 5%）
+
+---
+
+## 二、设计原则
+
+> **先识别 Action（plan / write / generate / expand），再识别 Modality（image / text / …）；资产名词不能单独决定路由。**
+
+### 2.1 三维意图模型（Planning Guard 扩展）
+
+在现有 L1–L4 模型上增加 **Action** 与 **Scope** 判定（规则 + LLM 共用词汇表）：
+
+| 维度 | 取值 | 说明 |
+|------|------|------|
+| **Action** | `plan` \| `write` \| `generate` \| `expand` \| `unknown` | 用户要做什么 |
+| **Scope** | `atomic` \| `campaign` \| `unknown` | 单点 vs 多节点链路 |
+| **Modality** | image / text / prompt / video / audio | 现有 `target_type` |
+
+### 2.2 动词词表
+
+**Planning 动词**（命中则禁止 image rule fast path）：
+
+```
+设计, 方案, 构图, 策划, 规划, 结构, 框架, 思路, 布局, 模块, 视觉方案, 视觉策划
+```
+
+**Generation 动词**（明确允许 image atomic 快路径）：
+
+```
+生成一张, 生成一个, 来一张, 做一张, 出图, 直接生成, 帮我生成一张, 帮我做一张
+```
+
+**Write 动词**（倾向 text）：
+
+```
+写, 撰写, 起草, 输出文案
+```
+
+> 注意：「帮我生成」单独出现仍为 vague → clarify（已有逻辑保留）。
+
+### 2.3 组合规则（Planning Guard）
+
+| 条件 | 路由 / 模态 | 置信度 |
+|------|-------------|--------|
+| Planning + `详情页` + (`构图`\|`方案`\|`结构`) | **campaign**（intake override） | orchestration=campaign |
+| Planning + `marketing_intent` + 无 Generation | **clarify** 或 campaign | confidence ≤ 0.65 |
+| Planning + 仅「构图方案/视觉方案」无出图动词 | **text** 或 clarify | target=text 或 clarify |
+| Generation + `主图` | **image** atomic | 保持 0.96 fast path |
+| `主图` + `详情页` + 无 Generation | **campaign** 或 clarify | 禁止 image fast path |
+
+### 2.4 示例 utterance 期望
+
+| Utterance | 期望 route | 期望 outcome |
+|-----------|------------|--------------|
+| 请你帮我设计一个蓝牙耳机主图，详情页的构图方案 | campaign 或 clarify | **非** image 直出 |
+| 生成一张蓝牙耳机主图 | atomic_create | image |
+| 帮我做一套天猫蓝牙耳机详情页营销方案 | campaign | plan gate |
+| 写一份详情页主图与模块的构图策划（文字版） | atomic_create | text |
+| 用提示词模式扩写：赛博朋克耳机主图 | atomic_create | prompt |
+
+---
+
+## 三、架构与 Hook 点
+
+```mermaid
+flowchart TD
+  A[utterance] --> B[intake: resolve_intake_route]
+  B --> C{orchestration_complexity}
+  C -->|campaign| D[campaign flow]
+  C -->|atomic| E[atomic_parse]
+  E --> F{planning_guard}
+  F -->|conflict| G[clarify / lower confidence]
+  F -->|clear generate| H[rule fast path OK]
+  G --> I[LLM parse or clarify node]
+  H --> J[create node]
+```
+
+### 3.1 新增模块
+
+**`services/agent-runtime/app/graph/planning_guard.py`**
+
+| 函数 | 职责 |
+|------|------|
+| `detect_action(text) -> Literal[plan, write, generate, expand, unknown]` | 动词分类 |
+| `is_planning_intent(text) -> bool` | Planning 动词或组合 pattern |
+| `is_explicit_generation_intent(text) -> bool` | 明确出图/生成 |
+| `has_planning_image_conflict(text) -> bool` | 主图/详情页 + planning 无 generation |
+| `planning_guard_confidence_cap(text, base_conf) -> float` | 冲突时 cap ≤ 0.65 |
+| `planning_clarify_question(text) -> str` | 专用追问文案 |
+
+### 3.2 修改现有文件
+
+| 文件 | 改动 |
+|------|------|
+| `atomic_intent.py` | 扩展 `CAMPAIGN_COMPLEXITY_PHRASES`；`orchestration_complexity_intent` 识别 planning 组合 |
+| `atomic_parse_util.py` | `rule_parse_confidence` 调用 planning_guard cap |
+| `atomic_parse_schema.py` | `validate_parse_result` 新增 planning conflict → clarify |
+| `atomic_parse_llm.py` | system prompt 增加 Action/Scope 说明 |
+| `clarify_atomic_intent.py` | 透传 `clarify_question`（已有，仅确保 planning 文案） |
+| `intent-taxonomy.yaml` | 同步 planning/generation 词表（可选，便于运营调整） |
+
+### 3.3 intake 行为（不变优先级文档，增强 orchestration）
+
+`intake.py` 已有逻辑：
+
+```python
+if orch == "campaign" and (is_atomic or is_variant_create):
+    is_atomic = False
+    route = "campaign"
+```
+
+**扩展 `orchestration_complexity_intent`** 使 planning 组合返回 `campaign`，即可在不改 `resolve_intake_route` 优先级的前提下，把「详情页构图方案」从 atomic 拉回 Campaign。
+
+对 **atomic-only planning**（无 marketing 词、只要文字策划）走 parse 层 clarify 或 text。
+
+---
+
+## 四、Clarify 文案模板
+
+### 4.1 Planning + 电商资产冲突（默认）
+
+```
+您提到「主图」和「详情页构图方案」。请确认：
+1）单张主图直接出图；
+2）完整详情页 Campaign 方案（多节点：主图/白底/场景等）；
+3）只要文字版构图策划（不出图）。
+回复 1 / 2 / 3，或补充具体需求。
+```
+
+### 4.2 Campaign vs atomic（已有，扩展触发）
+
+当 `详情页` + `方案|构图|设计` 且非明确「生成一张」时，优先走 campaign；若仍进 parse 则 clarify。
+
+---
+
+## 五、评测（Eval）
+
+### 5.1 新增 gold set
+
+**`eval-planning-guard-set.yaml`**（25 cases，独立文件便于回归）
+
+分类：
+- `plan-campaign`（10）：详情页/营销/构图方案 → campaign
+- `plan-clarify`（5）：主图+详情页双命中 → clarify
+- `plan-text`（5）：文字版构图策划 → text
+- `control-generate`（5）：明确生成一张主图 → image atomic（不得回归）
+
+### 5.2 扩展现有 set
+
+- `eval-orchestration-set.yaml`：+5 planning cases
+- `eval-intent-set.yaml`：+3（含用户原始 case）
+
+### 5.3 测试入口
+
+```bash
+pytest services/agent-runtime/tests/test_planning_guard.py
+pytest services/agent-runtime/tests/test_atomic_create_intent_eval.py
+pytest services/agent-runtime/tests/test_orchestration_intent_eval.py
+```
+
+### 5.4 生产 smoke（可选 P1）
+
+`deploy/prod-atomic-studio-verify.py` 增加 1 条 planning utterance，断言 **非** image 直出或 SSE 含 clarify/Campaign。
+
+---
+
+## 六、Global Constraints
+
+- `CLARIFY_THRESHOLD = 0.70`（不变）
+- `RULE_FAST_PATH_THRESHOLD = 0.95`（不变；planning conflict 须 cap 至 < 0.70）
+- 不降低明确「生成一张主图」类 case 的 fast path 性能
+- 中文 clarify 文案，与现有 SSE 风格一致
+- Python 与 TS promptMode **本阶段不解耦**（planning 走 text/campaign，不新增 promptMode）
+
+---
+
+## 七、验收标准
+
+1. 「请你帮我设计一个蓝牙耳机主图，详情页的构图方案」→ **route=campaign** 或 **phase=clarify**，**禁止** `target_type=image` 且 confidence≥0.95
+2. 「生成一张蓝牙耳机主图」→ 仍为 atomic image，confidence≥0.95
+3. eval-planning-guard-set 25/25 PASS
+4. 现有 eval-intent-set + eval-orchestration-set **零回归**
+5. prod smoke planning case PASS（若纳入 P1）
+
+---
+
+## 八、风险与缓解
+
+| 风险 | 缓解 |
+|------|------|
+| 「设计一张海报」被误判 planning | Generation 子串「一张」+ 设计 → 仍视为 generate（规则：`设计`+量词+资产 → generate） |
+| Campaign 过重 | clarify 提供「文字版策划」选项 |
+| 词表维护成本 | `planning_guard.py` + yaml 词表；eval 驱动迭代 |
+
+---
+
+## 九、Phase C 概要（完整规格见独立文档）
+
+> **完整设计**：[2026-08-05-intent-llm-structured-parse-design.md](./2026-08-05-intent-llm-structured-parse-design.md)  
+> **实施计划**：[2026-08-05-intent-llm-structured-parse.md](../plans/2026-08-05-intent-llm-structured-parse.md)
+
+Phase C 目标：将 L0–L4 **主路径**从规则 keyword 切换为 **LLM 结构化 parse**，B 的 `planning_guard` + Clarify **保留为 guardrail**（永不删除）。
+
+| 能力 | C 阶段交付 |
+|------|-----------|
+| 统一 parse schema | `{ action, scope, route, structure, items[], confidence, needs_clarify }` |
+| 取消 blanket rule fast path | 仅「高置信 + 无 planning 冲突 + eval 对照组」保留 fast path |
+| promptMode 前置 | L3 路由层感知 `commercial_storyboard` / `character_turnaround` 等 |
+| Clarify 续聊 | 用户回复「1/2/3」→ `classify_clarify_reply` 解析续路由 |
+| Eval 扩展 | 100+ utterances，含 adversarial 子串陷阱 |
+| Feature flag | `INTENT_LLM_PARSE=1` 灰度，可回退 B |
+
+**B 与 C 共存策略**：C 上线后 parse 流程为 `LLM parse → planning_guard validate → validate_parse_result → clarify|create`；规则层从「决策者」降为「校验器」。
+
+---

--- a/services/agent-runtime/app/graph/atomic_intent.py
+++ b/services/agent-runtime/app/graph/atomic_intent.py
@@ -105,6 +105,10 @@ CAMPAIGN_OVERRIDE_PHRASES = (
 CAMPAIGN_COMPLEXITY_PHRASES = (
     "详情页方案",
     "详情页营销",
+    "详情页构图",
+    "详情页的构图",
+    "构图方案",
+    "视觉方案",
     "14节点",
     "14个节点",
     "整套分镜",
@@ -324,9 +328,16 @@ def atomic_regenerate_intent(text: str) -> bool:
 
 def orchestration_complexity_intent(text: str) -> OrchestrationComplexity:
     """Phase 4: route high-complexity requests toward Campaign vs atomic."""
+    from app.graph.planning_guard import detect_action, has_planning_image_conflict, is_planning_intent
+
     t = (text or "").strip()
     if not t:
         return "clarify"
+    if has_planning_image_conflict(t):
+        return "campaign"
+    if "详情页" in t and is_planning_intent(t):
+        if detect_action(t) != "write":
+            return "campaign"
     if any(p in t for p in CAMPAIGN_COMPLEXITY_PHRASES) or _is_campaign_override(t):
         return "campaign"
     shots = _storyboard_shot_count(t)
@@ -339,6 +350,8 @@ def orchestration_complexity_intent(text: str) -> OrchestrationComplexity:
     from app.graph.atomic_parse_util import parse_atomic_multi_items
 
     if parse_atomic_multi_items(t):
+        return "atomic"
+    if detect_action(t) == "write":
         return "atomic"
     if atomic_create_intent(t):
         return "atomic"
@@ -359,6 +372,14 @@ def resolve_intake_route(
         and not modify_intent(text)
     ):
         return "single_node"
+    from app.graph.planning_guard import detect_action, has_planning_image_conflict, is_planning_intent
+
+    if has_planning_image_conflict(text):
+        return "campaign"
+    if "详情页" in text and is_planning_intent(text) and detect_action(text) != "write":
+        return "campaign"
+    if detect_action(text) == "write":
+        return "atomic_create"
     if atomic_create_intent(text):
         return "atomic_create"
     if marketing_intent(text):
@@ -368,6 +389,8 @@ def resolve_intake_route(
 
 def parse_atomic_target_type(text: str) -> AtomicTargetType:
     """Classify modality from user utterance."""
+    from app.graph.planning_guard import is_explicit_generation_intent, is_planning_intent
+
     t = (text or "").strip()
     lowered = t.lower()
     if _has_prompt_explicit(t):
@@ -378,6 +401,8 @@ def parse_atomic_target_type(text: str) -> AtomicTargetType:
         return "text"
     if any(k in lowered for k in VIDEO_KEYWORDS):
         return "video"
+    if is_planning_intent(t) and not is_explicit_generation_intent(t):
+        return "text"
     if any(k in lowered for k in IMAGE_KEYWORDS):
         return "image"
     return "image"

--- a/services/agent-runtime/app/graph/atomic_parse_llm.py
+++ b/services/agent-runtime/app/graph/atomic_parse_llm.py
@@ -37,6 +37,8 @@ _PARSE_SYSTEM = """你是 Atomic Studio 意图解析器。根据用户一句话�
 - 「生成一张三视图/三视图各来一张」且无「提示词」→ target_type=image，pipeline=turnaround_image（内部扩写后出图，非原句直出）
 - multi：用户要多张/多项时 structure=multi，items 逐条拆分 prompt/title
 - 营销方案/14节点/全链路 → confidence<0.7，clarify_question 建议走 Campaign
+- 「设计/构图方案/详情页策划/视觉方案」且无「生成一张/来一张」→ needs_clarify 或 target_type=text，confidence<0.7；「主图+详情页+方案」勿直接 image，建议 Campaign
+- 明确「生成一张主图/来一张白底图」→ target_type=image，confidence≥0.9
 - 意图不清（如仅「帮我生成」）→ confidence<0.7 并给出 clarify_question
 - 「再生成一张/按刚才风格/重新生成」→ 非首轮 create parse；confidence<0.5，clarify 引导同会话 regenerate/变体（勿判 Campaign）
 """

--- a/services/agent-runtime/app/graph/atomic_parse_schema.py
+++ b/services/agent-runtime/app/graph/atomic_parse_schema.py
@@ -8,6 +8,7 @@ from langchain_core.messages import AIMessage
 
 from app.graph.atomic_intent import confirm_gate_for_type, _is_campaign_override, turnaround_pipeline_user_note
 from app.graph.intent import marketing_intent
+from app.graph.planning_guard import has_planning_image_conflict, planning_clarify_question
 
 CLARIFY_THRESHOLD = 0.70
 RULE_FAST_PATH_THRESHOLD = 0.95
@@ -89,6 +90,14 @@ def validate_parse_result(
             "confidence": 0.0,
             "reason": "invalid_payload",
             "clarify_question": _default_clarify_question(utterance),
+        }
+
+    if has_planning_image_conflict(utterance):
+        return {
+            "kind": "clarify",
+            "confidence": 0.0,
+            "reason": "planning_image_conflict",
+            "clarify_question": planning_clarify_question(utterance),
         }
 
     if _is_campaign_override(utterance) or (

--- a/services/agent-runtime/app/graph/atomic_parse_util.py
+++ b/services/agent-runtime/app/graph/atomic_parse_util.py
@@ -351,23 +351,24 @@ def rule_parse_confidence(
     multi_items: list[dict[str, Any]] | None,
 ) -> float:
     """Heuristic confidence for rule-only parse (Phase 2 fast path)."""
-    if multi_items and len(multi_items) >= 2:
-        return 0.98
-    t = (utterance or "").strip()
-    if not t or t in _VAGUE_UTTERANCES:
-        return 0.40
-    prompt = str(spec.get("prompt") or "").strip()
-    if len(prompt) < 4:
-        return 0.50
-    if any(k in t for k in _STRONG_SIGNAL_KEYWORDS):
-        return 0.96
-    if spec.get("target_type") in ("video", "audio"):
-        return 0.95
-    from app.graph.atomic_intent import atomic_create_intent
+    from app.graph.planning_guard import planning_guard_confidence_cap
 
-    if atomic_create_intent(t):
-        return 0.88
-    return 0.55
+    t = (utterance or "").strip()
+    if multi_items and len(multi_items) >= 2:
+        conf = 0.98
+    elif not t or t in _VAGUE_UTTERANCES:
+        conf = 0.40
+    elif len(str(spec.get("prompt") or "").strip()) < 4:
+        conf = 0.50
+    elif any(k in t for k in _STRONG_SIGNAL_KEYWORDS):
+        conf = 0.96
+    elif spec.get("target_type") in ("video", "audio"):
+        conf = 0.95
+    else:
+        from app.graph.atomic_intent import atomic_create_intent
+
+        conf = 0.88 if atomic_create_intent(t) else 0.55
+    return planning_guard_confidence_cap(t, conf)
 
 
 def rule_parse_atomic(

--- a/services/agent-runtime/app/graph/planning_guard.py
+++ b/services/agent-runtime/app/graph/planning_guard.py
@@ -1,0 +1,118 @@
+"""Planning Guard — distinguish plan/design vs generate/create utterances."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+ActionKind = Literal["plan", "write", "generate", "expand", "unknown"]
+
+PLANNING_VERBS = (
+    "视觉方案",
+    "视觉策划",
+    "构图方案",
+    "构图",
+    "策划",
+    "规划",
+    "结构",
+    "框架",
+    "思路",
+    "布局",
+    "模块",
+    "方案",
+    "设计",
+)
+
+GENERATION_PATTERNS = (
+    r"生成一张",
+    r"生成一个",
+    r"来一张",
+    r"做一张",
+    r"出一张",
+    r"直接生成",
+    r"帮我生成一张",
+    r"帮我做一张",
+    r"帮我生成一个",
+)
+
+WRITE_VERBS = ("写", "撰写", "起草", "输出文案", "输出")
+
+EXPAND_MARKERS = ("提示词", "prompt", "扩写")
+
+PLANNING_CONFIDENCE_CAP = 0.65
+
+
+def detect_action(text: str) -> ActionKind:
+    t = (text or "").strip()
+    if not t:
+        return "unknown"
+    if any(m in t for m in EXPAND_MARKERS):
+        return "expand"
+    if is_explicit_generation_intent(t):
+        return "generate"
+    if any(v in t for v in WRITE_VERBS):
+        return "write"
+    if is_planning_intent(t):
+        return "plan"
+    return "unknown"
+
+
+def is_planning_intent(text: str) -> bool:
+    t = (text or "").strip()
+    if not t:
+        return False
+    if any(v in t for v in PLANNING_VERBS):
+        return True
+    if "详情页" in t and any(x in t for x in ("构图", "方案", "结构", "布局", "模块")):
+        return True
+    return False
+
+
+def is_explicit_generation_intent(text: str) -> bool:
+    t = (text or "").strip()
+    if not t:
+        return False
+    for pat in GENERATION_PATTERNS:
+        if re.search(pat, t):
+            return True
+    # 「设计一张海报」→ generate；「设计一个…方案」留给 planning
+    if re.search(r"设计一张", t):
+        return True
+    return False
+
+
+def has_planning_image_conflict(text: str) -> bool:
+    """True when planning + ecommerce hero/detail assets without explicit generation."""
+    t = (text or "").strip()
+    if not t or is_explicit_generation_intent(t):
+        return False
+    if detect_action(t) == "write":
+        return False
+    if not is_planning_intent(t):
+        return False
+    has_hero = "主图" in t
+    has_detail = "详情页" in t
+    if has_hero and has_detail:
+        return True
+    if has_hero and any(x in t for x in ("方案", "构图", "布局", "结构")):
+        return True
+    return False
+
+
+def planning_guard_confidence_cap(text: str, base_conf: float) -> float:
+    if has_planning_image_conflict(text):
+        return min(base_conf, PLANNING_CONFIDENCE_CAP)
+    if is_planning_intent(text) and not is_explicit_generation_intent(text):
+        return min(base_conf, PLANNING_CONFIDENCE_CAP)
+    return base_conf
+
+
+def planning_clarify_question(utterance: str) -> str:
+    snippet = (utterance or "").strip()[:32]
+    return (
+        f"您提到「{snippet}…」涉及主图/详情页与构图方案。请确认：\n"
+        "1）单张主图直接出图；\n"
+        "2）完整详情页 Campaign 方案（多节点：主图/白底/场景等）；\n"
+        "3）只要文字版构图策划（不出图）。\n"
+        "回复 1 / 2 / 3，或补充具体需求。"
+    )

--- a/services/agent-runtime/skills/atomic-create/eval-intent-set.yaml
+++ b/services/agent-runtime/skills/atomic-create/eval-intent-set.yaml
@@ -506,3 +506,9 @@ cases:
     utterance: 帮我做一张该产品的三视图
     focus_node_id: prod-001
     gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  - id: plan-01
+    utterance: 请你帮我设计一个蓝牙耳机主图，详情页的构图方案
+    focus_node_id: null
+    gold: { route: campaign, target_type: image, confirm_gate: false }
+    notes: planning guard — intake routes campaign; target_type ignored when not atomic_create

--- a/services/agent-runtime/skills/atomic-create/eval-orchestration-set.yaml
+++ b/services/agent-runtime/skills/atomic-create/eval-orchestration-set.yaml
@@ -81,6 +81,10 @@ cases:
     utterance: 生成十个镜头分镜
     gold: { complexity: campaign, route: campaign }
 
+  - id: orch-21
+    utterance: 请你帮我设计一个蓝牙耳机主图，详情页的构图方案
+    gold: { complexity: campaign, route: campaign }
+
   - id: orch-20
     utterance: 做一个Banner图
     gold: { complexity: atomic, route: atomic_create }

--- a/services/agent-runtime/skills/atomic-create/eval-planning-guard-set.yaml
+++ b/services/agent-runtime/skills/atomic-create/eval-planning-guard-set.yaml
@@ -1,0 +1,110 @@
+# Phase B: Planning Guard eval gold set (25 cases)
+# Run: pytest tests/test_planning_guard_eval.py
+version: 1
+meta:
+  spec: docs/superpowers/specs/2026-08-05-intent-planning-guard-design.md
+
+cases:
+  # --- plan-campaign (10) ---
+  - id: pg-01
+    utterance: 请你帮我设计一个蓝牙耳机主图，详情页的构图方案
+    gold: { route: campaign, complexity: campaign, forbid_target: image, allow_clarify: true }
+
+  - id: pg-02
+    utterance: 帮我规划天猫蓝牙耳机详情页的视觉结构和模块顺序
+    gold: { route: campaign, complexity: campaign, forbid_target: image }
+
+  - id: pg-03
+    utterance: 蓝牙耳机详情页构图方案
+    gold: { route: campaign, complexity: campaign, forbid_target: image }
+
+  - id: pg-04
+    utterance: 设计一套详情页视觉方案，含主图和白底
+    gold: { route: campaign, complexity: campaign, forbid_target: image }
+
+  - id: pg-05
+    utterance: 详情页营销视觉策划，运动耳机
+    gold: { route: campaign, complexity: campaign, forbid_target: image }
+
+  - id: pg-06
+    utterance: 帮我做详情页方案，主图场景图布局
+    gold: { route: campaign, complexity: campaign, forbid_target: image }
+
+  - id: pg-07
+    utterance: 电商详情页整体框架设计，蓝牙耳机
+    gold: { route: campaign, complexity: campaign, forbid_target: image }
+
+  - id: pg-08
+    utterance: 主图加详情页模块的完整视觉方案
+    gold: { route: campaign, complexity: campaign, forbid_target: image }
+
+  - id: pg-09
+    utterance: 详情页结构布局方案，3C数码耳机
+    gold: { route: campaign, complexity: campaign, forbid_target: image }
+
+  - id: pg-10
+    utterance: 帮我设计详情页Banner和主图的整体思路
+    gold: { route: campaign, complexity: campaign, forbid_target: image }
+
+  # --- plan-clarify via validate (5) ---
+  - id: pg-cl-01
+    utterance: 请你帮我设计一个蓝牙耳机主图，详情页的构图方案
+    gold: { validate_clarify: true, reason: planning_image_conflict }
+
+  - id: pg-cl-02
+    utterance: 主图和详情页构图方案一起给我
+    gold: { validate_clarify: true, reason: planning_image_conflict }
+
+  - id: pg-cl-03
+    utterance: 设计白底主图和详情页视觉方案
+    gold: { validate_clarify: true, reason: planning_image_conflict }
+
+  - id: pg-cl-04
+    utterance: 蓝牙耳机详情页主图构图策划
+    gold: { validate_clarify: true, reason: planning_image_conflict }
+
+  - id: pg-cl-05
+    utterance: 详情页主图布局方案，要专业
+    gold: { validate_clarify: true, reason: planning_image_conflict }
+
+  # --- plan-text (atomic planning copy, 5) ---
+  - id: pg-txt-01
+    utterance: 写一份详情页模块构图策划文档，不出图
+    gold: { route: atomic_create, target_type: text, complexity: atomic }
+
+  - id: pg-txt-02
+    utterance: 撰写电商详情页视觉思路说明
+    gold: { route: atomic_create, target_type: text, complexity: atomic }
+
+  - id: pg-txt-03
+    utterance: 起草主图拍摄构图的文字策划
+    gold: { route: atomic_create, target_type: text, complexity: atomic }
+
+  - id: pg-txt-04
+    utterance: 输出详情页结构规划文案
+    gold: { route: atomic_create, target_type: text, complexity: atomic }
+
+  - id: pg-txt-05
+    utterance: 写一段详情页视觉布局思路
+    gold: { route: atomic_create, target_type: text, complexity: atomic }
+
+  # --- control-generate (5) ---
+  - id: pg-ctrl-01
+    utterance: 生成一张蓝牙耳机主图
+    gold: { route: atomic_create, target_type: image, complexity: atomic, min_confidence: 0.90 }
+
+  - id: pg-ctrl-02
+    utterance: 来一张白底产品图，耳机
+    gold: { route: atomic_create, target_type: image, complexity: atomic, min_confidence: 0.90 }
+
+  - id: pg-ctrl-03
+    utterance: 帮我做一张场景图，客厅摆耳机
+    gold: { route: atomic_create, target_type: image, complexity: atomic, min_confidence: 0.88 }
+
+  - id: pg-ctrl-04
+    utterance: 设计一张赛博朋克海报
+    gold: { route: atomic_create, target_type: image, complexity: atomic, min_confidence: 0.90 }
+
+  - id: pg-ctrl-05
+    utterance: 生成一个模特人物图
+    gold: { route: atomic_create, target_type: image, complexity: atomic, min_confidence: 0.88 }

--- a/services/agent-runtime/tests/test_atomic_create_intent.py
+++ b/services/agent-runtime/tests/test_atomic_create_intent.py
@@ -71,6 +71,16 @@ def test_turnaround_image_without_prompt_word_stays_image():
     assert parse_atomic_target_type("生成一张三视图，蓝牙耳机") == "image"
 
 
+def test_parse_atomic_target_type_planning_detail_page_is_text():
+    u = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    assert parse_atomic_target_type(u) == "text"
+
+
+def test_resolve_intake_route_planning_goes_campaign():
+    u = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    assert resolve_intake_route(u, focus_node_id=None) == "campaign"
+
+
 def test_turnaround_pipeline_spec_for_direct_image_request():
     utterance = "山海经吞金兽的三视图，CG风格"
     assert is_turnaround_image_intent(utterance)

--- a/services/agent-runtime/tests/test_atomic_orchestration.py
+++ b/services/agent-runtime/tests/test_atomic_orchestration.py
@@ -30,6 +30,11 @@ def orch_cases() -> list[dict]:
     return doc["cases"]
 
 
+def test_orchestration_design_detail_page_is_campaign():
+    u = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    assert orchestration_complexity_intent(u) == "campaign"
+
+
 def test_eval_orchestration_complexity(orch_cases: list[dict]):
     mismatches: list[str] = []
     for case in orch_cases:
@@ -68,6 +73,16 @@ def test_mixed_modal_routes_to_confirm():
         )
         == "await_atomic_confirm"
     )
+
+
+@pytest.mark.asyncio
+async def test_intake_planning_detail_page_redirects_to_campaign(tmp_path: Path):
+    skills = Path(__file__).resolve().parents[1] / "skills"
+    intake = make_intake_node(skills)
+    u = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    out = await intake({"messages": [HumanMessage(content=u)]})
+    assert out["flow_mode"] == "campaign"
+    assert out.get("skill_id") is not None
 
 
 @pytest.mark.asyncio

--- a/services/agent-runtime/tests/test_atomic_parse_schema.py
+++ b/services/agent-runtime/tests/test_atomic_parse_schema.py
@@ -95,3 +95,17 @@ def test_validate_campaign_override_clarify():
     )
     assert out["kind"] == "clarify"
     assert "Campaign" in out["clarify_question"] or "营销" in out["clarify_question"]
+
+
+def test_validate_parse_planning_conflict_clarifies():
+    u = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    out = validate_parse_result(
+        {
+            "items": [{"target_type": "image", "prompt": u, "title": "x"}],
+            "confidence": 0.96,
+        },
+        utterance=u,
+    )
+    assert out["kind"] == "clarify"
+    assert out["reason"] == "planning_image_conflict"
+    assert "1" in out["clarify_question"]

--- a/services/agent-runtime/tests/test_atomic_parse_util.py
+++ b/services/agent-runtime/tests/test_atomic_parse_util.py
@@ -147,3 +147,19 @@ def test_load_atomic_parse_few_shots():
         assert user.strip()
         # Phase 2 few-shots use full structured JSON; legacy single-spec still valid
         assert assistant.strip().startswith("{")
+
+
+def test_rule_confidence_capped_for_planning_conflict():
+    from app.graph.atomic_parse_util import rule_parse_confidence
+
+    u = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    spec = {"target_type": "image", "prompt": u}
+    assert rule_parse_confidence(u, spec, None) <= 0.65
+
+
+def test_rule_confidence_unchanged_for_explicit_generate():
+    from app.graph.atomic_parse_util import rule_parse_confidence
+
+    u = "生成一张蓝牙耳机主图"
+    spec = {"target_type": "image", "prompt": u}
+    assert rule_parse_confidence(u, spec, None) == 0.96

--- a/services/agent-runtime/tests/test_planning_guard.py
+++ b/services/agent-runtime/tests/test_planning_guard.py
@@ -1,0 +1,51 @@
+from app.graph.planning_guard import (
+    detect_action,
+    has_planning_image_conflict,
+    is_explicit_generation_intent,
+    is_planning_intent,
+    planning_clarify_question,
+    planning_guard_confidence_cap,
+)
+
+
+def test_design_detail_page_planning_conflict():
+    u = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    assert is_planning_intent(u)
+    assert has_planning_image_conflict(u)
+    assert not is_explicit_generation_intent(u)
+    assert detect_action(u) == "plan"
+
+
+def test_generate_single_hero_not_planning_conflict():
+    u = "生成一张蓝牙耳机主图"
+    assert is_explicit_generation_intent(u)
+    assert not has_planning_image_conflict(u)
+    assert detect_action(u) == "generate"
+
+
+def test_design_one_poster_is_generation_not_planning():
+    u = "设计一张赛博朋克海报"
+    assert is_explicit_generation_intent(u)
+    assert detect_action(u) == "generate"
+
+
+def test_confidence_cap_on_conflict():
+    u = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    assert planning_guard_confidence_cap(u, 0.96) <= 0.65
+
+
+def test_confidence_unchanged_for_explicit_generate():
+    u = "生成一张蓝牙耳机主图"
+    assert planning_guard_confidence_cap(u, 0.96) == 0.96
+
+
+def test_clarify_question_nonempty():
+    q = planning_clarify_question("主图详情页构图方案")
+    assert "1" in q and "2" in q
+    assert "Campaign" in q or "方案" in q
+
+
+def test_detail_page_write_only_not_conflict():
+    u = "写一份详情页模块构图策划文档，不出图"
+    assert is_planning_intent(u)
+    assert not has_planning_image_conflict(u)

--- a/services/agent-runtime/tests/test_planning_guard_eval.py
+++ b/services/agent-runtime/tests/test_planning_guard_eval.py
@@ -1,0 +1,85 @@
+"""Planning Guard eval gold set."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from app.graph.atomic_intent import (
+    build_atomic_spec,
+    orchestration_complexity_intent,
+    parse_atomic_target_type,
+    resolve_intake_route,
+)
+from app.graph.atomic_parse_schema import validate_parse_result
+from app.graph.atomic_parse_util import rule_parse_confidence
+
+EVAL_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "atomic-create"
+    / "eval-planning-guard-set.yaml"
+)
+
+
+@pytest.fixture(scope="module")
+def planning_cases() -> list[dict]:
+    doc = yaml.safe_load(EVAL_PATH.read_text(encoding="utf-8"))
+    return doc["cases"]
+
+
+def test_eval_planning_guard_gold(planning_cases: list[dict]):
+    mismatches: list[str] = []
+    for case in planning_cases:
+        utterance = case["utterance"]
+        gold = case["gold"]
+        case_id = case["id"]
+
+        if "route" in gold:
+            route = resolve_intake_route(utterance, focus_node_id=None)
+            if route != gold["route"]:
+                mismatches.append(f"{case_id}: route {route} != {gold['route']}")
+
+        if "complexity" in gold:
+            orch = orchestration_complexity_intent(utterance)
+            if orch != gold["complexity"]:
+                mismatches.append(f"{case_id}: complexity {orch} != {gold['complexity']}")
+
+        if gold.get("target_type"):
+            pred = parse_atomic_target_type(utterance)
+            if pred != gold["target_type"]:
+                mismatches.append(f"{case_id}: target_type {pred} != {gold['target_type']}")
+
+        if gold.get("forbid_target") == "image":
+            pred = parse_atomic_target_type(utterance)
+            if pred == "image":
+                mismatches.append(f"{case_id}: forbidden target_type image")
+
+        if gold.get("min_confidence"):
+            spec = build_atomic_spec(utterance)
+            conf = rule_parse_confidence(utterance, spec, None)
+            if conf < gold["min_confidence"]:
+                mismatches.append(f"{case_id}: confidence {conf} < {gold['min_confidence']}")
+
+        if gold.get("validate_clarify"):
+            out = validate_parse_result(
+                {
+                    "items": [
+                        {
+                            "target_type": "image",
+                            "prompt": utterance,
+                            "title": "x",
+                        }
+                    ],
+                    "confidence": 0.96,
+                },
+                utterance=utterance,
+            )
+            if out["kind"] != "clarify":
+                mismatches.append(f"{case_id}: expected clarify, got {out['kind']}")
+            elif gold.get("reason") and out.get("reason") != gold["reason"]:
+                mismatches.append(f"{case_id}: reason {out.get('reason')} != {gold['reason']}")
+
+    assert not mismatches, "\n".join(mismatches)


### PR DESCRIPTION
## Summary
- 新增 `planning_guard` 模块：先识别 Action（plan / write / generate），再决定路由与 modality
- 修复「设计蓝牙耳机主图+详情页构图方案」等 planning 意图误走 image 直出的问题
- 接入 orchestration complexity、rule parse confidence cap、clarify 冲突检测
- LLM parse system prompt 补充 planning 规则；`resolve_intake_route` 对 write 动作优先 atomic_create
- 新增 25 case eval set + prod `verify_planning_guard` smoke
- 附带 Phase C（LLM 结构化 parse）完整 spec/plan 文档，B 完成后可接续

## Test plan
- [x] `pnpm build`
- [x] `pytest tests/test_planning_guard*.py tests/test_atomic_create_intent.py tests/test_atomic_orchestration.py tests/test_atomic_parse_schema.py tests/test_atomic_parse_util.py` — 51 passed
- [ ] CI green
- [ ] 部署后 `verify_planning_guard` prod smoke（可选）


Made with [Cursor](https://cursor.com)