### PR TITLE
fix(studio): pass platform credentials to image providers

### DIFF
--- a/apps/server/src/canvas/material.service.ts
+++ b/apps/server/src/canvas/material.service.ts
@@ -101,11 +101,12 @@ function extractReferenceImages(refs?: GenerationRefPayload[]): string[] {
     .map((r) => r.url!.trim())
 }
 
-function userProviderOpts(resolved: ResolvedGenerationProvider) {
-  if (resolved.source !== 'user') return undefined
+function providerOpts(resolved: ResolvedGenerationProvider) {
+  const { apiKey, baseUrl } = resolved.credentials
+  if (resolved.source === 'user' && !apiKey) return undefined
   return {
-    apiKey: resolved.credentials.apiKey,
-    baseUrl: resolved.credentials.baseUrl || undefined,
+    apiKey,
+    baseUrl: baseUrl || undefined,
   }
 }
 
@@ -819,7 +820,7 @@ export class MaterialService {
       if (resolved.source === 'user' && !resolved.credentials.apiKey) {
         throw new Error('missing api key')
       }
-      const provider = createImageProvider(userProviderOpts(resolved))
+      const provider = createImageProvider(providerOpts(resolved))
       const { url } = await provider.generate(effectivePrompt, providerOptions)
       const existing = await this.prisma.material.findFirst({ where: { id: materialId } })
       if (!existing || existing.status !== 'generating') return
@@ -958,7 +959,7 @@ export class MaterialService {
       if (resolved.source === 'user' && !resolved.credentials.apiKey) {
         throw new Error('missing api key')
       }
-      const { url } = await createVideoProvider(userProviderOpts(resolved)).generate(
+      const { url } = await createVideoProvider(providerOpts(resolved)).generate(
         effectivePrompt,
         {
           model: gatewayModel,

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -78,11 +78,12 @@ function extractReferenceImages(refs?: StudioRefInput[]): string[] {
     .map((r) => r.url!.trim())
 }
 
-function userProviderOpts(resolved: ResolvedGenerationProvider) {
-  if (resolved.source !== 'user') return undefined
+function providerOpts(resolved: ResolvedGenerationProvider) {
+  const { apiKey, baseUrl } = resolved.credentials
+  if (resolved.source === 'user' && !apiKey) return undefined
   return {
-    apiKey: resolved.credentials.apiKey,
-    baseUrl: resolved.credentials.baseUrl || undefined,
+    apiKey,
+    baseUrl: baseUrl || undefined,
   }
 }
 
@@ -358,7 +359,7 @@ export class StudioService {
       if (resolved.source === 'user' && !resolved.credentials.apiKey) {
         throw new Error('missing api key')
       }
-      const opts = userProviderOpts(resolved)
+      const opts = providerOpts(resolved)
       const { text } =
         referenceImages.length > 0
           ? await generateTextWithImages(mergedText, referenceImages, {
@@ -448,7 +449,7 @@ export class StudioService {
     const gatewayModelId =
       resolved.source === 'user' ? resolved.modelName : entry.gatewayModelId
     const storeModel = resolved.source === 'user' ? model ?? resolvedKey : resolvedKey
-    const opts = userProviderOpts(resolved)
+    const opts = providerOpts(resolved)
     const baseMeta = {
       modelKey: resolvedKey,
       gatewayModelId,
@@ -541,7 +542,7 @@ export class StudioService {
     const { modelKey: resolvedKey, entry } = resolveModelKey('text', resolved.modelName)
     const gatewayModelId =
       resolved.source === 'user' ? resolved.modelName : entry.gatewayModelId
-    const opts = userProviderOpts(resolved)
+    const opts = providerOpts(resolved)
     if (resolved.source === 'user' && !resolved.credentials.apiKey) {
       throw new Error('missing api key')
     }
@@ -725,7 +726,7 @@ export class StudioService {
       if (resolved.source === 'user' && !resolved.credentials.apiKey) {
         throw new Error('missing api key')
       }
-      const { url, urls } = await createImageProvider(userProviderOpts(resolved)).generate(
+      const { url, urls } = await createImageProvider(providerOpts(resolved)).generate(
         prompt,
         options,
       )
@@ -792,7 +793,7 @@ export class StudioService {
       if (resolved.source === 'user' && !resolved.credentials.apiKey) {
         throw new Error('missing api key')
       }
-      const { url } = await createImageProvider(userProviderOpts(resolved)).generate(combined, {
+      const { url } = await createImageProvider(providerOpts(resolved)).generate(combined, {
         modelId: resolved.modelName || undefined,
       })
       if (cancel?.isCancelled()) {
@@ -1014,7 +1015,7 @@ export class StudioService {
       if (resolved.source === 'user' && !resolved.credentials.apiKey) {
         throw new Error('missing api key')
       }
-      const { url } = await createAudioProvider(userProviderOpts(resolved)).generate(
+      const { url } = await createAudioProvider(providerOpts(resolved)).generate(
         built.text,
         audioOpts,
       )
@@ -1442,7 +1443,7 @@ export class StudioService {
       if (resolved.source === 'user' && !resolved.credentials.apiKey) {
         throw new Error('missing api key')
       }
-      const { url } = await createVideoProvider(userProviderOpts(resolved)).generate(
+      const { url } = await createVideoProvider(providerOpts(resolved)).generate(
         prompt,
         options,
       )

--- a/packages/agent/src/studio/generation-adapter.test.ts
+++ b/packages/agent/src/studio/generation-adapter.test.ts
@@ -149,6 +149,20 @@ describe('buildImageProviderOptions', () => {
     expect(r.effectivePromptSuffix).toBe('[ref-image:https://cdn.example/b.png]')
   })
 
+  it('recognizes BYOK APIMart gateway model ids for async profile', () => {
+    const r = buildImageProviderOptions({
+      modelKey: 'doubao-seedream-5-0-pro',
+      aspectRatio: '1:1',
+      resolution: '1K',
+      n: 1,
+      referenceImages: [],
+    })
+    expect(r.meta.modelKey).toBe('doubao-seedream-5-0-pro')
+    expect(r.meta.gatewayModelId).toBe('doubao-seedream-5-0-pro')
+    expect(r.meta.responseMode).toBe('async_task')
+    expect(r.meta.modelFallback).toBeUndefined()
+  })
+
   it('buildImageProviderGenerateOptions forwards async profile fields', () => {
     const built = buildImageProviderOptions({
       modelKey: 'seedream-5.0-pro',

--- a/packages/agent/src/studio/generation-adapter.ts
+++ b/packages/agent/src/studio/generation-adapter.ts
@@ -4,6 +4,7 @@ import {
   resolveImageGatewayModelId,
   resolveImageModelProfile,
   usesNativeImageRefs,
+  isApimartBackedImageModel,
   SUPPORTED_ASPECT_RATIOS,
   type ImageRefWire,
   type ImageResolutionTier,
@@ -329,9 +330,17 @@ export function buildImageProviderOptions(input: {
     n,
     referenceImages,
   } = input
-  const { modelKey: resolvedKey, entry, fallback } = resolveModelKey('image', modelKey)
-  const profile = resolveImageModelProfile(resolvedKey, entry.gatewayModelId)
-  const gatewayModelId = resolveImageGatewayModelId(resolvedKey, entry.gatewayModelId)
+  const catalog = resolveModelKey('image', modelKey)
+  let resolvedKey = catalog.modelKey
+  let catalogGateway = catalog.entry.gatewayModelId
+  let catalogFallback = catalog.fallback
+  if (modelKey && isApimartBackedImageModel(modelKey)) {
+    resolvedKey = modelKey
+    catalogGateway = resolveImageGatewayModelId(modelKey, modelKey)
+    catalogFallback = false
+  }
+  const profile = resolveImageModelProfile(resolvedKey, catalogGateway)
+  const gatewayModelId = resolveImageGatewayModelId(resolvedKey, catalogGateway)
   const clamped = clampImageGenerationInput(profile, {
     n,
     resolution,
@@ -405,7 +414,7 @@ export function buildImageProviderOptions(input: {
       referenceImageCount: refCount,
       responseMode: profile.responseMode,
       refWire: refCount > 0 ? profile.refWire : 'none',
-      ...(fallback ? { modelFallback: true } : {}),
+      ...(catalogFallback ? { modelFallback: true } : {}),
     },
   }
 }


### PR DESCRIPTION
## Summary
- Fix `providerOpts` to forward platform channel credentials (APIMart for image2/seedream) to `createImageProvider`
- Root cause of failed Studio E2E: resolver returned APIMart creds but `userProviderOpts` returned `undefined` for platform → fell back to Agnes env

## Test plan
- [ ] Deploy fix branch to CVM
- [ ] Studio E2E platform + BYOK image2/seedream


Made with [Cursor](https://cursor.com)