### PR TITLE
feat: Phase C — LLM structured intent parse (C0–C5)

### DIFF
--- a/deploy/prod-atomic-intent-shadow-verify.py
+++ b/deploy/prod-atomic-intent-shadow-verify.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Production shadow verify — planning guard + fixture agreement (Phase C).
+
+Usage:
+  python3 deploy/prod-atomic-intent-shadow-verify.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent
+RUNTIME = ROOT.parent / "services" / "agent-runtime"
+sys.path.insert(0, str(RUNTIME))
+
+spec = importlib.util.spec_from_file_location("studio_verify", ROOT / "prod-atomic-studio-verify.py")
+studio = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(studio)
+
+from app.graph.intent_parse_schema import intent_result_to_parse_outcome  # noqa: E402
+from app.graph.planning_guard import validate_llm_parse  # noqa: E402
+
+PLANNING_UTTERANCE = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+GENERATE_UTTERANCE = "生成一张蓝牙耳机主图"
+
+
+def main() -> int:
+    print("=== Phase C intent shadow production verify ===")
+    print(f"BASE={studio.BASE}\n")
+
+    try:
+        studio.http("POST", "/auth/send-code", {"phone": studio.PHONE})
+    except Exception:
+        pass
+    try:
+        tok = studio.http("POST", "/auth/login", {"phone": studio.PHONE, "code": studio.CODE})["data"]["token"]
+        studio.record("Login", True)
+    except Exception as exc:  # noqa: BLE001
+        studio.record("Login", False, str(exc))
+        return 1
+
+    rt = studio.http("GET", "/agent/runtime-health", t=tok)
+    studio.record("Runtime health", bool((rt.get("data") or {}).get("ok")))
+
+    sid = studio.http("POST", "/sessions", {"title": f"C-shadow-plan-{int(time.time())}"}, t=tok)["data"]["id"]
+    tid = f"{sid}:{uuid.uuid4()}"
+    _, text, _types, _exit = studio.sse_collect(tok, sid, PLANNING_UTTERANCE, tid, timeout=120)
+    studio.record(
+        "planning not image direct",
+        "image 节点（直达）" not in text or "方案" in text or "确认" in text,
+        text[:120],
+    )
+    studio.record(
+        "planning campaign or clarify",
+        "方案" in text or "拟定拆解" in text or "请确认" in text or "1）" in text,
+        text[:80],
+    )
+
+    sid2 = studio.http("POST", "/sessions", {"title": f"C-shadow-gen-{int(time.time())}"}, t=tok)["data"]["id"]
+    tid2 = f"{sid2}:{uuid.uuid4()}"
+    _, text2, _types2, _exit2 = studio.sse_collect(tok, sid2, GENERATE_UTTERANCE, tid2, timeout=180)
+    studio.record(
+        "generate image atomic path",
+        "image 节点" in text2 and "直达" in text2,
+        text2[:100],
+    )
+
+    eval_path = RUNTIME / "skills" / "atomic-create" / "eval-intent-llm-set.yaml"
+    cases = yaml.safe_load(eval_path.read_text(encoding="utf-8"))["cases"]
+    ok = 0
+    for case in cases:
+        fix = case.get("llm_fixture")
+        if not fix:
+            continue
+        guard = validate_llm_parse(fix, case["utterance"])  # type: ignore[arg-type]
+        outcome = guard or intent_result_to_parse_outcome(fix, case["utterance"])  # type: ignore[arg-type]
+        gold = case["gold"]
+        if gold.get("outcome") == "clarify" and outcome.get("kind") == "clarify":
+            ok += 1
+        elif gold.get("outcome") == "success" and outcome.get("kind") == "success":
+            ok += 1
+    rate = ok / len(cases)
+    studio.record("fixture agreement rate", rate >= 0.90, f"{ok}/{len(cases)}={rate:.1%}")
+    print(
+        json.dumps(
+            {
+                "fixture_agreement_rate": round(rate, 4),
+                "shadow_env": os.environ.get("INTENT_LLM_PARSE_SHADOW"),
+            },
+            ensure_ascii=False,
+        )
+    )
+
+    print(f"\n=== Summary PASS={studio.PASS} FAIL={studio.FAIL} ===")
+    return 0 if studio.FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/prod-p4-full-regression.py
+++ b/deploy/prod-p4-full-regression.py
@@ -6,6 +6,7 @@ Runs (in order):
   2. prod-atomic-confirm-gate-verify.py — video/audio await_atomic_confirm
   3. prod-single-node-gen-verify.py    — P3 regression (A5)
   4. prod-phase-b-user-verify.py       — Phase B (optional, SKIP_PHASE_B=1)
+  5. prod-atomic-intent-shadow-verify.py — Phase C shadow (optional, SKIP_INTENT_SHADOW=1)
 
 Usage:
   python3 deploy/prod-p4-full-regression.py
@@ -26,6 +27,8 @@ SCRIPTS = [
 ]
 if os.environ.get("SKIP_PHASE_B", "").strip() not in ("1", "true", "yes"):
     SCRIPTS.append(ROOT / "prod-phase-b-user-verify.py")
+if os.environ.get("SKIP_INTENT_SHADOW", "").strip() not in ("1", "true", "yes"):
+    SCRIPTS.append(ROOT / "prod-atomic-intent-shadow-verify.py")
 
 
 def main() -> int:

--- a/packages/agent/src/prompt-modes/taxonomy.yaml
+++ b/packages/agent/src/prompt-modes/taxonomy.yaml
@@ -1,0 +1,72 @@
+# Shared prompt_mode taxonomy — mirrors classify.ts heuristicMode patterns
+version: 1
+modes:
+  - id: character_turnaround
+    patterns:
+      - 三视图
+      - 多视图
+      - 正侧背
+      - turnaround
+      - 模特图
+      - 角色设定
+      - 模特定妆
+      - 四视图
+      - q版
+      - q萌
+      - chibi
+      - 二头身
+      - 洛丽塔
+      - lolita
+      - 婚纱
+      - 战术
+      - 军事
+      - 牛仔
+      - 皮克斯
+      - 绘本
+      - 水彩
+  - id: commercial_storyboard
+    patterns:
+      - 商业分镜
+      - 品牌分镜
+      - 品牌广告
+      - 营销战役
+      - TVC
+      - 问界
+      - AITO
+      - 汽车广告
+      - 15秒
+      - 30秒
+      - 60秒
+      - 抖音前贴
+      - 发布会暖场
+      - 品牌形象片
+      - 闪电切割
+      - AIDA
+  - id: storyboard
+    patterns:
+      - 分镜
+  - id: script
+    patterns:
+      - 剧本
+      - 剧本大纲
+      - 人生观
+  - id: copywriting
+    patterns:
+      - 旁白
+      - 口播
+      - 文案
+  - id: image_prompt_multi_style
+    patterns:
+      - 提示词
+      - midjourney
+      - stable diffusion
+      - 绘画
+      - 车模
+  - id: vision_text
+    patterns:
+      - 视觉方案
+      - 构图策划
+      - 视觉脚本
+      - 页面结构稿
+  - id: generic
+    patterns: []

--- a/services/agent-runtime/app/config.py
+++ b/services/agent-runtime/app/config.py
@@ -1,3 +1,4 @@
+from pydantic import Field
 from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
@@ -32,6 +33,9 @@ class Settings(BaseSettings):
     # W19: JSON map skill_id -> pinned prompt version for rollback, e.g.
     # {"enterprise-marketing-campaign":"1.0.0"}
     prompt_version_overrides: str = "{}"
+    # Phase C: LLM structured intent parse (default off until C4)
+    intent_llm_parse: bool = Field(default=False, validation_alias="INTENT_LLM_PARSE")
+    intent_llm_parse_shadow: bool = Field(default=False, validation_alias="INTENT_LLM_PARSE_SHADOW")
 
     class Config:
         env_prefix = "LNKPI_"

--- a/services/agent-runtime/app/graph/atomic_parse_schema.py
+++ b/services/agent-runtime/app/graph/atomic_parse_schema.py
@@ -25,6 +25,8 @@ class AtomicParseItem(TypedDict, total=False):
     pipeline: str
     imageAspect: str
     resolutionBump: bool
+    promptMode: str
+    prompt_mode: str
 
 
 class AtomicParseSuccess(TypedDict):
@@ -68,6 +70,9 @@ def _normalize_item(raw: dict[str, Any]) -> AtomicParseItem | None:
         item["imageAspect"] = str(raw["imageAspect"])
     if raw.get("resolutionBump") is not None:
         item["resolutionBump"] = bool(raw["resolutionBump"])
+    pm = raw.get("promptMode") or raw.get("prompt_mode")
+    if pm:
+        item["promptMode"] = str(pm)
     return item  # type: ignore[return-value]
 
 
