### PR TITLE
fix(agent): NestEventProxy forward sidebar attachments

### DIFF
--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -292,6 +292,23 @@ class NestEventProxy:
             await self._inner.attach_refs(node_id, ref_order)
         )
 
+    async def apply_sidebar_attachments(
+        self,
+        *,
+        node_ids: list[str],
+        attachments: list[dict[str, Any]],
+        ref_order: list[str] | None,
+        mode: str,
+    ) -> dict[str, Any]:
+        return await self._forward_actions(
+            await self._inner.apply_sidebar_attachments(
+                node_ids=node_ids,
+                attachments=attachments,
+                ref_order=ref_order,
+                mode=mode,
+            )
+        )
+
     async def run_image_generation(self, node_id: str) -> dict[str, Any]:
         return await self._run_studio_generation(node_id, "run_image_generation")
 

--- a/services/agent-runtime/tests/test_nest_event_proxy.py
+++ b/services/agent-runtime/tests/test_nest_event_proxy.py
@@ -10,6 +10,7 @@ from app.runs import NestEventProxy
 class FakeInner:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str]] = []
+        self.apply_calls: list[dict] = []
 
     async def run_text_generation(self, node_id: str) -> dict:
         self.calls.append(("run_text_generation", node_id))
@@ -18,6 +19,62 @@ class FakeInner:
             "generationRecordId": "rec-text-1",
             "actions": [{"type": "update_node", "payload": {"id": node_id}}],
         }
+
+    async def apply_sidebar_attachments(
+        self,
+        *,
+        node_ids: list[str],
+        attachments: list[dict],
+        ref_order: list[str] | None,
+        mode: str,
+    ) -> dict:
+        self.apply_calls.append(
+            {
+                "node_ids": node_ids,
+                "attachments": attachments,
+                "ref_order": ref_order,
+                "mode": mode,
+            }
+        )
+        return {
+            "actions": [
+                {
+                    "type": "update_node",
+                    "payload": {"id": node_ids[0], "data": {"localRefs": attachments}},
+                }
+            ],
+            "sourceNodeIds": [],
+        }
+
+
+@pytest.mark.asyncio
+async def test_proxy_forwards_apply_sidebar_attachments():
+    inner = FakeInner()
+    events: list[dict] = []
+
+    async def capture(ev: dict) -> None:
+        events.append(ev)
+
+    proxy = NestEventProxy(inner, capture)
+    attachments = [
+        {
+            "id": "a1",
+            "mediaType": "image",
+            "sourceKind": "upload",
+            "label": "ref.jpg",
+            "url": "https://example.com/a.jpg",
+        }
+    ]
+    result = await proxy.apply_sidebar_attachments(
+        node_ids=["node-img-1"],
+        attachments=attachments,
+        ref_order=["a1"],
+        mode="localRefs",
+    )
+    assert inner.apply_calls
+    assert inner.apply_calls[0]["mode"] == "localRefs"
+    assert any(ev.get("type") == "canvas_action" for ev in events)
+    assert result["actions"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- `NestEventProxy` 缺少 `apply_sidebar_attachments` 转发，导致生产环境 atomic/campaign 侧栏 refs 被静默跳过
- 补充 proxy 方法与单测

## Test plan

- [x] pytest test_nest_event_proxy + test_atomic_sidebar_refs (6 passed)
- [ ] 合并部署后重跑 prod-sidebar-attachments-verify.py


Made with [Cursor](https://cursor.com)