### PR TITLE
feat(agent): execution trace P1/P2 — step events, explore, replay

### DIFF
--- a/apps/web/src/components/agent/AgentExecutionTrace.vue
+++ b/apps/web/src/components/agent/AgentExecutionTrace.vue
@@ -89,6 +89,8 @@ function onStepClick(step: ExecutionStep) {
           step.meta?.nodeId ? 'cursor-pointer hover:text-[var(--neo-accent-text)]' : '',
           step.status === 'failed' ? 'text-red-400/90' : 'text-[var(--neo-text-muted)]',
           step.status === 'running' ? 'animate-pulse' : '',
+          step.kind === 'thinking' ? 'italic opacity-80' : '',
+          step.kind === 'explore' ? 'opacity-90' : '',
         ]"
         @click="onStepClick(step)"
       >

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -28,11 +28,8 @@ import {
   shouldApplyReconciledAssistant,
 } from '@/components/agent/assistantReconcile'
 import { detectAgentChipSet } from '@/components/agent/agentChipSet'
-import {
-  chipSetFromInterrupt,
-  interruptPayloadFromThreadState,
-  type AgentInterruptPayload,
-} from '@/components/agent/agentInterruptGate'
+import { chipSetFromInterrupt, interruptPayloadFromThreadState, type AgentInterruptPayload } from '@/components/agent/agentInterruptGate'
+import { phaseHintFromInterrupt } from '@/components/agent/executionStepLabels'
 import {
   buildIdempotencyKey,
   createAgentThreadId,
@@ -544,6 +541,11 @@ async function reconnectStream() {
     hasAtomicCheckpoint.value = Boolean(json.data?.hasAtomicCheckpoint)
     interruptGate.value = interruptPayloadFromThreadState(json.data)
 
+    const hint = phaseHintFromInterrupt(interruptGate.value)
+    if (hint) {
+      agent.trackPhaseHint({ phase: interruptGate.value?.phase ?? undefined, label: hint })
+    }
+
     if (agent.isStreaming) {
       agent.finishStreaming()
     }
@@ -670,6 +672,18 @@ function handleEvent(event: { type: string; data: unknown }) {
       agent.trackNodeStatus(data)
       break
     }
+    case 'step':
+      agent.trackStep(event.data as Parameters<typeof agent.trackStep>[0])
+      break
+    case 'phase_hint':
+      agent.trackPhaseHint(event.data as { phase?: string; label: string })
+      break
+    case 'thinking':
+      agent.trackThinking(event.data as { status: string; summary?: string })
+      break
+    case 'explore':
+      agent.trackExplore(event.data as Parameters<typeof agent.trackExplore>[0])
+      break
     case 'task_list':
     case 'task_update':
     case 'task_summary': {
@@ -684,6 +698,7 @@ function handleEvent(event: { type: string; data: unknown }) {
           id?: string
           status?: string
           errorHint?: string
+          errorCode?: string
         }
         const item = taskProgress.value.items.find((it) => it.id === data.id)
         if (item) {
@@ -693,6 +708,7 @@ function handleEvent(event: { type: string; data: unknown }) {
             title: item.title,
             nodeId: item.nodeId,
             errorHint: data.errorHint ?? item.errorHint,
+            errorCode: data.errorCode ?? item.errorCode,
           })
         }
         if (item?.recordId && item.nodeId) {
@@ -723,9 +739,17 @@ function handleEvent(event: { type: string; data: unknown }) {
       }
       break
     }
-    case 'error':
-      agent.appendText(`\n\n⚠️ ${(event.data as { message: string }).message}`)
+    case 'error': {
+      const data = event.data as {
+        message?: string
+        error_type?: string
+        retry_hint?: string
+        tool_name?: string
+      }
+      agent.trackStructuredError(data)
+      agent.appendText(`\n\n⚠️ ${data.message || '发生错误'}`)
       break
+    }
   }
 }
 