@@ -211,6 +216,10 @@ def parse_outcome_to_state(outcome: ParseOutcome, *, canvas_context: str | None 
         first["canvas_context"] = canvas_context
         for item in items:
             item.setdefault("canvas_context", canvas_context)
+    for item in items:
+        pm = item.get("prompt_mode") or item.get("promptMode")
+        if pm and "promptMode" not in item:
+            item["promptMode"] = pm
 
     if len(items) == 1:
         spec = first

--- a/services/agent-runtime/app/graph/clarify_reply.py
+++ b/services/agent-runtime/app/graph/clarify_reply.py
@@ -1,0 +1,99 @@
+"""Phase C: classify user replies after planning/clarify prompts."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from app.graph.intent_parse_schema import IntentParseResult
+
+ClarifyReplyResult = IntentParseResult | Literal["none"]
+
+_CHOICE_ONE = frozenset({"1", "1）", "一", "单张主图", "单张", "直接出图", "只要主图", "出主图"})
+_CHOICE_TWO = frozenset(
+    {"2", "2）", "二", "完整方案", "campaign", "全链路", "营销方案", "完整详情页", "详情页方案"}
+)
+_CHOICE_THREE = frozenset(
+    {"3", "3）", "三", "文字策划", "文字版", "不出图", "构图策划", "只要文字", "文字方案"}
+)
+
+
+def _normalize_reply(reply: str) -> str:
+    return (reply or "").strip().lower()
+
+
+def classify_clarify_reply(
+    original_utterance: str,
+    clarify_question: str,
+    user_reply: str,
+    *,
+    checkpoint: dict[str, Any] | None = None,
+) -> ClarifyReplyResult:
+    """Map 1/2/3 or natural-language clarify follow-ups to IntentParseResult."""
+    del clarify_question, checkpoint  # reserved for future LLM fallback
+    raw = (user_reply or "").strip()
+    if not raw:
+        return "none"
+
+    lowered = _normalize_reply(raw)
+    if lowered in _CHOICE_ONE or any(k in raw for k in ("单张主图", "直接出图", "只要主图")):
+        prompt = "生成一张蓝牙耳机主图"
+        if "蓝牙耳机" in original_utterance:
+            prompt = "生成一张蓝牙耳机主图"
+        elif "主图" in original_utterance:
+            prompt = "生成一张主图"
+        return {
+            "action": "generate",
+            "scope": "atomic",
+            "route": "atomic_create",
+            "structure": "single",
+            "items": [
+                {
+                    "target_type": "image",
+                    "title": prompt[:24],
+                    "prompt": prompt,
+                    "confirm_gate": False,
+                }
+            ],
+            "confidence": 0.92,
+            "needs_clarify": False,
+            "reason": "clarify_reply_generate_image",
+        }
+
+    if lowered in _CHOICE_TWO or any(
+        k in raw for k in ("完整方案", "Campaign", "campaign", "全链路", "营销方案")
+    ):
+        return {
+            "action": "plan",
+            "scope": "campaign",
+            "route": "campaign",
+            "structure": "single",
+            "items": [],
+            "confidence": 0.90,
+            "needs_clarify": False,
+            "reason": "clarify_reply_campaign",
+        }
+
+    if lowered in _CHOICE_THREE or any(
+        k in raw for k in ("文字策划", "不出图", "文字版", "构图策划")
+    ):
+        prompt = original_utterance.strip() or "视觉构图策划"
+        return {
+            "action": "write",
+            "scope": "atomic",
+            "route": "atomic_create",
+            "structure": "single",
+            "items": [
+                {
+                    "target_type": "text",
+                    "title": "构图策划",
+                    "prompt": prompt,
+                    "confirm_gate": False,
+                    "prompt_mode": "vision_text",
+                }
+            ],
+            "confidence": 0.90,
+            "needs_clarify": False,
+            "reason": "clarify_reply_vision_text",
+        }
+
+    return "none"

--- a/services/agent-runtime/app/graph/intent_parse_llm.py
+++ b/services/agent-runtime/app/graph/intent_parse_llm.py
@@ -1,0 +1,118 @@
+"""Phase C: LLM structured intent parse (Action × Scope × Route × Modality)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from app.graph.atomic_parse_util import atomic_skill_path, load_atomic_parse_few_shots
+from app.graph.few_shot import build_llm_messages, load_few_shots
+from app.graph.intent_parse_schema import IntentParseResult, parse_llm_json
+
+logger = logging.getLogger(__name__)
+
+LLM_PARSE_TIMEOUT_SEC = 8
+
+_STRUCTURED_PARSE_SYSTEM = """你是 Lnkpi 意图结构化解析器。根据用户 utterance 与上下文，输出 JSON（不要 markdown 代码块）。
+
+输出 schema：
+{
+  "action": "plan|write|generate|expand|regenerate|unknown",
+  "scope": "atomic|campaign|unknown",
+  "route": "campaign|atomic_create|atomic_regenerate|single_node|chat",
+  "structure": "single|multi",
+  "items": [
+    {
+      "target_type": "image|text|video|audio|prompt",
+      "title": "节点标题，≤24字",
+      "prompt": "送入 Studio 的完整提示词",
+      "confirm_gate": false,
+      "prompt_mode": null,
+      "pipeline": null
+    }
+  ],
+  "confidence": 0.0,
+  "needs_clarify": false,
+  "clarify_question": null,
+  "reason": "简短中文分类依据"
+}
+
+硬约束（与 planning_guard 一致）：
+- action=plan 且含「主图+详情页/构图方案」→ route=campaign 或 needs_clarify=true，禁止 items 仅 image 直出
+- action=write → route=atomic_create，items 为 text（vision_text 策划文档）
+- action=expand → route=atomic_create，items 为 prompt，可带 prompt_mode
+- action=generate + 「生成一张/来一张」→ route=atomic_create，target_type=image，confidence≥0.85
+- video/audio → confirm_gate=true
+- 营销方案/14节点/全链路 → route=campaign，scope=campaign
+- multi items >5 → needs_clarify=true，建议 campaign
+- 「再生成一张/按刚才风格」→ route=atomic_regenerate 或 needs_clarify（需 checkpoint）
+- 意图不清 → confidence<0.7，needs_clarify=true
+"""
+
+
+def load_structured_intent_few_shots(skills_dir: Any = None) -> list[tuple[str, str]]:
+    skill = atomic_skill_path(skills_dir)
+    shots = load_few_shots(skill).get("parse_intent_structured")
+    if shots:
+        return shots
+    return load_atomic_parse_few_shots(skills_dir)
+
+
+def _format_context_block(
+    *,
+    canvas_summary: str | None = None,
+    dialogue: str | None = None,
+    checkpoint: dict[str, Any] | None = None,
+) -> str:
+    parts: list[str] = []
+    if canvas_summary:
+        parts.append(f"[画布摘要] {canvas_summary}")
+    if dialogue:
+        parts.append(f"[近期对话] {dialogue}")
+    if checkpoint:
+        parts.append(f"[checkpoint] {json.dumps(checkpoint, ensure_ascii=False)}")
+    return "\n".join(parts)
+
+
+async def llm_parse_intent(
+    llm: Any,
+    utterance: str,
+    *,
+    canvas_summary: str | None = None,
+    dialogue: str | None = None,
+    checkpoint: dict[str, Any] | None = None,
+    few_shots: list[tuple[str, str]] | None = None,
+) -> IntentParseResult | None:
+    """Call LLM for structured intent parse; None on failure."""
+    if llm is None:
+        return None
+
+    shots = few_shots if few_shots is not None else load_structured_intent_few_shots()
+    user_block = utterance.strip()
+    ctx = _format_context_block(
+        canvas_summary=canvas_summary,
+        dialogue=dialogue,
+        checkpoint=checkpoint,
+    )
+    if ctx:
+        user_block = f"{user_block}\n\n{ctx}"
+
+    messages = build_llm_messages(
+        system=_STRUCTURED_PARSE_SYSTEM,
+        user=user_block,
+        few_shots=shots,
+    )
+
+    for attempt in range(2):
+        try:
+            resp = await llm.ainvoke(messages)
+            content = getattr(resp, "content", None) or ""
+            parsed = parse_llm_json(str(content))
+            if parsed is not None:
+                return parsed
+            logger.warning("llm_parse_intent invalid JSON (attempt %s)", attempt + 1)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("llm_parse_intent failed (attempt %s): %s", attempt + 1, exc)
+
+    return None

--- a/services/agent-runtime/app/graph/intent_parse_schema.py
+++ b/services/agent-runtime/app/graph/intent_parse_schema.py
@@ -1,0 +1,176 @@
+"""Phase C: LLM structured intent parse schema and outcome mapping."""
+
+from __future__ import annotations
+
+from typing import Any, Literal, TypedDict
+
+from app.graph.atomic_parse_schema import (
+    AtomicParseItem,
+    ParseOutcome,
+    validate_parse_result,
+)
+from app.graph.atomic_parse_llm import extract_json_object
+
+VALID_ACTIONS = frozenset({"plan", "write", "generate", "expand", "regenerate", "unknown"})
+VALID_SCOPES = frozenset({"atomic", "campaign", "unknown"})
+VALID_ROUTES = frozenset(
+    {"campaign", "atomic_create", "atomic_regenerate", "single_node", "chat"}
+)
+VALID_STRUCTURES = frozenset({"single", "multi"})
+VALID_TARGET_TYPES = frozenset({"image", "text", "video", "audio", "prompt"})
+
+
+class IntentParseItem(TypedDict, total=False):
+    target_type: str
+    title: str
+    prompt: str
+    confirm_gate: bool
+    prompt_mode: str
+    pipeline: str
+    imageAspect: str
+    resolutionBump: bool
+
+
+class IntentParseResult(TypedDict, total=False):
+    action: str
+    scope: str
+    route: str
+    structure: str
+    items: list[IntentParseItem]
+    confidence: float
+    needs_clarify: bool
+    clarify_question: str | None
+    reason: str
+
+
+def _clamp_confidence(value: Any) -> float:
+    try:
+        conf = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, min(1.0, conf))
+
+
+def _normalize_parse_item(raw: dict[str, Any]) -> IntentParseItem | None:
+    target = str(raw.get("target_type") or "").strip()
+    if target not in VALID_TARGET_TYPES:
+        return None
+    prompt = str(raw.get("prompt") or "").strip()
+    if not prompt:
+        return None
+    title = str(raw.get("title") or prompt[:24] or target).strip()
+    item: dict[str, Any] = {
+        "target_type": target,
+        "title": title,
+        "prompt": prompt,
+    }
+    if raw.get("confirm_gate") is not None:
+        item["confirm_gate"] = bool(raw["confirm_gate"])
+    if raw.get("prompt_mode"):
+        item["prompt_mode"] = str(raw["prompt_mode"])
+    if raw.get("pipeline"):
+        item["pipeline"] = str(raw["pipeline"])
+    if raw.get("imageAspect"):
+        item["imageAspect"] = str(raw["imageAspect"])
+    if raw.get("resolutionBump") is not None:
+        item["resolutionBump"] = bool(raw["resolutionBump"])
+    return item  # type: ignore[return-value]
+
+
+def parse_llm_json(raw: str) -> IntentParseResult | None:
+    """Parse LLM JSON string into validated IntentParseResult; None if invalid."""
+    data = extract_json_object(raw)
+    if not isinstance(data, dict):
+        return None
+
+    action = str(data.get("action") or "unknown").strip()
+    if action not in VALID_ACTIONS:
+        action = "unknown"
+
+    scope = str(data.get("scope") or "unknown").strip()
+    if scope not in VALID_SCOPES:
+        scope = "unknown"
+
+    route = str(data.get("route") or "chat").strip()
+    if route not in VALID_ROUTES:
+        route = "chat"
+
+    structure = str(data.get("structure") or "single").strip()
+    if structure not in VALID_STRUCTURES:
+        structure = "single" if structure != "multi" else "multi"
+
+    raw_items = data.get("items")
+    items: list[IntentParseItem] = []
+    if isinstance(raw_items, list):
+        for raw in raw_items:
+            if isinstance(raw, dict):
+                item = _normalize_parse_item(raw)
+                if item is not None:
+                    items.append(item)
+
+    confidence = _clamp_confidence(data.get("confidence"))
+    needs_clarify = bool(data.get("needs_clarify"))
+    clarify_q = data.get("clarify_question")
+    clarify_question = str(clarify_q).strip() if clarify_q else None
+    reason = str(data.get("reason") or "llm_parse").strip()
+
+    return {
+        "action": action,
+        "scope": scope,
+        "route": route,
+        "structure": structure,  # type: ignore[typeddict-item]
+        "items": items,
+        "confidence": confidence,
+        "needs_clarify": needs_clarify,
+        "clarify_question": clarify_question,
+        "reason": reason,
+    }
+
+
+def _campaign_clarify(result: IntentParseResult) -> ParseOutcome:
+    question = result.get("clarify_question") or (
+        "这听起来像完整营销/Campaign 方案需求。"
+        "请确认是否进入 Campaign 全链路（多节点方案），或说明只要单张/单条原子创作。"
+    )
+    return {
+        "kind": "clarify",
+        "confidence": result.get("confidence", 0.0),
+        "reason": "llm_route_campaign",
+        "clarify_question": question,
+    }
+
+
+def intent_result_to_parse_outcome(
+    result: IntentParseResult,
+    utterance: str,
+) -> ParseOutcome:
+    """Map validated IntentParseResult to atomic ParseOutcome for graph state."""
+    route = str(result.get("route") or "chat")
+    if route == "campaign":
+        return _campaign_clarify(result)
+
+    if route in ("atomic_regenerate", "single_node", "chat"):
+        question = result.get("clarify_question") or (
+            f"我还不太确定「{utterance[:24]}」要如何执行。"
+            "请补充是要重新生成、单节点出图，还是其他操作。"
+        )
+        return {
+            "kind": "clarify",
+            "confidence": result.get("confidence", 0.0),
+            "reason": f"llm_route_{route}",
+            "clarify_question": question,
+        }
+
+    atomic_items: list[AtomicParseItem] = []
+    for item in result.get("items") or []:
+        atomic_items.append(dict(item))  # type: ignore[arg-type]
+
+    payload: dict[str, Any] = {
+        "structure": result.get("structure") or ("multi" if len(atomic_items) > 1 else "single"),
+        "items": atomic_items,
+        "confidence": result.get("confidence", 0.0),
+        "reason": f"{result.get('action', 'unknown')}:{result.get('reason', 'llm')}",
+        "clarify_question": result.get("clarify_question"),
+        "needs_clarify": result.get("needs_clarify"),
+    }
+    return validate_parse_result(payload, utterance=utterance)

--- a/services/agent-runtime/app/graph/nodes/atomic_parse.py
+++ b/services/agent-runtime/app/graph/nodes/atomic_parse.py
@@ -1,16 +1,21 @@
-"""P4 + Phase 2: hybrid rule/LLM parse user utterance → atomic_spec."""
+"""P4 + Phase 2/C: hybrid rule/LLM structured parse user utterance → atomic_spec."""
 
 from __future__ import annotations
 
+import asyncio
+import json
+import logging
 from typing import Any, Callable
 
 from langchain_core.messages import AIMessage
 
