### PR TITLE
feat(agent): 侧栏文案规范 + ContextPacket 上下文工程

### DIFF
--- a/apps/server/src/agent/agent.service.ts
+++ b/apps/server/src/agent/agent.service.ts
@@ -261,6 +261,9 @@ export class AgentService {
       if (event.type === 'text_delta') {
         assistantText += (event.data as { text: string }).text
       }
+      if (event.type === 'text_replace') {
+        assistantText = (event.data as { text: string }).text
+      }
       if (event.type === 'canvas_action') {
         canvasActions.push(event.data as CanvasAction)
       }

--- a/apps/web/src/components/agent/AgentFloatingWindow.vue
+++ b/apps/web/src/components/agent/AgentFloatingWindow.vue
@@ -108,6 +108,9 @@ async function send() {
 
 function handleEvent(event: { type: string; data: unknown }) {
   switch (event.type) {
+    case 'text_replace':
+      agent.replaceAssistantText((event.data as { text: string }).text)
+      break
     case 'text_delta':
       agent.appendText((event.data as { text: string }).text)
       scrollToBottom()

--- a/apps/web/src/components/agent/AgentPanel.vue
+++ b/apps/web/src/components/agent/AgentPanel.vue
@@ -90,6 +90,9 @@ async function send() {
 
 function handleEvent(event: { type: string; data: unknown }) {
   switch (event.type) {
+    case 'text_replace':
+      agent.replaceAssistantText((event.data as { text: string }).text)
+      break
     case 'text_delta':
       agent.appendText((event.data as { text: string }).text)
       scrollToBottom()

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -643,6 +643,10 @@ async function reconcileLatestAssistant() {
 
 function handleEvent(event: { type: string; data: unknown }) {
   switch (event.type) {
+    case 'text_replace':
+      agent.replaceAssistantText((event.data as { text: string }).text)
+      scrollToBottom()
+      break
     case 'text_delta':
       agent.appendText((event.data as { text: string }).text)
       scrollToBottom()

--- a/apps/web/src/components/agent/agentChipSet.test.ts
+++ b/apps/web/src/components/agent/agentChipSet.test.ts
@@ -47,6 +47,12 @@ describe('detectAgentChipSet', () => {
     ).toBe('atomic')
   })
 
+  it('detects atomic confirm gate from sidebar copy snippet', () => {
+    expect(
+      detectAgentChipSet('收到，将为你创建视频「展示片」。提交前需你确认。'),
+    ).toBe('atomic')
+  })
+
   it('detects topo gate and prefers topo over bare plan words', () => {
     expect(
       detectAgentChipSet(
@@ -57,6 +63,10 @@ describe('detectAgentChipSet', () => {
 
   it('returns null for ordinary replies', () => {
     expect(detectAgentChipSet('出图成功')).toBe(null)
+  })
+
+  it('returns null for user-facing atomic ack without confirm gate', () => {
+    expect(detectAgentChipSet('好的，我来生成图片「主图」。')).toBe(null)
   })
 
   // 修复 P1-4 + P2-1：modify intent 检测的新优先级逻辑

--- a/apps/web/src/components/agent/agentChipSet.ts
+++ b/apps/web/src/components/agent/agentChipSet.ts
@@ -41,7 +41,7 @@ export function detectAgentChipSet(
   if (t.includes('【主文案草稿】') && !t.includes('已将确认的主文案写入')) return 'copy'
   if (t.includes('【主文案草稿】') && TOPO_SNIPPETS.some((s) => t.includes(s))) return 'topo'
   if (t.includes('视频/音频生成将消耗积分')) return 'atomic'
-  if (t.includes('原子创作：') && t.includes('需确认')) return 'atomic'
+  if (t.includes('提交前需你确认')) return 'atomic'
   if (TOPO_SNIPPETS.some((s) => t.includes(s))) return 'topo'
   if (COPY_SNIPPETS.some((s) => t.includes(s))) return 'copy'
   if (PLAN_SNIPPETS.some((s) => t.includes(s))) return 'plan'

--- a/apps/web/src/stores/agent.ts
+++ b/apps/web/src/stores/agent.ts
@@ -42,6 +42,13 @@ export const useAgentStore = defineStore('agent', () => {
     }
   }
 
+  function replaceAssistantText(text: string) {
+    const last = messages.value[messages.value.length - 1]
+    if (last?.role === 'assistant') {
+      last.content = text
+    }
+  }
+
   function addToolCall(name: string, result?: unknown) {
     const last = messages.value[messages.value.length - 1]
     if (last?.role === 'assistant') {
@@ -85,6 +92,7 @@ export const useAgentStore = defineStore('agent', () => {
     addUserMessage,
     startAssistantMessage,
     appendText,
+    replaceAssistantText,
     addToolCall,
     addCanvasAction,
     flushActions,

--- a/docs/superpowers/specs/2026-08-06-agent-context-engineering-design.md
+++ b/docs/superpowers/specs/2026-08-06-agent-context-engineering-design.md
@@ -1,0 +1,326 @@
+# Agent Context Engineering 设计（侧栏文案规范延伸）
+
+> 状态：**已确认**（2026-08-06）  
+> 前置：[2026-08-06-agent-sidebar-copy-design.md](./2026-08-06-agent-sidebar-copy-design.md)（Presentation 层）  
+> 关联：[2026-08-05-intent-llm-structured-parse-design.md](./2026-08-05-intent-llm-structured-parse-design.md)（L0–L4 意图模型）  
+> 原则：**用户看到的 ≠ 模型看到的**；上下文是稀缺资源，按任务按需装配
+
+---
+
+## 0. 为什么要单独设计 Context
+
+侧栏文案规范解决了 **Presentation 泄露**（把 parse 调试串给用户）。  
+但山海经案例的根因还有一半在 **Model Context 设计**：
+
+| 现象 | Context 层问题 |
+| --- | --- |
+| 蓝牙耳机 / 智慧园区污染 parse | 无差别注入「近期对话 2 轮 + 画布全摘要」 |
+| 用户换话题 Agent 仍像粘旧任务 | 缺少 **topic boundary** 与 relevance gate |
+| parse / plan / gen 混用同一 history | **未按阶段**切分 working memory |
+| 500 字硬截断 | 扁平字符串 ` \| ` 拼接，无优先级丢弃策略 |
+
+Context Engineering 目标：**让模型「刚好看见」完成当前步所需的信息**，且与用户侧栏文案彻底解耦。
+
+---
+
+## 1. 两层记忆模型（Pi / harness 通用模式）
+
+```mermaid
+flowchart TB
+  subgraph presentation ["Presentation Layer（用户可见）"]
+    SB["sidebar_copy 模板"]
+    TC["task_list / 进度卡"]
+  end
+
+  subgraph control ["Control Plane（LangGraph State）"]
+    PH["phase / flow_mode / user_decision"]
+    CK["checkpoint: atomic_spec, skill_id, focus_node_id"]
+  end
+
+  subgraph context ["Context Plane（仅 LLM / parse 消费）"]
+    AP["ActivePacket — 本轮任务包"]
+    EP["EpisodicPacket — 可选历史片段"]
+    CP["CanvasPacket — 画布摘要（引用 id）"]
+  end
+
+  subgraph truth ["Truth Plane（不进入 prompt）"]
+    NEST["Nest Session.canvasData"]
+    SNAP["context_snapshot 表"]
+  end
+
+  User --> presentation
+  User --> control
+  control --> context
+  context --> LLM["Parse / Plan LLM"]
+  NEST --> CP
+  SNAP --> EP
+  presentation -.->|禁止| LLM
+```
+
+| 层 | 存什么 | 不存什么 |
+| --- | --- | --- |
+| **Truth** | 全量 nodes/edges/url | 不进 LangGraph messages |
+| **Control** | phase、interrupt、atomic_spec 指针 | 长文 plan 正文（用 snapshot） |
+| **Context** | 结构化、有预算、可丢弃的摘要 | 用户侧栏文案、debug 字段 |
+| **Presentation** | 人话 + 进度 | canvas_context、confidence、route 名 |
+
+---
+
+## 2. ContextPacket 结构（替代扁平 `canvas_context` 字符串）
+
+**现状**（`atomic_context.py`）：
+
+```
+上轮原子:prompt:蓝牙耳机… | 画布 3 节点（image×2, prompt×1）| 近期对话:用户:…→助手:…
+```
+
+**目标**：typed blocks + 独立预算 + 显式 relevance。
+
+```typescript
+interface ContextPacket {
+  /** 当前 utterance 的语义锚点 — 永远保留 */
+  active: {
+    utterance: string
+    focus_node_id?: string
+    thread_phase?: string
+    flow_mode?: string
+  }
+
+  /** 仅在与当前任务相关时注入 */
+  task?: {
+    kind: 'atomic' | 'campaign' | 'regenerate' | 'single_node'
+    prior_title?: string      // 上轮 atomic title（短）
+    prior_target_type?: string
+    style_inherit?: boolean   // 「按刚才风格」时为 true
+  }
+
+  /** 画布 — 只给 id/type/title/status，不给 content/url */
+  canvas?: {
+    node_count: number
+    type_counts: Record<string, number>
+    relevant_nodes?: Array<{ id: string; type: string; title: string; status?: string }>
+    selected_node?: { id: string; type: string; title: string; prompt_hint?: string }
+  }
+
+  /** 历史 — 默认不注入；仅 style_inherit / regenerate / 指代消解时 */
+  episodic?: {
+    turns: Array<{ user: string; assistant_summary: string }>
+    max_turns: number
+  }
+
+  /** 元数据 — 永不进 prompt，仅日志/shadow eval */
+  meta?: {
+    topic_switch: boolean
+    dropped_sections: string[]
+    char_budget_used: number
+  }
+}
+```
+
+**LLM 侧序列化**（示例）：
+
+```markdown
+## 当前请求
+帮我生成一个山海经的神兽的三视图
+
+## 画布（摘要）
+共 3 节点：image×2, prompt×1
+选中节点：无
+
+## 任务上下文
+类型：atomic_create（新任务，与上轮「蓝牙耳机三视图 prompt」无关 — 已忽略上轮）
+
+## 规则
+仅解析当前请求；勿继承无关历史主题。
+```
+
+---
+
+## 3. 按阶段注入（Stage-Aware Context）
+
+不同图节点 **不应共用同一 context 配方**。
+
+| 阶段 | 消费者 | 应注入 | 应排除 |
+| --- | --- | --- | --- |
+| **intake / parse** | Intent LLM | `active.utterance`、精简 `canvas`、**条件** `task.prior_*` | Campaign 方案全文、assistant 侧栏旧文案、2 轮以上对话 |
+| **plan** | Plan LLM | `user_brief` anchor、`plan_draft` 摘要、skill body | 无关 atomic 历史、其他 session 节点 content |
+| **split / gen** | 工具编排 | manifest keys、node ids、depends_on | 对话 history |
+| **chat** | Chat LLM | 最近 1–2 轮 + 简短 canvas 一行 | 营销 manifest、atomic_spec |
+| **clarify** | 无 LLM 或极小 | 仅 `clarify_question` 模板 | 一切其它 |
+
+**硬规则：**
+
+1. **Parse 默认零 episodic** — 只有检测到指代/风格继承才打开 `episodic`。
+2. **Plan 默认零 canvas 全量** — 用 `context_snapshot` + `get_canvas_summary` 的 title 列表即可。
+3. **Gen 零 messages** — 只传 `node_id`，结果回 Nest。
+
+---
+
+## 4. Relevance Gate（解决话题污染）
+
+在 `build_context_packet()` 内增加 **相关性门控**（规则优先，LLM 可选）：
+
+### 4.1 Topic Switch 检测（已有 `topic_switch_prefix` 的用户侧版本）
+
+模型侧更严格：
+
+```python
+def should_include_prior_task(utterance: str, prior_spec: dict | None) -> bool:
+    if not prior_spec:
+        return False
+    if is_regenerate_phrase(utterance):      # 「再生成」「按刚才风格」
+        return True
+    if has_deictic_reference(utterance):    # 「这个」「那张」「同上」
+        return True
+    if titles_semantically_overlap(utterance, prior_spec["title"]):
+        return False  # 同主题续作 — 可带 prior
+    return False      # 默认：新 utterance = 新任务，丢弃 prior
+```
+
+**山海经 vs 蓝牙耳机**：`should_include_prior_task` → `False` → `task` block 省略或显式写「与上轮无关」。
+
+### 4.2 Canvas 节点筛选
+
+不要注入「已有：帮我拟定蓝牙耳机…」这种 title 全文列表。
+
+| 策略 | 做法 |
+| --- | --- |
+| **focus 优先** | 有 `focus_node_id` → 只注入该节点 + 直接上游 ref |
+| **类型过滤** | parse image 请求 → 最多列 3 个同类最近节点 title |
+| **状态过滤** | 优先 `generating` / 刚 `completed` 的节点（用户可能 regenerate） |
+| **Campaign 隔离** | `flow_mode=campaign` 的 plan 节点 title 不进入 atomic parse |
+
+### 4.3 Episodic 条件打开
+
+| 触发 | 注入量 |
+| --- | --- |
+| 「按刚才 / 同风格 / 再来一张」 | 1 轮 user+assistant **摘要**（非侧栏原文） |
+| 「改成 / 调整」且 prior_spec 存在 | prior title + 用户 modify 句 |
+| 全新主题 | **0 轮** |
+
+Assistant 摘要应用 **semantic summary**，不是侧栏 `sidebar_copy` 字符串：
+
+```python
+def summarize_assistant_for_context(content: str) -> str:
+    # 例：「已完成蓝牙耳机主图生成」而非「已在画布创建节点，正在生成…四格…」
+```
+
+---
+
+## 5. Context Budget（优先级丢弃）
+
+总预算建议（parse 路径）：
+
+| 块 | 上限 | 优先级 |
+| --- | --- | --- |
+| `active.utterance` | 200 字 | P0 — 永不丢 |
+| `task` | 80 字 | P1 |
+| `canvas.relevant_nodes` | 150 字 | P2 |
+| `canvas` 一行统计 | 60 字 | P3 |
+| `episodic` | 120 字 | P4 — 最先丢 |
+
+丢弃顺序：**episodic → canvas 详单 → canvas 统计 → task.prior**（除非 regenerate）。
+
+`meta.dropped_sections` 写日志，便于 shadow eval 对比。
+
+---
+
+## 6. Progressive Disclosure（Skills / 规则）
+
+对齐 Pi / Agent Skills 的 **按需加载**：
+
+| 层级 | 内容 | 何时加载 |
+| --- | --- | --- |
+| **L0** | Intent schema + 10 条硬约束 | 每次 parse |
+| **L1** | `intent-taxonomy.yaml` 摘要（route 定义） | parse |
+| **L2** | few-shots（按 detected action 过滤） | 低置信或 shadow |
+| **L3** | 完整 skill body | plan 节点 only |
+| **L4** | `canvas-manifest.yaml` | split / orchestrate_gen only |
+
+**不要**在 parse system prompt 里塞 turnaround 四格全文 — 只保留一条：`三视图无「提示词」→ pipeline=turnaround_image`。
+
+---
+
+## 7. 与现有组件的映射
+
+| 现有 | 演进 |
+| --- | --- |
+| `atomic_context.build_atomic_parse_context` | → `context_packet.build_parse_packet()` |
+| `atomic_parse_llm` 的 `[画布上下文] {string}` | → `render_packet_for_llm(packet, stage='parse')` |
+| `history_trim.trim_history` | 保留；Campaign plan 用 anchor |
+| `context_snapshot` | episodic 替代源；存 plan/manifest 摘要 |
+| `sidebar_copy` | 只读 `packet.active` + 执行结果，**不读** packet 全量 |
+| LangGraph `messages` | 只存 **用户可见** 往返；不把 context packet 写入 messages |
+
+---
+
+## 8. 实施路线（在侧栏规范之上）
+
+### Phase 1 — 结构化 + 门控（1–2 天，高收益）
+
+- [ ] 新增 `app/graph/context_packet.py`（`ContextPacket` + `build_parse_packet`）
+- [ ] `should_include_prior_task` / `should_include_episodic`
+- [ ] `atomic_parse_llm` / `intent_parse_llm` 改用 markdown block 渲染
+- [ ] 删除 pipe 拼接字符串；`atomic_spec.canvas_context` 改为存 JSON packet（或仅 debug log）
+
+### Phase 2 — Assistant 摘要与 Canvas 筛选（2–3 天）
+
+- [ ] `summarize_assistant_for_context()` — 从执行结果生成，非侧栏 copy
+- [ ] focus 节点 + 类型过滤的 `relevant_nodes`
+- [ ] shadow eval：`eval-intent-llm-set.yaml` 增加 **topic switch** 用例
+
+### Phase 3 — 分阶段配方（3–5 天）
+
+- [ ] `STAGE_CONTEXT_RECIPES`  registry（parse / plan / chat）
+- [ ] plan 节点读 snapshot，不读 messages 里的旧 atomic 文案
+- [ ] 统一 observability：`context_packet.meta` 进 LangSmith / 结构化 log
+
+---
+
+## 9. 验收（Context 层）
+
+1. **Topic switch**：蓝牙耳机 prompt → 山海经三视图；parse prompt **不含**蓝牙耳机/episodic。  
+2. **Style inherit**：「按刚才风格再来一张」；parse prompt **含** 1 轮 episodic + prior title。  
+3. **Focus**：选中 image 节点 + 「快速生成」；canvas 块 **仅**该节点。  
+4. **Budget**：超长 session；`active.utterance` 完整，episodic 被丢弃且 parse 仍正确。  
+5. **隔离**：侧栏文案变更 **不**改变 parse prompt（presentation ↔ context 零耦合）。
+
+---
+
+## 10. 反模式 checklist
+
+| 反模式 | 正确做法 |
+| --- | --- |
+| 把 debug context 拼进 AIMessage | packet 仅进 LLM user block |
+| 每轮注入最近 2 轮完整对话 | 默认 0；指代/风格才开 episodic |
+| 画布 title 全量列表 | relevant_nodes ≤3 或 focus only |
+| 同一字符串服务 UI + LLM | `sidebar_copy` vs `context_packet` 分离 |
+| 截断 500 字从右截 | 按优先级丢块，保留 utterance |
+| 在 messages 里累积机器 phase 文案 | messages = 用户可见历史；phase 在 state |
+
+---
+
+## 11. 与 Pi harness 的对照
+
+| Pi 实践 | lnkpi 映射 |
+| --- | --- |
+| Minimal system prompt | parse/plan 分阶段短 system + taxonomy |
+| Skills on demand | L0–L4 progressive disclosure |
+| Dynamic context injection | `ContextPacket` per stage |
+| Append-only session tree | LangGraph checkpoint + snapshot；messages 仅 visible |
+| Tool results → context | Nest tool 结果进 state pointer，不进 messages 全文 |
+
+lnkpi **额外**需要：Campaign HITL 门、canvas SoT 分离 — 这些不适合 Pi 默认 4-tool loop，但 **context 分层思想完全适用**。
+
+---
+
+## 12. 相关文件（规划）
+
+| 文件 | 职责 |
+| --- | --- |
+| `app/graph/context_packet.py` | **新建** — packet 构建、relevance gate、budget |
+| `app/graph/context_render.py` | **新建** — stage → markdown/json for LLM |
+| `app/graph/atomic_context.py` | 薄封装 / deprecated 转发 |
+| `app/graph/atomic_parse_llm.py` | 消费 rendered packet |
+| `app/graph/intent_parse_llm.py` | 同上 |
+| `docs/.../agent-sidebar-copy-design.md` | Presentation 层（已完成） |

--- a/docs/superpowers/specs/2026-08-06-agent-sidebar-copy-design.md
+++ b/docs/superpowers/specs/2026-08-06-agent-sidebar-copy-design.md
@@ -1,0 +1,171 @@
+# Agent 侧栏 Assistant 文案规范
+
+> 状态：**已确认**（2026-08-06）  
+> 范围：`AgentSideRail` 用户可见助手文案、SSE 呈现协议、原子创作（atomic_create）路径  
+> 触发：山海经三视图对话暴露内部 context 泄露、多段拼接、术语外露等问题  
+> 非范围：三视图四格的事前确认弹窗（产品已定：仅 informational 说明，不阻断）
+
+---
+
+## 0. 原则
+
+| 原则 | 说明 |
+| --- | --- |
+| **用户语言优先** | 侧栏只展示创作者能读懂的中文，禁止路由名、节点 type、debug context |
+| **一轮一气泡、阶段替换** | 同一 user turn 内助手气泡用 `text_replace` 随阶段更新，不 append 多段机器日志 |
+| **内外分离** | `canvas_context`、checkpoint、confidence 仅给 LLM/parse，**禁止**拼进 `AIMessage` |
+| **进度可感知** | 原子路径 emit `task_list` / `task_update`，与 Campaign 任务卡一致 |
+| **说一次** | turnaround 四格说明只在「创建节点→生成中」阶段出现一次 |
+
+---
+
+## 1. 可见 vs 不可见
+
+### 1.1 禁止出现在侧栏
+
+- `原子创作：`、`image 节点（直达）`、`flow_mode`、`atomic_parse`
+- 方括号内的 parse context：`[上轮原子:… \| 画布 N 节点 \| 近期对话:…]`
+- `record:`、`generationRecordId`、内部 error type
+- Campaign 方案全文、无关会话摘要
+
+### 1.2 允许（info，非 confirm）
+
+- 三视图 pipeline 说明：`已按角色设定图模版扩写…四格横排…2:1 画幅（非账户默认比例）。`  
+  — **仅**在「已在画布创建节点，正在生成…」阶段附加一次，**不**事前询问「可以吗」
+
+---
+
+## 2. SSE 协议
+
+| 事件 | 用途 | 前端行为 |
+| --- | --- | --- |
+| `text_replace` | 图节点产出的**整段**用户可见文案（每阶段一次） | 替换当前 assistant 气泡 `content` |
+| `text_delta` | LLM 流式 token（Campaign plan 等） | 追加 token（保留现有行为） |
+| `task_list` | 原子/Campaign 任务清单初始化 | 渲染任务进度卡 |
+| `task_update` | 单任务状态变更 | 更新进度卡 |
+| `node_status` | 画布节点 generating/completed | 画布 + 可选轮询（已有） |
+
+**规则：** `runs.py` 对 LangGraph 节点 `AIMessage` 发 `text_replace`；仅真实 LLM streaming 用 `text_delta`。
+
+---
+
+## 3. 原子创作（atomic_create）文案模板
+
+实现：`services/agent-runtime/app/graph/sidebar_copy.py`
+
+### 3.1 阶段 A — 意图确认（parse_atomic_intent）
+
+**时机：** 解析成功，尚未建节点  
+
+**单节点：**
+
+| 条件 | 模板 |
+| --- | --- |
+| 默认 | `好的，我来生成{模态}「{title}」。` |
+| turnaround_image | `好的，我来生成「{title}」的角色设定图（四格）。` |
+| confirm_gate（video/audio） | `收到，将为你创建{模态}「{title}」。提交前需你确认。` |
+| 话题切换 | 前缀 `已按你的新需求处理：` |
+
+**多图：**
+
+`好的，我将创建 {N} 张图片：{title1}、{title2}、…。`
+
+### 3.2 阶段 B — 创建节点（create_atomic_node）
+
+`已在画布创建节点，正在为「{title}」生成…`
+
+- turnaround：`+ turnaround_pipeline_user_note()`（四格 + 2:1 说明）
+- 其他：`可在画布查看进度。`
+
+同时 emit：
+
+```json
+{ "type": "task_list", "data": { "items": [{ "id": "...", "title": "...", "status": "pending", "nodeId": "..." }] } }
+```
+
+### 3.3 阶段 C — 生成完成（run_atomic_gen）
+
+| 结果 | 模板 |
+| --- | --- |
+| 成功 | `「{title}」生成完成，请在画布查看节点。` |
+| 部分失败 | `部分完成：…；未完成：…。请在画布查看。` |
+| 失败 | `「{title}」生成未完成（{reason}）。可在画布节点重试。` |
+
+emit `task_update`：`running` → `done` / `failed`
+
+### 3.4 澄清（clarify）
+
+直接使用 `clarify_question` 原文，已是用户语言。
+
+---
+
+## 4. 问题对照与修复
+
+| 级别 | 问题 | 修复 |
+| --- | --- | --- |
+| **P0** | `canvas_context` 泄露到侧栏 | `parse_outcome_to_state` 不再把 context 拼进 `AIMessage`；仅写入 state/LLM |
+| **P0** | 多阶段 AIMessage 被 append 成乱文 | Runtime 发 `text_replace`；前端 `replaceAssistantText` |
+| **P0** | turnaround 说明重复两次 | 仅从 `format_atomic_create_progress` 输出一次 |
+| **P1** | 开发者术语 | 统一走 `sidebar_copy` 模板 |
+| **P1** | 话题切换无 acknowledge | `topic_switch_prefix()` 检测 prior vs new title |
+| **P2** | 原子路径无进度卡 | `create_atomic_node` → `task_list`；`run_atomic_gen` → `task_update` |
+| **P2** | `record:` 泄露 | 完成文案不再附加 record id |
+
+### Phase 1 实现（本 PR）
+
+- [x] `app/graph/context_packet.py` — packet 构建 + relevance gate
+- [x] `app/graph/context_render.py` — markdown 渲染
+- [x] `atomic_context.py` — 委托 packet/render
+- [x] `intent_parse_llm` / `atomic_parse_llm` — `context_markdown`
+- [x] `tests/test_context_packet.py`
+
+---
+
+## 5. Campaign / 其他路径（后续）
+
+本期仅强制 atomic_create。Campaign 路径沿用现有文案，但应逐步：
+
+- plan 摘要避免 manifest 机器列表裸露
+- busy tip / 出图汇总保持短句 + 任务卡
+
+---
+
+## 6. 验收
+
+1. 输入「帮我生成一个山海经的神兽的三视图」  
+   - 侧栏**无**蓝牙耳机/营销方案/方括号 context  
+   - **无**「原子创作」「image 节点（直达）」  
+   - 四格说明**最多出现一次**  
+2. 同一 turn 内气泡内容随阶段**替换**，非无限变长拼接  
+3. 生成过程中任务进度卡可见，完成后可定位节点  
+4. 连发不同主题时，第二条含「已按你的新需求处理：」（当 title 明显不同）
+
+---
+
+## 7. 相关文件
+
+| 文件 | 职责 |
+| --- | --- |
+| `app/graph/sidebar_copy.py` | 文案模板 |
+| `app/graph/atomic_parse_schema.py` | parse 阶段 AIMessage |
+| `app/graph/nodes/atomic_create_node.py` | 创建 + task_list |
+| `app/graph/nodes/run_atomic_gen.py` | 完成文案 + task_update |
+| `app/runs.py` | `text_replace` 发射 |
+| `apps/web/src/stores/agent.ts` | `replaceAssistantText` |
+| `apps/web/src/components/agent/AgentSideRail.vue` | 处理 `text_replace` |
+| `apps/web/src/components/agent/agentChipSet.ts` | atomic 确认门检测 snippet |
+
+---
+
+## 8. Context Engineering（延伸）
+
+Presentation 层（本文）与 Model Context 层分离。上下文如何按阶段装配、避免话题污染、预算丢弃策略，见：
+
+**[2026-08-06-agent-context-engineering-design.md](./2026-08-06-agent-context-engineering-design.md)**
+
+要点摘要：
+
+- **ContextPacket** 替代扁平 `canvas_context` 字符串
+- **默认零 episodic**；仅指代/风格继承时注入历史
+- **Topic switch** 时丢弃 prior atomic，parse prompt 显式声明「新任务」
+- parse / plan / gen **分阶段配方**，不共用同一 history 块

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -36,6 +36,7 @@ export interface AgentContext {
 export interface AgentStreamEvent {
   type:
     | 'text_delta'
+    | 'text_replace'
     | 'tool_call'
     | 'tool_result'
     | 'canvas_action'

--- a/services/agent-runtime/app/graph/atomic_context.py
+++ b/services/agent-runtime/app/graph/atomic_context.py
@@ -1,10 +1,11 @@
-"""Phase 3: compact context for atomic parse (canvas + recent dialogue)."""
+"""Phase 3: compact context for atomic parse — delegates to ContextPacket."""
 
 from __future__ import annotations
 
 from typing import Any
 
-from app.graph.atomic_parse_util import canvas_summary_nodes, format_canvas_context_line
+from app.graph.context_packet import build_parse_packet
+from app.graph.context_render import render_packet_for_llm
 
 _MAX_CONTEXT_CHARS = 500
 
@@ -26,7 +27,7 @@ def _message_content(msg: Any) -> str:
 
 
 def summarize_recent_turns(messages: list[Any] | None, *, max_turns: int = 2) -> str:
-    """Compact summary of the last N user→assistant turns."""
+    """Compact summary of the last N user→assistant turns (legacy helper / tests)."""
     turns: list[str] = []
     pending_user: str | None = None
     for msg in messages or []:
@@ -53,24 +54,9 @@ def build_atomic_parse_context(
     canvas_summary: dict[str, Any] | None = None,
     max_chars: int = _MAX_CONTEXT_CHARS,
 ) -> str:
-    """Canvas one-liner + last 2 dialogue turns for hybrid parse."""
-    parts: list[str] = []
-    prior = state.get("atomic_spec")
-    if isinstance(prior, dict):
-        title = str(prior.get("title") or "").strip()
-        target = str(prior.get("target_type") or "").strip()
-        if title:
-            parts.append(f"上轮原子:{target or 'image'}:{title[:32]}")
-    nodes = canvas_summary_nodes(canvas_summary)
-    canvas_line = format_canvas_context_line(nodes)
-    if canvas_line:
-        parts.append(canvas_line)
-    history = summarize_recent_turns(state.get("messages") or [])
-    if history:
-        parts.append(f"近期对话:{history}")
-    if not parts:
-        return ""
-    ctx = " | ".join(parts)
-    if len(ctx) <= max_chars:
-        return ctx
-    return ctx[: max_chars - 1] + "…"
+    """Structured markdown context for parse LLM (replaces pipe-delimited string)."""
+    packet = build_parse_packet(state, canvas_summary=canvas_summary)
+    rendered = render_packet_for_llm(packet)
+    if len(rendered) <= max_chars:
+        return rendered
+    return rendered[: max_chars - 1] + "…"

--- a/services/agent-runtime/app/graph/atomic_parse_llm.py
+++ b/services/agent-runtime/app/graph/atomic_parse_llm.py
@@ -69,6 +69,7 @@ async def llm_parse_atomic_intent(
     utterance: str,
     *,
     canvas_context: str | None = None,
+    context_markdown: str | None = None,
     few_shots: list[tuple[str, str]] | None = None,
 ) -> dict[str, Any] | None:
     """Call LLM for structured atomic parse JSON; None on failure."""
@@ -76,8 +77,9 @@ async def llm_parse_atomic_intent(
         return None
     shots = few_shots if few_shots is not None else load_atomic_parse_few_shots()
     user_block = utterance.strip()
-    if canvas_context:
-        user_block = f"{user_block}\n\n[画布上下文] {canvas_context}"
+    ctx = (context_markdown or canvas_context or "").strip()
+    if ctx:
+        user_block = f"{user_block}\n\n{ctx}"
     messages = build_llm_messages(system=_PARSE_SYSTEM, user=user_block, few_shots=shots)
     try:
         resp = await llm.ainvoke(messages)

--- a/services/agent-runtime/app/graph/atomic_parse_schema.py
+++ b/services/agent-runtime/app/graph/atomic_parse_schema.py
@@ -6,7 +6,8 @@ from typing import Any, Literal, TypedDict
 
 from langchain_core.messages import AIMessage
 
-from app.graph.atomic_intent import confirm_gate_for_type, _is_campaign_override, turnaround_pipeline_user_note
+from app.graph.atomic_intent import confirm_gate_for_type, _is_campaign_override
+from app.graph.sidebar_copy import format_atomic_multi_ack, format_atomic_parse_ack
 from app.graph.intent import marketing_intent
 from app.graph.planning_guard import has_planning_image_conflict, planning_clarify_question
 
@@ -200,7 +201,12 @@ def outcome_from_rule_items(
     return validate_parse_result(payload, utterance=items[0].get("prompt", "") if items else "")
 
 
-def parse_outcome_to_state(outcome: ParseOutcome, *, canvas_context: str | None = None) -> dict[str, Any]:
+def parse_outcome_to_state(
+    outcome: ParseOutcome,
+    *,
+    canvas_context: str | None = None,
+    prior_spec: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Map validated parse outcome to graph state patch."""
     if outcome["kind"] == "clarify":
         return {
@@ -223,12 +229,7 @@ def parse_outcome_to_state(outcome: ParseOutcome, *, canvas_context: str | None 
 
     if len(items) == 1:
         spec = first
-        target = spec["target_type"]
-        gate = "需确认" if spec["confirm_gate"] else "直达"
-        ctx_note = f" [{canvas_context}]" if canvas_context else ""
-        msg = f"原子创作：{target} 节点（{gate}）— {spec['title']}{ctx_note}"
-        if spec.get("pipeline") == "turnaround_image":
-            msg += turnaround_pipeline_user_note()
+        msg = format_atomic_parse_ack(spec, prior_spec=prior_spec)
         return {
             "phase": "atomic_parse",
             "flow_mode": "atomic_create",
@@ -238,9 +239,7 @@ def parse_outcome_to_state(outcome: ParseOutcome, *, canvas_context: str | None 
             "messages": [AIMessage(content=msg)],
         }
 
-    titles = "、".join(str(i.get("title") or "") for i in items)
-    ctx_note = f" [{canvas_context}]" if canvas_context else ""
-    msg = f"原子创作：{len(items)} 张 image 节点 — {titles}{ctx_note}"
+    msg = format_atomic_multi_ack(items, prior_spec=prior_spec)
     return {
         "phase": "atomic_parse",
         "flow_mode": "atomic_create",

--- a/services/agent-runtime/app/graph/atomic_parse_util.py
+++ b/services/agent-runtime/app/graph/atomic_parse_util.py
@@ -69,7 +69,7 @@ def canvas_summary_nodes(canvas_summary: dict[str, Any] | None) -> list[dict[str
     return [n for n in raw if isinstance(n, dict)]
 
 
-def format_canvas_context_line(nodes: list[dict[str, Any]]) -> str:
+def format_canvas_context_line(nodes: list[dict[str, Any]], *, include_titles: bool = True) -> str:
     """Compact canvas stats for parse context (P4-05)."""
     if not nodes:
         return "画布为空"
@@ -78,9 +78,11 @@ def format_canvas_context_line(nodes: list[dict[str, Any]]) -> str:
         kind = str(node.get("type") or "unknown")
         by_type[kind] = by_type.get(kind, 0) + 1
     counts = ", ".join(f"{k}×{v}" for k, v in sorted(by_type.items()))
-    titles = [str(n.get("title") or "").strip() for n in nodes if n.get("title")]
-    titles = [t for t in titles if t][:8]
-    title_bit = f"；已有：{'、'.join(titles)}" if titles else ""
+    title_bit = ""
+    if include_titles:
+        titles = [str(n.get("title") or "").strip() for n in nodes if n.get("title")]
+        titles = [t for t in titles if t][:8]
+        title_bit = f"；已有：{'、'.join(titles)}" if titles else ""
     return f"画布 {len(nodes)} 节点（{counts}）{title_bit}"
 
 
@@ -106,7 +108,17 @@ def dedupe_atomic_title(title: str, nodes: list[dict[str, Any]]) -> str:
 def style_seed_from_context(parse_context: str | None) -> str | None:
     """Pull prior user topic from compact dialogue summary for style inheritance."""
     ctx = (parse_context or "").strip()
-    if not ctx or "近期对话:" not in ctx:
+    if not ctx:
+        return None
+    if "## 近期" in ctx:
+        for line in ctx.splitlines():
+            line = line.strip()
+            if not line.startswith("用户:"):
+                continue
+            user_part = line.split("用户:", 1)[1].split("→", 1)[0].strip()
+            if user_part and len(user_part) >= 4:
+                return user_part[:80]
+    if "近期对话:" not in ctx:
         return None
     tail = ctx.split("近期对话:", 1)[1]
     for chunk in tail.split("；"):

--- a/services/agent-runtime/app/graph/context_packet.py
+++ b/services/agent-runtime/app/graph/context_packet.py
@@ -1,0 +1,248 @@
+"""Structured context packets for LLM parse (replaces flat pipe-delimited strings)."""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+from app.graph.atomic_parse_util import (
+    _DEICTIC_HINTS,
+    _STYLE_INHERIT_HINTS,
+    canvas_summary_nodes,
+    format_canvas_context_line,
+)
+from app.graph.atomic_intent import is_regenerate_new_variant
+
+# Budget limits (chars) — see docs/.../agent-context-engineering-design.md
+_BUDGET_UTTERANCE = 200
+_BUDGET_TASK = 80
+_BUDGET_CANVAS_NODES = 150
+_BUDGET_CANVAS_STATS = 60
+_BUDGET_EPISODIC = 120
+_MAX_RELEVANT_NODES = 3
+
+
+class EpisodicTurn(TypedDict):
+    user: str
+    assistant_summary: str
+
+
+class ContextPacket(TypedDict, total=False):
+    active: dict[str, Any]
+    task: dict[str, Any]
+    canvas: dict[str, Any]
+    episodic: dict[str, Any]
+    meta: dict[str, Any]
+
+
+def _latest_utterance(state: dict[str, Any]) -> str:
+    for msg in reversed(state.get("messages") or []):
+        role = getattr(msg, "type", None) or (msg.get("role") if isinstance(msg, dict) else None)
+        content = getattr(msg, "content", None) or (msg.get("content") if isinstance(msg, dict) else "")
+        if role in ("human", "user") and content:
+            return str(content).strip()
+    return ""
+
+
+def _has_deictic_reference(text: str) -> bool:
+    return any(h in (text or "") for h in _DEICTIC_HINTS)
+
+
+def _has_style_inherit(text: str) -> bool:
+    return any(h in (text or "") for h in _STYLE_INHERIT_HINTS)
+
+
+def _titles_overlap(utterance: str, prior_title: str) -> bool:
+    prior = (prior_title or "").strip()
+    new = (utterance or "").strip()
+    if not prior or not new:
+        return False
+    if prior == new or prior in new or new in prior:
+        return True
+    prior_tokens = {t for t in prior.replace("，", " ").split() if len(t) >= 2}
+    new_tokens = {t for t in new.replace("，", " ").split() if len(t) >= 2}
+    return bool(prior_tokens & new_tokens)
+
+
+def should_include_prior_task(utterance: str, prior_spec: dict[str, Any] | None) -> bool:
+    if not prior_spec:
+        return False
+    if is_regenerate_new_variant(utterance):
+        return True
+    if _has_style_inherit(utterance):
+        return True
+    if _has_deictic_reference(utterance):
+        return True
+    title = str(prior_spec.get("title") or "")
+    if _titles_overlap(utterance, title):
+        return True
+    return False
+
+
+def should_include_episodic(utterance: str, prior_spec: dict[str, Any] | None) -> bool:
+    if _has_style_inherit(utterance) or is_regenerate_new_variant(utterance):
+        return True
+    if _has_deictic_reference(utterance) and prior_spec:
+        return True
+    return False
+
+
+def _summarize_assistant_for_context(content: str) -> str:
+    """Semantic one-liner for episodic — not raw sidebar copy."""
+    text = (content or "").strip().replace("\n", " ")
+    if not text:
+        return ""
+    if "生成完成" in text or "已完成" in text:
+        return "生成已完成"
+    if "正在生成" in text or "已在画布创建" in text:
+        return "正在生成"
+    if "角色设定图" in text or "四格" in text:
+        return "角色设定图处理中"
+    if "确认" in text and "方案" in text:
+        return "方案待确认"
+    if len(text) > 80:
+        return text[:77] + "…"
+    return text
+
+
+def _build_episodic_turns(messages: list[Any] | None, *, max_turns: int = 1) -> list[EpisodicTurn]:
+    turns: list[EpisodicTurn] = []
+    pending_user: str | None = None
+    for msg in messages or []:
+        role = getattr(msg, "type", None) or (msg.get("role") if isinstance(msg, dict) else None)
+        content = getattr(msg, "content", None) or (msg.get("content") if isinstance(msg, dict) else "")
+        content = str(content or "").strip()
+        if not content:
+            continue
+        if role in ("human", "user"):
+            pending_user = content[:80] + ("…" if len(content) > 80 else "")
+        elif role in ("ai", "assistant") and pending_user:
+            turns.append(
+                {
+                    "user": pending_user,
+                    "assistant_summary": _summarize_assistant_for_context(content),
+                }
+            )
+            pending_user = None
+    return turns[-max_turns:]
+
+
+def _select_relevant_nodes(
+    nodes: list[dict[str, Any]],
+    *,
+    focus_node_id: str | None,
+    utterance: str,
+) -> list[dict[str, Any]]:
+    if focus_node_id:
+        for node in nodes:
+            if str(node.get("id") or "") == focus_node_id:
+                return [node]
+    if not nodes:
+        return []
+    # Prefer recently completed / generating image nodes when no focus
+    scored: list[tuple[int, dict[str, Any]]] = []
+    for node in nodes:
+        status = str(node.get("status") or "").lower()
+        score = 0
+        if status in ("completed", "generating", "success"):
+            score += 2
+        if str(node.get("type") or "") == "image":
+            score += 1
+        scored.append((score, node))
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [n for _, n in scored[:_MAX_RELEVANT_NODES]]
+
+
+def build_parse_packet(
+    state: dict[str, Any],
+    *,
+    canvas_summary: dict[str, Any] | None = None,
+    utterance: str | None = None,
+) -> ContextPacket:
+    """Build structured context for parse-stage LLM."""
+    text = (utterance or _latest_utterance(state)).strip()
+    prior_spec = state.get("atomic_spec")
+    prior = prior_spec if isinstance(prior_spec, dict) else None
+    focus_node_id = str(state.get("focus_node_id") or "").strip() or None
+    nodes = canvas_summary_nodes(canvas_summary)
+
+    dropped: list[str] = []
+    include_prior = should_include_prior_task(text, prior)
+    include_episodic = should_include_episodic(text, prior)
+    topic_switch = bool(prior and not include_prior and str(prior.get("title") or "").strip())
+
+    packet: ContextPacket = {
+        "active": {
+            "utterance": text[:_BUDGET_UTTERANCE],
+            "focus_node_id": focus_node_id,
+            "thread_phase": str(state.get("phase") or "") or None,
+            "flow_mode": str(state.get("flow_mode") or "") or None,
+        },
+        "meta": {
+            "topic_switch": topic_switch,
+            "dropped_sections": dropped,
+            "char_budget_used": 0,
+        },
+    }
+
+    if include_prior and prior:
+        task: dict[str, Any] = {
+            "kind": "atomic",
+            "prior_title": str(prior.get("title") or "")[:32],
+            "prior_target_type": str(prior.get("target_type") or "image"),
+            "style_inherit": _has_style_inherit(text),
+        }
+        packet["task"] = task  # type: ignore[assignment]
+    elif topic_switch:
+        packet["task"] = {  # type: ignore[assignment]
+            "kind": "atomic",
+            "note": "新任务，与上轮 atomic 主题无关，勿继承上轮 prompt/title",
+        }
+
+    by_type: dict[str, int] = {}
+    for node in nodes:
+        kind = str(node.get("type") or "unknown")
+        by_type[kind] = by_type.get(kind, 0) + 1
+
+    relevant = _select_relevant_nodes(nodes, focus_node_id=focus_node_id, utterance=text)
+    canvas_block: dict[str, Any] = {
+        "node_count": len(nodes),
+        "type_counts": by_type,
+    }
+    if topic_switch and nodes:
+        canvas_block["stats_line"] = format_canvas_context_line(nodes, include_titles=False)[
+            :_BUDGET_CANVAS_STATS
+        ]
+    elif relevant:
+        canvas_block["relevant_nodes"] = [
+            {
+                "id": str(n.get("id") or ""),
+                "type": str(n.get("type") or ""),
+                "title": str(n.get("title") or "")[:32],
+                **({"status": str(n.get("status"))} if n.get("status") else {}),
+            }
+            for n in relevant
+        ]
+        if focus_node_id and relevant:
+            node = relevant[0]
+            data = node.get("data") if isinstance(node.get("data"), dict) else {}
+            hint = str(data.get("prompt") or data.get("content") or node.get("title") or "")[:60]
+            canvas_block["selected_node"] = {
+                "id": focus_node_id,
+                "type": str(node.get("type") or ""),
+                "title": str(node.get("title") or "")[:32],
+                **({"prompt_hint": hint} if hint else {}),
+            }
+    elif nodes:
+        canvas_block["stats_line"] = format_canvas_context_line(nodes)[:_BUDGET_CANVAS_STATS]
+
+    if canvas_block.get("node_count") or canvas_block.get("relevant_nodes"):
+        packet["canvas"] = canvas_block
+
+    if include_episodic:
+        turns = _build_episodic_turns(state.get("messages") or [], max_turns=1)
+        if turns:
+            packet["episodic"] = {"turns": turns, "max_turns": 1}
+    else:
+        dropped.append("episodic")
+
+    return packet

--- a/services/agent-runtime/app/graph/context_render.py
+++ b/services/agent-runtime/app/graph/context_render.py
@@ -1,0 +1,90 @@
+"""Render ContextPacket to markdown for LLM consumption."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.graph.context_packet import ContextPacket
+
+_BUDGET_TOTAL = 500
+
+
+def render_packet_for_llm(packet: ContextPacket | None, *, stage: str = "parse") -> str:
+    """Serialize packet to markdown blocks for parse/plan LLM user blocks."""
+    if not packet:
+        return ""
+
+    lines: list[str] = []
+    dropped: list[str] = list((packet.get("meta") or {}).get("dropped_sections") or [])
+
+    active = packet.get("active") or {}
+    utterance = str(active.get("utterance") or "").strip()
+    if utterance:
+        lines.append("## 当前请求")
+        lines.append(utterance)
+
+    task = packet.get("task")
+    if task:
+        lines.append("")
+        lines.append("## 任务上下文")
+        if task.get("note"):
+            lines.append(str(task["note"]))
+        else:
+            parts = [f"kind: {task.get('kind', 'atomic')}"]
+            if task.get("prior_title"):
+                parts.append(f"prior: {task['prior_title']} ({task.get('prior_target_type', 'image')})")
+            if task.get("style_inherit"):
+                parts.append("style_inherit: true")
+            lines.append("；".join(parts))
+
+    canvas = packet.get("canvas") or {}
+    if canvas:
+        lines.append("")
+        lines.append("## 画布（摘要）")
+        if canvas.get("selected_node"):
+            sn = canvas["selected_node"]
+            lines.append(
+                f"选中: [{sn.get('type')}] {sn.get('title')} (id={sn.get('id')})"
+            )
+            if sn.get("prompt_hint"):
+                lines.append(f"prompt_hint: {sn['prompt_hint']}")
+        elif canvas.get("stats_line"):
+            lines.append(str(canvas["stats_line"]))
+        else:
+            counts = canvas.get("type_counts") or {}
+            count_str = ", ".join(f"{k}×{v}" for k, v in sorted(counts.items()))
+            lines.append(f"共 {canvas.get('node_count', 0)} 节点（{count_str}）")
+        for node in canvas.get("relevant_nodes") or []:
+            if canvas.get("selected_node"):
+                continue
+            status = f", status={node['status']}" if node.get("status") else ""
+            lines.append(f"- [{node.get('type')}] {node.get('title')} (id={node.get('id')}{status})")
+
+    episodic = packet.get("episodic")
+    if episodic and episodic.get("turns"):
+        lines.append("")
+        lines.append("## 近期（摘要）")
+        for turn in episodic["turns"]:
+            lines.append(
+                f"用户: {turn.get('user', '')} → 助手: {turn.get('assistant_summary', '')}"
+            )
+    elif "episodic" in dropped:
+        pass  # intentionally omitted
+
+    if stage == "parse":
+        meta = packet.get("meta") or {}
+        if meta.get("topic_switch"):
+            lines.append("")
+            lines.append("## 规则")
+            lines.append("仅解析「当前请求」；勿继承无关历史主题。")
+
+    text = "\n".join(lines).strip()
+    if len(text) > _BUDGET_TOTAL:
+        text = text[: _BUDGET_TOTAL - 1] + "…"
+        meta = packet.setdefault("meta", {})
+        meta["char_budget_used"] = _BUDGET_TOTAL
+        meta.setdefault("dropped_sections", []).append("truncated")
+    else:
+        meta = packet.setdefault("meta", {})
+        meta["char_budget_used"] = len(text)
+    return text

--- a/services/agent-runtime/app/graph/intent_parse_llm.py
+++ b/services/agent-runtime/app/graph/intent_parse_llm.py
@@ -82,6 +82,7 @@ async def llm_parse_intent(
     canvas_summary: str | None = None,
     dialogue: str | None = None,
     checkpoint: dict[str, Any] | None = None,
+    context_markdown: str | None = None,
     few_shots: list[tuple[str, str]] | None = None,
 ) -> IntentParseResult | None:
     """Call LLM for structured intent parse; None on failure."""
@@ -90,13 +91,16 @@ async def llm_parse_intent(
 
     shots = few_shots if few_shots is not None else load_structured_intent_few_shots()
     user_block = utterance.strip()
-    ctx = _format_context_block(
-        canvas_summary=canvas_summary,
-        dialogue=dialogue,
-        checkpoint=checkpoint,
-    )
-    if ctx:
-        user_block = f"{user_block}\n\n{ctx}"
+    if context_markdown:
+        user_block = f"{user_block}\n\n{context_markdown.strip()}"
+    else:
+        ctx = _format_context_block(
+            canvas_summary=canvas_summary,
+            dialogue=dialogue,
+            checkpoint=checkpoint,
+        )
+        if ctx:
+            user_block = f"{user_block}\n\n{ctx}"
 
     messages = build_llm_messages(
         system=_STRUCTURED_PARSE_SYSTEM,

--- a/services/agent-runtime/app/graph/nodes/atomic_create_node.py
+++ b/services/agent-runtime/app/graph/nodes/atomic_create_node.py
@@ -6,6 +6,8 @@ from typing import Any, Callable
 
 from langchain_core.messages import AIMessage
 
+from app.graph.sidebar_copy import format_atomic_create_progress
+
 
 def _atomic_batch_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
     batch: list[dict[str, Any]] = []
@@ -32,6 +34,28 @@ def _atomic_batch_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
             }
         )
     return batch
+
+
+async def _emit_atomic_task_list(nest: Any, created_items: list[dict[str, Any]]) -> None:
+    emit_list = getattr(nest, "emit_task_list", None)
+    if emit_list is None:
+        return
+    tasks: list[dict[str, Any]] = []
+    for idx, item in enumerate(created_items):
+        node_id = str(item.get("node_id") or "").strip()
+        if not node_id:
+            continue
+        title = str(item.get("title") or item.get("target_type") or f"任务{idx + 1}")
+        tasks.append(
+            {
+                "id": f"atomic-{node_id}",
+                "title": title,
+                "status": "pending",
+                "nodeId": node_id,
+            }
+        )
+    if tasks:
+        await emit_list(tasks)
 
 
 def make_create_atomic_node(*, nest: Any) -> Callable:
@@ -81,17 +105,10 @@ def make_create_atomic_node(*, nest: Any) -> Callable:
             created["node_id"] = node_id
             created_items.append(created)
 
-        first = created_items[0]
-        target_type = str(first.get("target_type") or "image")
-        count = len(created_items)
-        if count == 1:
-            msg = f"已创建 {target_type} 节点，准备生产。"
-        else:
-            msg = f"已创建 {count} 个 {target_type} 节点，准备生产。"
-        if str(first.get("pipeline") or "") == "turnaround_image":
-            from app.graph.atomic_intent import turnaround_pipeline_user_note
+        await _emit_atomic_task_list(nest, created_items)
 
-            msg += turnaround_pipeline_user_note()
+        first = created_items[0]
+        msg = format_atomic_create_progress(first, count=len(created_items))
 
         return {
             "phase": "atomic_create",

--- a/services/agent-runtime/app/graph/nodes/atomic_parse.py
+++ b/services/agent-runtime/app/graph/nodes/atomic_parse.py
@@ -102,8 +102,7 @@ async def _structured_llm_outcome(
     llm: Any,
     text: str,
     *,
-    canvas_summary: str | None,
-    dialogue: str | None,
+    context_markdown: str | None,
     checkpoint: dict[str, Any] | None,
 ) -> tuple[ParseOutcome | None, IntentParseResult | None, bool]:
     """Returns (outcome, llm_result, guard_triggered)."""
@@ -112,8 +111,7 @@ async def _structured_llm_outcome(
             llm_parse_intent(
                 llm,
                 text,
-                canvas_summary=canvas_summary,
-                dialogue=dialogue,
+                context_markdown=context_markdown,
                 checkpoint=checkpoint,
             ),
             timeout=LLM_PARSE_TIMEOUT_SEC,
@@ -137,8 +135,7 @@ async def _maybe_shadow_diff(
     text: str,
     rule_outcome: ParseOutcome,
     *,
-    canvas_summary: str | None,
-    dialogue: str | None,
+    context_markdown: str | None,
     checkpoint: dict[str, Any] | None,
 ) -> None:
     if not settings.intent_llm_parse_shadow or settings.intent_llm_parse:
@@ -146,8 +143,7 @@ async def _maybe_shadow_diff(
     llm_outcome, llm_result, _ = await _structured_llm_outcome(
         llm,
         text,
-        canvas_summary=canvas_summary,
-        dialogue=dialogue,
+        context_markdown=context_markdown,
         checkpoint=checkpoint,
     )
     if llm_outcome is None:
@@ -191,6 +187,8 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
 
         focus_node_id = state.get("focus_node_id")
         parse_ctx = build_atomic_parse_context(state, canvas_summary=canvas_summary)
+        prior_atomic = state.get("atomic_spec")
+        prior_spec = prior_atomic if isinstance(prior_atomic, dict) else None
         checkpoint = {
             "atomic_node_id": state.get("atomic_node_id"),
             "atomic_spec": state.get("atomic_spec"),
@@ -214,7 +212,9 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
                     llm_result=classified,
                     guard_triggered=guard is not None,
                 )
-                patch = parse_outcome_to_state(outcome, canvas_context=parse_ctx)
+                patch = parse_outcome_to_state(
+                    outcome, canvas_context=parse_ctx, prior_spec=prior_spec
+                )
                 patch.pop("clarify_context", None)
                 return patch
 
@@ -236,7 +236,9 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
                 reason="variant_new_node_from_checkpoint",
             )
             _log_intent_parse(source="rule_variant", utterance=text, outcome=outcome)
-            return parse_outcome_to_state(outcome, canvas_context=parse_ctx)
+            return parse_outcome_to_state(
+                outcome, canvas_context=parse_ctx, prior_spec=prior_spec
+            )
 
         canvas_ctx = parse_ctx
         dialogue = None
@@ -248,8 +250,7 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
             outcome, llm_result, guard_triggered = await _structured_llm_outcome(
                 llm,
                 text,
-                canvas_summary=parse_ctx,
-                dialogue=dialogue,
+                context_markdown=parse_ctx or None,
                 checkpoint=checkpoint,
             )
             if outcome is None:
@@ -303,7 +304,7 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
                 llm_raw = await llm_parse_atomic_intent(
                     llm,
                     text,
-                    canvas_context=canvas_ctx,
+                    context_markdown=canvas_ctx,
                     few_shots=load_atomic_parse_few_shots(),
                 )
                 if llm_raw is not None:
@@ -334,12 +335,13 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
                     llm,
                     text,
                     outcome,
-                    canvas_summary=parse_ctx,
-                    dialogue=dialogue,
+                    context_markdown=parse_ctx or None,
                     checkpoint=checkpoint,
                 )
 
-        patch = parse_outcome_to_state(outcome, canvas_context=canvas_ctx)
+        patch = parse_outcome_to_state(
+            outcome, canvas_context=canvas_ctx, prior_spec=prior_spec
+        )
         if outcome["kind"] == "clarify":
             patch["clarify_context"] = {
                 "original_utterance": text,

--- a/services/agent-runtime/app/graph/nodes/run_atomic_gen.py
+++ b/services/agent-runtime/app/graph/nodes/run_atomic_gen.py
@@ -6,6 +6,12 @@ from typing import Any, Callable
 
 from langchain_core.messages import AIMessage
 
+from app.graph.sidebar_copy import (
+    format_atomic_gen_failed,
+    format_atomic_gen_partial,
+    format_atomic_gen_success,
+)
+
 
 def _is_success(result: Any) -> bool:
     if not isinstance(result, dict):
@@ -22,6 +28,12 @@ def _result_record_id(result: Any) -> str | None:
         return None
     rid = result.get("generationRecordId")
     return str(rid) if rid else None
+
+
+async def _emit_task_update(nest: Any, **payload: Any) -> None:
+    fn = getattr(nest, "emit_task_update", None)
+    if fn is not None:
+        await fn(**payload)
 
 
 def make_run_atomic_gen_node(*, nest: Any) -> Callable:
@@ -58,6 +70,7 @@ def make_run_atomic_gen_node(*, nest: Any) -> Callable:
             node_id = str(item.get("node_id") or state.get("atomic_node_id") or "").strip()
             target_type = str(item.get("target_type") or "image")
             title = str(item.get("title") or target_type)
+            task_id = f"atomic-{node_id}" if node_id else None
             if not node_id:
                 failed.append(title)
                 last_error = "missing atomic_node_id"
@@ -69,11 +82,28 @@ def make_run_atomic_gen_node(*, nest: Any) -> Callable:
                 last_error = f"unsupported target_type: {target_type}"
                 continue
 
+            if task_id:
+                await _emit_task_update(
+                    nest,
+                    id=task_id,
+                    status="running",
+                    nodeId=node_id,
+                    recordId=None,
+                )
+
             try:
                 result = await run(node_id)
             except Exception as exc:  # noqa: BLE001
                 failed.append(title)
                 last_error = str(exc)
+                if task_id:
+                    await _emit_task_update(
+                        nest,
+                        id=task_id,
+                        status="failed",
+                        nodeId=node_id,
+                        errorCode="exception",
+                    )
                 continue
 
             record_id = _result_record_id(result)
@@ -85,20 +115,34 @@ def make_run_atomic_gen_node(*, nest: Any) -> Callable:
 
             if _is_success(result):
                 completed.append(title)
+                if task_id:
+                    await _emit_task_update(
+                        nest,
+                        id=task_id,
+                        status="done",
+                        nodeId=node_id,
+                        recordId=record_id,
+                    )
             else:
                 status = str(result.get("status") or "error") if isinstance(result, dict) else "error"
                 failed.append(title)
                 last_error = status
+                if task_id:
+                    await _emit_task_update(
+                        nest,
+                        id=task_id,
+                        status="failed",
+                        nodeId=node_id,
+                        errorCode=status,
+                    )
 
         if completed and not failed:
             if len(completed) == 1:
-                msg = f"「{completed[0]}」生成完成。"
+                msg = format_atomic_gen_success(completed[0])
             else:
-                msg = f"已完成 {len(completed)} 张：{'、'.join(completed)}。"
+                msg = format_atomic_gen_success(completed[0], count=len(completed))
             if last_completion_summary:
                 msg += last_completion_summary
-            elif last_record_id:
-                msg += f"（record: {last_record_id}）"
             return {
                 "phase": "done",
                 "atomic_record_id": last_record_id,
@@ -106,7 +150,7 @@ def make_run_atomic_gen_node(*, nest: Any) -> Callable:
             }
 
         if completed and failed:
-            msg = f"部分完成：{'、'.join(completed)}；未完成：{'、'.join(failed)}。"
+            msg = format_atomic_gen_partial(completed, failed)
             return {
                 "phase": "error",
                 "atomic_record_id": last_record_id,
@@ -120,7 +164,7 @@ def make_run_atomic_gen_node(*, nest: Any) -> Callable:
             "phase": "error",
             "atomic_record_id": last_record_id,
             "last_error": status,
-            "messages": [AIMessage(content=f"「{title}」生成未完成（{status}）。")],
+            "messages": [AIMessage(content=format_atomic_gen_failed(title, status))],
         }
 
     return run_atomic_gen

--- a/services/agent-runtime/app/graph/sidebar_copy.py
+++ b/services/agent-runtime/app/graph/sidebar_copy.py
@@ -1,0 +1,99 @@
+"""User-facing assistant copy for Agent side rail (not LLM / debug context)."""
+
+from __future__ import annotations
+
+from app.graph.atomic_intent import turnaround_pipeline_user_note
+
+TARGET_TYPE_LABELS: dict[str, str] = {
+    "image": "图片",
+    "text": "文本",
+    "video": "视频",
+    "audio": "音频",
+    "prompt": "提示词",
+}
+
+# Shown for video/audio confirm gate — keep in sync with agentChipSet.ts
+ATOMIC_CONFIRM_SNIPPET = "提交前需你确认"
+
+
+def _display_title(spec: dict) -> str:
+    title = str(spec.get("title") or spec.get("prompt") or "").strip()
+    return title[:48] + ("…" if len(title) > 48 else "")
+
+
+def topic_switch_prefix(prior_title: str | None, new_title: str) -> str:
+    """When the new request clearly differs from the last atomic task."""
+    prior = (prior_title or "").strip()
+    new = (new_title or "").strip()
+    if not prior or not new:
+        return ""
+    if prior == new or prior in new or new in prior:
+        return ""
+    # Share at most one meaningful token → still treat as switch
+    prior_tokens = {t for t in prior.replace("，", " ").split() if len(t) >= 2}
+    new_tokens = {t for t in new.replace("，", " ").split() if len(t) >= 2}
+    if prior_tokens & new_tokens:
+        return ""
+    return "已按你的新需求处理："
+
+
+def format_atomic_parse_ack(
+    spec: dict,
+    *,
+    prior_spec: dict | None = None,
+) -> str:
+    """Brief acknowledgment after intent parse — no internal routing labels."""
+    title = _display_title(spec)
+    target = TARGET_TYPE_LABELS.get(str(spec.get("target_type") or ""), "内容")
+    prefix = topic_switch_prefix(
+        str(prior_spec.get("title") or "") if prior_spec else None,
+        title,
+    )
+    if str(spec.get("pipeline") or "") == "turnaround_image":
+        body = f"好的，{prefix}我来生成「{title}」的角色设定图（四格）。"
+    elif spec.get("confirm_gate"):
+        body = (
+            f"收到，{prefix}将为你创建{target}「{title}」。"
+            f"{ATOMIC_CONFIRM_SNIPPET}。"
+        )
+    else:
+        body = f"好的，{prefix}我来生成{target}「{title}」。"
+    return body
+
+
+def format_atomic_multi_ack(items: list[dict], *, prior_spec: dict | None = None) -> str:
+    titles = "、".join(_display_title(i) for i in items)
+    prefix = topic_switch_prefix(
+        str(prior_spec.get("title") or "") if prior_spec else None,
+        _display_title(items[0]),
+    )
+    return f"好的，{prefix}我将创建 {len(items)} 张图片：{titles}。"
+
+
+def format_atomic_create_progress(spec: dict, *, count: int = 1) -> str:
+    """After canvas node exists, before / during Studio generation."""
+    title = _display_title(spec)
+    target = TARGET_TYPE_LABELS.get(str(spec.get("target_type") or ""), "内容")
+    if count > 1:
+        head = f"已在画布创建 {count} 个{target}节点，正在生成…"
+    else:
+        head = f"已在画布创建节点，正在为「{title}」生成…"
+    if str(spec.get("pipeline") or "") == "turnaround_image":
+        head += turnaround_pipeline_user_note()
+    else:
+        head += "可在画布查看进度。"
+    return head
+
+
+def format_atomic_gen_success(title: str, *, count: int = 1) -> str:
+    if count > 1:
+        return f"已完成 {count} 项生成，请在画布查看结果。"
+    return f"「{title}」生成完成，请在画布查看节点。"
+
+
+def format_atomic_gen_partial(completed: list[str], failed: list[str]) -> str:
+    return f"部分完成：{'、'.join(completed)}；未完成：{'、'.join(failed)}。请在画布查看。"
+
+
+def format_atomic_gen_failed(title: str, status: str) -> str:
+    return f"「{title}」生成未完成（{status}）。可在画布节点重试。"

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -634,7 +634,7 @@ async def stream_run_events(
                                 if text == last_text_delta:
                                     continue
                                 last_text_delta = text
-                                await emit({"type": "text_delta", "data": {"text": text}})
+                                await emit({"type": "text_replace", "data": {"text": text}})
             post = await graph.aget_state(config)
             post_next = [str(n) for n in (getattr(post, "next", None) or [])]
             post_vals = getattr(post, "values", None) or {}

--- a/services/agent-runtime/tests/test_atomic_context.py
+++ b/services/agent-runtime/tests/test_atomic_context.py
@@ -32,10 +32,9 @@ def test_build_atomic_parse_context_respects_max_length():
     ]
     ctx = build_atomic_parse_context({"messages": messages}, max_chars=500)
     assert len(ctx) <= 500
-    assert ctx.endswith("…") or len(ctx) <= 500
 
 
-def test_build_atomic_parse_context_includes_canvas_and_history():
+def test_build_atomic_parse_context_includes_canvas_stats():
     summary = {
         "nodes": [
             {"id": "n1", "type": "image", "title": "主图"},
@@ -46,17 +45,17 @@ def test_build_atomic_parse_context_includes_canvas_and_history():
         AIMessage(content="主图已创建"),
     ]
     ctx = build_atomic_parse_context({"messages": messages}, canvas_summary=summary)
-    assert "画布" in ctx
-    assert "主图" in ctx
-    assert "近期对话" in ctx
+    assert "画布" in ctx or "节点" in ctx
+    assert "近期对话" not in ctx
 
 
-def test_build_atomic_parse_context_includes_prior_atomic_spec():
+def test_build_atomic_parse_context_topic_switch_omits_prior():
     ctx = build_atomic_parse_context(
         {
-            "messages": [],
-            "atomic_spec": {"target_type": "image", "title": "模特人物图", "prompt": "模特"},
+            "messages": [HumanMessage(content="帮我生成山海经神兽三视图")],
+            "atomic_spec": {"target_type": "prompt", "title": "蓝牙耳机 prompt"},
         },
         canvas_summary={"nodes": []},
     )
-    assert "上轮原子:image:模特人物图" in ctx
+    assert "蓝牙耳机" not in ctx
+    assert "山海经" in ctx

--- a/services/agent-runtime/tests/test_context_packet.py
+++ b/services/agent-runtime/tests/test_context_packet.py
@@ -1,0 +1,98 @@
+"""ContextPacket build + render tests."""
+
+from __future__ import annotations
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from app.graph.atomic_context import build_atomic_parse_context
+from app.graph.context_packet import (
+    build_parse_packet,
+    should_include_episodic,
+    should_include_prior_task,
+)
+from app.graph.context_render import render_packet_for_llm
+
+
+def test_topic_switch_drops_prior_and_episodic():
+    state = {
+        "messages": [
+            HumanMessage(content="帮我拟定蓝牙耳机三视图 prompt"),
+            AIMessage(content="好的，我来生成提示词「蓝牙耳机三视图」。"),
+            HumanMessage(content="帮我生成一个山海经的神兽的三视图"),
+        ],
+        "atomic_spec": {
+            "target_type": "prompt",
+            "title": "蓝牙耳机三视图 prompt",
+            "prompt": "蓝牙耳机",
+        },
+    }
+    summary = {
+        "nodes": [
+            {"id": "n1", "type": "prompt", "title": "蓝牙耳机 prompt"},
+            {"id": "n2", "type": "image", "title": "主图"},
+        ]
+    }
+    packet = build_parse_packet(state, canvas_summary=summary)
+    assert should_include_prior_task("帮我生成一个山海经的神兽的三视图", state["atomic_spec"]) is False
+    assert should_include_episodic("帮我生成一个山海经的神兽的三视图", state["atomic_spec"]) is False
+    assert packet.get("meta", {}).get("topic_switch") is True
+    assert "episodic" not in packet
+    rendered = render_packet_for_llm(packet)
+    assert "山海经" in rendered
+    assert "蓝牙耳机" not in rendered
+    assert "近期" not in rendered
+    assert "勿继承" in rendered or "无关" in rendered
+
+
+def test_style_inherit_includes_episodic():
+    state = {
+        "messages": [
+            HumanMessage(content="山海经神兽三视图"),
+            AIMessage(content="「山海经神兽三视图」生成完成，请在画布查看节点。"),
+            HumanMessage(content="按刚才那个风格，再生成一张赛博朋克版主图"),
+        ],
+        "atomic_spec": {
+            "target_type": "image",
+            "title": "山海经神兽三视图",
+        },
+    }
+    utterance = "按刚才那个风格，再生成一张赛博朋克版主图"
+    assert should_include_prior_task(utterance, state["atomic_spec"]) is True
+    assert should_include_episodic(utterance, state["atomic_spec"]) is True
+    packet = build_parse_packet(state, canvas_summary={"nodes": []}, utterance=utterance)
+    assert packet.get("episodic")
+    rendered = render_packet_for_llm(packet)
+    assert "## 近期" in rendered
+    assert "style_inherit" in rendered or "prior" in rendered
+
+
+def test_focus_node_in_canvas_packet():
+    state = {
+        "messages": [HumanMessage(content="快速生成")],
+        "focus_node_id": "n-8",
+    }
+    summary = {
+        "nodes": [
+            {"id": "n-8", "type": "image", "title": "白底图", "data": {"prompt": "纯白背景"}},
+            {"id": "n-9", "type": "image", "title": "主图"},
+        ]
+    }
+    packet = build_parse_packet(state, canvas_summary=summary)
+    canvas = packet.get("canvas") or {}
+    assert canvas.get("selected_node", {}).get("id") == "n-8"
+    rendered = render_packet_for_llm(packet)
+    assert "白底图" in rendered
+    assert "选中" in rendered
+
+
+def test_build_atomic_parse_context_uses_markdown_not_legacy_pipe():
+    ctx = build_atomic_parse_context(
+        {
+            "messages": [HumanMessage(content="生成一张主图")],
+            "atomic_spec": {"title": "旧任务", "target_type": "image"},
+        },
+        canvas_summary={"nodes": [{"id": "n1", "type": "image", "title": "旧任务"}]},
+    )
+    assert " | " not in ctx
+    assert "上轮原子" not in ctx
+    assert "##" in ctx

--- a/services/agent-runtime/tests/test_runs_stream.py
+++ b/services/agent-runtime/tests/test_runs_stream.py
@@ -146,7 +146,7 @@ def test_runs_stream_ndjson_smoke():
 
     types = [e["type"] for e in events]
     # plan 确认前不写画布，首轮只有文本门
-    assert "text_delta" in types
+    assert "text_replace" in types or "text_delta" in types
     assert "interrupt" in types
     interrupt_ev = next(e for e in events if e["type"] == "interrupt")
     assert interrupt_ev["data"]["interrupted"] is True
@@ -158,7 +158,8 @@ def test_runs_stream_ndjson_smoke():
     assert "upsert_prompt_node" not in nest.calls
     assert "canvas_action" not in types
 
-    text = "".join(
-        e["data"]["text"] for e in events if e["type"] == "text_delta"
-    )
+    text_parts = [
+        e["data"]["text"] for e in events if e["type"] in ("text_delta", "text_replace")
+    ]
+    text = text_parts[-1] if text_parts else ""
     assert "1 / A" in text or "确认方案" in text or "方案" in text

--- a/services/agent-runtime/tests/test_sidebar_copy.py
+++ b/services/agent-runtime/tests/test_sidebar_copy.py
@@ -1,0 +1,65 @@
+"""Sidebar copy template tests."""
+
+from __future__ import annotations
+
+from app.graph.atomic_parse_schema import parse_outcome_to_state
+from app.graph.sidebar_copy import (
+    format_atomic_create_progress,
+    format_atomic_parse_ack,
+    topic_switch_prefix,
+)
+
+
+def test_parse_outcome_user_message_excludes_canvas_context():
+    state = parse_outcome_to_state(
+        {
+            "kind": "success",
+            "structure": "single",
+            "items": [
+                {
+                    "target_type": "image",
+                    "prompt": "山海经的神兽的三视图",
+                    "title": "山海经的神兽的三视图",
+                    "confirm_gate": False,
+                    "pipeline": "turnaround_image",
+                }
+            ],
+            "confidence": 0.95,
+            "reason": "test",
+        },
+        canvas_context="上轮原子:prompt:蓝牙耳机 | 近期对话:用户:营销方案",
+    )
+    msg = state["messages"][0].content
+    assert "原子创作" not in msg
+    assert "canvas_context" not in msg
+    assert "蓝牙耳机" not in msg
+    assert "近期对话" not in msg
+    assert "角色设定图" in msg
+    assert state["atomic_spec"].get("canvas_context")
+
+
+def test_turnaround_note_only_on_create_progress():
+    spec = {
+        "target_type": "image",
+        "title": "山海经的神兽的三视图",
+        "pipeline": "turnaround_image",
+    }
+    ack = format_atomic_parse_ack(spec)
+    progress = format_atomic_create_progress(spec)
+    assert "近景特写" not in ack
+    assert "近景特写" in progress
+
+
+def test_topic_switch_prefix():
+    assert topic_switch_prefix("蓝牙耳机三视图", "山海经神兽三视图").startswith("已按你的新需求处理")
+    assert topic_switch_prefix("山海经神兽三视图", "山海经神兽三视图扩展") == ""
+
+
+def test_video_confirm_gate_copy():
+    spec = {
+        "target_type": "video",
+        "title": "15秒产品展示",
+        "confirm_gate": True,
+    }
+    msg = format_atomic_parse_ack(spec)
+    assert "提交前需你确认" in msg


### PR DESCRIPTION
## Summary

- **Presentation 层**：侧栏用户可见文案统一走 `sidebar_copy` 模板；图节点阶段用 `text_replace` 替换气泡，避免多段机器日志拼接；turnaround 四格说明只出现一次；原子路径 emit `task_list` / `task_update`。
- **Context 层（Phase 1）**：用结构化 `ContextPacket` + markdown 渲染替代 pipe 字符串；默认零 episodic；话题切换时丢弃 prior task 与节点 title 噪声；focus 节点 / 风格继承时按需注入。
- **规范文档**：`docs/superpowers/specs/2026-08-06-agent-sidebar-copy-design.md`、`docs/superpowers/specs/2026-08-06-agent-context-engineering-design.md`

## Test plan

- [x] `python3 -m pytest services/agent-runtime/tests/test_context_packet.py services/agent-runtime/tests/test_sidebar_copy.py services/agent-runtime/tests/test_atomic_context.py services/agent-runtime/tests/test_runs_stream.py`
- [x] `pnpm --filter @lnkpi/agent test`
- [x] `pnpm --filter @lnkpi/web exec vitest run src/components/agent/agentChipSet.test.ts`
- [ ] 手动：输入「山海经神兽三视图」确认侧栏无 `[canvas_context]` / 蓝牙耳机污染
- [ ] 手动：「按刚才风格再来一张」确认 parse context 含 episodic


Made with [Cursor](https://cursor.com)