### PR TITLE
fix(studio): BYOK APIMart image passthrough and gemini aliases

### DIFF
--- a/apps/server/src/canvas/material.service.ts
+++ b/apps/server/src/canvas/material.service.ts
@@ -807,6 +807,8 @@ export class MaterialService {
       pixelSize,
       n: 1,
       referenceImages,
+      byok: resolved.source === 'user',
+      channelBaseUrl: resolved.credentials.baseUrl,
     })
     const modelId = resolved.source === 'user' ? resolved.modelName : built.modelId
     const effectivePrompt = buildEffectiveImagePrompt(

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -643,6 +643,8 @@ export class StudioService {
       pixelSize,
       n,
       referenceImages,
+      byok: resolved.source === 'user',
+      channelBaseUrl: resolved.credentials.baseUrl,
     })
     const modelId = resolved.source === 'user' ? resolved.modelName : built.modelId
     const storeModel =

--- a/packages/agent/src/studio/generation-adapter.test.ts
+++ b/packages/agent/src/studio/generation-adapter.test.ts
@@ -149,6 +149,42 @@ describe('buildImageProviderOptions', () => {
     expect(r.effectivePromptSuffix).toBe('[ref-image:https://cdn.example/b.png]')
   })
 
+  it('BYOK passthrough keeps unknown gateway id off platform catalog default', () => {
+    const r = buildImageProviderOptions({
+      modelKey: 'brand-new-upstream-image',
+      aspectRatio: '16:9',
+      resolution: '1K',
+      n: 1,
+      referenceImages: ['https://cdn.example/a.png'],
+      byok: true,
+      channelBaseUrl: 'https://api.apimart.ai/v1',
+    })
+    expect(r.modelId).toBe('brand-new-upstream-image')
+    expect(r.meta.gatewayModelId).toBe('brand-new-upstream-image')
+    expect(r.meta.modelFallback).toBeUndefined()
+    expect(r.meta.responseMode).toBe('async_task')
+    expect(r.meta.refWire).toBe('apimart_image_urls')
+  })
+
+  it('recognizes APIMart gemini-3.6-flash alias as image2 with multi-ref wire', () => {
+    const r = buildImageProviderOptions({
+      modelKey: 'gemini-3.6-flash',
+      aspectRatio: '16:9',
+      resolution: '1K',
+      n: 1,
+      referenceImages: [
+        'https://cdn.example/model.png',
+        'https://cdn.example/product.png',
+      ],
+    })
+    expect(r.modelId).toBe('gpt-image-2-official')
+    expect(r.meta.gatewayModelId).toBe('gpt-image-2-official')
+    expect(r.meta.responseMode).toBe('async_task')
+    expect(r.meta.refWire).toBe('apimart_image_urls')
+    expect(r.meta.modelFallback).toBeUndefined()
+    expect(r.meta.nativeParams.image_urls).toHaveLength(2)
+  })
+
   it('recognizes BYOK APIMart gateway model ids for async profile', () => {
     const r = buildImageProviderOptions({
       modelKey: 'doubao-seedream-5-0-pro',

--- a/packages/agent/src/studio/generation-adapter.ts
+++ b/packages/agent/src/studio/generation-adapter.ts
@@ -314,6 +314,9 @@ export function buildImageProviderOptions(input: {
   pixelSize?: string
   n: number
   referenceImages: string[]
+  /** BYOK: keep upstream gateway id; never fall back to platform catalog default. */
+  byok?: boolean
+  channelBaseUrl?: string
 }): {
   modelId: string
   size: string
@@ -329,6 +332,8 @@ export function buildImageProviderOptions(input: {
     pixelSize,
     n,
     referenceImages,
+    byok = false,
+    channelBaseUrl,
   } = input
   const catalog = resolveModelKey('image', modelKey)
   let resolvedKey = catalog.modelKey
@@ -338,8 +343,12 @@ export function buildImageProviderOptions(input: {
     resolvedKey = modelKey
     catalogGateway = resolveImageGatewayModelId(modelKey, modelKey)
     catalogFallback = false
+  } else if (modelKey && byok && catalog.fallback) {
+    resolvedKey = modelKey
+    catalogGateway = modelKey
+    catalogFallback = false
   }
-  const profile = resolveImageModelProfile(resolvedKey, catalogGateway)
+  const profile = resolveImageModelProfile(resolvedKey, catalogGateway, { channelBaseUrl })
   const gatewayModelId = resolveImageGatewayModelId(resolvedKey, catalogGateway)
   const clamped = clampImageGenerationInput(profile, {
     n,

--- a/packages/shared/src/imageModelProfiles.test.ts
+++ b/packages/shared/src/imageModelProfiles.test.ts
@@ -24,6 +24,28 @@ describe('resolveImageModelProfile', () => {
     expect(p.maxRefs).toBe(16)
   })
 
+  it('maps APIMart gemini-3.x-flash aliases to gpt-image-2-official', () => {
+    for (const alias of ['gemini-3.5-flash', 'gemini-3.6-flash']) {
+      const p = resolveImageModelProfile(alias, alias)
+      expect(p.gatewayModelId).toBe('gpt-image-2-official')
+      expect(p.refWire).toBe('apimart_image_urls')
+      expect(p.responseMode).toBe('async_task')
+    }
+  })
+
+  it('uses APIMart generic async profile for unknown BYOK ids on apimart baseUrl', () => {
+    const p = resolveImageModelProfile('some-new-apimart-image', 'some-new-apimart-image', {
+      channelBaseUrl: 'https://api.apimart.ai/v1',
+    })
+    expect(p.gatewayModelId).toBe('some-new-apimart-image')
+    expect(p.refWire).toBe('apimart_image_urls')
+    expect(p.responseMode).toBe('async_task')
+  })
+
+  it('maps gpt-image-2 shorthand to gpt-image-2-official', () => {
+    expect(resolveImageGatewayModelId('gpt-image-2', 'gpt-image-2')).toBe('gpt-image-2-official')
+  })
+
   it('keeps agnes on extra_body sync wire', () => {
     const p = resolveImageModelProfile('agnes-image-2.1-flash', 'agnes-image-2.1-flash')
     expect(p.refWire).toBe('agnes_extra_body')

--- a/packages/shared/src/imageModelProfiles.ts
+++ b/packages/shared/src/imageModelProfiles.ts
@@ -68,9 +68,23 @@ function isSeedreamModel(modelKey: string, gatewayModelId: string): boolean {
   )
 }
 
+/** APIMart renames Image2 as gemini-3.x-flash in /models listings. */
+function isGptImage2Alias(value: string): boolean {
+  return (
+    value === 'image2' ||
+    /^gpt-image-2$/i.test(value) ||
+    /^gemini-3\.[0-9]+-flash$/i.test(value) ||
+    /gemini-.*-flash-image/i.test(value)
+  )
+}
+
+export function isApimartBaseUrl(baseUrl?: string): boolean {
+  return !!baseUrl?.trim() && /apimart\.ai/i.test(baseUrl)
+}
+
 function isGptImage2Model(modelKey: string, gatewayModelId: string): boolean {
   return (
-    modelKey === 'image2' ||
+    isGptImage2Alias(modelKey) ||
     /^gpt-image-2/i.test(modelKey) ||
     /^gpt-image-2/i.test(gatewayModelId)
   )
@@ -92,9 +106,29 @@ export function resolveImageGatewayModelId(modelKey: string, gatewayModelId: str
   return gatewayModelId
 }
 
+const APIMART_IMAGE2_PROFILE: Omit<ImageModelProfile, 'gatewayModelId'> = {
+  ...APIMART_PROFILE_BASE,
+  maxRefs: 16,
+  maxN: 4,
+  allowedResolutions: RATIO_RESOLUTIONS,
+  resolutionCase: 'lower',
+  defaultQuality: 'high',
+  maxPollMs: 360_000,
+}
+
+const APIMART_GENERIC_IMAGE_PROFILE: Omit<ImageModelProfile, 'gatewayModelId'> = {
+  ...APIMART_PROFILE_BASE,
+  maxRefs: 16,
+  maxN: 4,
+  allowedResolutions: RATIO_RESOLUTIONS,
+  resolutionCase: 'lower',
+  maxPollMs: 360_000,
+}
+
 export function resolveImageModelProfile(
   modelKey: string,
   gatewayModelId: string,
+  options?: { channelBaseUrl?: string },
 ): ImageModelProfile {
   const resolvedGateway = resolveImageGatewayModelId(modelKey, gatewayModelId)
 
@@ -115,16 +149,11 @@ export function resolveImageModelProfile(
   }
 
   if (isGptImage2Model(modelKey, gatewayModelId)) {
-    return {
-      ...APIMART_PROFILE_BASE,
-      gatewayModelId: resolvedGateway,
-      maxRefs: 16,
-      maxN: 4,
-      allowedResolutions: RATIO_RESOLUTIONS,
-      resolutionCase: 'lower',
-      defaultQuality: 'high',
-      maxPollMs: 360_000,
-    }
+    return { ...APIMART_IMAGE2_PROFILE, gatewayModelId: resolvedGateway }
+  }
+
+  if (isApimartBaseUrl(options?.channelBaseUrl)) {
+    return { ...APIMART_GENERIC_IMAGE_PROFILE, gatewayModelId: resolvedGateway }
   }
 
   return { ...LEGACY_PROFILE, gatewayModelId: resolvedGateway }


### PR DESCRIPTION
## Summary
- Preserve upstream BYOK model ids when they are absent from the studio catalog, instead of falling back to platform Agnes defaults.
- Infer APIMart async profile (`gpt-image-2-official`, `apimart_image_urls`) from channel baseUrl for unknown image models.
- Map `gemini-3.x-flash` BYOK ids to the APIMart GPT Image2 gateway alias.
- Pass `byok` + `channelBaseUrl` from studio/material into the image generation adapter.

## Test plan
- [x] `pnpm build`
- [x] `pnpm --filter @lnkpi/shared test -- imageModelProfiles.test.ts`
- [x] `pnpm --filter @lnkpi/agent test -- generation-adapter.test.ts`
- [x] Prod BYOK `gemini-3.5-flash` + ref → `refWire=apimart_image_urls`
- [x] Prod BYOK `gpt-image-2-official` + ref → `refWire=apimart_image_urls`


Made with [Cursor](https://cursor.com)