+from app.config import settings
 from app.graph.atomic_parse_llm import llm_parse_atomic_intent
 from app.graph.atomic_context import build_atomic_parse_context
 from app.graph.atomic_parse_schema import (
     CLARIFY_THRESHOLD,
     RULE_FAST_PATH_THRESHOLD,
+    ParseOutcome,
     outcome_from_rule_items,
     parse_outcome_to_state,
     validate_parse_result,
@@ -21,6 +26,13 @@ from app.graph.atomic_parse_util import (
     rule_parse_atomic,
 )
 from app.graph.atomic_intent import is_regenerate_new_variant
+from app.graph.clarify_reply import classify_clarify_reply
+from app.graph.intent_parse_llm import LLM_PARSE_TIMEOUT_SEC, llm_parse_intent
+from app.graph.intent_parse_schema import IntentParseResult, intent_result_to_parse_outcome
+from app.graph.planning_guard import validate_llm_parse
+from app.tools.prompt_mode_taxonomy import resolve_prompt_mode
+
+logger = logging.getLogger(__name__)
 
 
 def _latest_user_text(messages: list[Any]) -> str:
@@ -30,6 +42,132 @@ def _latest_user_text(messages: list[Any]) -> str:
         if role in ("human", "user") and content:
             return str(content)
     return ""
+
+
+def _log_intent_parse(
+    *,
+    source: str,
+    utterance: str,
+    outcome: ParseOutcome | None = None,
+    llm_result: IntentParseResult | None = None,
+    guard_triggered: bool = False,
+) -> None:
+    payload: dict[str, Any] = {
+        "intent_parse_source": source,
+        "utterance_snippet": utterance[:48],
+        "guard_triggered": guard_triggered,
+    }
+    if llm_result:
+        payload.update(
+            {
+                "action": llm_result.get("action"),
+                "route": llm_result.get("route"),
+                "confidence": llm_result.get("confidence"),
+            }
+        )
+    if outcome:
+        payload["outcome_kind"] = outcome.get("kind")
+        payload["outcome_reason"] = outcome.get("reason")
+    logger.info("intent_parse %s", json.dumps(payload, ensure_ascii=False))
+
+
+def _apply_prompt_mode_to_result(result: IntentParseResult, utterance: str) -> IntentParseResult:
+    mode = resolve_prompt_mode(utterance)
+    if not mode:
+        return result
+    items = []
+    for item in result.get("items") or []:
+        patched = dict(item)
+        if not patched.get("prompt_mode") and not patched.get("promptMode"):
+            if str(patched.get("target_type") or "") in ("prompt", "text"):
+                patched["prompt_mode"] = mode
+        items.append(patched)  # type: ignore[arg-type]
+    if items:
+        result = dict(result)
+        result["items"] = items  # type: ignore[assignment]
+    return result
+
+
+def _outcome_label(outcome: ParseOutcome) -> str:
+    if outcome["kind"] == "clarify":
+        return f"clarify:{outcome.get('reason', '')}"
+    items = outcome.get("items") or []
+    if not items:
+        return "success:empty"
+    types = ",".join(str(i.get("target_type") or "") for i in items)
+    return f"success:{types}"
+
+
+async def _structured_llm_outcome(
+    llm: Any,
+    text: str,
+    *,
+    canvas_summary: str | None,
+    dialogue: str | None,
+    checkpoint: dict[str, Any] | None,
+) -> tuple[ParseOutcome | None, IntentParseResult | None, bool]:
+    """Returns (outcome, llm_result, guard_triggered)."""
+    try:
+        raw = await asyncio.wait_for(
+            llm_parse_intent(
+                llm,
+                text,
+                canvas_summary=canvas_summary,
+                dialogue=dialogue,
+                checkpoint=checkpoint,
+            ),
+            timeout=LLM_PARSE_TIMEOUT_SEC,
+        )
+    except TimeoutError:
+        logger.warning("llm_parse_intent timeout after %ss", LLM_PARSE_TIMEOUT_SEC)
+        return None, None, False
+
+    if raw is None:
+        return None, None, False
+
+    raw = _apply_prompt_mode_to_result(raw, text)
+    guard = validate_llm_parse(raw, text)
+    if guard is not None:
+        return guard, raw, True
+    return intent_result_to_parse_outcome(raw, text), raw, False
+
+
+async def _maybe_shadow_diff(
+    llm: Any,
+    text: str,
+    rule_outcome: ParseOutcome,
+    *,
+    canvas_summary: str | None,
+    dialogue: str | None,
+    checkpoint: dict[str, Any] | None,
+) -> None:
+    if not settings.intent_llm_parse_shadow or settings.intent_llm_parse:
+        return
+    llm_outcome, llm_result, _ = await _structured_llm_outcome(
+        llm,
+        text,
+        canvas_summary=canvas_summary,
+        dialogue=dialogue,
+        checkpoint=checkpoint,
+    )
+    if llm_outcome is None:
+        logger.info(
+            "intent_parse_shadow diff=llm_unavailable rule=%s",
+            _outcome_label(rule_outcome),
+        )
+        return
+    rule_label = _outcome_label(rule_outcome)
+    llm_label = _outcome_label(llm_outcome)
+    if rule_label != llm_label:
+        logger.warning(
+            "intent_parse_shadow disagree utterance=%r rule=%s llm=%s llm_route=%s",
+            text[:64],
+            rule_label,
+            llm_label,
+            (llm_result or {}).get("route"),
+        )
+    else:
+        logger.info("intent_parse_shadow agree label=%s", rule_label)
 
 
 def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = None) -> Callable:
@@ -53,6 +191,32 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
 
         focus_node_id = state.get("focus_node_id")
         parse_ctx = build_atomic_parse_context(state, canvas_summary=canvas_summary)
+        checkpoint = {
+            "atomic_node_id": state.get("atomic_node_id"),
+            "atomic_spec": state.get("atomic_spec"),
+        }
+
+        clarify_ctx = state.get("clarify_context") if isinstance(state.get("clarify_context"), dict) else None
+        if state.get("phase") == "clarify" and clarify_ctx:
+            original = str(clarify_ctx.get("original_utterance") or "")
+            question = str(clarify_ctx.get("clarify_question") or state.get("clarify_question") or "")
+            classified = classify_clarify_reply(original, question, text, checkpoint=checkpoint)
+            if classified != "none":
+                classified = _apply_prompt_mode_to_result(classified, original or text)
+                reason = str(classified.get("reason") or "")
+                validation_u = classified["items"][0]["prompt"] if reason == "clarify_reply_generate_image" else (original or text)
+                guard = None if reason == "clarify_reply_generate_image" else validate_llm_parse(classified, original or text)
+                outcome = guard or intent_result_to_parse_outcome(classified, validation_u)
+                _log_intent_parse(
+                    source="clarify_reply",
+                    utterance=text,
+                    outcome=outcome,
+                    llm_result=classified,
+                    guard_triggered=guard is not None,
+                )
+                patch = parse_outcome_to_state(outcome, canvas_context=parse_ctx)
+                patch.pop("clarify_context", None)
+                return patch
 
         prior_spec = state.get("atomic_spec")
         if (
@@ -71,51 +235,117 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
                 confidence=0.96,
                 reason="variant_new_node_from_checkpoint",
             )
+            _log_intent_parse(source="rule_variant", utterance=text, outcome=outcome)
             return parse_outcome_to_state(outcome, canvas_context=parse_ctx)
 
-        rule_items, rule_conf = rule_parse_atomic(
-            text,
-            canvas_summary=canvas_summary,
-            focus_node_id=focus_node_id,
-            parse_context=parse_ctx or None,
-        )
-        canvas_ctx = parse_ctx or (rule_items[0].get("canvas_context") if rule_items else None)
+        canvas_ctx = parse_ctx
+        dialogue = None
+        outcome: ParseOutcome | None = None
+        llm_result: IntentParseResult | None = None
+        guard_triggered = False
 
