### PR TITLE
fix(provider): pull-models errors and channel manual save UX

### DIFF
--- a/apps/server/src/provider/provider.service.test.ts
+++ b/apps/server/src/provider/provider.service.test.ts
@@ -379,6 +379,22 @@ describe('ProviderService', () => {
     expect(byName['kling-v2']).toBe('video')
   })
 
+  it('pullModels maps fetch failures to BadRequestException with host hint', async () => {
+    const ch = await svc.createChannel('u1', {
+      name: 'pull-timeout',
+      apiFormat: 'openai',
+      baseUrl: 'https://api.apimart.ai/v1',
+      apiKey: 'sk-test',
+    })
+    const timeout = new TypeError('fetch failed')
+    ;(timeout as TypeError & { cause: Error }).cause = Object.assign(new Error('Connect Timeout'), {
+      code: 'UND_ERR_CONNECT_TIMEOUT',
+    })
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(timeout))
+
+    await expect(svc.pullModels('u1', ch.id)).rejects.toThrow(/api\.apimart\.ai/)
+  })
+
   it('rejects intranet WebDAV URL on update and test', async () => {
     await expect(
       svc.updateWebdav('u1', { url: 'https://10.0.0.5/webdav' }),

--- a/apps/server/src/provider/provider.service.ts
+++ b/apps/server/src/provider/provider.service.ts
@@ -173,6 +173,28 @@ function catalogModels(): ChannelModelEntry[] {
   }))
 }
 