--- a/apps/web/src/components/agent/AgentTaskProgressCard.vue
+++ b/apps/web/src/components/agent/AgentTaskProgressCard.vue
@@ -39,6 +39,7 @@ const statusLabel: Record<string, string> = {
             {{ item.attempt }}/{{ item.maxAttempts || 2 }}
           </span>
           <div v-if="item.errorHint" class="mt-0.5 opacity-60">{{ item.errorHint }}</div>
+          <div v-if="item.errorCode && !item.errorHint" class="mt-0.5 opacity-50">{{ item.errorCode }}</div>
         </span>
       </li>
     </ul>

--- a/apps/web/src/components/agent/agentTaskProgress.ts
+++ b/apps/web/src/components/agent/agentTaskProgress.ts
@@ -17,6 +17,7 @@ export interface AgentTaskItem {
   attempt?: number
   maxAttempts?: number
   errorHint?: string
+  errorCode?: string
 }
 
 export interface AgentTaskProgressState {
@@ -49,6 +50,7 @@ type TaskEvent =
         attempt?: number
         maxAttempts?: number
         errorHint?: string
+        errorCode?: string
       }
     }
   | {

--- a/apps/web/src/components/agent/executionStepErrors.ts
+++ b/apps/web/src/components/agent/executionStepErrors.ts
@@ -1,0 +1,28 @@
+/** Map runtime error_type to user-facing trace detail. */
+
+const ERROR_TYPE_DETAIL: Record<string, string> = {
+  tool_timeout: '服务响应超时，可稍后重试',
+  downstream_unavailable: '生成服务暂不可用',
+  circuit_open: '服务繁忙，请稍后再试',
+  internal_error: '内部错误，请重试或联系支持',
+}
+
+export function errorDetailFromType(errorType: string | undefined): string | undefined {
+  if (!errorType) return undefined
+  return ERROR_TYPE_DETAIL[errorType] ?? undefined
+}
+
+export function formatStructuredError(data: {
+  message?: string
+  error_type?: string
+  retry_hint?: string
+  tool_name?: string
+}): { label: string; detail: string } {
+  const detail =
+    data.retry_hint?.trim()
+    || errorDetailFromType(data.error_type)
+    || data.message?.trim()
+    || '发生未知错误'
+  const label = data.tool_name ? `「${data.tool_name}」执行失败` : '执行失败'
+  return { label, detail: detail.slice(0, 220) }
+}

--- a/apps/web/src/components/agent/executionStepLabels.ts
+++ b/apps/web/src/components/agent/executionStepLabels.ts
@@ -78,3 +78,22 @@ export function formatDuration(ms: number): string {
   const rem = s % 60
   return rem ? `${m}m ${rem}s` : `${m}m`
 }
+
+const PHASE_HINT_LABELS: Record<string, string> = {
+  await_confirm: '等待你确认方案',
+  await_copy_confirm: '等待你确认主文案',
+  await_topo: '等待你确认节点结构',
+  await_atomic_confirm: '等待你确认生成参数',
+}
+
+export function phaseHintFromInterrupt(payload: {
+  phase?: string | null
+  node?: string | null
+} | null): string | null {
+  if (!payload) return null
+  const phase = payload.phase?.trim()
+  if (phase && PHASE_HINT_LABELS[phase]) return PHASE_HINT_LABELS[phase]
+  const node = payload.node?.trim()
+  if (node && PHASE_HINT_LABELS[node]) return PHASE_HINT_LABELS[node]
+  return null
+}

--- a/apps/web/src/components/agent/executionTraceReducer.test.ts
+++ b/apps/web/src/components/agent/executionTraceReducer.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   applyCanvasAction,
   applyNodeStatus,
+  applyPhaseHint,
+  applyStep,
   applyTextReplaceStage,
   applyToolCall,
   createExecutionTrace,
@@ -51,5 +53,24 @@ describe('executionTraceReducer', () => {
     finalizeExecutionTrace(trace)
     expect(trace.totalMs).toBeGreaterThanOrEqual(0)
     expect(trace.steps[0]?.status).toBe('done')
+  })
+
+  it('applies step events and dedupes text_stage', () => {
+    const trace = createExecutionTrace()
+    applyTextReplaceStage(trace, '好的，我来生成图片「模特」')
+    applyStep(trace, {
+      id: 'node:parse_atomic_intent',
+      label: '理解需求',
+      status: 'done',
+      ms: 50,
+    })
+    expect(trace.steps.some((s) => s.kind === 'text_stage')).toBe(false)
+    expect(trace.steps.some((s) => s.id === 'node:parse_atomic_intent')).toBe(true)
+  })
+
+  it('applies phase hint as waiting_user', () => {
+    const trace = createExecutionTrace()
+    applyPhaseHint(trace, { phase: 'await_confirm', label: '等待你确认方案' })
+    expect(trace.steps[0]?.status).toBe('waiting_user')
   })
 })

--- a/apps/web/src/components/agent/executionTraceReducer.ts
+++ b/apps/web/src/components/agent/executionTraceReducer.ts
@@ -1,4 +1,5 @@
 import type { CanvasAction } from '@lnkpi/shared'