-        outcome = None
-        if rule_conf >= RULE_FAST_PATH_THRESHOLD:
-            outcome = outcome_from_rule_items(
-                rule_items,
-                confidence=rule_conf,
-                reason="rule_fast_path",
-            )
-        elif llm is not None:
-            llm_raw = await llm_parse_atomic_intent(
+        if settings.intent_llm_parse and llm is not None:
+            outcome, llm_result, guard_triggered = await _structured_llm_outcome(
                 llm,
                 text,
-                canvas_context=canvas_ctx,
-                few_shots=load_atomic_parse_few_shots(),
+                canvas_summary=parse_ctx,
+                dialogue=dialogue,
+                checkpoint=checkpoint,
             )
-            if llm_raw is not None:
-                outcome = validate_parse_result(llm_raw, utterance=text)
+            if outcome is None:
+                rule_items, rule_conf = rule_parse_atomic(
+                    text,
+                    canvas_summary=canvas_summary,
+                    focus_node_id=focus_node_id,
+                    parse_context=parse_ctx or None,
+                )
+                canvas_ctx = parse_ctx or (rule_items[0].get("canvas_context") if rule_items else None)
+                if rule_conf >= CLARIFY_THRESHOLD:
+                    outcome = outcome_from_rule_items(
+                        rule_items, confidence=rule_conf, reason="rule_fallback_after_llm"
+                    )
+                else:
+                    outcome = validate_parse_result(
+                        {
+                            "confidence": rule_conf,
+                            "reason": "ambiguous_utterance",
+                            "clarify_question": None,
+                            "items": [],
+                        },
+                        utterance=text,
+                    )
+                _log_intent_parse(source="rule", utterance=text, outcome=outcome)
+            else:
+                _log_intent_parse(
+                    source="llm",
+                    utterance=text,
+                    outcome=outcome,
+                    llm_result=llm_result,
+                    guard_triggered=guard_triggered,
+                )
+        else:
+            rule_items, rule_conf = rule_parse_atomic(
+                text,
+                canvas_summary=canvas_summary,
+                focus_node_id=focus_node_id,
+                parse_context=parse_ctx or None,
+            )
+            canvas_ctx = parse_ctx or (rule_items[0].get("canvas_context") if rule_items else None)
+            use_fast_path = not settings.intent_llm_parse_shadow
 
-        if outcome is None:
-            if rule_conf >= CLARIFY_THRESHOLD:
+            if use_fast_path and rule_conf >= RULE_FAST_PATH_THRESHOLD:
                 outcome = outcome_from_rule_items(
                     rule_items,
                     confidence=rule_conf,
-                    reason="rule_fallback",
+                    reason="rule_fast_path",
                 )
-            else:
-                outcome = validate_parse_result(
-                    {
-                        "confidence": rule_conf,
-                        "reason": "ambiguous_utterance",
-                        "clarify_question": None,
-                        "items": [],
-                    },
-                    utterance=text,
+            elif llm is not None and rule_conf < RULE_FAST_PATH_THRESHOLD and not settings.intent_llm_parse:
+                llm_raw = await llm_parse_atomic_intent(
+                    llm,
+                    text,
+                    canvas_context=canvas_ctx,
+                    few_shots=load_atomic_parse_few_shots(),
+                )
+                if llm_raw is not None:
+                    outcome = validate_parse_result(llm_raw, utterance=text)
+
+            if outcome is None:
+                if rule_conf >= CLARIFY_THRESHOLD:
+                    outcome = outcome_from_rule_items(
+                        rule_items,
+                        confidence=rule_conf,
+                        reason="rule_fallback",
+                    )
+                else:
+                    outcome = validate_parse_result(
+                        {
+                            "confidence": rule_conf,
+                            "reason": "ambiguous_utterance",
+                            "clarify_question": None,
+                            "items": [],
+                        },
+                        utterance=text,
+                    )
+
+            _log_intent_parse(source="rule", utterance=text, outcome=outcome)
+
+            if llm is not None:
+                await _maybe_shadow_diff(
+                    llm,
+                    text,
+                    outcome,
+                    canvas_summary=parse_ctx,
+                    dialogue=dialogue,
+                    checkpoint=checkpoint,
                 )
 
-        return parse_outcome_to_state(outcome, canvas_context=canvas_ctx)
+        patch = parse_outcome_to_state(outcome, canvas_context=canvas_ctx)
+        if outcome["kind"] == "clarify":
+            patch["clarify_context"] = {
+                "original_utterance": text,
+                "clarify_question": outcome.get("clarify_question") or "",
+                "clarify_kind": outcome.get("reason") or "unknown",
+            }
+        return patch
 
     return parse_atomic_intent

--- a/services/agent-runtime/app/graph/planning_guard.py
+++ b/services/agent-runtime/app/graph/planning_guard.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import re
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from app.graph.intent_parse_schema import IntentParseResult
+    from app.graph.atomic_parse_schema import ParseOutcome
 
 ActionKind = Literal["plan", "write", "generate", "expand", "unknown"]
 
@@ -116,3 +120,48 @@ def planning_clarify_question(utterance: str) -> str:
         "3）只要文字版构图策划（不出图）。\n"
         "回复 1 / 2 / 3，或补充具体需求。"
     )
+
+
+def validate_llm_parse(result: "IntentParseResult", utterance: str) -> "ParseOutcome | None":
+    """Return clarify outcome if LLM parse conflicts with planning guard; None if OK."""
+    from app.graph.atomic_parse_schema import ParseOutcome
+
+    action = str(result.get("action") or "unknown")
+    items = result.get("items") or []
+
+    if action == "generate" and has_planning_image_conflict(utterance):
+        out: ParseOutcome = {
+            "kind": "clarify",
+            "confidence": min(float(result.get("confidence") or 0.0), PLANNING_CONFIDENCE_CAP),
+            "reason": "planning_image_conflict",
+            "clarify_question": planning_clarify_question(utterance),
+        }
+        return out
+
+    if action == "plan":
+        if any(str(i.get("target_type") or "") == "image" for i in items):
+            return {
+                "kind": "clarify",
+                "confidence": min(float(result.get("confidence") or 0.0), PLANNING_CONFIDENCE_CAP),
+                "reason": "planning_image_conflict",
+                "clarify_question": planning_clarify_question(utterance),
+            }
+        if has_planning_image_conflict(utterance) and str(result.get("route") or "") == "atomic_create":
+            for item in items:
+                if str(item.get("target_type") or "") == "image":
+                    return {
+                        "kind": "clarify",
+                        "confidence": min(float(result.get("confidence") or 0.0), PLANNING_CONFIDENCE_CAP),
+                        "reason": "planning_image_conflict",
+                        "clarify_question": planning_clarify_question(utterance),
+                    }
+
+    if bool(result.get("needs_clarify")) and has_planning_image_conflict(utterance):
+        return {
+            "kind": "clarify",
+            "confidence": float(result.get("confidence") or 0.0),
+            "reason": "planning_image_conflict",
+            "clarify_question": result.get("clarify_question") or planning_clarify_question(utterance),
+        }
+
+    return None

--- a/services/agent-runtime/app/tools/prompt_mode_taxonomy.py
+++ b/services/agent-runtime/app/tools/prompt_mode_taxonomy.py
@@ -1,0 +1,55 @@
+"""Load shared prompt_mode taxonomy and resolve mode from utterance."""
+
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_TAXONOMY_REL = Path(__file__).resolve().parents[4] / "packages" / "agent" / "src" / "prompt-modes" / "taxonomy.yaml"
+
+
+@lru_cache(maxsize=1)
+def _load_taxonomy() -> list[dict[str, Any]]:
+    path = _TAXONOMY_REL
+    if not path.is_file():
+        return []
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    modes = raw.get("modes") or []
+    return [m for m in modes if isinstance(m, dict) and m.get("id")]
+
+
+def resolve_prompt_mode(utterance: str) -> str | None:
+    """Heuristic prompt_mode from utterance; mirrors packages/agent classify.ts."""
+    text = (utterance or "").strip()
+    if not text:
+        return None
+    lower = text.lower()
+
+    ordered_ids = (
+        "character_turnaround",
+        "commercial_storyboard",
+        "storyboard",
+        "script",
+        "copywriting",
+        "image_prompt_multi_style",
+        "vision_text",
+    )
+    by_id = {str(m["id"]): m for m in _load_taxonomy()}
+    for mode_id in ordered_ids:
+        mode = by_id.get(mode_id)
+        if not mode:
+            continue
+        patterns = mode.get("patterns") or []
+        for pat in patterns:
+            p = str(pat)
+            if p.lower() in lower or p in text:
+                if mode_id == "storyboard" and re.search(
+                    r"商业分镜|品牌分镜|问界|AITO", text, re.I
+                ):
+                    continue
+                return mode_id
+    return "generic"

--- a/services/agent-runtime/skills/atomic-create/assets/few-shots.yaml
+++ b/services/agent-runtime/skills/atomic-create/assets/few-shots.yaml
@@ -74,3 +74,52 @@ nodes:
     - user: 来一段30秒短视频口播稿
       assistant: |
         {"structure":"single","items":[{"target_type":"text","prompt":"30秒短视频口播稿","title":"口播稿","confirm_gate":false}],"confidence":0.91,"reason":"口播稿 text","clarify_question":null}
+  parse_intent_structured:
+    - user: 请你帮我设计一个蓝牙耳机主图，详情页的构图方案
+      assistant: |
+        {"action":"plan","scope":"campaign","route":"campaign","structure":"single","items":[],"confidence":0.90,"needs_clarify":false,"clarify_question":null,"reason":"主图+详情页构图方案 → Campaign"}
+    - user: 写一份详情页模块构图策划文档，不出图
+      assistant: |
+        {"action":"write","scope":"atomic","route":"atomic_create","structure":"single","items":[{"target_type":"text","prompt":"详情页模块构图策划文档","title":"构图策划","confirm_gate":false,"prompt_mode":"vision_text"}],"confidence":0.92,"needs_clarify":false,"reason":"write 文字策划"}
+    - user: 生成一张蓝牙耳机主图
+      assistant: |
+        {"action":"generate","scope":"atomic","route":"atomic_create","structure":"single","items":[{"target_type":"image","prompt":"蓝牙耳机主图","title":"蓝牙耳机主图","confirm_gate":false}],"confidence":0.94,"needs_clarify":false,"reason":"明确 generate image"}
+    - user: 帮我对「蓝牙耳机」做 prompt 扩写，出图用
+      assistant: |
+        {"action":"expand","scope":"atomic","route":"atomic_create","structure":"single","items":[{"target_type":"prompt","prompt":"蓝牙耳机","title":"蓝牙耳机 prompt 扩写","confirm_gate":false,"prompt_mode":"generic"}],"confidence":0.93,"needs_clarify":false,"reason":"expand prompt"}
+    - user: 帮我生成三张图，分别是蓝牙耳机主图、白底图、三视图。
+      assistant: |
+        {"action":"generate","scope":"atomic","route":"atomic_create","structure":"multi","items":[{"target_type":"image","prompt":"蓝牙耳机主图","title":"主图","confirm_gate":false},{"target_type":"image","prompt":"白底图","title":"白底图","confirm_gate":false},{"target_type":"image","prompt":"三视图","title":"三视图","confirm_gate":false}],"confidence":0.96,"needs_clarify":false,"reason":"multi image generate"}
+    - user: 帮我做一套天猫蓝牙耳机详情页营销方案
+      assistant: |
+        {"action":"plan","scope":"campaign","route":"campaign","structure":"single","items":[],"confidence":0.91,"needs_clarify":false,"reason":"全链路 Campaign"}
+    - user: 写一段天猫详情页开场文案
+      assistant: |
+        {"action":"write","scope":"atomic","route":"atomic_create","structure":"single","items":[{"target_type":"text","prompt":"天猫详情页开场文案","title":"详情页开场文案","confirm_gate":false}],"confidence":0.93,"needs_clarify":false,"reason":"write text"}
+    - user: 做一个15秒产品展示视频
+      assistant: |
+        {"action":"generate","scope":"atomic","route":"atomic_create","structure":"single","items":[{"target_type":"video","prompt":"15秒产品展示视频","title":"15秒产品展示视频","confirm_gate":true}],"confidence":0.92,"needs_clarify":false,"reason":"video confirm gate"}
+    - user: 给这段文案配一段旁白
+      assistant: |
+        {"action":"generate","scope":"atomic","route":"atomic_create","structure":"single","items":[{"target_type":"audio","prompt":"给这段文案配一段旁白","title":"文案旁白","confirm_gate":true}],"confidence":0.90,"needs_clarify":false,"reason":"audio confirm gate"}
+    - user: 帮我生成一个年轻漂亮亚洲女性模特的三视图/四视图的提示词
+      assistant: |
+        {"action":"expand","scope":"atomic","route":"atomic_create","structure":"single","items":[{"target_type":"prompt","prompt":"年轻漂亮亚洲女性模特的三视图/四视图","title":"模特多视图提示词","confirm_gate":false,"prompt_mode":"character_turnaround","pipeline":"turnaround_image"}],"confidence":0.95,"needs_clarify":false,"reason":"turnaround prompt expand"}
+    - user: 帮我生成问界M9的15秒商业分镜提示词
+      assistant: |
+        {"action":"expand","scope":"atomic","route":"atomic_create","structure":"single","items":[{"target_type":"prompt","prompt":"问界M9 15秒商业分镜","title":"商业分镜提示词","confirm_gate":false,"prompt_mode":"commercial_storyboard"}],"confidence":0.93,"needs_clarify":false,"reason":"commercial storyboard expand"}
+    - user: 帮我生成
+      assistant: |
+        {"action":"unknown","scope":"unknown","route":"chat","structure":"single","items":[],"confidence":0.35,"needs_clarify":true,"clarify_question":"你想生成什么？例如图片、文案或视频，以及具体主题。","reason":"缺少模态与主题"}
+    - user: 重新生成一张
+      assistant: |
+        {"action":"regenerate","scope":"atomic","route":"atomic_regenerate","structure":"single","items":[],"confidence":0.25,"needs_clarify":true,"clarify_question":"若要重新生成已有节点，请在同一会话中直接说「再试一次」。","reason":"regenerate 需 checkpoint"}
+    - user: 整一个详情页的感觉
+      assistant: |
+        {"action":"plan","scope":"campaign","route":"campaign","structure":"single","items":[],"confidence":0.72,"needs_clarify":true,"clarify_question":"您是要完整详情页 Campaign 方案，还是单张主图/文字策划？回复 2 走 Campaign，3 只要文字策划。","reason":"口语 planning 模糊"}
+    - user: hero image + detail page layout for bluetooth earbuds
+      assistant: |
+        {"action":"plan","scope":"campaign","route":"campaign","structure":"single","items":[],"confidence":0.85,"needs_clarify":false,"reason":"英文混排 planning → campaign"}
+    - user: 写文案并生成主图
+      assistant: |
+        {"action":"unknown","scope":"unknown","route":"chat","structure":"multi","items":[],"confidence":0.55,"needs_clarify":true,"clarify_question":"您同时提到文案和主图。请先选：1）单张主图；2）完整 Campaign；3）只要文字策划。","reason":"多意图需 clarify"}

--- a/services/agent-runtime/skills/atomic-create/eval-intent-llm-set.yaml
+++ b/services/agent-runtime/skills/atomic-create/eval-intent-llm-set.yaml
@@ -1,0 +1,1566 @@
+version: 1
+meta:
+  spec: phase-c-intent-llm-structured-parse
+cases:
+- id: llm-001
+  category: llm-plan-campaign
+  utterance: 请你帮我设计一个蓝牙耳机主图，详情页的构图方案
+  gold:
+    route: campaign
+    outcome: clarify
+    action: plan
+    forbid_image: true
+  llm_fixture:
+    action: plan
+    scope: campaign
+    route: campaign
+    structure: single
+    items: []
+    confidence: 0.88
+    needs_clarify: false
+    reason: plan campaign
+- id: llm-002
+  category: llm-plan-campaign
+  utterance: 帮我规划天猫蓝牙耳机详情页的视觉结构和模块顺序
+  gold:
+    route: campaign
+    outcome: clarify
+    action: plan
+    forbid_image: true
+  llm_fixture:
+    action: plan
+    scope: campaign
+    route: campaign
+    structure: single
+    items: []
+    confidence: 0.88
+    needs_clarify: false
+    reason: plan campaign
+- id: llm-003
+  category: llm-plan-campaign
+  utterance: 蓝牙耳机详情页构图方案
+  gold:
+    route: campaign
+    outcome: clarify
+    action: plan
+    forbid_image: true
+  llm_fixture:
+    action: plan
+    scope: campaign
+    route: campaign
+    structure: single
+    items: []
+    confidence: 0.88
+    needs_clarify: false
+    reason: plan campaign
+- id: llm-004
+  category: llm-plan-campaign
+  utterance: 设计一套详情页视觉方案，含主图和白底
+  gold:
+    route: campaign
+    outcome: clarify
+    action: plan
+    forbid_image: true
+  llm_fixture:
+    action: plan
+    scope: campaign
+    route: campaign
+    structure: single
+    items: []
+    confidence: 0.88
+    needs_clarify: false
+    reason: plan campaign
+- id: llm-005
+  category: llm-plan-campaign
+  utterance: 详情页营销视觉策划，运动耳机
+  gold:
+    route: campaign
+    outcome: clarify
+    action: plan
+    forbid_image: true
+  llm_fixture:
+    action: plan
+    scope: campaign
+    route: campaign
+    structure: single
+    items: []
+    confidence: 0.88
+    needs_clarify: false
+    reason: plan campaign
+- id: llm-006
+  category: llm-plan-campaign
+  utterance: 帮我做详情页方案，主图场景图布局
+  gold:
+    route: campaign
+    outcome: clarify
+    action: plan
+    forbid_image: true
+  llm_fixture:
+    action: plan
+    scope: campaign
+    route: campaign
+    structure: single
+    items: []
+    confidence: 0.88
+    needs_clarify: false
+    reason: plan campaign
+- id: llm-007
+  category: llm-plan-campaign
+  utterance: 电商详情页整体框架设计，蓝牙耳机
+  gold:
+    route: campaign
+    outcome: clarify
+    action: plan
+    forbid_image: true
+  llm_fixture:
+    action: plan
+    scope: campaign
+    route: campaign
+    structure: single
+    items: []
+    confidence: 0.88
+    needs_clarify: false
+    reason: plan campaign
+- id: llm-008
+  category: llm-plan-campaign
+  utterance: 主图加详情页模块的完整视觉方案
+  gold:
+    route: campaign
+    outcome: clarify
+    action: plan
+    forbid_image: true
+  llm_fixture:
+    action: plan
+    scope: campaign
+    route: campaign
+    structure: single
+    items: []
+    confidence: 0.88
+    needs_clarify: false
+    reason: plan campaign
+- id: llm-009
+  category: llm-plan-campaign
+  utterance: 详情页结构布局方案，3C数码耳机
+  gold:
+    route: campaign
+    outcome: clarify
+    action: plan
+    forbid_image: true
+  llm_fixture:
+    action: plan
+    scope: campaign
+    route: campaign
+    structure: single
+    items: []
+    confidence: 0.88
+    needs_clarify: false
+    reason: plan campaign
+- id: llm-010
+  category: llm-plan-campaign
+  utterance: 帮我设计详情页Banner和主图的整体思路
+  gold:
+    route: campaign
+    outcome: clarify
+    action: plan
+    forbid_image: true
+  llm_fixture:
+    action: plan
+    scope: campaign
+    route: campaign
+    structure: single
+    items: []
+    confidence: 0.88
+    needs_clarify: false
+    reason: plan campaign
+- id: llm-011
+  category: llm-plan-campaign
+  utterance: 整一个详情页的感觉
+  gold:
+    route: campaign
+    outcome: clarify
+    action: plan
+    forbid_image: true
+  llm_fixture:
+    action: plan
+    scope: campaign
+    route: campaign
+    structure: single
+    items: []
+    confidence: 0.88
+    needs_clarify: false
+    reason: plan campaign
+- id: llm-012
+  category: llm-plan-campaign
+  utterance: hero image + detail page layout for bluetooth earbuds
+  gold:
+    route: campaign
+    outcome: clarify
+    action: plan
+    forbid_image: true
+  llm_fixture:
+    action: plan
+    scope: campaign
+    route: campaign
+    structure: single
+    items: []
+    confidence: 0.88
+    needs_clarify: false
+    reason: plan campaign
+- id: llm-013
+  category: llm-plan-campaign
+  utterance: 帮我做一套天猫蓝牙耳机详情页营销方案
+  gold:
+    route: campaign
+    outcome: clarify
+    action: plan
+    forbid_image: true
+  llm_fixture:
+    action: plan
+    scope: campaign
+    route: campaign
+    structure: single
+    items: []
+    confidence: 0.88
+    needs_clarify: false
+    reason: plan campaign
+- id: llm-014
+  category: llm-plan-campaign
+  utterance: 14节点营销全链路方案，智能手表
+  gold:
+    route: campaign
+    outcome: clarify
+    action: plan
+    forbid_image: true
+  llm_fixture:
+    action: plan
+    scope: campaign
+    route: campaign
+    structure: single
+    items: []
+    confidence: 0.88
+    needs_clarify: false
+    reason: plan campaign
+- id: llm-015
+  category: llm-plan-campaign
+  utterance: 详情页视觉脚本和页面结构稿
+  gold:
+    route: campaign
+    outcome: clarify
+    action: plan
+    forbid_image: true
+  llm_fixture:
+    action: plan
+    scope: campaign
+    route: campaign
+    structure: single
+    items: []
+    confidence: 0.88
+    needs_clarify: false
+    reason: plan campaign
+- id: llm-g01
+  category: llm-generate-image
+  utterance: 生成一张蓝牙耳机主图
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: image
+      title: 生成一张蓝牙耳机主图
+      prompt: 生成一张蓝牙耳机主图
+      confirm_gate: false
+    confidence: 0.93
+    needs_clarify: false
+    reason: generate image
+- id: llm-g02
+  category: llm-generate-image
+  utterance: 来一张运动风海报
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: image
+      title: 来一张运动风海报
+      prompt: 来一张运动风海报
+      confirm_gate: false
+    confidence: 0.93
+    needs_clarify: false
+    reason: generate image
+- id: llm-g03
+  category: llm-generate-image
+  utterance: 帮我生成一个模特人物图
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: image
+      title: 帮我生成一个模特人物图
+      prompt: 帮我生成一个模特人物图
+      confirm_gate: false
+    confidence: 0.93
+    needs_clarify: false
+    reason: generate image
+- id: llm-g04
+  category: llm-generate-image
+  utterance: 做一个品牌视觉图，极简风
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: image
+      title: 做一个品牌视觉图，极简风
+      prompt: 做一个品牌视觉图，极简风
+      confirm_gate: false
+    confidence: 0.93
+    needs_clarify: false
+    reason: generate image
+- id: llm-g05
+  category: llm-generate-image
+  utterance: 设计一张赛博朋克海报
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: image
+      title: 设计一张赛博朋克海报
+      prompt: 设计一张赛博朋克海报
+      confirm_gate: false
+    confidence: 0.93
+    needs_clarify: false
+    reason: generate image
+- id: llm-g06
+  category: llm-generate-image
+  utterance: 出一张白底产品图
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: image
+      title: 出一张白底产品图
+      prompt: 出一张白底产品图
+      confirm_gate: false
+    confidence: 0.93
+    needs_clarify: false
+    reason: generate image
+- id: llm-g07
+  category: llm-generate-image
+  utterance: 帮我做一张场景图，客厅摆放耳机
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: image
+      title: 帮我做一张场景图，客厅摆
+      prompt: 帮我做一张场景图，客厅摆放耳机
+      confirm_gate: false
+    confidence: 0.93
+    needs_clarify: false
+    reason: generate image
+- id: llm-g08
+  category: llm-generate-image
+  utterance: 生成一张电商主图，降噪耳机
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: image
+      title: 生成一张电商主图，降噪耳
+      prompt: 生成一张电商主图，降噪耳机
+      confirm_gate: false
+    confidence: 0.93
+    needs_clarify: false
+    reason: generate image
+- id: llm-g09
+  category: llm-generate-image
+  utterance: 来一张3C数码产品图
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: image
+      title: 来一张3C数码产品图
+      prompt: 来一张3C数码产品图
+      confirm_gate: false
+    confidence: 0.93
+    needs_clarify: false
+    reason: generate image
+- id: llm-g10
+  category: llm-generate-image
+  utterance: 直接生成主图，蓝牙耳机
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: image
+      title: 直接生成主图，蓝牙耳机
+      prompt: 直接生成主图，蓝牙耳机
+      confirm_gate: false
+    confidence: 0.93
+    needs_clarify: false
+    reason: generate image
+- id: llm-g11
+  category: llm-generate-image
+  utterance: 帮我生成一张白底图
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: image
+      title: 帮我生成一张白底图
+      prompt: 帮我生成一张白底图
+      confirm_gate: false
+    confidence: 0.93
+    needs_clarify: false
+    reason: generate image
+- id: llm-g12
+  category: llm-generate-image
+  utterance: 做一张Banner图
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: image
+      title: 做一张Banner图
+      prompt: 做一张Banner图
+      confirm_gate: false
+    confidence: 0.93
+    needs_clarify: false
+    reason: generate image
+- id: llm-g13
+  category: llm-generate-image
+  utterance: 生成一个产品特写图
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: image
+      title: 生成一个产品特写图
+      prompt: 生成一个产品特写图
+      confirm_gate: false
+    confidence: 0.93
+    needs_clarify: false
+    reason: generate image
+- id: llm-g14
+  category: llm-generate-image
+  utterance: 来一张极简风主图
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: image
+      title: 来一张极简风主图
+      prompt: 来一张极简风主图
+      confirm_gate: false
+    confidence: 0.93
+    needs_clarify: false
+    reason: generate image
+- id: llm-g15
+  category: llm-generate-image
+  utterance: 帮我生成一张详情页首屏主图
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: image
+      title: 帮我生成一张详情页首屏主
+      prompt: 帮我生成一张详情页首屏主图
+      confirm_gate: false
+    confidence: 0.93
+    needs_clarify: false
+    reason: generate image
+- id: llm-w01
+  category: llm-write-text
+  utterance: 写一段天猫详情页开场文案
+  gold:
+    route: atomic_create
+    outcome: success
+    action: write
+    target_type: text
+  llm_fixture:
+    action: write
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: text
+      title: 写一段天猫详情页开场文案
+      prompt: 写一段天猫详情页开场文案
+      confirm_gate: false
+    confidence: 0.91
+    needs_clarify: false
+    reason: write text
+- id: llm-w02
+  category: llm-write-text
+  utterance: 写一份详情页模块构图策划文档，不出图
+  gold:
+    route: atomic_create
+    outcome: success
+    action: write
+    target_type: text
+  llm_fixture:
+    action: write
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: text
+      title: 写一份详情页模块构图策划
+      prompt: 写一份详情页模块构图策划文档，不出图
+      confirm_gate: false
+      prompt_mode: vision_text
+    confidence: 0.91
+    needs_clarify: false
+    reason: write text
+- id: llm-w03
+  category: llm-write-text
+  utterance: 帮我写广告词，强调降噪
+  gold:
+    route: atomic_create
+    outcome: success
+    action: write
+    target_type: text
+  llm_fixture:
+    action: write
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: text
+      title: 帮我写广告词，强调降噪
+      prompt: 帮我写广告词，强调降噪
+      confirm_gate: false
+    confidence: 0.91
+    needs_clarify: false
+    reason: write text
+- id: llm-w04
+  category: llm-write-text
+  utterance: 输出文案，蓝牙耳机卖点
+  gold:
+    route: atomic_create
+    outcome: success
+    action: write
+    target_type: text
+  llm_fixture:
+    action: write
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: text
+      title: 输出文案，蓝牙耳机卖点
+      prompt: 输出文案，蓝牙耳机卖点
+      confirm_gate: false
+    confidence: 0.91
+    needs_clarify: false
+    reason: write text
+- id: llm-w05
+  category: llm-write-text
+  utterance: 来一段30秒短视频口播稿
+  gold:
+    route: atomic_create
+    outcome: success
+    action: write
+    target_type: text
+  llm_fixture:
+    action: write
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: text
+      title: 来一段30秒短视频口播稿
+      prompt: 来一段30秒短视频口播稿
+      confirm_gate: false
+    confidence: 0.91
+    needs_clarify: false
+    reason: write text
+- id: llm-w06
+  category: llm-write-text
+  utterance: 起草产品详情页文案
+  gold:
+    route: atomic_create
+    outcome: success
+    action: write
+    target_type: text
+  llm_fixture:
+    action: write
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: text
+      title: 起草产品详情页文案
+      prompt: 起草产品详情页文案
+      confirm_gate: false
+    confidence: 0.91
+    needs_clarify: false
+    reason: write text
+- id: llm-w07
+  category: llm-write-text
+  utterance: 写脚本，15秒产品介绍
+  gold:
+    route: atomic_create
+    outcome: success
+    action: write
+    target_type: text
+  llm_fixture:
+    action: write
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: text
+      title: 写脚本，15秒产品介绍
+      prompt: 写脚本，15秒产品介绍
+      confirm_gate: false
+    confidence: 0.91
+    needs_clarify: false
+    reason: write text
+- id: llm-w08
+  category: llm-write-text
+  utterance: 输出详情页模块说明文字
+  gold:
+    route: atomic_create
+    outcome: success
+    action: write
+    target_type: text
+  llm_fixture:
+    action: write
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: text
+      title: 输出详情页模块说明文字
+      prompt: 输出详情页模块说明文字
+      confirm_gate: false
+    confidence: 0.91
+    needs_clarify: false
+    reason: write text
+- id: llm-w09
+  category: llm-write-text
+  utterance: 撰写品牌slogan文案
+  gold:
+    route: atomic_create
+    outcome: success
+    action: write
+    target_type: text
+  llm_fixture:
+    action: write
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: text
+      title: 撰写品牌slogan文案
+      prompt: 撰写品牌slogan文案
+      confirm_gate: false
+    confidence: 0.91
+    needs_clarify: false
+    reason: write text
+- id: llm-w10
+  category: llm-write-text
+  utterance: 写一段品牌故事文案
+  gold:
+    route: atomic_create
+    outcome: success
+    action: write
+    target_type: text
+  llm_fixture:
+    action: write
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: text
+      title: 写一段品牌故事文案
+      prompt: 写一段品牌故事文案
+      confirm_gate: false
+    confidence: 0.91
+    needs_clarify: false
+    reason: write text
+- id: llm-e01
+  category: llm-expand-prompt
+  utterance: 帮我对「蓝牙耳机」做 prompt 扩写，出图用
+  gold:
+    route: atomic_create
+    outcome: success
+    action: expand
+    target_type: prompt
+  llm_fixture:
+    action: expand
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: prompt
+      title: 帮我对「蓝牙耳机」做 p
+      prompt: 帮我对「蓝牙耳机」做 prompt 扩写，出图用
+      confirm_gate: false
+      prompt_mode: generic
+    confidence: 0.92
+    needs_clarify: false
+    reason: expand prompt
+- id: llm-e02
+  category: llm-expand-prompt
+  utterance: 帮我生成一个年轻漂亮亚洲女性模特的三视图/四视图的提示词
+  gold:
+    route: atomic_create
+    outcome: success
+    action: expand
+    target_type: prompt
+  llm_fixture:
+    action: expand
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: prompt
+      title: 帮我生成一个年轻漂亮亚洲
+      prompt: 帮我生成一个年轻漂亮亚洲女性模特的三视图/四视图的提示词
+      confirm_gate: false
+      prompt_mode: character_turnaround
+    confidence: 0.92
+    needs_clarify: false
+    reason: expand prompt
+- id: llm-e03
+  category: llm-expand-prompt
+  utterance: 帮我生成问界M9的15秒商业分镜提示词
+  gold:
+    route: atomic_create
+    outcome: success
+    action: expand
+    target_type: prompt
+  llm_fixture:
+    action: expand
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: prompt
+      title: 帮我生成问界M9的15秒
+      prompt: 帮我生成问界M9的15秒商业分镜提示词
+      confirm_gate: false
+      prompt_mode: commercial_storyboard
+    confidence: 0.92
+    needs_clarify: false
+    reason: expand prompt
+- id: llm-e04
+  category: llm-expand-prompt
+  utterance: 用提示词模式扩写：赛博朋克耳机主图
+  gold:
+    route: atomic_create
+    outcome: success
+    action: expand
+    target_type: prompt
+  llm_fixture:
+    action: expand
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: prompt
+      title: 用提示词模式扩写：赛博朋
+      prompt: 用提示词模式扩写：赛博朋克耳机主图
+      confirm_gate: false
+      prompt_mode: generic
+    confidence: 0.92
+    needs_clarify: false
+    reason: expand prompt
+- id: llm-e05
+  category: llm-expand-prompt
+  utterance: 多模式扩写这个主图 prompt
+  gold:
+    route: atomic_create
+    outcome: success
+    action: expand
+    target_type: prompt
+  llm_fixture:
+    action: expand
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: prompt
+      title: 多模式扩写这个主图 pr
+      prompt: 多模式扩写这个主图 prompt
+      confirm_gate: false
+      prompt_mode: generic
+    confidence: 0.92
+    needs_clarify: false
+    reason: expand prompt
+- id: llm-e06
+  category: llm-expand-prompt
+  utterance: 帮我生成一个蓝牙耳机的分镜提示词
+  gold:
+    route: atomic_create
+    outcome: success
+    action: expand
+    target_type: prompt
+  llm_fixture:
+    action: expand
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: prompt
+      title: 帮我生成一个蓝牙耳机的分
+      prompt: 帮我生成一个蓝牙耳机的分镜提示词
+      confirm_gate: false
+      prompt_mode: generic
+    confidence: 0.92
+    needs_clarify: false
+    reason: expand prompt
+- id: llm-e07
+  category: llm-expand-prompt
+  utterance: 扩写三视图提示词，CG风格
+  gold:
+    route: atomic_create
+    outcome: success
+    action: expand
+    target_type: prompt
+  llm_fixture:
+    action: expand
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: prompt
+      title: 扩写三视图提示词，CG风
+      prompt: 扩写三视图提示词，CG风格
+      confirm_gate: false
+      prompt_mode: character_turnaround
+    confidence: 0.92
+    needs_clarify: false
+    reason: expand prompt
+- id: llm-e08
+  category: llm-expand-prompt
+  utterance: prompt扩写，商业分镜问界
+  gold:
+    route: atomic_create
+    outcome: success
+    action: expand
+    target_type: prompt
+  llm_fixture:
+    action: expand
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: prompt
+      title: prompt扩写，商业分
+      prompt: prompt扩写，商业分镜问界
+      confirm_gate: false
+      prompt_mode: commercial_storyboard
+    confidence: 0.92
+    needs_clarify: false
+    reason: expand prompt
+- id: llm-e09
+  category: llm-expand-prompt
+  utterance: 生成商业分镜提示词，AITO
+  gold:
+    route: atomic_create
+    outcome: success
+    action: expand
+    target_type: prompt
+  llm_fixture:
+    action: expand
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: prompt
+      title: 生成商业分镜提示词，AI
+      prompt: 生成商业分镜提示词，AITO
+      confirm_gate: false
+      prompt_mode: commercial_storyboard
+    confidence: 0.92
+    needs_clarify: false
+    reason: expand prompt
+- id: llm-e10
+  category: llm-expand-prompt
+  utterance: 扩写角色设定图提示词
+  gold:
+    route: atomic_create
+    outcome: success
+    action: expand
+    target_type: prompt
+  llm_fixture:
+    action: expand
+    scope: atomic
+    route: atomic_create
+    structure: single
+    items:
+    - target_type: prompt
+      title: 扩写角色设定图提示词
+      prompt: 扩写角色设定图提示词
+      confirm_gate: false
+      prompt_mode: character_turnaround
+    confidence: 0.92
+    needs_clarify: false
+    reason: expand prompt
+- id: llm-m01
+  category: llm-multi-image
+  utterance: 帮我生成三张图，分别是蓝牙耳机主图、白底图、三视图。
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+    multi: true
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: multi
+    items:
+    - target_type: image
+      title: 图1
+      prompt: 帮我生成三张图，分别是蓝牙耳机主图、白底图、三视图。
+      confirm_gate: false
+    - target_type: image
+      title: 图2
+      prompt: 帮我生成三张图，分别是蓝牙耳机主图、白底图、三视图。
+      confirm_gate: false
+    confidence: 0.9
+    needs_clarify: false
+    reason: multi image
+- id: llm-m02
+  category: llm-multi-image
+  utterance: 主图、白底和三视图各来一张
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+    multi: true
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: multi
+    items:
+    - target_type: image
+      title: 图1
+      prompt: 主图、白底和三视图各来一张
+      confirm_gate: false
+    - target_type: image
+      title: 图2
+      prompt: 主图、白底和三视图各来一张
+      confirm_gate: false
+    confidence: 0.9
+    needs_clarify: false
+    reason: multi image
+- id: llm-m03
+  category: llm-multi-image
+  utterance: 生成2张图片，分别是白底图、场景图。
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+    multi: true
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: multi
+    items:
+    - target_type: image
+      title: 图1
+      prompt: 生成2张图片，分别是白底图、场景图。
+      confirm_gate: false
+    - target_type: image
+      title: 图2
+      prompt: 生成2张图片，分别是白底图、场景图。
+      confirm_gate: false
+    confidence: 0.9
+    needs_clarify: false
+    reason: multi image
+- id: llm-m04
+  category: llm-multi-image
+  utterance: 来三张：主图、细节图、场景图
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+    multi: true
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: multi
+    items:
+    - target_type: image
+      title: 图1
+      prompt: 来三张：主图、细节图、场景图
+      confirm_gate: false
+    - target_type: image
+      title: 图2
+      prompt: 来三张：主图、细节图、场景图
+      confirm_gate: false
+    confidence: 0.9
+    needs_clarify: false
+    reason: multi image
+- id: llm-m05
+  category: llm-multi-image
+  utterance: 帮我生成主图、白底、Banner各一张
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+    multi: true
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: multi
+    items:
+    - target_type: image
+      title: 图1
+      prompt: 帮我生成主图、白底、Banner各一张
+      confirm_gate: false
+    - target_type: image
+      title: 图2
+      prompt: 帮我生成主图、白底、Banner各一张
+      confirm_gate: false
+    confidence: 0.9
+    needs_clarify: false
+    reason: multi image
+- id: llm-m06
+  category: llm-multi-image
+  utterance: 白底图、场景图、细节图各一张
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+    multi: true
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: multi
+    items:
+    - target_type: image
+      title: 图1
+      prompt: 白底图、场景图、细节图各一张
+      confirm_gate: false
+    - target_type: image
+      title: 图2
+      prompt: 白底图、场景图、细节图各一张
+      confirm_gate: false
+    confidence: 0.9
+    needs_clarify: false
+    reason: multi image
+- id: llm-m07
+  category: llm-multi-image
+  utterance: 生成三张产品图：正面、侧面、背面
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+    multi: true
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: multi
+    items:
+    - target_type: image
+      title: 图1
+      prompt: 生成三张产品图：正面、侧面、背面
+      confirm_gate: false
+    - target_type: image
+      title: 图2
+      prompt: 生成三张产品图：正面、侧面、背面
+      confirm_gate: false
+    confidence: 0.9
+    needs_clarify: false
+    reason: multi image
+- id: llm-m08
+  category: llm-multi-image
+  utterance: 主图和白底各来一张
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+    multi: true
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: multi
+    items:
+    - target_type: image
+      title: 图1
+      prompt: 主图和白底各来一张
+      confirm_gate: false
+    - target_type: image
+      title: 图2
+      prompt: 主图和白底各来一张
+      confirm_gate: false
+    confidence: 0.9
+    needs_clarify: false
+    reason: multi image
+- id: llm-m09
+  category: llm-multi-image
+  utterance: 帮我做三张电商图
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+    multi: true
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: multi
+    items:
+    - target_type: image
+      title: 图1
+      prompt: 帮我做三张电商图
+      confirm_gate: false
+    - target_type: image
+      title: 图2
+      prompt: 帮我做三张电商图
+      confirm_gate: false
+    confidence: 0.9
+    needs_clarify: false
+    reason: multi image
+- id: llm-m10
+  category: llm-multi-image
+  utterance: 生成多图：主图、场景、白底
+  gold:
+    route: atomic_create
+    outcome: success
+    action: generate
+    target_type: image
+    multi: true
+  llm_fixture:
+    action: generate
+    scope: atomic
+    route: atomic_create
+    structure: multi
+    items:
+    - target_type: image
+      title: 图1
+      prompt: 生成多图：主图、场景、白底
+      confirm_gate: false
+    - target_type: image
+      title: 图2
+      prompt: 生成多图：主图、场景、白底
+      confirm_gate: false
+    confidence: 0.9
+    needs_clarify: false
+    reason: multi image
+- id: llm-a01
+  category: llm-adversarial
+  utterance: 重新生成一张
+  gold:
+    route: atomic_regenerate
+    outcome: clarify
+  llm_fixture:
+    action: regenerate
+    route: atomic_regenerate
+    items: []
+    confidence: 0.2
+    needs_clarify: true
+    scope: atomic
+    structure: single
+    reason: adversarial
+- id: llm-a02
+  category: llm-adversarial
+  utterance: 按刚才那个风格再生成一张
+  gold:
+    route: atomic_regenerate
+    outcome: clarify
+  llm_fixture:
+    action: regenerate
+    route: atomic_regenerate
+    items: []
+    confidence: 0.18
+    needs_clarify: true
+    scope: atomic
+    structure: single
+    reason: adversarial
+- id: llm-a03
+  category: llm-adversarial
+  utterance: 重新生成一张，背景改成白色
+  gold:
+    route: atomic_regenerate
+    outcome: clarify
+  llm_fixture:
+    action: regenerate
+    route: atomic_regenerate
+    items: []
+    confidence: 0.18
+    needs_clarify: true
+    scope: atomic
+    structure: single
+    reason: adversarial
+- id: llm-a04
+  category: llm-adversarial
+  utterance: 确认出图
+  gold:
+    route: chat
+    outcome: clarify
+  llm_fixture:
+    action: unknown
+    route: chat
+    items: []
+    confidence: 0.3
+    needs_clarify: true
+    scope: atomic
+    structure: single
+    reason: adversarial
+- id: llm-a05
+  category: llm-adversarial
+  utterance: 蓝牙耳机主图
+  gold:
+    route: atomic_create
+    outcome: clarify
+  llm_fixture:
+    action: unknown
+    route: chat
+    items: []
+    confidence: 0.45
+    needs_clarify: true
+    scope: atomic
+    structure: single
+    reason: adversarial
+- id: llm-a06
+  category: llm-adversarial
+  utterance: 设计方案
+  gold:
+    route: campaign
+    outcome: clarify
+    forbid_image: true
+  llm_fixture:
+    action: plan
+    route: campaign
+    items: []
+    confidence: 0.7
+    needs_clarify: true
+    scope: campaign
+    structure: single
+    reason: adversarial
+- id: llm-a07
+  category: llm-adversarial
+  utterance: 写文案并生成主图
+  gold:
+    route: chat
+    outcome: clarify
+  llm_fixture:
+    action: unknown
+    route: chat
+    items: []
+    confidence: 0.5
+    needs_clarify: true
+    scope: atomic
+    structure: single
+    reason: adversarial
+- id: llm-a08
+  category: llm-adversarial
+  utterance: 帮我生成
+  gold:
+    route: chat
+    outcome: clarify
+  llm_fixture:
+    action: unknown
+    route: chat
+    items: []
+    confidence: 0.35
+    needs_clarify: true
+    scope: atomic
+    structure: single
+    reason: adversarial
+- id: llm-a09
+  category: llm-adversarial
+  utterance: 生成一下
+  gold:
+    route: chat
+    outcome: clarify
+  llm_fixture:
+    action: unknown
+    route: chat
+    items: []
+    confidence: 0.3
+    needs_clarify: true
+    scope: atomic
+    structure: single
+    reason: adversarial
+- id: llm-a10
+  category: llm-adversarial
+  utterance: 再试一次
+  gold:
+    route: atomic_regenerate
+    outcome: clarify
+  llm_fixture:
+    action: regenerate
+    route: atomic_regenerate
+    items: []
+    confidence: 0.25
+    needs_clarify: true
+    scope: atomic
+    structure: single
+    reason: adversarial
+- id: llm-c01
+  category: llm-clarify-expected
+  utterance: 帮我生成
+  gold:
+    route: chat
+    outcome: clarify
+  llm_fixture:
+    action: unknown
+    scope: unknown
+    route: chat
+    items: []
+    confidence: 0.4
+    needs_clarify: true
+    structure: single
+    reason: clarify expected
+- id: llm-c02
+  category: llm-clarify-expected
+  utterance: 生成一下
+  gold:
+    route: chat
+    outcome: clarify
+  llm_fixture:
+    action: unknown
+    scope: unknown
+    route: chat
+    items: []
+    confidence: 0.4
+    needs_clarify: true
+    structure: single
+    reason: clarify expected
+- id: llm-c03
+  category: llm-clarify-expected
+  utterance: 帮我做营销
+  gold:
+    route: chat
+    outcome: clarify
+  llm_fixture:
+    action: unknown
+    scope: unknown
+    route: chat
+    items: []
+    confidence: 0.4
+    needs_clarify: true
+    structure: single
+    reason: clarify expected
+- id: llm-c04
+  category: llm-clarify-expected
+  utterance: 设计
+  gold:
+    route: chat
+    outcome: clarify
+  llm_fixture:
+    action: unknown
+    scope: unknown
+    route: chat
+    items: []
+    confidence: 0.4
+    needs_clarify: true
+    structure: single
+    reason: clarify expected
+- id: llm-c05
+  category: llm-clarify-expected
+  utterance: 详情页
+  gold:
+    route: chat
+    outcome: clarify
+  llm_fixture:
+    action: unknown
+    scope: unknown
+    route: chat
+    items: []
+    confidence: 0.4
+    needs_clarify: true
+    structure: single
+    reason: clarify expected
+- id: llm-c06
+  category: llm-clarify-expected
+  utterance: 整一个方案
+  gold:
+    route: campaign
+    outcome: clarify
+  llm_fixture:
+    action: plan
+    scope: campaign
+    route: campaign
+    items: []
+    confidence: 0.65
+    needs_clarify: true
+    structure: single
+    reason: clarify expected
+- id: llm-c07
+  category: llm-clarify-expected
+  utterance: 帮我搞一下
+  gold:
+    route: chat
+    outcome: clarify
+  llm_fixture:
+    action: unknown
+    scope: unknown
+    route: chat
+    items: []
+    confidence: 0.4
+    needs_clarify: true
+    structure: single
+    reason: clarify expected
+- id: llm-c08
+  category: llm-clarify-expected
+  utterance: 做个东西
+  gold:
+    route: chat
+    outcome: clarify
+  llm_fixture:
+    action: unknown
+    scope: unknown
+    route: chat
+    items: []
+    confidence: 0.4
+    needs_clarify: true
+    structure: single
+    reason: clarify expected
+- id: llm-c09
+  category: llm-clarify-expected
+  utterance: 帮我整一个
+  gold:
+    route: chat
+    outcome: clarify
+  llm_fixture:
+    action: unknown
+    scope: unknown
+    route: chat
+    items: []
+    confidence: 0.4
+    needs_clarify: true
+    structure: single
+    reason: clarify expected
+- id: llm-c10
+  category: llm-clarify-expected
+  utterance: 来一个方案
+  gold:
+    route: campaign
+    outcome: clarify
+  llm_fixture:
+    action: plan
+    scope: campaign
+    route: campaign
+    items: []
+    confidence: 0.65
+    needs_clarify: true
+    structure: single
+    reason: clarify expected

--- a/services/agent-runtime/tests/test_clarify_reply.py
+++ b/services/agent-runtime/tests/test_clarify_reply.py
@@ -1,0 +1,40 @@
+from app.graph.clarify_reply import classify_clarify_reply
+from app.graph.intent_parse_schema import intent_result_to_parse_outcome
+
+
+def test_clarify_reply_choice_1_generate_image():
+    original = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    result = classify_clarify_reply(original, "q", "1")
+    assert result != "none"
+    assert result["route"] == "atomic_create"
+    assert result["items"][0]["target_type"] == "image"
+    outcome = intent_result_to_parse_outcome(result, "生成一张蓝牙耳机主图")
+    assert outcome["kind"] == "success"
+
+
+def test_clarify_reply_choice_2_campaign():
+    original = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    result = classify_clarify_reply(original, "q", "2")
+    assert result != "none"
+    assert result["route"] == "campaign"
+    outcome = intent_result_to_parse_outcome(result, original)
+    assert outcome["kind"] == "clarify"
+    assert outcome["reason"] == "llm_route_campaign"
+
+
+def test_clarify_reply_choice_3_vision_text():
+    original = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    result = classify_clarify_reply(original, "q", "3")
+    assert result != "none"
+    assert result["items"][0]["target_type"] == "text"
+    assert result["items"][0].get("prompt_mode") == "vision_text"
+
+
+def test_clarify_reply_natural_language():
+    result = classify_clarify_reply("主图详情页方案", "q", "只要文字版构图策划，不出图")
+    assert result != "none"
+    assert result["action"] == "write"
+
+
+def test_clarify_reply_unknown():
+    assert classify_clarify_reply("x", "q", "随便说说") == "none"

--- a/services/agent-runtime/tests/test_intent_llm_parse.py
+++ b/services/agent-runtime/tests/test_intent_llm_parse.py
@@ -1,0 +1,82 @@
+"""Phase C: LLM structured intent parse tests."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from app.graph.intent_parse_llm import llm_parse_intent, load_structured_intent_few_shots
+
+
+class FakeLLM:
+    def __init__(self, content: str) -> None:
+        self._content = content
+        self.calls = 0
+
+    async def ainvoke(self, messages):  # noqa: ANN001
+        self.calls += 1
+        return AIMessage(content=self._content)
+
+
+def test_load_structured_intent_few_shots():
+    shots = load_structured_intent_few_shots()
+    assert len(shots) >= 1
+
+
+@pytest.mark.asyncio
+async def test_llm_parse_intent_planning_campaign():
+    payload = {
+        "action": "plan",
+        "scope": "campaign",
+        "route": "campaign",
+        "structure": "single",
+        "items": [],
+        "confidence": 0.91,
+        "needs_clarify": False,
+        "clarify_question": None,
+        "reason": "主图+详情页构图方案 → Campaign",
+    }
+    llm = FakeLLM(json.dumps(payload))
+    result = await llm_parse_intent(
+        llm,
+        "请你帮我设计一个蓝牙耳机主图，详情页的构图方案",
+    )
+    assert result is not None
+    assert result["route"] == "campaign"
+    assert result["action"] == "plan"
+    assert llm.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_llm_parse_intent_retry_on_invalid_json():
+    llm = FakeLLM("not json")
+    result = await llm_parse_intent(llm, "生成一张主图")
+    assert result is None
+    assert llm.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_llm_parse_intent_generate_image():
+    payload = {
+        "action": "generate",
+        "scope": "atomic",
+        "route": "atomic_create",
+        "structure": "single",
+        "items": [
+            {
+                "target_type": "image",
+                "title": "主图",
+                "prompt": "蓝牙耳机主图",
+                "confirm_gate": False,
+            }
+        ],
+        "confidence": 0.94,
+        "needs_clarify": False,
+        "reason": "明确 generate image",
+    }
+    llm = FakeLLM(json.dumps(payload))
+    result = await llm_parse_intent(llm, "生成一张蓝牙耳机主图")
+    assert result is not None
+    assert result["items"][0]["target_type"] == "image"

--- a/services/agent-runtime/tests/test_intent_llm_parse_eval.py
+++ b/services/agent-runtime/tests/test_intent_llm_parse_eval.py
@@ -1,0 +1,129 @@
+"""Phase C: eval-intent-llm-set.yaml gold runner."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from app.graph.atomic_intent import parse_atomic_target_type, resolve_intake_route
+from app.graph.intent_parse_schema import intent_result_to_parse_outcome
+from app.graph.planning_guard import validate_llm_parse
+
+EVAL_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "atomic-create"
+    / "eval-intent-llm-set.yaml"
+)
+
+AGREEMENT_MIN = 0.90
+
+
+@pytest.fixture(scope="module")
+def llm_cases() -> list[dict]:
+    doc = yaml.safe_load(EVAL_PATH.read_text(encoding="utf-8"))
+    return doc["cases"]
+
+
+def test_eval_set_has_80_cases(llm_cases: list[dict]):
+    assert len(llm_cases) == 80
+
+
+def _outcome_matches_gold(outcome: dict, gold: dict, utterance: str) -> bool:
+    expected_outcome = gold.get("outcome")
+    if expected_outcome == "clarify":
+        if outcome.get("kind") != "clarify":
+            return False
+    elif expected_outcome == "success":
+        if outcome.get("kind") != "success":
+            return False
+        tt = gold.get("target_type")
+        if tt and outcome.get("items"):
+            if outcome["items"][0].get("target_type") != tt:
+                return False
+    if gold.get("forbid_image"):
+        if outcome.get("kind") == "success":
+            items = outcome.get("items") or []
+            if any(i.get("target_type") == "image" for i in items):
+                return False
+    route = gold.get("route")
+    if route == "campaign" and outcome.get("kind") == "clarify":
+        if outcome.get("reason") not in ("llm_route_campaign", "planning_image_conflict", "campaign_override"):
+            pass  # still OK for campaign expected clarify
+    if route == "atomic_create" and expected_outcome == "success":
+        if outcome.get("kind") != "success":
+            return False
+    del utterance
+    return True
+
+
+def test_eval_llm_fixture_gold(llm_cases: list[dict]):
+    mismatches: list[str] = []
+    for case in llm_cases:
+        fixture = case.get("llm_fixture")
+        if not fixture:
+            mismatches.append(f"{case['id']}: missing llm_fixture")
+            continue
+        utterance = case["utterance"]
+        gold = case["gold"]
+        guard = validate_llm_parse(fixture, utterance)  # type: ignore[arg-type]
+        outcome = guard or intent_result_to_parse_outcome(fixture, utterance)  # type: ignore[arg-type]
+        if not _outcome_matches_gold(outcome, gold, utterance):
+            mismatches.append(
+                f"{case['id']}: outcome {outcome.get('kind')}/{outcome.get('reason')} != gold {gold}"
+            )
+    assert not mismatches, "\n".join(mismatches)
+
+
+def test_eval_fixture_rule_route_agreement(llm_cases: list[dict]):
+    """Rule intake route agrees with gold.route on routable cases (≥90%)."""
+    routable = [
+        c
+        for c in llm_cases
+        if c["gold"].get("route") in ("campaign", "atomic_create")
+        and c["category"] not in ("llm-adversarial", "llm-clarify-expected")
+    ]
+    agree = 0
+    mismatches: list[str] = []
+    for case in routable:
+        utterance = case["utterance"]
+        gold_route = case["gold"]["route"]
+        pred = resolve_intake_route(utterance, focus_node_id=None)
+        if gold_route == "campaign":
+            ok = pred == "campaign"
+        else:
+            ok = pred == "atomic_create"
+            if not ok and parse_atomic_target_type(utterance):
+                ok = pred == "atomic_create"
+        if ok:
+            agree += 1
+        else:
+            mismatches.append(f"{case['id']}: rule route {pred} != {gold_route}")
+    rate = agree / len(routable) if routable else 1.0
+    assert rate >= AGREEMENT_MIN, f"agreement {rate:.1%}\n" + "\n".join(mismatches[:15])
+
+
+def test_agreement_report_artifact(llm_cases: list[dict], tmp_path: Path):
+    """Write agreement summary for CI artifact."""
+    total = len(llm_cases)
+    fixture_ok = 0
+    for case in llm_cases:
+        fixture = case.get("llm_fixture")
+        if not fixture:
+            continue
+        guard = validate_llm_parse(fixture, case["utterance"])  # type: ignore[arg-type]
+        outcome = guard or intent_result_to_parse_outcome(fixture, case["utterance"])  # type: ignore[arg-type]
+        if _outcome_matches_gold(outcome, case["gold"], case["utterance"]):
+            fixture_ok += 1
+    report = {
+        "total_cases": total,
+        "fixture_pass": fixture_ok,
+        "fixture_agreement_rate": round(fixture_ok / total, 4),
+        "gate_min": AGREEMENT_MIN,
+    }
+    out = tmp_path / "intent-llm-agreement.json"
+    out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    assert report["fixture_agreement_rate"] >= AGREEMENT_MIN

