### PR TITLE
fix(studio): Agnes img2img native refs (single + multi)

### DIFF
--- a/apps/server/src/canvas/material.service.ts
+++ b/apps/server/src/canvas/material.service.ts
@@ -6,11 +6,14 @@ import {
   NotFoundException,
 } from '@nestjs/common'
 import {
+  buildEffectiveImagePrompt,
   buildImageProviderOptions,
   buildVideoProviderOptions,
   createImageProvider,
   createVideoProvider,
   mergeRefsToPrompt,
+  providerReferenceImages,
+  stripRefImagePromptTags,
   type MergeTextSource,
 } from '@lnkpi/agent'
 import {
@@ -93,13 +96,6 @@ function extractReferenceImages(refs?: GenerationRefPayload[]): string[] {
   return (refs ?? [])
     .filter((r) => r.mediaType === 'image' && r.url?.trim())
     .map((r) => r.url!.trim())
-}
-
-function buildPromptWithRefImage(prompt: string, refImageUrl: string): string {
-  const trimmed = prompt.trim()
-  const ref = refImageUrl.trim()
-  if (!ref) return trimmed
-  return `${trimmed} [ref-image:${ref}]`
 }
 
 function userProviderOpts(resolved: ResolvedGenerationProvider) {
@@ -468,11 +464,20 @@ export class MaterialService {
             ? meta.modelKey
             : undefined
         const modelId = resolveModelKey('image', modelKey).entry.gatewayModelId
-        const prompt = String(meta.effectivePrompt ?? material.prompt ?? '')
-        const { url } = await createImageProvider(undefined).generate(prompt, {
+        const refs = Array.isArray(meta.referenceImages)
+          ? (meta.referenceImages as string[]).filter((url) => typeof url === 'string' && url.trim())
+          : []
+        const useNativeRefs =
+          refs.length > 0 &&
+          (meta.refImageMode === 'native' || /^agnes-image-/i.test(modelId))
+        const fallbackPrompt = useNativeRefs
+          ? stripRefImagePromptTags(String(meta.effectivePrompt ?? material.prompt ?? ''))
+          : String(meta.effectivePrompt ?? material.prompt ?? '')
+        const { url } = await createImageProvider(undefined).generate(fallbackPrompt, {
           modelId,
           size,
           n: 1,
+          referenceImages: useNativeRefs ? refs : undefined,
         })
         if (cancel?.isCancelled()) {
           await this.points.refund(userId, platformCost, '平台回退-取消退款')
@@ -484,7 +489,7 @@ export class MaterialService {
             url,
             thumbnail: url,
             status: 'completed',
-            prompt,
+            prompt: fallbackPrompt,
             metadata: JSON.stringify({
               ...chargedMeta,
               gatewayModelId: modelId,
@@ -772,9 +777,8 @@ export class MaterialService {
       referenceImages,
     })
     const modelId = resolved.source === 'user' ? resolved.modelName : built.modelId
-    const primary = built.referenceImages[0]
-    const base = primary ? buildPromptWithRefImage(mergedText, primary) : mergedText
-    const effectivePrompt = [base, built.effectivePromptSuffix].filter(Boolean).join('\n')
+    const effectivePrompt = buildEffectiveImagePrompt(mergedText, built)
+    const nativeReferenceImages = providerReferenceImages(built)
 
     try {
       if (resolved.source === 'user' && !resolved.credentials.apiKey) {
@@ -785,6 +789,7 @@ export class MaterialService {
         modelId,
         size: built.size,
         n: built.n,
+        referenceImages: nativeReferenceImages,
       })
       const existing = await this.prisma.material.findFirst({ where: { id: materialId } })
       if (!existing || existing.status !== 'generating') return

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common'
 import {
   buildAudioRequest,
+  buildEffectiveImagePrompt,
   buildImageProviderOptions,
   buildVideoProviderOptions,
   createAudioProvider,
@@ -10,6 +11,8 @@ import {
   generatePromptFromUserInput,
   generateTextWithImages,
   mergeRefsToPrompt,
+  providerReferenceImages,
+  stripRefImagePromptTags,
   type MergeTextSource,
 } from '@lnkpi/agent'
 import {
@@ -70,13 +73,6 @@ function extractReferenceImages(refs?: StudioRefInput[]): string[] {
   return (refs ?? [])
     .filter((r) => r.mediaType === 'image' && r.url?.trim())
     .map((r) => r.url!.trim())
-}
-
-function buildPromptWithRefImage(prompt: string, refImageUrl: string): string {
-  const trimmed = prompt.trim()
-  const ref = refImageUrl.trim()
-  if (!ref) return trimmed
-  return `${trimmed} [ref-image:${ref}]`
 }
 
 function userProviderOpts(resolved: ResolvedGenerationProvider) {
@@ -643,9 +639,8 @@ export class StudioService {
     const modelId = resolved.source === 'user' ? resolved.modelName : built.modelId
     const storeModel =
       resolved.source === 'user' ? model ?? built.meta.modelKey : built.meta.modelKey
-    const primaryRef = built.referenceImages[0]
-    const basePrompt = primaryRef ? buildPromptWithRefImage(mergedText, primaryRef) : mergedText
-    const effectivePrompt = [basePrompt, built.effectivePromptSuffix].filter(Boolean).join('\n')
+    const effectivePrompt = buildEffectiveImagePrompt(mergedText, built)
+    const nativeReferenceImages = providerReferenceImages(built)
     const record = await this.prisma.generationRecord.create({
       data: {
         userId,
@@ -680,7 +675,7 @@ export class StudioService {
       cost,
       chargeReason,
       effectivePrompt,
-      { modelId, size: built.size, n: built.n },
+      { modelId, size: built.size, n: built.n, referenceImages: nativeReferenceImages },
       resolved,
     ).catch((err) => {
       console.error('Image generation failed:', err)
@@ -705,7 +700,7 @@ export class StudioService {
     cost: number,
     chargeReason: string,
     prompt: string,
-    options: { modelId?: string; size?: string; n?: number },
+    options: { modelId?: string; size?: string; n?: number; referenceImages?: string[] },
     resolved: ResolvedGenerationProvider,
   ) {
     try {
@@ -718,6 +713,7 @@ export class StudioService {
           size: options.size,
           n: options.n,
           modelId: options.modelId,
+          referenceImages: options.referenceImages,
         },
       )
       const imageUrls = urls?.length ? urls : [url]
@@ -1132,10 +1128,18 @@ export class StudioService {
         const size = String(meta.size ?? '1024x1024')
         const n = Number(meta.count ?? 1) || 1
         const modelId = this.platformGatewayModelId('image', meta)
-        const { url, urls } = await createImageProvider(undefined).generate(record.prompt, {
+        const refs = Array.isArray(meta.referenceImages)
+          ? (meta.referenceImages as string[]).filter((url) => typeof url === 'string' && url.trim())
+          : []
+        const useNativeRefs =
+          refs.length > 0 &&
+          (meta.refImageMode === 'native' || /^agnes-image-/i.test(modelId))
+        const prompt = useNativeRefs ? stripRefImagePromptTags(record.prompt) : record.prompt
+        const { url, urls } = await createImageProvider(undefined).generate(prompt, {
           size,
           n,
           modelId,
+          referenceImages: useNativeRefs ? refs : undefined,
         })
         const imageUrls = urls?.length ? urls : [url]
         if (cancel?.isCancelled()) {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -35,6 +35,9 @@ export type { VisionTextOptions } from './refs/vision-text'
 export {
   buildAudioRequest,
   buildImageProviderOptions,
+  buildEffectiveImagePrompt,
+  providerReferenceImages,
+  stripRefImagePromptTags,
   buildVideoProviderOptions,
 } from './studio/generation-adapter'
 export type { AdapterMeta, BuiltAudioRequest } from './studio/generation-adapter'

--- a/packages/agent/src/studio/generation-adapter.test.ts
+++ b/packages/agent/src/studio/generation-adapter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import * as shared from '@lnkpi/shared'
-import { buildAudioRequest, buildVideoProviderOptions, buildImageProviderOptions } from './generation-adapter'
+import { buildAudioRequest, buildVideoProviderOptions, buildImageProviderOptions, buildEffectiveImagePrompt } from './generation-adapter'
 
 describe('buildAudioRequest', () => {
   it('maps native speed/volume/pitch for minimax and prefixes language when needed', () => {
@@ -100,6 +100,46 @@ describe('buildImageProviderOptions', () => {
     expect(r.meta.refImageMode).toBe('none')
     expect(r.meta.referenceImageCount).toBe(0)
     expect(r.effectivePromptSuffix).toBeUndefined()
+  })
+
+  it('uses native ref mode for a single agnes-image reference', () => {
+    const r = buildImageProviderOptions({
+      modelKey: 'agnes-image-2.1-flash',
+      size: '1024x768',
+      n: 1,
+      referenceImages: ['https://cdn.example/a.png'],
+    })
+    expect(r.referenceImages).toEqual(['https://cdn.example/a.png'])
+    expect(r.meta.refImageMode).toBe('native')
+    expect(r.meta.nativeParams).toMatchObject({
+      image: ['https://cdn.example/a.png'],
+    })
+    expect(r.effectivePromptSuffix).toBeUndefined()
+  })
+
+  it('uses native ref mode for agnes-image models with all reference URLs', () => {
+    const r = buildImageProviderOptions({
+      modelKey: 'agnes-image-2.0-flash',
+      size: '1024x768',
+      n: 1,
+      referenceImages: ['https://cdn.example/a.png', 'https://cdn.example/b.png'],
+    })
+    expect(r.referenceImages).toEqual([
+      'https://cdn.example/a.png',
+      'https://cdn.example/b.png',
+    ])
+    expect(r.meta.refImageMode).toBe('native')
+    expect(r.effectivePromptSuffix).toBeUndefined()
+  })
+
+  it('buildEffectiveImagePrompt omits ref-image tags for native mode', () => {
+    const built = buildImageProviderOptions({
+      modelKey: 'agnes-image-2.1-flash',
+      size: '1024x768',
+      n: 1,
+      referenceImages: ['https://cdn.example/a.png'],
+    })
+    expect(buildEffectiveImagePrompt('draw a cat', built)).toBe('draw a cat')
   })
 
   it('uses primary_image for a single reference', () => {

--- a/packages/agent/src/studio/generation-adapter.ts
+++ b/packages/agent/src/studio/generation-adapter.ts
@@ -146,8 +146,14 @@ export function buildAudioRequest(input: {
   }
 }
 
-function usesNativeImageRefs(modelKey: string, entry: StudioModelEntry): boolean {
-  return [modelKey, entry.modelKey, entry.gatewayModelId].some((k) => /^agnes-image-/i.test(k))
+function usesNativeImageRefs(
+  requestedModelKey: string | undefined,
+  resolvedKey: string,
+  catalogFallback: boolean,
+): boolean {
+  if (requestedModelKey && /^agnes-image-/i.test(requestedModelKey)) return true
+  if (!catalogFallback && /^agnes-image-/i.test(resolvedKey)) return true
+  return false
 }
 
 function appendRefImageTag(prompt: string, refImageUrl: string): string {
@@ -219,7 +225,7 @@ export function buildImageProviderOptions(input: {
   let refImageMode: AdapterMeta['refImageMode'] = 'none'
   const nativeParams: Record<string, unknown> = { model: entry.gatewayModelId, size, n }
 
-  if (refCount > 0 && usesNativeImageRefs(modelKey ?? resolvedKey, entry)) {
+  if (refCount > 0 && usesNativeImageRefs(modelKey, resolvedKey, fallback)) {
     result.referenceImages = [...referenceImages]
     refImageMode = 'native'
     nativeParams.image = [...referenceImages]

--- a/packages/agent/src/studio/generation-adapter.ts
+++ b/packages/agent/src/studio/generation-adapter.ts
@@ -146,6 +146,46 @@ export function buildAudioRequest(input: {
   }
 }
 
+function usesNativeImageRefs(modelKey: string, entry: StudioModelEntry): boolean {
+  return [modelKey, entry.modelKey, entry.gatewayModelId].some((k) => /^agnes-image-/i.test(k))
+}
+
+function appendRefImageTag(prompt: string, refImageUrl: string): string {
+  const trimmed = prompt.trim()
+  const ref = refImageUrl.trim()
+  if (!ref) return trimmed
+  return `${trimmed} [ref-image:${ref}]`
+}
+
+/** Remove legacy prompt URL tags before native img2img provider calls (e.g. platform fallback). */
+export function stripRefImagePromptTags(prompt: string): string {
+  return prompt.replace(/\s*\[ref-image:[^\]]+\]/g, '').trim()
+}
+
+export function buildEffectiveImagePrompt(
+  mergedText: string,
+  built: Pick<
+    ReturnType<typeof buildImageProviderOptions>,
+    'referenceImages' | 'effectivePromptSuffix' | 'meta'
+  >,
+): string {
+  if (built.meta.refImageMode === 'native' && built.referenceImages.length > 0) {
+    return mergedText.trim()
+  }
+  const primaryRef = built.referenceImages[0]
+  const base = primaryRef ? appendRefImageTag(mergedText, primaryRef) : mergedText.trim()
+  return [base, built.effectivePromptSuffix].filter(Boolean).join('\n')
+}
+
+export function providerReferenceImages(
+  built: Pick<ReturnType<typeof buildImageProviderOptions>, 'referenceImages' | 'meta'>,
+): string[] | undefined {
+  if (built.meta.refImageMode === 'native' && built.referenceImages.length > 0) {
+    return built.referenceImages
+  }
+  return undefined
+}
+
 export function buildImageProviderOptions(input: {
   modelKey?: string
   size: string
@@ -176,26 +216,33 @@ export function buildImageProviderOptions(input: {
     referenceImages: [],
   }
 
-  if (refCount === 1) {
+  let refImageMode: AdapterMeta['refImageMode'] = 'none'
+  const nativeParams: Record<string, unknown> = { model: entry.gatewayModelId, size, n }
+
+  if (refCount > 0 && usesNativeImageRefs(modelKey ?? resolvedKey, entry)) {
+    result.referenceImages = [...referenceImages]
+    refImageMode = 'native'
+    nativeParams.image = [...referenceImages]
+  } else if (refCount === 1) {
     result.referenceImages = [referenceImages[0]]
+    refImageMode = 'primary_image'
   } else if (refCount > 1) {
     result.referenceImages = [referenceImages[0]]
     result.effectivePromptSuffix = referenceImages
       .slice(1)
       .map((url) => `[ref-image:${url}]`)
       .join(' ')
+    refImageMode = 'primary_image'
   }
-
-  const refImageMode = refCount > 0 ? 'primary_image' : 'none'
 
   return {
     ...result,
     meta: {
       modelKey: resolvedKey,
       gatewayModelId: entry.gatewayModelId,
-      nativeParams: { model: entry.gatewayModelId, size, n },
+      nativeParams,
       droppedFields: [],
-      refImageMode,
+      refImageMode: refImageMode ?? 'none',
       referenceImageCount: refCount,
       ...(fallback ? { modelFallback: true } : {}),
     },

--- a/packages/agent/src/tools/image-provider.test.ts
+++ b/packages/agent/src/tools/image-provider.test.ts
@@ -66,4 +66,61 @@ describe('OpenAIImageProvider', () => {
       size: '512x512',
     })
   })
+
+  it('sends extra_body.image for agnes-image single-ref img2img', async () => {
+    const provider = new OpenAIImageProvider(
+      'test-key',
+      'https://apihub.agnes-ai.com/v1',
+      'agnes-image-2.0-flash',
+    )
+    await provider.generate('white background product photo', {
+      modelId: 'agnes-image-2.0-flash',
+      size: '1024x768',
+      n: 1,
+      referenceImages: ['https://cdn.example/ref.jpg'],
+    })
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(JSON.parse(String(init.body))).toEqual({
+      model: 'agnes-image-2.0-flash',
+      prompt: 'white background product photo',
+      n: 1,
+      size: '1024x768',
+      extra_body: {
+        image: ['https://cdn.example/ref.jpg'],
+        response_format: 'url',
+      },
+    })
+  })
+
+  it('sends all reference images in extra_body.image for agnes multi-ref', async () => {
+    const provider = new OpenAIImageProvider(
+      'test-key',
+      'https://apihub.agnes-ai.com/v1',
+      'agnes-image-2.0-flash',
+    )
+    await provider.generate('combine these into one scene', {
+      modelId: 'agnes-image-2.0-flash',
+      size: '1024x768',
+      n: 1,
+      referenceImages: [
+        'https://cdn.example/a.png',
+        'https://cdn.example/b.png',
+        'https://cdn.example/c.png',
+      ],
+    })
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      extra_body: {
+        image: [
+          'https://cdn.example/a.png',
+          'https://cdn.example/b.png',
+          'https://cdn.example/c.png',
+        ],
+        response_format: 'url',
+      },
+    })
+  })
 })

--- a/packages/agent/src/tools/image-provider.ts
+++ b/packages/agent/src/tools/image-provider.ts
@@ -2,6 +2,7 @@ export interface ImageGenerateOptions {
   modelId?: string
   size?: string
   n?: number
+  referenceImages?: string[]
 }
 
 export interface ImageProvider {
@@ -32,10 +33,32 @@ export class OpenAIImageProvider implements ImageProvider {
     private model = 'dall-e-3',
   ) {}
 
+  private buildRequestBody(prompt: string, options?: ImageGenerateOptions): Record<string, unknown> {
+    const model = options?.modelId || this.model
+    const n = Math.max(1, Math.min(4, options?.n ?? 1))
+    const size = options?.size ?? '1024x1024'
+    const refs = (options?.referenceImages ?? []).map((url) => url.trim()).filter(Boolean)
+
+    const body: Record<string, unknown> = {
+      model,
+      prompt,
+      n: model.includes('dall-e-3') ? 1 : Math.min(n, 4),
+      size,
+    }
+
+    if (refs.length > 0 && (isAgnesImageApi(this.baseUrl, model))) {
+      body.extra_body = {
+        image: refs,
+        response_format: 'url',
+      }
+    }
+
+    return body
+  }
+
   async generate(prompt: string, options?: ImageGenerateOptions): Promise<{ url: string; urls?: string[] }> {
     const n = Math.max(1, Math.min(4, options?.n ?? 1))
-    // dall-e-3 only supports n=1; request sequentially when n>1
-    const size = options?.size ?? '1024x1024'
+    const model = options?.modelId || this.model
     const urls: string[] = []
     for (let i = 0; i < n; i += 1) {
       const res = await fetch(`${this.baseUrl}/images/generations`, {
@@ -44,23 +67,23 @@ export class OpenAIImageProvider implements ImageProvider {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${this.apiKey}`,
         },
-        body: JSON.stringify({
-          model: options?.modelId || this.model,
-          prompt,
-          n: this.model.includes('dall-e-3') ? 1 : Math.min(n, 4),
-          size,
-        }),
+        body: JSON.stringify(this.buildRequestBody(prompt, options)),
       })
       if (!res.ok) throw new Error(`Image API ${res.status}: ${await res.text()}`)
       const json = await res.json() as { data: Array<{ url: string }> }
       for (const item of json.data) {
         if (item.url) urls.push(item.url)
       }
-      if (!this.model.includes('dall-e-3')) break
+      if (!model.includes('dall-e-3')) break
     }
     if (!urls.length) throw new Error('Image API returned no urls')
     return { url: urls[0], urls }
   }
+}
+
+function isAgnesImageApi(baseUrl?: string, model?: string): boolean {
+  if (model && /^agnes-image-/i.test(model)) return true
+  return Boolean(baseUrl?.includes('agnes-ai.com') || baseUrl?.includes('agnes-ai.cn'))
 }
 
 export type ProviderCredentialOpts = { apiKey?: string; baseUrl?: string; model?: string }

--- a/packages/shared/src/studioModelCatalog.test.ts
+++ b/packages/shared/src/studioModelCatalog.test.ts
@@ -14,7 +14,14 @@ describe('studioModelCatalog', () => {
       'deepseek-v4',
       'gpt-5.5',
     ])
-    expect(listModels('image')).toHaveLength(5)
+    expect(listModels('image').map((m) => m.modelKey)).toEqual([
+      'agnes-image-2.0-flash',
+      'agnes-image-2.1-flash',
+      'image2',
+      'navo-pro',
+      'seedream-5.0-pro',
+      'midjourney-8.1',
+    ])
     expect(listModels('video')).toHaveLength(4)
     expect(listModels('audio').map((m) => m.modelKey)).toEqual([
       'seed-audio-1.0',

--- a/packages/shared/src/studioModelCatalog.ts
+++ b/packages/shared/src/studioModelCatalog.ts
@@ -96,6 +96,14 @@ export const STUDIO_MODEL_CATALOG: StudioModelEntry[] = [
 
   // Image (§3.2)
   {
+    modelKey: 'agnes-image-2.0-flash',
+    displayName: 'Agnes Image 2.0 Flash',
+    gatewayModelId: 'agnes-image-2.0-flash',
+    modality: 'image',
+    providerBinding: 'gateway-openai-compat',
+    params: IMAGE_PARAMS,
+  },
+  {
     modelKey: 'agnes-image-2.1-flash',
     displayName: 'Agnes Image 2.1 Flash',
     gatewayModelId: 'agnes-image-2.1-flash',


### PR DESCRIPTION
## Summary
- Route `agnes-image-*` reference images through official `extra_body.image` instead of `[ref-image:URL]` prompt tags
- Support single (I1) and multi-image (I1+I2+…) composition in one native array
- Add `agnes-image-2.0-flash` to studio model catalog; platform fallback strips legacy prompt tags and restores refs from metadata

## Test plan
- [x] `pnpm build`
- [x] `pnpm --filter @lnkpi/agent test` (74 passed)
- [x] `pnpm --filter @lnkpi/server exec vitest run src/canvas/material.service.test.ts src/studio/studio.integration.test.ts`
- [ ] Post-merge: prod img2img with upstream I1+T1 on agnes-image-2.0-flash BYOK


Made with [Cursor](https://cursor.com)