+import { formatStructuredError } from '@/components/agent/executionStepErrors'
 import {
   canvasActionLabel,
   labelFromTextReplace,
@@ -20,6 +21,8 @@ export type ExecutionStepKind =
   | 'tool'
   | 'node_gen'
   | 'task'
+  | 'thinking'
+  | 'explore'
 
 export interface ExecutionStep {
   id: string
@@ -91,9 +94,152 @@ function upsertTextStage(trace: ExecutionTraceState, label: string, detail?: str
   })
 }
 
+function removeDuplicateTextStage(trace: ExecutionTraceState, label: string) {
+  const idx = trace.steps.findIndex(
+    (s) => s.kind === 'text_stage' && s.label === label && s.status === 'done',
+  )
+  if (idx >= 0) trace.steps.splice(idx, 1)
+}
+
+export function applyStep(
+  trace: ExecutionTraceState,
+  data: {
+    id: string
+    kind?: string
+    label: string
+    status: string
+    detail?: string
+    ms?: number
+    nodeId?: string
+  },
+) {
+  const status = data.status as ExecutionStepStatus
+  let step = trace.steps.find((s) => s.id === data.id)
+  const now = Date.now()
+  if (!step) {
+    step = {
+      id: data.id,
+      kind: 'phase',
+      label: data.label,
+      status,
+      startedAt: now,
+      meta: data.nodeId ? { nodeId: data.nodeId } : undefined,
+      detail: data.detail,
+    }
+    trace.steps.push(step)
+    removeDuplicateTextStage(trace, data.label)
+  } else {
+    step.label = data.label
+    step.status = status
+    if (data.detail) step.detail = data.detail
+  }
+  if (status === 'done' || status === 'failed' || status === 'waiting_user') {
+    step.endedAt = now
+    step.ms = data.ms ?? (step.startedAt ? now - step.startedAt : 0)
+  }
+}
+
+export function applyPhaseHint(
+  trace: ExecutionTraceState,
+  data: { phase?: string; label: string },
+) {
+  const id = `phase-hint:${data.phase || 'gate'}`
+  let step = trace.steps.find((s) => s.id === id)
+  if (!step) {
+    step = {
+      id,
+      kind: 'phase',
+      label: data.label,
+      status: 'waiting_user',
+      startedAt: Date.now(),
+    }
+    trace.steps.push(step)
+  } else {
+    step.label = data.label
+    step.status = 'waiting_user'
+  }
+}
+
+export function applyStructuredError(
+  trace: ExecutionTraceState,
+  data: {
+    message?: string
+    error_type?: string
+    retry_hint?: string
+    tool_name?: string
+  },
+) {
+  const { label, detail } = formatStructuredError(data)
+  const now = Date.now()
+  trace.steps.push({
+    id: nextStepId('error'),
+    kind: 'phase',
+    label,
+    detail,
+    status: 'failed',
+    startedAt: now,
+    endedAt: now,
+    ms: 0,
+    meta: data.error_type ? { errorCode: data.error_type } : undefined,
+  })
+}
+
+export function applyThinking(
+  trace: ExecutionTraceState,
+  data: { status: string; summary?: string },
+) {
+  const id = 'thinking:parse'
+  let step = trace.steps.find((s) => s.id === id)
+  if (!step) {
+    step = {
+      id,
+      kind: 'thinking',
+      label: '思考中…',
+      status: data.status === 'done' ? 'done' : 'running',
+      startedAt: Date.now(),
+      detail: data.summary,
+    }
+    trace.steps.unshift(step)
+  } else {
+    step.status = data.status === 'done' ? 'done' : 'running'
+    if (data.summary) step.detail = data.summary
+    if (data.status === 'done') completeStep(step)
+  }
+}
+
+export function applyExplore(
+  trace: ExecutionTraceState,
+  data: {
+    label?: string
+    nodeCount?: number
+    nodeTitles?: string[]
+    episodicUsed?: boolean
+    topicSwitch?: boolean
+  },
+) {
+  const titles = (data.nodeTitles || []).slice(0, 3).join('、')
+  const suffix = (data.nodeCount || 0) > 3 ? '等' : ''
+  const detailParts: string[] = []
+  if (titles) detailParts.push(titles + suffix)
+  if (data.topicSwitch) detailParts.push('已切换话题，未引用历史任务')
+  else if (data.episodicUsed === false) detailParts.push('未引用历史对话')
+  const now = Date.now()
+  trace.steps.push({
+    id: nextStepId('explore'),
+    kind: 'explore',
+    label: data.label || '参考画布上下文',
+    detail: detailParts.join('；') || `已参考 ${data.nodeCount ?? 0} 个节点`,
+    status: 'done',
+    startedAt: now,
+    endedAt: now,
+    ms: 0,
+  })
+}
+
 export function applyTextReplaceStage(trace: ExecutionTraceState, text: string) {
   const label = labelFromTextReplace(text)
   if (!label) return
+  if (trace.steps.some((s) => s.kind === 'phase' && s.label === label)) return
   upsertTextStage(trace, label, text.slice(0, 120))
 }
 