--- a/services/agent-runtime/tests/test_intent_parse_schema.py
+++ b/services/agent-runtime/tests/test_intent_parse_schema.py
@@ -1,0 +1,144 @@
+"""Phase C: IntentParseResult schema tests."""
+
+from __future__ import annotations
+
+import json
+
+from app.graph.intent_parse_schema import (
+    intent_result_to_parse_outcome,
+    parse_llm_json,
+)
+
+
+def test_parse_llm_json_valid():
+    raw = json.dumps(
+        {
+            "action": "generate",
+            "scope": "atomic",
+            "route": "atomic_create",
+            "structure": "single",
+            "items": [
+                {
+                    "target_type": "image",
+                    "title": "主图",
+                    "prompt": "蓝牙耳机主图",
+                    "confirm_gate": False,
+                }
+            ],
+            "confidence": 0.92,
+            "needs_clarify": False,
+            "clarify_question": None,
+            "reason": "明确出图",
+        }
+    )
+    result = parse_llm_json(raw)
+    assert result is not None
+    assert result["action"] == "generate"
+    assert result["route"] == "atomic_create"
+    assert len(result["items"]) == 1
+    assert result["confidence"] == 0.92
+
+
+def test_parse_llm_json_missing_fields_defaults():
+    raw = json.dumps({"items": []})
+    result = parse_llm_json(raw)
+    assert result is not None
+    assert result["action"] == "unknown"
+    assert result["route"] == "chat"
+    assert result["confidence"] == 0.0
+
+
+def test_parse_llm_json_invalid_target_type_skipped():
+    raw = json.dumps(
+        {
+            "route": "atomic_create",
+            "items": [
+                {"target_type": "pdf", "prompt": "x", "title": "x"},
+                {"target_type": "text", "prompt": "文案", "title": "文案"},
+            ],
+            "confidence": 0.9,
+        }
+    )
+    result = parse_llm_json(raw)
+    assert result is not None
+    assert len(result["items"]) == 1
+    assert result["items"][0]["target_type"] == "text"
+
+
+def test_parse_llm_json_confidence_clamped():
+    raw = json.dumps({"confidence": 1.5, "items": []})
+    result = parse_llm_json(raw)
+    assert result is not None
+    assert result["confidence"] == 1.0
+
+
+def test_intent_result_campaign_route_clarify():
+    result = parse_llm_json(
+        json.dumps(
+            {
+                "action": "plan",
+                "scope": "campaign",
+                "route": "campaign",
+                "items": [],
+                "confidence": 0.88,
+                "reason": "详情页方案",
+            }
+        )
+    )
+    assert result is not None
+    outcome = intent_result_to_parse_outcome(result, "设计蓝牙耳机详情页方案")
+    assert outcome["kind"] == "clarify"
+    assert outcome["reason"] == "llm_route_campaign"
+
+
+def test_intent_result_atomic_create_success():
+    result = parse_llm_json(
+        json.dumps(
+            {
+                "action": "generate",
+                "scope": "atomic",
+                "route": "atomic_create",
+                "structure": "single",
+                "items": [
+                    {
+                        "target_type": "image",
+                        "title": "主图",
+                        "prompt": "蓝牙耳机主图",
+                    }
+                ],
+                "confidence": 0.93,
+                "reason": "明确 generate",
+            }
+        )
+    )
+    assert result is not None
+    outcome = intent_result_to_parse_outcome(result, "生成一张蓝牙耳机主图")
+    assert outcome["kind"] == "success"
+    assert outcome["items"][0]["target_type"] == "image"
+
+
+def test_intent_result_planning_conflict_clarify():
+    result = parse_llm_json(
+        json.dumps(
+            {
+                "action": "generate",
+                "scope": "atomic",
+                "route": "atomic_create",
+                "structure": "single",
+                "items": [
+                    {
+                        "target_type": "image",
+                        "title": "主图",
+                        "prompt": "蓝牙耳机主图",
+                    }
+                ],
+                "confidence": 0.95,
+                "reason": "wrong image direct",
+            }
+        )
+    )
+    assert result is not None
+    utterance = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    outcome = intent_result_to_parse_outcome(result, utterance)
+    assert outcome["kind"] == "clarify"
+    assert outcome["reason"] == "planning_image_conflict"

