### PR TITLE
fix: audio confirm gate parse for vo utterance

### DIFF
--- a/services/agent-runtime/app/graph/atomic_parse_util.py
+++ b/services/agent-runtime/app/graph/atomic_parse_util.py
@@ -265,15 +265,19 @@ def build_variant_spec_from_checkpoint(
 
 def extract_atomic_prompt(utterance: str) -> str:
     """Strip leading atomic hint prefixes; keep semantic payload for node prompt."""
-    t = (utterance or "").strip()
-    if not t:
+    original = (utterance or "").strip()
+    if not original:
         return ""
+    t = original
     for prefix in sorted(_STRIP_PREFIXES, key=len, reverse=True):
         if t.startswith(prefix):
             t = t[len(prefix) :].strip()
             break
     t = re.sub(r'^["「『](.+?)["」』]', r"\1", t).strip()
-    return t or utterance.strip()
+    # Avoid collapsing vo/audio requests to bare modality labels (e.g. 「旁白」)
+    if len(t) < 4 and len(original) >= 4:
+        return original
+    return t or original
 
 
 def build_atomic_spec_enriched(
@@ -358,12 +362,12 @@ def rule_parse_confidence(
         conf = 0.98
     elif not t or t in _VAGUE_UTTERANCES:
         conf = 0.40
+    elif spec.get("target_type") in ("video", "audio"):
+        conf = 0.95
     elif len(str(spec.get("prompt") or "").strip()) < 4:
         conf = 0.50
     elif any(k in t for k in _STRONG_SIGNAL_KEYWORDS):
         conf = 0.96
-    elif spec.get("target_type") in ("video", "audio"):
-        conf = 0.95
     else:
         from app.graph.atomic_intent import atomic_create_intent
 

--- a/services/agent-runtime/tests/test_atomic_parse_util.py
+++ b/services/agent-runtime/tests/test_atomic_parse_util.py
@@ -29,6 +29,23 @@ def test_extract_atomic_prompt_strips_prefix():
     assert extract_atomic_prompt("写一段天猫详情页开场文案") == "天猫详情页开场文案"
 
 
+def test_extract_atomic_prompt_preserves_audio_vo_utterance():
+    utterance = "给这段文案配一段旁白"
+    assert extract_atomic_prompt(utterance) == utterance
+
+
+def test_rule_parse_audio_vo_reaches_confirm_gate_confidence():
+    from app.graph.atomic_parse_util import rule_parse_atomic
+    from app.graph.atomic_parse_schema import outcome_from_rule_items
+
+    items, conf = rule_parse_atomic("给这段文案配一段旁白")
+    assert items[0]["target_type"] == "audio"
+    assert items[0]["confirm_gate"] is True
+    assert conf >= 0.95
+    outcome = outcome_from_rule_items(items, confidence=conf)
+    assert outcome["kind"] == "success"
+
+
 def test_parse_atomic_multi_items_three_images():
     from app.graph.atomic_parse_util import parse_atomic_multi_items
 


### PR DESCRIPTION
## Summary
- Fix `extract_atomic_prompt` so「给这段文案配一段旁白」is not stripped to「旁白」(2 chars), which caused rule confidence to fall below clarify threshold and skip `await_atomic_confirm`.
- Reorder `rule_parse_confidence` so audio/video modality checks run before the short-prompt penalty.

## Test plan
- [x] `pytest services/agent-runtime/tests/test_atomic_parse_util.py`
- [ ] CI green
- [ ] `deploy/prod-atomic-confirm-gate-verify.py` P4-06-5/6 pass after deploy


Made with [Cursor](https://cursor.com)