### PR TITLE
fix: prompt_mode taxonomy path for Docker deploy

### DIFF
--- a/services/agent-runtime/app/tools/prompt_mode_taxonomy.py
+++ b/services/agent-runtime/app/tools/prompt_mode_taxonomy.py
@@ -9,11 +9,11 @@ from typing import Any
 
 import yaml
 
-from app.graph.atomic_parse_util import atomic_skill_path
+from app.config import settings
 
 
 def _taxonomy_candidates() -> list[Path]:
-    skill = atomic_skill_path()
+    skill = Path(settings.skills_dir) / "atomic-create"
     candidates = [
         skill / "assets" / "prompt-mode-taxonomy.yaml",
     ]

--- a/services/agent-runtime/app/tools/prompt_mode_taxonomy.py
+++ b/services/agent-runtime/app/tools/prompt_mode_taxonomy.py
@@ -9,13 +9,34 @@ from typing import Any
 
 import yaml
 
-_TAXONOMY_REL = Path(__file__).resolve().parents[4] / "packages" / "agent" / "src" / "prompt-modes" / "taxonomy.yaml"
+from app.graph.atomic_parse_util import atomic_skill_path
+
+
+def _taxonomy_candidates() -> list[Path]:
+    skill = atomic_skill_path()
+    candidates = [
+        skill / "assets" / "prompt-mode-taxonomy.yaml",
+    ]
+    here = Path(__file__).resolve()
+    # Monorepo dev fallback (packages/agent shared taxonomy)
+    if len(here.parents) >= 5:
+        candidates.append(
+            here.parents[4] / "packages" / "agent" / "src" / "prompt-modes" / "taxonomy.yaml"
+        )
+    return candidates
+
+
+def _resolve_taxonomy_path() -> Path | None:
+    for path in _taxonomy_candidates():
+        if path.is_file():
+            return path
+    return None
 
 
 @lru_cache(maxsize=1)
 def _load_taxonomy() -> list[dict[str, Any]]:
-    path = _TAXONOMY_REL
-    if not path.is_file():
+    path = _resolve_taxonomy_path()
+    if path is None:
         return []
     raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     modes = raw.get("modes") or []

--- a/services/agent-runtime/skills/atomic-create/assets/prompt-mode-taxonomy.yaml
+++ b/services/agent-runtime/skills/atomic-create/assets/prompt-mode-taxonomy.yaml
@@ -1,0 +1,72 @@
+# Shared prompt_mode taxonomy — mirrors classify.ts heuristicMode patterns
+version: 1
+modes:
+  - id: character_turnaround
+    patterns:
+      - 三视图
+      - 多视图
+      - 正侧背
+      - turnaround
+      - 模特图
+      - 角色设定
+      - 模特定妆
+      - 四视图
+      - q版
+      - q萌
+      - chibi
+      - 二头身
+      - 洛丽塔
+      - lolita
+      - 婚纱
+      - 战术
+      - 军事
+      - 牛仔
+      - 皮克斯
+      - 绘本
+      - 水彩
+  - id: commercial_storyboard
+    patterns:
+      - 商业分镜
+      - 品牌分镜
+      - 品牌广告
+      - 营销战役
+      - TVC
+      - 问界
+      - AITO
+      - 汽车广告
+      - 15秒
+      - 30秒
+      - 60秒
+      - 抖音前贴
+      - 发布会暖场
+      - 品牌形象片
+      - 闪电切割
+      - AIDA
+  - id: storyboard
+    patterns:
+      - 分镜
+  - id: script
+    patterns:
+      - 剧本
+      - 剧本大纲
+      - 人生观
+  - id: copywriting
+    patterns:
+      - 旁白
+      - 口播
+      - 文案
+  - id: image_prompt_multi_style
+    patterns:
+      - 提示词
+      - midjourney
+      - stable diffusion
+      - 绘画
+      - 车模
+  - id: vision_text
+    patterns:
+      - 视觉方案
+      - 构图策划
+      - 视觉脚本
+      - 页面结构稿
+  - id: generic
+    patterns: []


### PR DESCRIPTION
## Summary
- 修复 Agent Runtime 部署失败：`parents[4]` 在 Docker `/app` 下 IndexError
- 将 taxonomy 复制到 `skills/atomic-create/assets/prompt-mode-taxonomy.yaml`
- 加载器改用 `settings.skills_dir`，避免循环 import

## Test plan
- [x] `from app.graph.nodes.atomic_parse import make_parse_atomic_intent_node` OK
- [x] pytest test_prompt_mode_taxonomy + test_intent* — 23 passed
- [ ] CI green
- [ ] Deploy Agent Runtime success
- [ ] prod-p4-full-regression


Made with [Cursor](https://cursor.com)