--- a/services/agent-runtime/tests/test_planning_guard.py
+++ b/services/agent-runtime/tests/test_planning_guard.py
@@ -49,3 +49,47 @@ def test_detail_page_write_only_not_conflict():
     u = "写一份详情页模块构图策划文档，不出图"
     assert is_planning_intent(u)
     assert not has_planning_image_conflict(u)
+
+
+def test_validate_llm_parse_blocks_generate_on_planning_conflict():
+    from app.graph.planning_guard import validate_llm_parse
+
+    u = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    result = {
+        "action": "generate",
+        "route": "atomic_create",
+        "items": [{"target_type": "image", "prompt": u, "title": "主图"}],
+        "confidence": 0.95,
+    }
+    out = validate_llm_parse(result, u)  # type: ignore[arg-type]
+    assert out is not None
+    assert out["kind"] == "clarify"
+    assert out["reason"] == "planning_image_conflict"
+
+
+def test_validate_llm_parse_blocks_plan_with_image_items():
+    from app.graph.planning_guard import validate_llm_parse
+
+    u = "详情页构图方案"
+    result = {
+        "action": "plan",
+        "route": "atomic_create",
+        "items": [{"target_type": "image", "prompt": u, "title": "x"}],
+        "confidence": 0.9,
+    }
+    out = validate_llm_parse(result, u)  # type: ignore[arg-type]
+    assert out is not None
+    assert out["kind"] == "clarify"
+
+
+def test_validate_llm_parse_ok_for_explicit_generate():
+    from app.graph.planning_guard import validate_llm_parse
+
+    u = "生成一张蓝牙耳机主图"
+    result = {
+        "action": "generate",
+        "route": "atomic_create",
+        "items": [{"target_type": "image", "prompt": u, "title": "主图"}],
+        "confidence": 0.94,
+    }
+    assert validate_llm_parse(result, u) is None  # type: ignore[arg-type]