+/** Turn undici/network fetch failures into actionable BYOK pull-models errors. */
+export function formatPullModelsFetchError(err: unknown, host: string): string {
+  const root = err instanceof Error && err.cause instanceof Error ? err.cause : err
+  const code =
+    root && typeof root === 'object' && 'code' in root ? String((root as { code?: string }).code) : ''
+  const message = root instanceof Error ? root.message : String(root ?? 'fetch failed')
+
+  if (code === 'UND_ERR_CONNECT_TIMEOUT' || /connect timeout/i.test(message)) {
+    return `无法连接渠道网关 ${host}（连接超时）。请检查服务器出网、DNS、防火墙，或配置 HTTPS 代理后重试。`
+  }
+  if (code === 'ENOTFOUND' || /getaddrinfo/i.test(message)) {
+    return `无法解析渠道网关域名 ${host}（DNS 失败）。请检查 Base URL 是否正确。`
+  }
+  if (code === 'ECONNREFUSED') {
+    return `渠道网关 ${host} 拒绝连接。请检查 Base URL 端口与服务是否可用。`
+  }
+  if (code === 'CERT_HAS_EXPIRED' || code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE') {
+    return `渠道网关 ${host} TLS 证书校验失败（${code}）。`
+  }
+  return `无法连接渠道网关 ${host}：${message}`
+}
+
 function defaultSelectableFor(modality: StudioModality): string[] {
   return STUDIO_MODEL_CATALOG.filter((entry) => entry.modality === modality).map((entry) =>
     encodeChannelModel(PLATFORM_CHANNEL_ID, entry.modelKey),
@@ -341,18 +363,26 @@ export class ProviderService {
     const modelsUrl = new URL(base.toString().replace(/\/?$/, '/') + 'models')
     this.safeOutboundUrl(modelsUrl.toString())
 
-    const response = await fetch(modelsUrl, {
-      redirect: 'manual',
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        Accept: 'application/json',
-      },
-    })
+    let response: Response
+    try {
+      response = await fetch(modelsUrl, {
+        redirect: 'manual',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          Accept: 'application/json',
+        },
+      })
+    } catch (err) {
+      throw new BadRequestException(formatPullModelsFetchError(err, modelsUrl.hostname))
+    }
     if (response.status >= 300 && response.status < 400) {
       throw new BadRequestException('redirects are not allowed when pulling models')
     }
     if (!response.ok) {
-      throw new BadRequestException(`failed to pull models (${response.status})`)
+      const snippet = (await response.text()).replace(/\s+/g, ' ').slice(0, 240)
+      throw new BadRequestException(
+        `failed to pull models from ${modelsUrl.hostname} (HTTP ${response.status})${snippet ? `: ${snippet}` : ''}`,
+      )
     }
 
     const body = (await response.json()) as { data?: Array<{ id?: string }> }
@@ -388,7 +418,8 @@ export class ProviderService {
       try {
         results.push(await this.pullModels(userId, channel.id))
       } catch {
-        results.push(this.toPublicChannel(channel, { readOnly: false }))
+        const fresh = await this.prisma.providerChannel.findUnique({ where: { id: channel.id } })
+        results.push(this.toPublicChannel(fresh ?? channel, { readOnly: false }))
       }
     }
     return results

--- a/apps/web/src/components/canvas/ProviderConfigDialog.vue
+++ b/apps/web/src/components/canvas/ProviderConfigDialog.vue
@@ -252,14 +252,15 @@ function setModelCapability(draft: ChannelDraft, name: string, capability: Model
 }
 
 function onModelNamesChange(draft: ChannelDraft, names: string[]) {
-  draft.modelNames = names
-  for (const name of names) {
+  const cleaned = names.map((name) => String(name).trim()).filter(Boolean)
+  draft.modelNames = cleaned
+  for (const name of cleaned) {
     if (!draft.modelMeta[name]) {
       draft.modelMeta[name] = inferModelCapability(name)
     }
   }
   for (const key of Object.keys(draft.modelMeta)) {
-    if (!names.includes(key)) delete draft.modelMeta[key]
+    if (!cleaned.includes(key)) delete draft.modelMeta[key]
   }
 }
 
@@ -287,6 +288,18 @@ async function persistChannel(draft: ChannelDraft) {
 
   const updated = await providerApi.updateChannel(draft.id, input)
   applyServerChannel(updated)
+  return updated
+}
+
+async function saveChannel(draft: ChannelDraft) {
+  if (draft.readOnly) return
+  try {
+    const updated = await persistChannel(draft)
+    if (!updated) return
+    ElMessage.success(`「${updated.name}」已保存（${updated.models.length} 个模型）`)
+  } catch (err) {
+    ElMessage.error(apiErrorMessage(err, '保存渠道失败'))
+  }
 }
 
 async function refreshChannelDrafts() {
@@ -340,6 +353,9 @@ async function pullChannelModels(draft: ChannelDraft) {
     ElMessage.success(`${updated.name} 模型列表已更新`)
   } catch (err) {
     ElMessage.error(apiErrorMessage(err, '拉取模型失败'))
+    if (!draft.readOnly) {
+      ElMessage.info('手动填写的模型已保存，可稍后在「模型」Tab 勾选使用')
+    }
   } finally {
     pullingId.value = ''
   }
@@ -559,6 +575,15 @@ function apiKeyPlaceholder(draft: ChannelDraft) {
                 </div>
                 <div class="flex shrink-0 gap-2">
                   <el-button
+                    v-if="!draft.readOnly"
+                    size="small"
+                    type="primary"
+                    plain
+                    @click="saveChannel(draft)"
+                  >
+                    保存
+                  </el-button>
+                  <el-button
                     size="small"
                     :loading="pullingId === draft.id"
                     @click="pullChannelModels(draft)"
@@ -623,7 +648,7 @@ function apiKeyPlaceholder(draft: ChannelDraft) {
                     allow-create
                     default-first-option
                     :disabled="draft.readOnly"
-                    placeholder="输入模型名，或点击拉取模型"
+                    placeholder="输入模型名后按 Enter 确认，或点击「保存」"
                     @update:model-value="onModelNamesChange(draft, $event)"
                   />
                   <div
@@ -650,7 +675,7 @@ function apiKeyPlaceholder(draft: ChannelDraft) {
                     </div>
                   </div>
                   <p class="mt-1.5 text-[10px] leading-4 text-[var(--neo-text-muted)]">
-                    能力标签决定模型优先出现在哪一类可选项；自定义渠道模型也可在任意类型中勾选。
+                    能力标签决定模型优先出现在哪一类可选项；自定义渠道模型也可在任意类型中勾选。填写后请点击「保存」或底部「完成」，再到「模型」Tab 勾选可选项。
                   </p>
                 </label>
               </div>


### PR DESCRIPTION
## Summary
- `pull-models` 将 `fetch failed`/连接超时映射为可读的 400 错误，不再返回 Internal server error
- HTTP 非 2xx 时附带 status 与响应片段，便于定位 APIMart 等网关问题
- 渠道配置增加「保存」按钮，手动模型需 Enter 确认；拉取失败时提示手动模型已保存
- `pull-all` 失败时从 DB 刷新渠道，避免覆盖已保存的手动模型列表

## Test plan
- [x] `pnpm --filter @lnkpi/server test -- src/provider/provider.service.test.ts`
- [x] `pnpm --filter @lnkpi/server build`
- [x] `pnpm --filter @lnkpi/web build`


Made with [Cursor](https://cursor.com)