@@ -188,6 +334,7 @@ export function applyTaskUpdate(
     title?: string
     nodeId?: string
     errorHint?: string
+    errorCode?: string
   },
 ) {
   const label = data.title ? `生成「${data.title}」` : '批量生成任务'
@@ -215,6 +362,9 @@ export function applyTaskUpdate(
   }
   if (data.status === 'failed' || data.status === 'needs_user') {
     step.detail = data.errorHint
+    if (data.errorCode) {
+      step.meta = { ...step.meta, errorCode: data.errorCode }
+    }
     completeStep(step, data.status === 'needs_user' ? 'waiting_user' : 'failed')
   }
 }

--- a/apps/web/src/pages/ReplayPage.vue
+++ b/apps/web/src/pages/ReplayPage.vue
@@ -32,6 +32,8 @@ interface ReplayStep {
 const route = useRoute()
 const router = useRouter()
 const sessionId = computed(() => route.params.sessionId as string)
+const agentDebug = computed(() => route.query.agentDebug === '1')
+const graphTimeline = ref<Array<{ phase?: string | null; step?: number | null }>>([])
 
 const sessionTitle = ref('创作回放')
 const steps = ref<ReplayStep[]>([])
@@ -93,6 +95,18 @@ async function loadReplay() {
     api.get<{ data: AgentMessage[] }>(`/agent/chat/user/messages?sessionId=${sessionId.value}`),
   ])
   sessionTitle.value = sessionRes.data.data.title