--- a/services/agent-runtime/tests/test_prompt_mode_taxonomy.py
+++ b/services/agent-runtime/tests/test_prompt_mode_taxonomy.py
@@ -1,0 +1,17 @@
+from app.tools.prompt_mode_taxonomy import resolve_prompt_mode
+
+
+def test_commercial_storyboard():
+    assert resolve_prompt_mode("帮我生成问界M9的15秒商业分镜提示词") == "commercial_storyboard"
+
+
+def test_character_turnaround():
+    assert resolve_prompt_mode("年轻女性模特三视图提示词") == "character_turnaround"
+
+
+def test_vision_text():
+    assert resolve_prompt_mode("写一份详情页视觉方案构图策划") == "vision_text"
+
+
+def test_generic_fallback():
+    assert resolve_prompt_mode("hello world product") == "generic"


### PR DESCRIPTION
## Summary
Phase C 完整实现（C0–C5），`INTENT_LLM_PARSE` 默认 **false**，生产行为与 Phase B 一致。

- C0: IntentParseResult schema + llm_parse_intent
- C1: eval-intent-llm-set 80 cases + shadow diff
- C2: validate_llm_parse + clarify 续聊 (1/2/3)
- C3: prompt_mode taxonomy 统一
- C4: LLM-first path + prod shadow verify
- C5: intent_parse 结构化日志

## Test plan
- [x] pytest 67 passed, B eval 25/25, pnpm build
- [ ] CI green
- [ ] 部署后 prod-atomic-intent-shadow-verify