+
+  if (agentDebug.value) {
+    try {
+      const threadId = `${sessionId.value}:latest`
+      const tl = await api.get<{ data: { entries?: Array<{ phase?: string | null; step?: number | null }> } }>(
+        `/agent/thread-timeline?threadId=${encodeURIComponent(threadId)}`,
+      )
+      graphTimeline.value = tl.data.data?.entries ?? []
+    } catch {
+      graphTimeline.value = []
+    }
+  }
 
   const built: ReplayStep[] = []
   for (const msg of msgRes.data.data) {
@@ -158,6 +172,14 @@ onUnmounted(() => { if (playTimer) clearInterval(playTimer) })
           暂无 Agent 对话记录
         </li>
       </ol>
+      <div v-if="agentDebug && graphTimeline.length" class="border-t border-white/5 p-3 text-[10px] text-white/40">
+        <p class="mb-1 font-medium text-white/60">Graph timeline (debug)</p>
+        <ul class="space-y-0.5">
+          <li v-for="(e, i) in graphTimeline" :key="i">
+            #{{ e.step ?? i }} · {{ e.phase ?? '—' }}
+          </li>
+        </ul>
+      </div>
     </aside>
 
     <div class="relative flex-1">

--- a/apps/web/src/stores/agent.ts
+++ b/apps/web/src/stores/agent.ts
@@ -3,9 +3,14 @@ import { ref } from 'vue'
 import type { AgentChatMessage, CanvasAction } from '@lnkpi/shared'
 import {
   applyCanvasAction,
+  applyExplore,
   applyNodeStatus,
+  applyPhaseHint,
+  applyStep,
+  applyStructuredError,
   applyTaskUpdate,
   applyTextReplaceStage,
+  applyThinking,
   applyToolCall,
   createExecutionTrace,
   finalizeExecutionTrace,
@@ -28,8 +33,7 @@ export const useAgentStore = defineStore('agent', () => {
   const pendingActions = ref<CanvasAction[]>([])
 
   function lastAssistant(): AgentStreamMessage | undefined {
-    const last = messages.value[messages.value.length - 1]
-    return last?.role === 'assistant' ? last : undefined
+    return [...messages.value].reverse().find((m) => m.role === 'assistant')
   }
 
   function ensureExecutionTrace() {
@@ -113,12 +117,43 @@ export const useAgentStore = defineStore('agent', () => {
     title?: string
     nodeId?: string
     errorHint?: string
+    errorCode?: string
   }) {
     ensureExecutionTrace()
     const last = lastAssistant()
     if (last?.executionTrace) {
       applyTaskUpdate(last.executionTrace, data)
     }
+  }
+
+  function trackStep(data: Parameters<typeof applyStep>[1]) {
+    ensureExecutionTrace()
+    const last = lastAssistant()
+    if (last?.executionTrace) applyStep(last.executionTrace, data)
+  }
+
+  function trackPhaseHint(data: { phase?: string; label: string }) {
+    ensureExecutionTrace()
+    const last = lastAssistant()
+    if (last?.executionTrace) applyPhaseHint(last.executionTrace, data)
+  }
+
+  function trackStructuredError(data: Parameters<typeof applyStructuredError>[1]) {
+    ensureExecutionTrace()
+    const last = lastAssistant()
+    if (last?.executionTrace) applyStructuredError(last.executionTrace, data)
+  }
+
+  function trackThinking(data: { status: string; summary?: string }) {
+    ensureExecutionTrace()
+    const last = lastAssistant()
+    if (last?.executionTrace) applyThinking(last.executionTrace, data)
+  }
+
+  function trackExplore(data: Parameters<typeof applyExplore>[1]) {
+    ensureExecutionTrace()
+    const last = lastAssistant()
+    if (last?.executionTrace) applyExplore(last.executionTrace, data)
   }
 
   function addCanvasAction(action: CanvasAction) {
@@ -165,6 +200,11 @@ export const useAgentStore = defineStore('agent', () => {
     addToolCall,
     trackNodeStatus,
     trackTaskUpdate,
+    trackStep,
+    trackPhaseHint,
+    trackStructuredError,
+    trackThinking,
+    trackExplore,
     addCanvasAction,
     flushActions,
     finishStreaming,

--- a/deploy/prod-execution-trace-verify.py
+++ b/deploy/prod-execution-trace-verify.py
@@ -122,6 +122,7 @@ def main() -> int:
     record("canvas_action emitted", len(canvas_actions) >= 1 or "canvas_action" in types, f"n={len(canvas_actions)}")
     record("node_status emitted", len(node_statuses) >= 1 or "node_status" in types, f"n={len(node_statuses)}")
     record("no forbidden labels", not any(f in stream for f in FORBIDDEN))
+    record("step events emitted", "step" in types, f"types={sorted(types)[:12]}")
 
     print(f"\n=== Summary PASS={PASS} FAIL={FAIL} ===")
     return 0 if FAIL == 0 else 1

--- a/docs/superpowers/plans/2026-08-06-agent-execution-trace-p1-p2.md
+++ b/docs/superpowers/plans/2026-08-06-agent-execution-trace-p1-p2.md
@@ -2,7 +2,8 @@
 
 > 日期：2026-08-06  
 > 前置：[2026-08-06-agent-execution-trace-design.md](../specs/2026-08-06-agent-execution-trace-design.md)  
-> P0 状态：实现中（本仓库 PR）
+> P0 状态：**已 merge**（PR #152）  
+> P1/P2 状态：**本 PR**
 
 ---
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -44,6 +44,13 @@ export interface AgentStreamEvent {
     | 'task_list'
     | 'task_update'
     | 'task_summary'
+    | 'step'
+    | 'phase_hint'
+    | 'thinking'
+    | 'explore'
+    | 'interrupt'
+    | 'force_choice'
+    | 'ping'
     | 'done'
     | 'error'
   data: unknown

--- a/services/agent-runtime/app/config.py
+++ b/services/agent-runtime/app/config.py
@@ -36,6 +36,7 @@ class Settings(BaseSettings):
     # Phase C: LLM structured intent parse (default off until C4)
     intent_llm_parse: bool = Field(default=False, validation_alias="INTENT_LLM_PARSE")
     intent_llm_parse_shadow: bool = Field(default=False, validation_alias="INTENT_LLM_PARSE_SHADOW")
+    agent_thinking_ui: bool = Field(default=False, validation_alias="AGENT_THINKING_UI")
 
     class Config:
         env_prefix = "LNKPI_"

--- a/services/agent-runtime/app/graph/atomic_context.py
+++ b/services/agent-runtime/app/graph/atomic_context.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from app.graph.context_packet import build_parse_packet
+from app.config import settings
+from app.graph.context_packet import build_parse_packet, explore_summary_from_packet
 from app.graph.context_render import render_packet_for_llm
 
 _MAX_CONTEXT_CHARS = 500
@@ -60,3 +61,11 @@ def build_atomic_parse_context(
     if len(rendered) <= max_chars:
         return rendered
     return rendered[: max_chars - 1] + "…"
+
+
+def build_atomic_parse_packet(
+    state: dict[str, Any],
+    *,
+    canvas_summary: dict[str, Any] | None = None,
+) -> Any:
+    return build_parse_packet(state, canvas_summary=canvas_summary)

--- a/services/agent-runtime/app/graph/context_packet.py
+++ b/services/agent-runtime/app/graph/context_packet.py
@@ -246,3 +246,24 @@ def build_parse_packet(
         dropped.append("episodic")
 
     return packet
+
+
+def explore_summary_from_packet(packet: ContextPacket) -> dict[str, Any]:
+    """User-facing explore step payload (no raw context text)."""
+    canvas = packet.get("canvas") or {}
+    relevant = canvas.get("relevant_nodes") or []
+    if isinstance(relevant, list) and relevant:
+        titles = [str(n.get("title") or "").strip() for n in relevant if n.get("title")]
+        node_count = len(relevant)
+    else:
+        titles = []
+        node_count = int(canvas.get("node_count") or 0)
+    meta = packet.get("meta") or {}
+    episodic = packet.get("episodic") or {}
+    return {
+        "label": "参考画布上下文",
+        "nodeCount": node_count,
+        "nodeTitles": [t[:32] for t in titles if t][:3],
+        "episodicUsed": bool(episodic.get("turns")),
+        "topicSwitch": bool(meta.get("topic_switch")),
+    }

--- a/services/agent-runtime/app/graph/nodes/atomic_parse.py
+++ b/services/agent-runtime/app/graph/nodes/atomic_parse.py
@@ -10,8 +10,9 @@ from typing import Any, Callable
 from langchain_core.messages import AIMessage
 
 from app.config import settings
+from app.graph.context_packet import explore_summary_from_packet
 from app.graph.atomic_parse_llm import llm_parse_atomic_intent
-from app.graph.atomic_context import build_atomic_parse_context
+from app.graph.atomic_context import build_atomic_parse_context, build_atomic_parse_packet
 from app.graph.atomic_parse_schema import (
     CLARIFY_THRESHOLD,
     RULE_FAST_PATH_THRESHOLD,
@@ -186,6 +187,7 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
                     canvas_summary = None
 
         focus_node_id = state.get("focus_node_id")
+        context_packet = build_atomic_parse_packet(state, canvas_summary=canvas_summary)
         parse_ctx = build_atomic_parse_context(state, canvas_summary=canvas_summary)
         prior_atomic = state.get("atomic_spec")
         prior_spec = prior_atomic if isinstance(prior_atomic, dict) else None
@@ -342,6 +344,14 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
         patch = parse_outcome_to_state(
             outcome, canvas_context=canvas_ctx, prior_spec=prior_spec
         )
+        patch["explore_summary"] = explore_summary_from_packet(context_packet)
+        if settings.agent_thinking_ui and outcome.get("kind") == "items":
+            items = outcome.get("items") or []
+            if items:
+                first = items[0]
+                target = str(first.get("target_type") or "内容")
+                title = str(first.get("title") or first.get("prompt") or "")[:48]
+                patch["thinking_summary"] = f"识别为{target}创作：{title or '未命名'}"
         if outcome["kind"] == "clarify":
             patch["clarify_context"] = {
                 "original_utterance": text,

--- a/services/agent-runtime/app/graph/step_copy.py
+++ b/services/agent-runtime/app/graph/step_copy.py
@@ -1,0 +1,80 @@
+"""User-facing step labels for LangGraph node execution (SSE ``step`` / ``phase_hint``)."""
+
+from __future__ import annotations
+
+NODE_STEP_LABELS: dict[str, str] = {
+    "intake": "理解你的需求",
+    "chat": "日常对话",
+    "decide_plan_mode": "判断任务类型",
+    "write_plan_node": "拟定营销方案",
+    "plan": "拟定营销方案",
+    "await_confirm": "等待你确认方案",
+    "split": "拆解画布任务",
+    "draft_copy": "起草主文案",
+    "await_copy_confirm": "等待你确认主文案",
+    "await_topo": "等待你确认节点结构",
+    "orchestrate_gen": "批量生成",
+    "collect_gen": "汇总生成结果",
+    "parse_atomic_intent": "解析创作意图",
+    "clarify_atomic_intent": "澄清创作需求",
+    "create_atomic_node": "创建画布节点",
+    "run_atomic_gen": "生成内容",
+    "await_atomic_confirm": "等待你确认生成参数",
+    "prepare_atomic_regenerate": "准备重新生成",
+    "prepare_single_gen": "准备单节点生成",
+    "run_single_gen": "单节点生成",
+    "done": "完成",
+}
+
+PHASE_HINT_LABELS: dict[str, str] = {
+    "await_confirm": "等待你确认方案",
+    "await_copy_confirm": "等待你确认主文案",
+    "await_topo": "等待你确认节点结构",
+    "await_atomic_confirm": "等待你确认生成参数",
+    "atomic_confirm_gate": "等待你确认生成参数",
+}
+
+
+def step_label(node_name: str) -> str:
+    return NODE_STEP_LABELS.get(node_name, "处理中")
+
+
+def phase_hint_label(phase: str | None, gate_node: str | None = None) -> str | None:
+    if phase and phase in PHASE_HINT_LABELS:
+        return PHASE_HINT_LABELS[phase]
+    if gate_node and gate_node in PHASE_HINT_LABELS:
+        return PHASE_HINT_LABELS[gate_node]
+    return None
+
+
+def step_event(
+    node_name: str,
+    *,
+    status: str,
+    ms: int | None = None,
+    detail: str | None = None,
+) -> dict:
+    data: dict = {
+        "id": f"node:{node_name}",
+        "kind": "phase",
+        "label": step_label(node_name),
+        "status": status,
+    }
+    if ms is not None:
+        data["ms"] = ms
+    if detail:
+        data["detail"] = detail[:200]
+    return {"type": "step", "data": data}
+
+
+def phase_hint_event(*, phase: str | None, gate_node: str | None = None) -> dict | None:
+    label = phase_hint_label(phase, gate_node)
+    if not label:
+        return None
+    return {
+        "type": "phase_hint",
+        "data": {
+            "phase": phase or gate_node,
+            "label": label,
+        },
+    }

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -15,8 +15,8 @@ from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 from pydantic import BaseModel
 
-from app.checkpoint_observability import checkpoint_diagnostics
 from app.config import settings
+from app.checkpoint_observability import checkpoint_diagnostics
 from app.errors import AgentToolError, error_to_sse_payload, from_exception
 from app.graph.builder import build_agent_graph
 from app.graph.hitl_resume import (
@@ -24,6 +24,7 @@ from app.graph.hitl_resume import (
     interrupt_event_payload,
     prepare_interrupt_resume,
 )
+from app.graph.step_copy import phase_hint_event, step_event
 from app.history_trim import trim_history
 from app.metrics import record_stream_error, thread_finished, thread_started, track_node
 from app.tracing import end_run_span, is_tracing_enabled, start_run_span, trace_node
@@ -604,8 +605,18 @@ async def stream_run_events(
                 if not isinstance(update, dict):
                     continue
                 for node_name, delta in update.items():
-                    with track_node(str(node_name)), trace_node(str(node_name)):
+                    node_key = str(node_name)
+                    t0 = time.monotonic()
+                    await emit(step_event(node_key, status="running"))
+                    with track_node(node_key), trace_node(node_key):
                         if not isinstance(delta, dict):
+                            await emit(
+                                step_event(
+                                    node_key,
+                                    status="done",
+                                    ms=int((time.monotonic() - t0) * 1000),
+                                )
+                            )
                             continue
                         force_choice = delta.get("force_choice")
                         if force_choice:
@@ -616,25 +627,42 @@ async def stream_run_events(
                                 }
                             )
                         messages = delta.get("messages")
-                        if not messages:
-                            continue
-                        seq = messages if isinstance(messages, list) else [messages]
-                        for msg in seq:
-                            content = getattr(msg, "content", None)
-                            if content is None and isinstance(msg, dict):
-                                content = msg.get("content")
-                            if not content:
-                                continue
-                            # Prefer AI replies for text_delta
-                            msg_type = getattr(msg, "type", None) or (
-                                msg.get("role") if isinstance(msg, dict) else None
-                            )
-                            if msg_type in ("ai", "assistant") or isinstance(msg, AIMessage):
-                                text = str(content)
-                                if text == last_text_delta:
+                        if messages:
+                            seq = messages if isinstance(messages, list) else [messages]
+                            for msg in seq:
+                                content = getattr(msg, "content", None)
+                                if content is None and isinstance(msg, dict):
+                                    content = msg.get("content")
+                                if not content:
                                     continue
-                                last_text_delta = text
-                                await emit({"type": "text_replace", "data": {"text": text}})
+                                # Prefer AI replies for text_delta
+                                msg_type = getattr(msg, "type", None) or (
+                                    msg.get("role") if isinstance(msg, dict) else None
+                                )
+                                if msg_type in ("ai", "assistant") or isinstance(msg, AIMessage):
+                                    text = str(content)
+                                    if text == last_text_delta:
+                                        continue
+                                    last_text_delta = text
+                                    await emit({"type": "text_replace", "data": {"text": text}})
+                        explore = delta.get("explore_summary")
+                        if isinstance(explore, dict):
+                            await emit({"type": "explore", "data": explore})
+                        thinking = delta.get("thinking_summary")
+                        if thinking and settings.agent_thinking_ui:
+                            await emit(
+                                {
+                                    "type": "thinking",
+                                    "data": {"status": "done", "summary": str(thinking)},
+                                }
+                            )
+                    await emit(
+                        step_event(
+                            node_key,
+                            status="done",
+                            ms=int((time.monotonic() - t0) * 1000),
+                        )
+                    )
             post = await graph.aget_state(config)
             post_next = [str(n) for n in (getattr(post, "next", None) or [])]
             post_vals = getattr(post, "values", None) or {}
@@ -647,10 +675,15 @@ async def stream_run_events(
             )
             if post_next:
                 phase = post_vals.get("phase")
+                phase_str = str(phase) if phase is not None else None
+                gate = post_next[0] if post_next else None
+                hint = phase_hint_event(phase=phase_str, gate_node=gate)
+                if hint:
+                    await emit(hint)
                 await emit(
                     interrupt_event_payload(
                         next_nodes=post_next,
-                        phase=str(phase) if phase is not None else None,
+                        phase=phase_str,
                     )
                 )
             await emit({"type": "done", "data": {}})

--- a/services/agent-runtime/tests/test_context_packet.py
+++ b/services/agent-runtime/tests/test_context_packet.py
@@ -7,6 +7,7 @@ from langchain_core.messages import AIMessage, HumanMessage
 from app.graph.atomic_context import build_atomic_parse_context
 from app.graph.context_packet import (
     build_parse_packet,
+    explore_summary_from_packet,
     should_include_episodic,
     should_include_prior_task,
 )
@@ -96,3 +97,21 @@ def test_build_atomic_parse_context_uses_markdown_not_legacy_pipe():
     assert " | " not in ctx
     assert "上轮原子" not in ctx
     assert "##" in ctx
+
+
+def test_explore_summary_from_packet_no_raw_context():
+    packet = build_parse_packet(
+        {
+            "messages": [HumanMessage(content="生成一张主图")],
+        },
+        canvas_summary={
+            "nodes": [
+                {"id": "n1", "type": "image", "title": "主图参考"},
+                {"id": "n2", "type": "prompt", "title": "文案"},
+            ],
+        },
+    )
+    summary = explore_summary_from_packet(packet)
+    assert summary["label"] == "参考画布上下文"
+    assert summary["nodeCount"] >= 1
+    assert "[canvas_context]" not in str(summary)

--- a/services/agent-runtime/tests/test_step_events.py
+++ b/services/agent-runtime/tests/test_step_events.py
@@ -1,0 +1,36 @@
+"""Tests for step_copy and step SSE helpers."""
+
+from app.graph.step_copy import (
+    NODE_STEP_LABELS,
+    phase_hint_event,
+    phase_hint_label,
+    step_event,
+    step_label,
+)
+
+
+def test_step_label_known_nodes():
+    assert step_label("parse_atomic_intent") == "解析创作意图"
+    assert step_label("unknown_node_xyz") == "处理中"
+
+
+def test_step_event_payload():
+    ev = step_event("intake", status="done", ms=120)
+    assert ev["type"] == "step"
+    data = ev["data"]
+    assert data["id"] == "node:intake"
+    assert data["label"] == NODE_STEP_LABELS["intake"]
+    assert data["status"] == "done"
+    assert data["ms"] == 120
+
+
+def test_phase_hint_label():
+    assert phase_hint_label("await_confirm") == "等待你确认方案"
+    assert phase_hint_label(None, "await_topo") == "等待你确认节点结构"
+
+
+def test_phase_hint_event():
+    ev = phase_hint_event(phase="await_confirm")
+    assert ev is not None
+    assert ev["type"] == "phase_hint"
+    assert ev["data"]["label"] == "等待你确认方案"


### PR DESCRIPTION
## Summary
- **P1**: Runtime `step` / `phase_hint` SSE; structured errors in trace; interrupt reconnect hints
- **P2**: `explore` from ContextPacket; optional `thinking` (`AGENT_THINKING_UI`); Replay debug timeline

Rebased on merged P0 (#152).

## Test plan
- [x] pnpm build, pytest, vitest
- [ ] CI
- [ ] prod: `python3 deploy/prod-execution-trace-verify.py`


Made with [Cursor](https://cursor.com)