### PR TITLE
feat(agent): M3 explicit sidebar refs, @ mentions, chip hover/click

### DIFF
--- a/apps/server/src/agent/agent-canvas-tools.controller.ts
+++ b/apps/server/src/agent/agent-canvas-tools.controller.ts
@@ -205,6 +205,23 @@ class ApplySidebarAttachmentsDto {
   mode!: 'localRefs' | 'attach_edges'
 }
 
+class UpdateNodesBatchItemDto {
+  @IsString()
+  nodeId!: string
+
+  patch!: Record<string, unknown>
+}
+
+class UpdateNodesBatchDto {
+  @IsString()
+  sessionId!: string
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => UpdateNodesBatchItemDto)
+  items!: UpdateNodesBatchItemDto[]
+}
+
 class RunImageGenerationDto {
   @IsString()
   sessionId!: string
@@ -432,6 +449,15 @@ export class AgentCanvasToolsController {
       >[0]['attachments'],
       refOrder: dto.refOrder,
       mode: dto.mode,
+    })
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('update-nodes-batch')
+  async updateNodesBatch(@Body() dto: UpdateNodesBatchDto) {
+    const data = await this.tools.updateNodesBatch({
+      sessionId: dto.sessionId,
+      items: dto.items,
     })
     return { code: 0, message: 'ok', data }
   }

--- a/apps/server/src/agent/agent-canvas-tools.service.test.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.test.ts
@@ -457,6 +457,40 @@ describe('AgentCanvasToolsService', () => {
     expect(canvas.nodes[0].data.url).toBe('https://cdn.example/audio.mp3')
   })
 
+  it('startImageGeneration passes node.data.mentionedKeys to studio', async () => {
+    canvas = {
+      nodes: [
+        {
+          id: 'img-1',
+          type: 'image',
+          position: { x: 0, y: 0 },
+          data: {
+            prompt: '洁具白底图',
+            status: 'draft',
+            mentionedKeys: ['I1', 'T1'],
+          },
+        },
+      ],
+      edges: [],
+    }
+    await svc.startImageGeneration({
+      sessionId: 's1',
+      userId: 'u1',
+      nodeId: 'img-1',
+    })
+    expect(generateImage).toHaveBeenCalledWith(
+      'u1',
+      '洁具白底图',
+      'platform::user-default-image',
+      '9:16',
+      expect.any(Array),
+      ['I1', 'T1'],
+      '2K',
+      2,
+      { sessionId: 's1', nodeId: 'img-1' },
+    )
+  })
+
   it('runImageGeneration prefers node image fields over account defaults', async () => {
     canvas = {
       nodes: [

--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -615,6 +615,18 @@ export class AgentCanvasToolsService {
     return { actions, sourceNodeIds }
   }
 
+  async updateNodesBatch(input: {
+    sessionId: string
+    items: Array<{ nodeId: string; patch: Record<string, unknown> }>
+  }): Promise<{ actions: CanvasAction[] }> {
+    const actions: CanvasAction[] = input.items.map((item) => ({
+      type: 'update_node',
+      payload: { id: item.nodeId, data: item.patch },
+    }))
+    await this.persist(input.sessionId, actions)
+    return { actions }
+  }
+
   async startImageGeneration(input: {
     sessionId: string
     userId: string
@@ -690,13 +702,16 @@ export class AgentCanvasToolsService {
       allActions.push(...expandActions)
     }
 
+    const mentionedKeys = Array.isArray(node.data?.mentionedKeys)
+      ? (node.data.mentionedKeys as string[])
+      : undefined
     const record = await this.studio.generateImage(
       input.userId,
       imagePrompt,
       model,
       aspectRatio,
       refs,
-      undefined,
+      mentionedKeys?.length ? mentionedKeys : undefined,
       resolution,
       count,
       { sessionId: input.sessionId, nodeId: input.nodeId },

--- a/apps/server/src/agent/agent-runtime.client.ts
+++ b/apps/server/src/agent/agent-runtime.client.ts
@@ -17,6 +17,7 @@ export interface RuntimeRunInput {
   llmBaseUrl?: string
   attachments?: SidebarAttachment[]
   refOrder?: string[]
+  mentionedKeys?: string[]
 }
 
 export interface RuntimeThreadState {
@@ -146,6 +147,7 @@ export class AgentRuntimeClient {
         focus_node_id: input.focusNodeId,
         attachments: input.attachments,
         ref_order: input.refOrder,
+        mentioned_keys: input.mentionedKeys,
       }),
     })
 

--- a/apps/server/src/agent/agent.controller.ts
+++ b/apps/server/src/agent/agent.controller.ts
@@ -91,6 +91,12 @@ class ConversationDto {
   @IsArray()
   @IsString({ each: true })
   refOrder?: string[]
+
+  /** 消息内 @ 提及的 refKey（优先参考） */
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  mentionedKeys?: string[]
 }
 
 class OptimizePromptDto {
@@ -208,6 +214,7 @@ export class AgentController {
         dto.focusNodeId,
         dto.attachments,
         dto.refOrder,
+        dto.mentionedKeys,
       )) {
         res.write(`data: ${JSON.stringify(event)}\n\n`)
       }

--- a/apps/server/src/agent/agent.service.ts
+++ b/apps/server/src/agent/agent.service.ts
@@ -1,7 +1,13 @@
 import { Inject, Injectable } from '@nestjs/common'
 import { CanvasAgent, applyCanvasActions, type AgentStreamEvent } from '@lnkpi/agent'
 import type { CanvasAction, CanvasData, SidebarAttachment } from '@lnkpi/shared'
-import { IMAGE_MODELS, TEXT_MODELS, VIDEO_MODELS, validateSidebarAttachments } from '@lnkpi/shared'
+import {
+  IMAGE_MODELS,
+  TEXT_MODELS,
+  VIDEO_MODELS,
+  normalizeMentionedKeys,
+  validateSidebarAttachments,
+} from '@lnkpi/shared'
 import { MaterialService } from '../canvas/material.service'
 import { ShotService } from '../canvas/shot.service'
 import { PrismaService } from '../prisma/prisma.service'
@@ -60,6 +66,7 @@ export class AgentService {
     focusNodeId?: string,
     attachments?: SidebarAttachment[],
     refOrder?: string[],
+    mentionedKeys?: string[],
   ): AsyncGenerator<AgentStreamEvent> {
     // Register idempotency key (if provided) before starting
     if (idempotencyKey) {
@@ -68,6 +75,8 @@ export class AgentService {
 
     const validatedAttachments =
       attachments?.length ? validateSidebarAttachments(attachments) : undefined
+    const validatedMentionedKeys =
+      mentionedKeys?.length ? normalizeMentionedKeys(mentionedKeys) : undefined
 
     await this.prisma.agentMessage.create({
       data: {
@@ -96,6 +105,7 @@ export class AgentService {
           focusNodeId,
           validatedAttachments,
           refOrder,
+          validatedMentionedKeys,
         )) {
           if (event.type === 'text_delta') {
             assistantText += (event.data as { text: string }).text
@@ -242,6 +252,7 @@ export class AgentService {
     focusNodeId?: string,
     attachments?: SidebarAttachment[],
     refOrder?: string[],
+    mentionedKeys?: string[],
   ): AsyncGenerator<AgentStreamEvent> {
     let assistantText = ''
     const canvasActions: CanvasAction[] = []
@@ -273,6 +284,7 @@ export class AgentService {
       focusNodeId,
       attachments,
       refOrder,
+      mentionedKeys,
     })) {
       if (event.type === 'text_delta') {
         assistantText += (event.data as { text: string }).text

--- a/apps/web/src/components/agent/AgentRefHoverPreview.vue
+++ b/apps/web/src/components/agent/AgentRefHoverPreview.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { NodeRef } from '@/composables/useNodeRefs'
+import { resolveMediaUrl } from '@/services/api-base'
+
+const props = defineProps<{
+  refItem: NodeRef
+  x: number
+  y: number
+}>()
+
+const emit = defineEmits<{
+  mouseenter: []
+  mouseleave: []
+}>()
+
+const mediaUrl = computed(() => {
+  const raw = props.refItem.payload.url ?? props.refItem.preview ?? ''
+  return raw ? resolveMediaUrl(raw) : ''
+})
+
+const textContent = computed(() => {
+  return props.refItem.payload.text ?? props.refItem.preview ?? ''
+})
+
+const style = computed(() => {
+  const margin = 12
+  let left = props.x
+  let top = props.y
+  if (typeof window !== 'undefined') {
+    if (left + 360 > window.innerWidth - margin) left = window.innerWidth - 360 - margin
+    if (top + 280 > window.innerHeight - margin) top = Math.max(margin, props.y - 280)
+    left = Math.max(margin, left)
+    top = Math.max(margin, top)
+  }
+  return { left: `${left}px`, top: `${top}px` }
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      class="agent-ref-hover-preview pointer-events-auto fixed z-[130] w-[340px] max-h-[min(420px,70vh)] overflow-hidden rounded-xl border border-white/12 bg-[rgba(24,24,24,0.96)] shadow-2xl backdrop-blur-xl"
+      :style="style"
+      @mouseenter="emit('mouseenter')"
+      @mouseleave="emit('mouseleave')"
+    >
+      <div class="flex items-center border-b border-white/8 px-3 py-2">
+        <span class="truncate text-xs text-white/70">{{ refItem.refKey }} · {{ refItem.label }}</span>
+      </div>
+
+      <div class="p-3">
+        <p
+          v-if="refItem.mediaType === 'text'"
+          class="max-h-[280px] overflow-y-auto whitespace-pre-wrap break-words text-xs leading-relaxed text-white/80"
+        >
+          {{ textContent || '（空文本）' }}
+        </p>
+
+        <img
+          v-else-if="refItem.mediaType === 'image' && mediaUrl"
+          :src="mediaUrl"
+          alt=""
+          class="max-h-[300px] w-full rounded-lg object-contain"
+        >
+
+        <video
+          v-else-if="refItem.mediaType === 'video' && mediaUrl"
+          :src="mediaUrl"
+          controls
+          class="pointer-events-auto max-h-[300px] w-full rounded-lg"
+        />
+
+        <audio
+          v-else-if="refItem.mediaType === 'audio' && mediaUrl"
+          :src="mediaUrl"
+          controls
+          class="pointer-events-auto w-full"
+        />
+
+        <p v-else class="text-xs text-white/40">暂无可预览内容</p>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/apps/web/src/components/agent/AgentRefStrip.vue
+++ b/apps/web/src/components/agent/AgentRefStrip.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { SidebarAttachment } from '@lnkpi/shared'
-import DockRefChip from '@/components/canvas/dock-studio/shared/DockRefChip.vue'
+import AgentSidebarRefChip from '@/components/agent/AgentSidebarRefChip.vue'
 import { computed } from 'vue'
 import type { NodeRef } from '@/composables/useNodeRefs'
 
@@ -8,7 +8,10 @@ const props = defineProps<{
   items: Array<{ attachment: SidebarAttachment; refKey: string }>
   removable?: boolean
 }>()
-const emit = defineEmits<{ remove: [id: string] }>()
+const emit = defineEmits<{
+  remove: [id: string]
+  mention: [refKey: string]
+}>()
 
 const refs = computed<NodeRef[]>(() =>
   props.items.map(({ attachment, refKey }) => ({
@@ -26,12 +29,14 @@ const refs = computed<NodeRef[]>(() =>
 <template>
   <div v-if="refs.length" class="agent-ref-strip">
     <div class="agent-ref-strip__scroll">
-      <DockRefChip
+      <AgentSidebarRefChip
         v-for="refItem in refs"
         :key="refItem.refId"
         :ref-item="refItem"
-      :class="{ 'agent-ref-strip__chip--readonly': !removable }"
+        :clickable="removable !== false"
+        :class="{ 'agent-ref-strip__chip--readonly': !removable }"
         @remove="emit('remove', refItem.refId)"
+        @mention="emit('mention', $event)"
       />
     </div>
   </div>

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -4,6 +4,7 @@ import { useRouter } from 'vue-router'
 import { useAgentStore } from '@/stores/agent'
 import { useAuthStore } from '@/stores/auth'
 import type { SidebarAttachment } from '@lnkpi/shared'
+import { normalizeMentionedKeys, SIDEBAR_ATTACHMENT_MAX } from '@lnkpi/shared'
 import { apiUrl } from '@/services/api-base'
 import { sessionsApi } from '@/services/sessions-api'
 import NeoAgentLogo from '@/components/agent/NeoAgentLogo.vue'
@@ -44,7 +45,9 @@ import ForceChoiceDialog, { type ForceChoiceKind } from '@/components/agent/Forc
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
-import { useSidebarAttachments, mergeFocusNodeRef, assignRefKeysFor } from '@/composables/useSidebarAttachments'
+import { useSidebarAttachments, assignRefKeysFor, type FocusNodeLike } from '@/composables/useSidebarAttachments'
+import { parseRefMentions } from '@/composables/useRefMentions'
+import MentionInput, { type MentionOption } from '@/components/canvas/MentionInput.vue'
 import { useClickOutside } from '@/composables/useClickOutside'
 import { useProviderBootstrap } from '@/composables/useProviderBootstrap'
 import { AGENT_SKILLS } from '@/constants/agentSkillMap'
@@ -74,7 +77,7 @@ const agent = useAgentStore()
 const auth = useAuthStore()
 const router = useRouter()
 const input = ref('')
-const composerRef = ref<HTMLTextAreaElement | null>(null)
+const composerRef = ref<InstanceType<typeof MentionInput> | null>(null)
 const fileInputRef = ref<HTMLInputElement | null>(null)
 const chatContainer = ref<HTMLElement>()
 const sidebar = useSidebarAttachments()
@@ -95,6 +98,20 @@ function makeAttachmentItems(
 const pendingAttachmentItems = computed(() =>
   makeAttachmentItems(sidebar.pendingAttachments.value, sidebar.assignRefKeys()),
 )
+
+const mentionOptions = computed((): MentionOption[] =>
+  pendingAttachmentItems.value.map(({ refKey, attachment }) => ({
+    id: attachment.id,
+    label: refKey,
+    type: attachment.mediaType,
+  })),
+)
+
+function insertRefMention(refKey: string) {
+  const token = `@${refKey} `
+  composerRef.value?.insertText(input.value ? ` ${token}` : token)
+  nextTick(() => composerRef.value?.focus())
+}
 
 /** Runtime LangGraph thread；与画布 sessionId 解耦，新建对话时重置 */
 const agentThreadId = ref(createAgentThreadId(props.sessionId))
@@ -157,10 +174,9 @@ const awaitingCopyConfirm = computed(() => chipSet.value === 'copy')
 const awaitingTopoConfirm = computed(() => chipSet.value === 'topo')
 const awaitingAtomicConfirm = computed(() => chipSet.value === 'atomic')
 
-const canSubmitComposer = computed(() => {
-  const fromRef = composerRef.value?.value.trim() ?? ''
-  return Boolean(input.value.trim() || fromRef || sidebar.pendingAttachments.value.length)
-})
+const canSubmitComposer = computed(() =>
+  Boolean(input.value.trim() || sidebar.pendingAttachments.value.length),
+)
 
 function openFilePicker() {
   if (!props.readOnly && !isUploading.value) {
@@ -206,13 +222,6 @@ function onDragLeave() {
 function onDrop(event: DragEvent) {
   isDragOver.value = false
   void addFiles(event.dataTransfer?.files ?? [])
-}
-
-function syncComposerFromDom() {
-  const el = composerRef.value
-  if (el && el.value !== input.value) {
-    input.value = el.value
-  }
 }
 
 /** 面板是否展开（收缩态只保留右下角 logo FAB） */
@@ -409,7 +418,6 @@ function toggleVoice() {
 }
 
 async function send() {
-  syncComposerFromDom()
   if (!canSubmitComposer.value || agent.isStreaming || isUploading.value) return
   if (!auth.isLoggedIn) {
     auth.openLogin()
@@ -476,7 +484,8 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
   }
 
   const { attachments: pendingAttachments } = sidebar.toPayload()
-  const attachments = mergeFocusNodeRef(pendingAttachments, props.selectedNode ?? null)
+  const attachments = pendingAttachments
+  const mentionedKeys = normalizeMentionedKeys(parseRefMentions(message))
   const refOrder = attachments.map((a) => a.id)
   const attachmentRefKeys = assignRefKeysFor(attachments)
   const userMessageExtras = attachments.length
@@ -531,6 +540,7 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
         focusNodeId: props.selectedNodeId || undefined,
         attachments: attachments.length ? attachments : undefined,
         refOrder: refOrder.length ? refOrder : undefined,
+        mentionedKeys,
       }),
     })
 
@@ -844,13 +854,6 @@ function scrollToBottom() {
   })
 }
 
-function onKeydown(e: KeyboardEvent) {
-  if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-    e.preventDefault()
-    void send()
-  }
-}
-
 function reconcileFromNodes(rawNodes: CanvasNodeLike[]) {
   if (!taskProgress.value.items.length) return
   let next = reconcileTaskProgress(taskProgress.value, rawNodes)
@@ -877,7 +880,15 @@ function reconcileFromNodes(rawNodes: CanvasNodeLike[]) {
   taskProgress.value = next
 }
 
-defineExpose({ openPanel, reconcileFromNodes })
+defineExpose({
+  openPanel,
+  reconcileFromNodes,
+  addFromCanvasNodes: (nodes: FocusNodeLike[]) => {
+    const n = sidebar.addFromCanvasNodes(nodes)
+    if (n < nodes.length) ElMessage.warning(`最多添加 ${SIDEBAR_ATTACHMENT_MAX} 个参考素材`)
+    return n
+  },
+})
 </script>
 
 <template>
@@ -1188,6 +1199,7 @@ defineExpose({ openPanel, reconcileFromNodes })
                 :items="pendingAttachmentItems"
                 :removable="true"
                 @remove="sidebar.remove"
+                @mention="insertRefMention"
               />
               <input
                 ref="fileInputRef"
@@ -1197,16 +1209,13 @@ defineExpose({ openPanel, reconcileFromNodes })
                 :disabled="readOnly || isUploading"
                 @change="onFileChange"
               >
-              <textarea
+              <MentionInput
                 ref="composerRef"
                 v-model="input"
-                class="agent-prompt-field"
-                rows="3"
+                :mentions="mentionOptions"
                 :placeholder="`向${activeSkill.label}助手描述需求，Cmd/Ctrl + Enter 发送...`"
                 :disabled="agent.isStreaming"
-                @focus="syncComposerFromDom"
-                @input="syncComposerFromDom"
-                @keydown="onKeydown"
+                @submit="send"
               />
 
               <div class="agent-dock-actions">

--- a/apps/web/src/components/agent/AgentSidebarRefChip.vue
+++ b/apps/web/src/components/agent/AgentSidebarRefChip.vue
@@ -1,0 +1,234 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { NodeRef, RefMediaType } from '@/composables/useNodeRefs'
+import DockTypeIcon from '@/components/canvas/dock-studio/shared/DockTypeIcon.vue'
+import AgentRefHoverPreview from '@/components/agent/AgentRefHoverPreview.vue'
+import { resolveMediaUrl } from '@/services/api-base'
+import type { DockNodeIconKind } from '@/components/canvas/dock-studio/shared/dockIcons'
+
+const props = defineProps<{
+  refItem: NodeRef
+  clickable?: boolean
+}>()
+
+const emit = defineEmits<{
+  mention: [refKey: string]
+  remove: []
+}>()
+
+const previewOpen = ref(false)
+const previewPos = ref({ x: 0, y: 0 })
+const hoverTimer = ref<number | null>(null)
+const isHoveringPreview = ref(false)
+
+const MEDIA_ICON: Record<RefMediaType, DockNodeIconKind> = {
+  text: 'text',
+  image: 'image',
+  video: 'video',
+  audio: 'audio',
+}
+
+const thumbUrl = computed(() => {
+  if (props.refItem.mediaType !== 'image' && props.refItem.mediaType !== 'video') return ''
+  const raw = props.refItem.payload.url ?? props.refItem.preview
+  return raw ? resolveMediaUrl(raw) : ''
+})
+
+function clearHoverTimer() {
+  if (hoverTimer.value !== null) {
+    window.clearTimeout(hoverTimer.value)
+    hoverTimer.value = null
+  }
+}
+
+function onEnter(event: MouseEvent) {
+  clearHoverTimer()
+  previewPos.value = { x: event.clientX + 8, y: event.clientY + 8 }
+  hoverTimer.value = window.setTimeout(() => {
+    previewOpen.value = true
+  }, 200)
+}
+
+function onLeave() {
+  clearHoverTimer()
+  hoverTimer.value = window.setTimeout(() => {
+    if (!isHoveringPreview.value) previewOpen.value = false
+  }, 80)
+}
+
+function onPreviewEnter() {
+  clearHoverTimer()
+  isHoveringPreview.value = true
+}
+
+function onPreviewLeave() {
+  isHoveringPreview.value = false
+  previewOpen.value = false
+}
+
+function onRemoveClick(event: MouseEvent) {
+  event.stopPropagation()
+  emit('remove')
+}
+
+function onClick() {
+  if (!props.clickable || props.refItem.stale) return
+  emit('mention', props.refItem.refKey)
+}
+</script>
+
+<template>
+  <div
+    class="dock-ref-chip"
+    :class="{
+      'is-stale': refItem.stale,
+      'has-media': !!thumbUrl,
+      'is-readonly': !clickable,
+    }"
+    :title="`${refItem.refKey} · ${refItem.label}`"
+    role="button"
+    tabindex="0"
+    @mouseenter="onEnter"
+    @mouseleave="onLeave"
+    @click="onClick"
+    @keydown.enter.prevent="onClick"
+  >
+    <span class="dock-ref-chip__key">{{ refItem.refKey }}</span>
+
+    <img
+      v-if="thumbUrl && refItem.mediaType === 'image'"
+      :src="thumbUrl"
+      alt=""
+      class="dock-ref-chip__media"
+      draggable="false"
+    >
+    <video
+      v-else-if="thumbUrl && refItem.mediaType === 'video'"
+      :src="thumbUrl"
+      class="dock-ref-chip__media"
+      muted
+      playsinline
+      preload="metadata"
+      draggable="false"
+    />
+    <span v-else class="dock-ref-chip__icon" aria-hidden="true">
+      <DockTypeIcon :icon="MEDIA_ICON[refItem.mediaType]" :size="14" />
+    </span>
+
+    <button
+      type="button"
+      class="dock-ref-chip__remove"
+      aria-label="移除引用"
+      @click="onRemoveClick"
+    >
+      <svg viewBox="0 0 24 24" width="8" height="8" fill="none" stroke="currentColor" stroke-width="2.5">
+        <path d="M18 6 6 18M6 6l12 12" />
+      </svg>
+    </button>
+  </div>
+
+  <AgentRefHoverPreview
+    v-if="previewOpen"
+    :ref-item="refItem"
+    :x="previewPos.x"
+    :y="previewPos.y"
+    @mouseenter="onPreviewEnter"
+    @mouseleave="onPreviewLeave"
+  />
+</template>
+
+<style scoped>
+.dock-ref-chip {
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  overflow: hidden;
+  border: 1px solid var(--neo-border-strong);
+  border-radius: 8px;
+  background: var(--neo-hover-bg);
+  color: var(--neo-text-secondary);
+  cursor: pointer;
+  user-select: none;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.dock-ref-chip.is-readonly {
+  cursor: default;
+}
+
+.dock-ref-chip.is-stale {
+  border-style: dashed;
+  border-color: var(--neo-border);
+  background: var(--neo-hover-bg);
+  color: var(--neo-text-muted);
+  cursor: default;
+}
+
+.dock-ref-chip__key {
+  position: absolute;
+  top: 1px;
+  left: 2px;
+  z-index: 1;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 8px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  color: var(--neo-text-primary);
+  pointer-events: none;
+}
+
+.dock-ref-chip.has-media .dock-ref-chip__key {
+  color: rgba(255, 255, 255, 0.9);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
+}
+
+.dock-ref-chip__media {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.dock-ref-chip.is-stale .dock-ref-chip__media {
+  opacity: 0.4;
+  filter: grayscale(1);
+}
+
+.dock-ref-chip__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.75;
+}
+
+.dock-ref-chip__remove {
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  z-index: 2;
+  display: none;
+  width: 14px;
+  height: 14px;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.65);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.dock-ref-chip:hover .dock-ref-chip__remove {
+  display: inline-flex;
+}
+
+.dock-ref-chip__remove:hover {
+  background: rgba(239, 68, 68, 0.75);
+}
+</style>

--- a/apps/web/src/components/canvas/CanvasContextMenu.vue
+++ b/apps/web/src/components/canvas/CanvasContextMenu.vue
@@ -48,6 +48,14 @@ function run(action: string, payload?: string) {
     <button
       v-if="nodeId && nodeType !== 'group'"
       class="neo-popover-item block w-full px-4 py-2 text-left text-xs"
+      @click="run('add-agent-ref')"
+    >
+      加入 Agent 引用
+    </button>
+
+    <button
+      v-if="nodeId && nodeType !== 'group'"
+      class="neo-popover-item block w-full px-4 py-2 text-left text-xs"
       @click="run('duplicate')"
     >
       复制节点

--- a/apps/web/src/components/canvas/MentionInput.vue
+++ b/apps/web/src/components/canvas/MentionInput.vue
@@ -12,6 +12,7 @@ const props = defineProps<{
   modelValue: string
   mentions: MentionOption[]
   placeholder?: string
+  disabled?: boolean
 }>()
 
 const emit = defineEmits<{ 'update:modelValue': [v: string]; submit: [] }>()
@@ -84,8 +85,35 @@ function insertMention(option: MentionOption) {
   })
 }
 
+function insertText(text: string) {
+  const el = textareaRef.value
+  if (!el) {
+    updateValue(`${props.modelValue}${text}`)
+    return
+  }
+  const start = el.selectionStart ?? el.value.length
+  const end = el.selectionEnd ?? start
+  const before = el.value.slice(0, start)
+  const after = el.value.slice(end)
+  const next = `${before}${text}${after}`
+  updateValue(next)
+  requestAnimationFrame(() => {
+    const pos = before.length + text.length
+    el.focus()
+    el.setSelectionRange(pos, pos)
+    syncBackdropScroll()
+  })
+}
+
+function focus() {
+  textareaRef.value?.focus()
+}
+
+defineExpose({ focus, insertText })
+
 function onKeydown(e: KeyboardEvent) {
   if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+    e.preventDefault()
     emit('submit')
     return
   }
@@ -126,6 +154,7 @@ function onKeydown(e: KeyboardEvent) {
         class="mention-input-field input-field min-h-[96px] w-full resize-none text-sm leading-[1.5] !text-transparent caret-[var(--neo-text-primary)]"
         rows="4"
         :placeholder="placeholder ?? '描述你想要生成的内容，@ 引用节点...'"
+        :disabled="disabled"
         @input="onInput"
         @keydown="onKeydown"
         @scroll="syncBackdropScroll"

--- a/apps/web/src/components/canvas/MultiSelectToolbar.vue
+++ b/apps/web/src/components/canvas/MultiSelectToolbar.vue
@@ -13,6 +13,7 @@ const emit = defineEmits<{
   layout: []
   generateVideo: []
   download: []
+  addAgentRef: []
 }>()
 </script>
 
@@ -54,6 +55,14 @@ const emit = defineEmits<{
         @click="emit('group')"
       >
         打组
+      </button>
+      <button
+        v-if="selectedIds.length >= 2"
+        type="button"
+        class="toolbar-action accent"
+        @click="emit('addAgentRef')"
+      >
+        加入 Agent 引用
       </button>
       <button
         v-if="selectedIds.length >= 2"

--- a/apps/web/src/components/canvas/MultiSelectToolbarOverlay.vue
+++ b/apps/web/src/components/canvas/MultiSelectToolbarOverlay.vue
@@ -17,6 +17,7 @@ const emit = defineEmits<{
   layout: []
   generateVideo: []
   download: []
+  addAgentRef: []
 }>()
 
 const { viewport, nodes: flowNodes } = useVueFlow()
@@ -93,5 +94,6 @@ const visible = computed(() => props.selectedIds.length >= 2 || !!props.canUngro
     @layout="emit('layout')"
     @generate-video="emit('generateVideo')"
     @download="emit('download')"
+    @add-agent-ref="emit('addAgentRef')"
   />
 </template>

--- a/apps/web/src/composables/useSidebarAttachments.test.ts
+++ b/apps/web/src/composables/useSidebarAttachments.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { mergeFocusNodeRef, useSidebarAttachments } from './useSidebarAttachments'
+import { mergeFocusNodeRef, nodeToSidebarAttachment, useSidebarAttachments } from './useSidebarAttachments'
 
 describe('useSidebarAttachments', () => {
   it('dedupes by url', () => {
@@ -69,5 +69,35 @@ describe('mergeFocusNodeRef', () => {
       text: 'hello',
     }]
     expect(mergeFocusNodeRef(existing, { id: 'empty', type: 'image', data: {} })).toBe(existing)
+  })
+})
+
+describe('nodeToSidebarAttachment', () => {
+  it('maps video node to V* mediaType', () => {
+    const item = nodeToSidebarAttachment({
+      id: 'v1',
+      type: 'video',
+      data: { url: 'https://cdn/x.mp4', title: 'demo' },
+    })
+    expect(item?.mediaType).toBe('video')
+    expect(item?.sourceKind).toBe('canvasNode')
+  })
+
+  it('returns null when no url or text', () => {
+    expect(nodeToSidebarAttachment({ id: 'e', type: 'image', data: {} })).toBeNull()
+  })
+})
+
+describe('addFromCanvasNodes', () => {
+  it('adds up to max and skips dup sourceNodeId', () => {
+    const { addFromCanvasNodes, pendingAttachments } = useSidebarAttachments()
+    const nodes = Array.from({ length: 6 }, (_, i) => ({
+      id: `n${i}`,
+      type: 'image' as const,
+      data: { url: `https://cdn/${i}.jpg` },
+    }))
+    const added = addFromCanvasNodes(nodes)
+    expect(added).toBe(5)
+    expect(pendingAttachments.value).toHaveLength(5)
   })
 })

--- a/apps/web/src/composables/useSidebarAttachments.ts
+++ b/apps/web/src/composables/useSidebarAttachments.ts
@@ -26,26 +26,40 @@ export function mergeFocusNodeRef(
   node: FocusNodeLike | null,
 ): SidebarAttachment[] {
   if (!node) return attachments
-  const data = node.data ?? {}
-  const url = String(data.url ?? '').trim()
-  const text = String(data.content ?? data.prompt ?? '').trim()
-  if (!url && !text) return attachments
-  const mediaType = node.type === 'text' || node.type === 'prompt' ? 'text' : 'image'
-  const item: SidebarAttachment = {
-    id: `focus-${node.id}`,
-    mediaType,
-    sourceKind: 'canvasNode',
-    label: String(data.title ?? data.label ?? node.type ?? node.id),
-    url: url || undefined,
-    text: text || undefined,
-    sourceNodeId: node.id,
-  }
+  const item = nodeToSidebarAttachment(node)
+  if (!item) return attachments
   const dup = attachments.some(
     (a) => (item.url && a.url === item.url) || (item.sourceNodeId && a.sourceNodeId === item.sourceNodeId),
   )
   if (dup) return attachments
   if (attachments.length >= SIDEBAR_ATTACHMENT_MAX) return attachments
-  return [...attachments, item]
+  return [...attachments, { ...item, id: `focus-${node.id}` }]
+}
+
+export function nodeToSidebarAttachment(node: FocusNodeLike): SidebarAttachment | null {
+  const data = node.data ?? {}
+  const url = String(data.url ?? '').trim()
+  const text = String(data.content ?? data.prompt ?? '').trim()
+  if (!url && !text) return null
+
+  const t = String(node.type ?? '')
+  let mediaType: SidebarAttachment['mediaType'] = 'image'
+  if (t === 'text' || t === 'prompt') mediaType = 'text'
+  else if (t === 'video') mediaType = 'video'
+  else if (t === 'audio') mediaType = 'audio'
+  else if (t === 'image' || t === 'mediaInput') mediaType = 'image'
+  else if (text && !url) mediaType = 'text'
+  else if (!url) return null
+
+  return {
+    id: randomId(),
+    mediaType,
+    sourceKind: 'canvasNode',
+    label: String(data.title ?? data.label ?? (t || node.id)),
+    url: url || undefined,
+    text: text || undefined,
+    sourceNodeId: node.id,
+  }
 }
 
 export function useSidebarAttachments() {
@@ -94,9 +108,26 @@ export function useSidebarAttachments() {
     return assignRefKeysFor(pendingAttachments.value)
   }
 
+  function addFromCanvasNode(node: FocusNodeLike): boolean {
+    const item = nodeToSidebarAttachment(node)
+    if (!item) return false
+    if (pendingAttachments.value.length >= SIDEBAR_ATTACHMENT_MAX) return false
+    addFromPayload(item)
+    return true
+  }
+
+  function addFromCanvasNodes(nodes: FocusNodeLike[]): number {
+    let count = 0
+    for (const n of nodes) {
+      if (pendingAttachments.value.length >= SIDEBAR_ATTACHMENT_MAX) break
+      if (addFromCanvasNode(n)) count += 1
+    }
+    return count
+  }
+
   function toPayload() {
     return { attachments: [...pendingAttachments.value], refOrder: refOrder.value }
   }
 
-  return { pendingAttachments, refOrder, addFromFile, addFromPayload, remove, clear, toPayload, assignRefKeys }
+  return { pendingAttachments, refOrder, addFromFile, addFromPayload, addFromCanvasNode, addFromCanvasNodes, remove, clear, toPayload, assignRefKeys }
 }

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -2083,10 +2083,41 @@ function closeContextMenu() {
   contextMenu.value = null
 }
 
+function handleAddToAgentRefs(sourceIds?: string[]) {
+  const ids = sourceIds?.length
+    ? sourceIds
+    : multiSelectedIds.value.length
+      ? multiSelectedIds.value
+      : selectedNodeId.value
+        ? [selectedNodeId.value]
+        : []
+  const focusNodes = ids
+    .map((id) => findNodeById(id))
+    .filter((node): node is EditableFlowNode => node != null)
+    .map((node) => ({
+      id: node.id,
+      type: node.type,
+      data: (node.data ?? {}) as Record<string, unknown>,
+    }))
+  agentRailRef.value?.addFromCanvasNodes(focusNodes)
+}
+
 function handleContextAction(action: string) {
   const menu = contextMenu.value
   contextMenu.value = null
   if (!menu) return
+
+  if (action === 'add-agent-ref') {
+    const ids = multiSelectedIds.value.length
+      ? [...multiSelectedIds.value]
+      : selectedNodeId.value
+        ? [selectedNodeId.value]
+        : menu.nodeId
+          ? [menu.nodeId]
+          : []
+    handleAddToAgentRefs(ids)
+    return
+  }
 
   if (action === 'edit-image' && menu.nodeId) {
     const node = findNodeById(menu.nodeId)
@@ -2599,6 +2630,7 @@ onMounted(() => {
             @layout="handleLayoutSelection"
             @generate-video="handleGenerateVideoFromSelection"
             @download="handlePackageDownload"
+            @add-agent-ref="handleAddToAgentRefs()"
           />
 
           <MultiSelectConnectOverlay

--- a/deploy/prod-sidebar-attachments-verify.py
+++ b/deploy/prod-sidebar-attachments-verify.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
-"""Production smoke verify for sidebar attachments (Task 12).
+"""Production smoke verify for sidebar attachments (M3 explicit refs).
 
 Sections:
   A) Runtime unit smoke — normalize_sidebar_attachments, atomic localRefs,
-     campaign apply_sidebar_refs (pytest, no network)
-  B) Production integration — SSE with attachment payload:
-     1. atomic_create → image node localRefs
-     2. campaign plan → confirm split → seed image ref edges
+     campaign apply_sidebar_refs, mentionedKeys patch (pytest, no network)
+  B) Production integration — SSE with explicit attachment + mentionedKeys payload:
+     1. focusNodeId alone → no silent localRefs (M3 D-A/D-B)
+     2. atomic_create + attachments + mentionedKeys → localRefs + node.data.mentionedKeys
+     3. campaign plan → confirm split → seed image ref edges
 
 Usage:
   python3 deploy/prod-sidebar-attachments-verify.py
@@ -88,6 +89,8 @@ def sse_collect(
     *,
     attachments: list[dict[str, Any]] | None = None,
     ref_order: list[str] | None = None,
+    mentioned_keys: list[str] | None = None,
+    focus_node_id: str | None = None,
     timeout: float = 300,
 ) -> tuple[list[dict], str, set[str], str]:
     body: dict[str, Any] = {"sessionId": sid, "message": msg, "threadId": tid}
@@ -95,6 +98,10 @@ def sse_collect(
         body["attachments"] = attachments
     if ref_order:
         body["refOrder"] = ref_order
+    if mentioned_keys:
+        body["mentionedKeys"] = mentioned_keys
+    if focus_node_id:
+        body["focusNodeId"] = focus_node_id
     h = {
         "Content-Type": "application/json",
         "Accept": "text/event-stream",
@@ -105,6 +112,7 @@ def sse_collect(
     events: list[dict] = []
     types: set[str] = set()
     parts: list[str] = []
+    replaces: list[str] = []
     end = time.time() + timeout
     exit_reason = "timeout"
     with urlopen(r, timeout=timeout) as resp:
@@ -129,7 +137,8 @@ def sse_collect(
                             continue
                         pl = line[5:].strip()
                         if pl == "[DONE]":
-                            return events, "".join(parts), types, "done_marker"
+                            text = replaces[-1] if replaces else "".join(parts)
+                            return events, text, types, "done_marker"
                         try:
                             ev = json.loads(pl)
                         except json.JSONDecodeError:
@@ -137,20 +146,60 @@ def sse_collect(
                         events.append(ev)
                         et = str(ev.get("type") or "")
                         types.add(et)
-                        if et == "text_delta":
-                            parts.append(str((ev.get("data") or {}).get("text") or ""))
+                        data = ev.get("data") or {}
+                        text_chunk = str(data.get("text") or "")
+                        if et == "text_delta" and text_chunk:
+                            parts.append(text_chunk)
+                        elif et == "text_replace" and text_chunk:
+                            replaces.append(text_chunk)
                         if et == "done":
-                            return events, "".join(parts), types, "done"
+                            text = replaces[-1] if replaces else "".join(parts)
+                            return events, text, types, "done"
                         if et == "error":
-                            return events, "".join(parts), types, "error"
+                            text = replaces[-1] if replaces else "".join(parts)
+                            return events, text, types, "error"
         except IncompleteRead:
             exit_reason = "eof"
-    return events, "".join(parts), types, exit_reason
+    text = replaces[-1] if replaces else "".join(parts)
+    return events, text, types, exit_reason
 
 
 def canvas_data(tok: str, sid: str) -> dict[str, Any]:
     sess = http("GET", f"/sessions/{sid}", t=tok)["data"]
     return sess.get("canvasData") or {}
+
+
+def put_canvas_data(tok: str, sid: str, canvas: dict[str, Any]) -> None:
+    http("PUT", f"/sessions/{sid}", {"canvasData": canvas}, t=tok)
+
+
+def seed_image_node(tok: str, sid: str, *, url: str, title: str = "focus-ref-seed") -> str:
+    canvas = canvas_data(tok, sid)
+    node_id = f"image-focus-{int(time.time())}"
+    nodes = list(canvas.get("nodes") or [])
+    nodes.append(
+        {
+            "id": node_id,
+            "type": "image",
+            "position": {"x": 640, "y": 320},
+            "data": {
+                "title": title,
+                "prompt": "侧栏 focus 解耦 smoke seed",
+                "url": url,
+                "status": "done",
+            },
+        }
+    )
+    put_canvas_data(
+        tok,
+        sid,
+        {
+            "nodes": nodes,
+            "edges": canvas.get("edges") or [],
+            "viewport": canvas.get("viewport"),
+        },
+    )
+    return node_id
 
 
 def latest_node(tok: str, sid: str, node_type: str) -> dict[str, Any] | None:
@@ -176,6 +225,33 @@ def run_unit_smoke() -> bool:
     return rc == 0
 
 
+def verify_focus_only_no_silent_ref(tok: str) -> None:
+    """M3: focusNodeId alone must not silently merge canvas node as sidebar ref."""
+    sid = http("POST", "/sessions", {"title": f"sidebar-focus-{int(time.time())}"}, t=tok)["data"]["id"]
+    focus_url = "https://picsum.photos/seed/lnkpi-sidebar-focus-only/512/512"
+    focus_id = seed_image_node(tok, sid, url=focus_url)
+    tid = f"{sid}:{uuid.uuid4()}"
+    _, text, types, exit_reason = sse_collect(
+        tok,
+        sid,
+        "按选中节点风格生成白底主图",
+        tid,
+        focus_node_id=focus_id,
+        timeout=SSE_TIMEOUT_SEC,
+    )
+    record("focus-only path started", "error" not in types, text[:140])
+
+    node = latest_node(tok, sid, "image")
+    data = (node or {}).get("data") or {}
+    local_refs = data.get("localRefs") or []
+    has_focus_url = any(str(r.get("url") or "") == focus_url for r in local_refs if isinstance(r, dict))
+    record(
+        "focus-only no silent localRefs",
+        not has_focus_url,
+        f"refs={len(local_refs)} focus={focus_id} exit={exit_reason}",
+    )
+
+
 def verify_atomic_local_refs(tok: str) -> None:
     sid = http("POST", "/sessions", {"title": f"sidebar-atomic-{int(time.time())}"}, t=tok)["data"]["id"]
     tid = f"{sid}:{uuid.uuid4()}"
@@ -188,6 +264,7 @@ def verify_atomic_local_refs(tok: str) -> None:
         tid,
         attachments=attachments,
         ref_order=ref_order,
+        mentioned_keys=["I1"],
         timeout=SSE_TIMEOUT_SEC,
     )
 
@@ -208,6 +285,12 @@ def verify_atomic_local_refs(tok: str) -> None:
         "atomic refOrder on image node",
         attachments[0]["id"] in ref_order_on_node,
         str(ref_order_on_node)[:120],
+    )
+    mentioned_keys = data.get("mentionedKeys") or []
+    record(
+        "atomic mentionedKeys on image node",
+        "I1" in mentioned_keys,
+        str(mentioned_keys)[:120],
     )
 
 
@@ -238,9 +321,16 @@ def verify_campaign_attach_edges(tok: str) -> None:
         tid,
         attachments=attachments,
         ref_order=ref_order,
+        mentioned_keys=["I1"],
         timeout=SSE_TIMEOUT_SEC,
     )
-    at_plan = "await_confirm" in types1 or "拟定" in text1 or "请确认" in text1 or "方案" in text1
+    at_plan = (
+        "await_confirm" in types1
+        or "interrupt" in types1
+        or "拟定拆解" in text1
+        or ("拟定" in text1 and "请确认" in text1)
+        or ("请确认" in text1 and ("拆解" in text1 or "模块" in text1))
+    )
     record("campaign plan with attachment", at_plan and "error" not in types1, text1[:140])
 
     _, text2, types2, exit2 = sse_collect(tok, sid, "1", tid, timeout=SSE_TIMEOUT_SEC)
@@ -282,12 +372,13 @@ def run_prod_smoke() -> None:
     rt = http("GET", "/agent/runtime-health", t=tok)
     record("Runtime health", bool((rt.get("data") or {}).get("ok")))
 
+    verify_focus_only_no_silent_ref(tok)
     verify_atomic_local_refs(tok)
     verify_campaign_attach_edges(tok)
 
 
 def main() -> int:
-    print("=== Sidebar attachments smoke verify (Task 12) ===")
+    print("=== Sidebar attachments smoke verify (M3 explicit refs) ===")
     if SKIP_UNIT:
         record("Unit smoke", True, "SKIP_UNIT=1", skip=True)
     else:

--- a/docs/superpowers/plans/2026-08-07-agent-sidebar-m3-explicit-refs.md
+++ b/docs/superpowers/plans/2026-08-07-agent-sidebar-m3-explicit-refs.md
@@ -1,0 +1,619 @@
+# Agent 侧栏 M3 — 显式引用、@ 语义与芯片交互 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 将 Agent 侧栏引用改为显式加入芯片、芯片 hover 预览/click 插入 `@`、侧栏 `@` 补全，并将 `mentionedKeys` 贯通至 atomic/Campaign 生成 merge。
+
+**Architecture:** 前端 `nodeToSidebarAttachment` + 画布右键/多选批量入口写入 `pendingAttachments`；`AgentSidebarRefChip` 负责 hover 浮层与 click mention；`MentionInput` 替换 plain textarea；发送时 `parseRefMentions` 产出 `mentionedKeys` 随 conversation API 进入 runtime state，在 atomic 建节点后写入 `node.data.mentionedKeys`，`startImageGeneration` 传给 `studio.generateImage`。废止 send 路径上的 `mergeFocusNodeRef`。**不含**画布节点拖拽进侧栏。
+
+**Tech Stack:** Vue 3、NestJS、`@lnkpi/shared`、LangGraph Python 3.11+、Vitest、pytest
+
+**Spec:** [docs/superpowers/specs/2026-08-07-agent-sidebar-m3-explicit-refs-design.md](../specs/2026-08-07-agent-sidebar-m3-explicit-refs-design.md)
+
+## Global Constraints
+
+- 复用 `LocalRefBinding` + `refOrder`；**不**新建侧栏持久化结构。
+- 单轮 attachments ≤ **5**；拒绝 `blob:` URL。
+- **废止** send 时 `mergeFocusNodeRef`；`focusNodeId` 仅指代，不自动进芯片。
+- 芯片内 ref **默认全量**参与生成；`@` 仅产生 `mentionedKeys`（优先参考，非过滤）。
+- 侧栏芯片：**hover 预览、click 插入 `@`**；**不修改** Dock `DockRefChip` 行为。
+- M3 生成侧仍以 **T\*/I\*** 为主消费；V/A 芯片可展示，生成消费仍 P1。
+- 侧栏文案禁止暴露 `localRefs`/`mentionedKeys` 等内部术语。
+- Commit per task；PR 前：`pnpm --filter @lnkpi/shared build`、`pnpm --filter @lnkpi/web test`、`cd services/agent-runtime && python -m pytest tests/test_sidebar* tests/test_atomic* -v`。
+
+## File map
+
+| File | Role |
+| --- | --- |
+| `packages/shared/src/agentContract.ts` | `mentionedKeys` on conversation schema |
+| `packages/shared/src/agentContract.test.ts` | **NEW/extend** — schema 单测 |
+| `apps/web/src/composables/useSidebarAttachments.ts` | `nodeToSidebarAttachment`, `addFromCanvasNodes` |
+| `apps/web/src/composables/useSidebarAttachments.test.ts` | 节点映射 + 批量 + 去重 |
+| `apps/web/src/components/agent/AgentRefHoverPreview.vue` | **NEW** — hover 浮层预览 |
+| `apps/web/src/components/agent/AgentSidebarRefChip.vue` | **NEW** — hover + click mention |
+| `apps/web/src/components/agent/AgentRefStrip.vue` | 换 chip 组件；emit `mention` |
+| `apps/web/src/components/agent/AgentSideRail.vue` | MentionInput；移除 silent merge；expose `addFromCanvasNodes` |
+| `apps/web/src/components/canvas/CanvasContextMenu.vue` | 「加入 Agent 引用」菜单项 |
+| `apps/web/src/pages/CanvasPage.vue` | 多选批量、context menu 接线（**无**节点 DnD） |
+| `apps/server/src/agent/agent.controller.ts` | DTO `mentionedKeys` |
+| `apps/server/src/agent/agent.service.ts` | 校验 + 转发 |
+| `apps/server/src/agent/agent-runtime.client.ts` | body 字段 |
+| `apps/server/src/agent/agent-canvas-tools.service.ts` | `startImageGeneration` 读 `node.data.mentionedKeys` |
+| `apps/server/src/agent/agent-canvas-tools.service.test.ts` | mentionedKeys 传入 studio |
+| `services/agent-runtime/app/runs.py` | `sidebar_mentioned_keys` |
+| `services/agent-runtime/app/graph/state.py` | state 字段 |
+| `services/agent-runtime/app/graph/sidebar_attachments.py` | `normalize_mentioned_keys` |
+| `services/agent-runtime/app/graph/nodes/atomic_create_node.py` | patch node mentionedKeys |
+| `services/agent-runtime/tests/test_atomic_sidebar_refs.py` | mentionedKeys 写入 |
+| `deploy/prod-sidebar-attachments-verify.py` | 更新：显式加入 + mentionedKeys 断言 |
+
+---
+
+### Task 1: Shared — `mentionedKeys` on conversation contract
+
+**Files:**
+- Modify: `packages/shared/src/agentContract.ts:557-569`
+- Create or modify: `packages/shared/src/agentContract.test.ts`
+
+**Interfaces:**
+- Produces: `AgentConversationRequestSchema` 增量 `mentionedKeys?: string[]`（max 5，regex `/^[TIVA]\d+$/`）
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// packages/shared/src/agentContract.test.ts
+import { describe, expect, it } from 'vitest'
+import { AgentConversationRequestSchema } from './agentContract'
+
+describe('AgentConversationRequestSchema mentionedKeys', () => {
+  it('accepts valid mentionedKeys', () => {
+    const parsed = AgentConversationRequestSchema.parse({
+      sessionId: 's1',
+      message: '@I1 风格',
+      mentionedKeys: ['I1', 'T2'],
+    })
+    expect(parsed.mentionedKeys).toEqual(['I1', 'T2'])
+  })
+
+  it('rejects invalid ref key format', () => {
+    expect(() =>
+      AgentConversationRequestSchema.parse({
+        sessionId: 's1',
+        message: 'x',
+        mentionedKeys: ['image1'],
+      }),
+    ).toThrow()
+  })
+})
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+Run: `pnpm --filter @lnkpi/shared test agentContract.test.ts`  
+Expected: FAIL
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// agentContract.ts — append to AgentConversationRequestSchema
+mentionedKeys: z
+  .array(z.string().regex(/^[TIVA]\d+$/i))
+  .max(5)
+  .optional(),
+```
+
+Export helper optional:
+
+```typescript
+export function normalizeMentionedKeys(keys?: string[]): string[] | undefined {
+  if (!keys?.length) return undefined
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const k of keys) {
+    const upper = k.toUpperCase()
+    if (seen.has(upper)) continue
+    seen.add(upper)
+    out.push(upper)
+  }
+  return out.length ? out : undefined
+}
+```
+
+- [ ] **Step 4: Run test + build**
+
+Run: `pnpm --filter @lnkpi/shared test agentContract.test.ts && pnpm --filter @lnkpi/shared build`  
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/agentContract.ts packages/shared/src/agentContract.test.ts
+git commit -m "feat(shared): add mentionedKeys to agent conversation contract"
+```
+
+---
+
+### Task 2: Composable — 显式画布节点引用 + 修正 mediaType
+
+**Files:**
+- Modify: `apps/web/src/composables/useSidebarAttachments.ts`
+- Modify: `apps/web/src/composables/useSidebarAttachments.test.ts`
+
+**Interfaces:**
+- Produces: `nodeToSidebarAttachment(node): SidebarAttachment | null`
+- Produces: `addFromCanvasNode(node)`, `addFromCanvasNodes(nodes[])`
+- **Removes usage** of `mergeFocusNodeRef` from send path (Task 5)；函数可保留供迁移测试或删除
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// useSidebarAttachments.test.ts — append
+import { nodeToSidebarAttachment } from './useSidebarAttachments'
+
+describe('nodeToSidebarAttachment', () => {
+  it('maps video node to V* mediaType', () => {
+    const item = nodeToSidebarAttachment({
+      id: 'v1',
+      type: 'video',
+      data: { url: 'https://cdn/x.mp4', title: 'demo' },
+    })
+    expect(item?.mediaType).toBe('video')
+    expect(item?.sourceKind).toBe('canvasNode')
+  })
+
+  it('returns null when no url or text', () => {
+    expect(nodeToSidebarAttachment({ id: 'e', type: 'image', data: {} })).toBeNull()
+  })
+})
+
+describe('addFromCanvasNodes', () => {
+  it('adds up to max and skips dup sourceNodeId', () => {
+    const { addFromCanvasNodes, pendingAttachments } = useSidebarAttachments()
+    const nodes = Array.from({ length: 6 }, (_, i) => ({
+      id: `n${i}`,
+      type: 'image' as const,
+      data: { url: `https://cdn/${i}.jpg` },
+    }))
+    const added = addFromCanvasNodes(nodes)
+    expect(added).toBe(5)
+    expect(pendingAttachments.value).toHaveLength(5)
+  })
+})
+```
+
+- [ ] **Step 2: Run — FAIL**
+
+Run: `pnpm --filter @lnkpi/web test useSidebarAttachments.test.ts`
+
+- [ ] **Step 3: Implement**
+
+```typescript
+export function nodeToSidebarAttachment(node: FocusNodeLike): SidebarAttachment | null {
+  const data = node.data ?? {}
+  const url = String(data.url ?? '').trim()
+  const text = String(data.content ?? data.prompt ?? '').trim()
+  if (!url && !text) return null
+
+  const t = String(node.type ?? '')
+  let mediaType: SidebarAttachment['mediaType'] = 'image'
+  if (t === 'text' || t === 'prompt') mediaType = 'text'
+  else if (t === 'video') mediaType = 'video'
+  else if (t === 'audio') mediaType = 'audio'
+  else if (t === 'image' || t === 'mediaInput') mediaType = 'image'
+  else if (text && !url) mediaType = 'text'
+  else if (!url) return null
+
+  return {
+    id: randomId(),
+    mediaType,
+    sourceKind: 'canvasNode',
+    label: String(data.title ?? data.label ?? t || node.id),
+    url: url || undefined,
+    text: text || undefined,
+    sourceNodeId: node.id,
+  }
+}
+
+function addFromCanvasNode(node: FocusNodeLike): boolean {
+  const item = nodeToSidebarAttachment(node)
+  if (!item) return false
+  if (pendingAttachments.value.length >= SIDEBAR_ATTACHMENT_MAX) return false
+  addFromPayload(item)
+  return true
+}
+
+function addFromCanvasNodes(nodes: FocusNodeLike[]): number {
+  let count = 0
+  for (const n of nodes) {
+    if (pendingAttachments.value.length >= SIDEBAR_ATTACHMENT_MAX) break
+    if (addFromCanvasNode(n)) count += 1
+  }
+  return count
+}
+```
+
+Return `addFromCanvasNode`, `addFromCanvasNodes` from composable factory.
+
+- [ ] **Step 4: Run tests — PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/composables/useSidebarAttachments.ts apps/web/src/composables/useSidebarAttachments.test.ts
+git commit -m "feat(web): explicit canvas node to sidebar attachment mapping"
+```
+
+---
+
+### Task 3: AgentRefHoverPreview + AgentSidebarRefChip
+
+**Files:**
+- Create: `apps/web/src/components/agent/AgentRefHoverPreview.vue`
+- Create: `apps/web/src/components/agent/AgentSidebarRefChip.vue`
+- Modify: `apps/web/src/components/agent/AgentRefStrip.vue`
+
+**Interfaces:**
+- Consumes: `NodeRef`（与 Dock 一致）
+- Produces: `AgentSidebarRefChip` emit `mention: [refKey: string]`, `remove: []`
+- Produces: hover 200ms 后显示 `AgentRefHoverPreview`；mouseleave 隐藏
+
+- [ ] **Step 1: AgentRefHoverPreview.vue**
+
+无 backdrop；`position: fixed`；内容区复用 DockRefPreview 的布局（图/文/视/音分支），props: `refItem`, `x`, `y`；`pointer-events: none` on root 或仅预览区可交互（视/音 controls 需 `pointer-events-auto`）。
+
+- [ ] **Step 2: AgentSidebarRefChip.vue**
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { NodeRef } from '@/composables/useNodeRefs'
+// 复用 DockRefChip 的 thumbUrl / 样式结构，但：
+// - @mouseenter (+200ms timer) → show hover preview
+// - @mouseleave → hide
+// - @click (非 remove) → emit('mention', refItem.refKey)
+// - remove 按钮行为不变
+const hoverTimer = ref<number | null>(null)
+function onEnter(e: MouseEvent) {
+  hoverTimer.value = window.setTimeout(() => { previewOpen.value = true; previewPos = ... }, 200)
+}
+function onClick(e: MouseEvent) {
+  if (props.refItem.stale) return
+  emit('mention', props.refItem.refKey)
+}
+</script>
+```
+
+- [ ] **Step 3: Wire AgentRefStrip**
+
+Replace `DockRefChip` with `AgentSidebarRefChip`；forward `@mention`；只读模式 `:clickable="false"` 禁用 click mention。
+
+- [ ] **Step 4: Manual check**
+
+Dev：上传图 → hover 见预览浮层 → click 触发 emit（暂接 console）。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/agent/AgentRefHoverPreview.vue \
+  apps/web/src/components/agent/AgentSidebarRefChip.vue \
+  apps/web/src/components/agent/AgentRefStrip.vue
+git commit -m "feat(web): agent sidebar ref chip hover preview and click mention"
+```
+
+---
+
+### Task 4: AgentSideRail — MentionInput + 芯片 click 插入 + 去掉 silent merge
+
+**Files:**
+- Modify: `apps/web/src/components/agent/AgentSideRail.vue`
+
+**Interfaces:**
+- Consumes: `MentionInput`, `parseRefMentions`, `normalizeMentionedKeys` from shared
+- Consumes: `sidebar.addFromCanvasNodes` expose via `defineExpose`
+- Produces: send body 含 `mentionedKeys`；**不再**调用 `mergeFocusNodeRef`
+
+- [ ] **Step 1: Replace textarea with MentionInput**
+
+```typescript
+import MentionInput, { type MentionOption } from '@/components/canvas/MentionInput.vue'
+import { parseRefMentions } from '@/composables/useRefMentions'
+import { normalizeMentionedKeys } from '@lnkpi/shared'
+
+const mentionOptions = computed((): MentionOption[] =>
+  pendingAttachmentItems.value.map(({ refKey, attachment }) => ({
+    id: attachment.id,
+    label: refKey,
+    type: attachment.mediaType,
+  })),
+)
+
+function insertRefMention(refKey: string) {
+  const el = composerRef.value // MentionInput 需 expose textarea ref 或通过 v-model 拼接
+  const token = `@${refKey}`
+  input.value = input.value ? `${input.value} ${token} ` : `${token} `
+  nextTick(() => composerRef.value?.focus())
+}
+```
+
+若 `MentionInput` 未 expose textarea，扩展其 `defineExpose({ focus, insertAtCursor(text) })` 或在 SideRail 用 v-model 拼接（最小改动优先 expose `insertText`）。
+
+- [ ] **Step 2: AgentRefStrip @mention handler**
+
+```vue
+<AgentRefStrip ... @mention="insertRefMention" />
+```
+
+- [ ] **Step 3: Fix sendMessage**
+
+```typescript
+// REMOVE:
+// const attachments = mergeFocusNodeRef(pendingAttachments, props.selectedNode ?? null)
+
+// USE:
+const { attachments: pendingAttachments } = sidebar.toPayload()
+const attachments = pendingAttachments
+const mentionedKeys = normalizeMentionedKeys(parseRefMentions(message))
+
+body: JSON.stringify({
+  ...
+  attachments: attachments.length ? attachments : undefined,
+  refOrder: attachments.length ? attachments.map(a => a.id) : undefined,
+  mentionedKeys,
+})
+```
+
+- [ ] **Step 4: defineExpose for canvas**
+
+```typescript
+defineExpose({
+  addFromCanvasNodes: (nodes: FocusNodeLike[]) => {
+    const n = sidebar.addFromCanvasNodes(nodes)
+    if (n < nodes.length) ElMessage.warning(`最多添加 ${SIDEBAR_ATTACHMENT_MAX} 个参考素材`)
+    return n
+  },
+})
+```
+
+- [ ] **Step 5: Manual smoke**
+
+1. 选中节点不发引用 → 无 localRefs  
+2. 手动加芯片 → click 芯片 → 输入框有 `@I1`  
+3. 打 `@I` → 补全列表
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/agent/AgentSideRail.vue apps/web/src/components/canvas/MentionInput.vue
+git commit -m "feat(web): agent sidebar mention input and remove silent focus merge"
+```
+
+---
+
+### Task 5: Canvas — 显式加入入口（右键 + 多选）
+
+**Files:**
+- Modify: `apps/web/src/components/canvas/CanvasContextMenu.vue`
+- Modify: `apps/web/src/pages/CanvasPage.vue`
+
+**Interfaces:**
+- Consumes: `agentRailRef.addFromCanvasNodes`
+- Produces: context menu action `add-agent-ref`；多选工具栏批量加入
+
+**Out of scope:** 画布节点拖拽到侧栏（用户确认不做）。
+
+- [ ] **Step 1: Context menu item**
+
+```vue
+<!-- CanvasContextMenu.vue — 在 duplicate 前插入 -->
+<button
+  v-if="nodeId && nodeType !== 'group'"
+  class="neo-popover-item block w-full px-4 py-2 text-left text-xs"
+  @click="run('add-agent-ref')"
+>
+  加入 Agent 引用
+</button>
+```
+
+- [ ] **Step 2: CanvasPage handle context action**
+
+```typescript
+function onContextMenuAction(action: string) {
+  if (action === 'add-agent-ref') {
+    const ids = multiSelectedIds.value.length ? multiSelectedIds.value : selectedNodeId.value ? [selectedNodeId.value] : []
+    const nodes = ids.map(id => findNodeById(id)).filter(Boolean)
+    agentRailRef.value?.addFromCanvasNodes(nodes)
+    return
+  }
+  // ...existing
+}
+```
+
+- [ ] **Step 3: Multi-select toolbar button（可选但推荐）**
+
+当选中 ≥2 节点时在画布工具栏或 selection bar 增加「加入 Agent 引用」（与现有「建组」并列）。
+
+- [ ] **Step 4: Manual smoke**
+
+右键单节点、框选 3 节点批量 — 均出现在芯片条。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/canvas/CanvasContextMenu.vue apps/web/src/pages/CanvasPage.vue
+git commit -m "feat(web): explicit add canvas nodes to agent sidebar refs"
+```
+
+---
+
+### Task 6: API — Nest + Runtime `mentionedKeys` 管道
+
+**Files:**
+- Modify: `apps/server/src/agent/agent.controller.ts`
+- Modify: `apps/server/src/agent/agent.service.ts`
+- Modify: `apps/server/src/agent/agent-runtime.client.ts`
+- Modify: `services/agent-runtime/app/runs.py`
+- Modify: `services/agent-runtime/app/graph/state.py`
+- Modify: `services/agent-runtime/app/graph/sidebar_attachments.py`
+- Create or extend: `services/agent-runtime/tests/test_sidebar_attachments.py`
+
+**Interfaces:**
+- Produces: state `sidebar_mentioned_keys: list[str] | None`
+- Produces: `normalize_mentioned_keys(raw) -> list[str]`
+
+- [ ] **Step 1: Python failing test**
+
+```python
+def test_normalize_mentioned_keys():
+    from app.graph.sidebar_attachments import normalize_mentioned_keys
+    assert normalize_mentioned_keys(["i1", "I1", "T2"]) == ["I1", "T2"]
+    assert normalize_mentioned_keys(None) == []
+```
+
+- [ ] **Step 2: Implement normalize + wire runs.py / state.py**
+
+Mirror `sidebar_attachments` pattern; Nest DTO + service forward.
+
+- [ ] **Step 3: Run pytest — PASS**
+
+Run: `cd services/agent-runtime && python -m pytest tests/test_sidebar_attachments.py -v`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(agent): pipe sidebar mentionedKeys through conversation API"
+```
+
+---
+
+### Task 7: 生成贯通 — node.data.mentionedKeys + startImageGeneration
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/nodes/atomic_create_node.py`
+- Modify: `apps/server/src/agent/agent-canvas-tools.service.ts`
+- Modify: `apps/server/src/agent/agent-canvas-tools.service.test.ts`
+- Extend: `services/agent-runtime/tests/test_atomic_sidebar_refs.py`
+
+**Interfaces:**
+- Consumes: `state.sidebar_mentioned_keys`
+- Produces: `update_node` action with `data: { mentionedKeys }` on atomic targets
+- Produces: `startImageGeneration` passes keys to `studio.generateImage`
+
+- [ ] **Step 1: Failing Nest test**
+
+```typescript
+it('startImageGeneration passes node.data.mentionedKeys to studio', async () => {
+  // node with mentionedKeys: ['I1','T1']
+  // assert studio.generateImage called with mentionedKeys
+})
+```
+
+- [ ] **Step 2: atomic_create_node patch**
+
+After `apply_sidebar_attachments`, if `sidebar_mentioned_keys`:
+
+```python
+keys = state.get("sidebar_mentioned_keys") or []
+if keys:
+    await nest.update_nodes_batch([
+        {"nodeId": nid, "patch": {"mentionedKeys": keys}}
+        for nid in node_ids
+    ])
+```
+
+（或使用现有 persist update_node batch API。）
+
+- [ ] **Step 3: startImageGeneration**
+
+```typescript
+const mentionedKeys = Array.isArray(node.data?.mentionedKeys)
+  ? (node.data.mentionedKeys as string[])
+  : undefined
+const record = await this.studio.generateImage(
+  input.userId,
+  imagePrompt,
+  model,
+  aspectRatio,
+  refs,
+  mentionedKeys?.length ? mentionedKeys : undefined,
+  resolution,
+  count,
+  { sessionId: input.sessionId, nodeId: input.nodeId },
+)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm --filter @lnkpi/server test agent-canvas-tools.service.test.ts`  
+Run: `cd services/agent-runtime && python -m pytest tests/test_atomic_sidebar_refs.py -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(agent): apply sidebar mentionedKeys to atomic image generation"
+```
+
+---
+
+### Task 8: 冒烟脚本 + 回归
+
+**Files:**
+- Modify: `deploy/prod-sidebar-attachments-verify.py`
+- Modify: `apps/web/src/composables/useSidebarAttachments.test.ts`（删除/更新 mergeFocusNodeRef send 相关用例若需）
+
+- [ ] **Step 1: Update verify script**
+
+- 移除「仅 focusNodeId 即 ref」断言  
+- 增加：payload 含 `mentionedKeys: ['I1']` 时 node.data.mentionedKeys 或 merge log  
+- Campaign plan 关键词断言放宽（既有误报）
+
+- [ ] **Step 2: Run local/staging**
+
+Run: `python deploy/prod-sidebar-attachments-verify.py`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deploy/prod-sidebar-attachments-verify.py
+git commit -m "test(deploy): update sidebar M3 explicit refs verify"
+```
+
+---
+
+## M3 backlog（本计划不阻塞 M3a–c）
+
+| 项 | 说明 |
+| --- | --- |
+| 芯片拖拽排序 | refOrder 手动调整 |
+| 粘贴板截图 | paste → addFromFile |
+| V/A 生成消费 | studio 路径扩展 |
+| 设置项「选中自动加入引用」 | 默认关 |
+| Campaign text merge mentionedKeys | 若 text gen 走 mergeRefs |
+
+---
+
+## Spec self-review
+
+| Spec 章节 | Task |
+| --- | --- |
+| D-A 废止 silent merge | 4, 5 |
+| D-B focus 解耦 | 4 |
+| D-C @ 语义 | 1, 4, 6, 7 |
+| D-D 多选显式 | 2, 5 |
+| D-E hover/click 芯片 | 3, 4 |
+| D-F MentionInput | 4 |
+| §3 节点映射 | 2 |
+| §4 API mentionedKeys | 1, 6, 7 |
+| §7 测试要点 | 8 |
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-08-07-agent-sidebar-m3-explicit-refs.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** — 每个 Task 派发独立 subagent，Task 间 review  
+2. **Inline Execution** — 本会话按 Task 顺序实现，checkpoint 处暂停 review  
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-08-07-agent-sidebar-m3-explicit-refs-design.md
+++ b/docs/superpowers/specs/2026-08-07-agent-sidebar-m3-explicit-refs-design.md
@@ -1,0 +1,197 @@
+# Agent 侧栏 M3 — 显式引用、@ 语义与芯片交互
+
+> 状态：**已确认**（2026-08-07）  
+> 范围：在 M1/M2 侧栏素材引用基础上，修正「选中即 silent ref」误操作风险；贯通 `@` 优先语义；芯片 hover 预览 + 点击插入 `@`  
+> 前置：[2026-08-07-agent-sidebar-material-entry-design.md](./2026-08-07-agent-sidebar-material-entry-design.md)、[2026-07-18-node-data-flow-refs-design.md](./2026-07-18-node-data-flow-refs-design.md)  
+> 非范围：V\*/A\* 生成侧消费（仍 P1）、芯片拖拽排序（P1）、粘贴板截图（P1）
+
+---
+
+## 0. 决策摘要（相对 M2 的变更）
+
+| # | 决策 | 说明 |
+|---|------|------|
+| **D-A** | **画布节点默认不 silent 进芯片** | 取消 `sendMessage` 时 `mergeFocusNodeRef`；须显式「加入 Agent 引用」 |
+| **D-B** | **`focusNodeId` 与 img2img ref 解耦** | `focusNodeId` 仅作指代/续作上下文；img2img 必须先进芯片条 |
+| **D-C** | **芯片条 = 全量 ref 池；`@` = 优先/分工说明** | 芯片内 ref 默认全部参与生成；`@I1/@T1` 产生 `mentionedKeys`，非开关 |
+| **D-D** | **多选仅支持批量显式加入** | 右键/工具栏/拖拽；不支持选中态隐式合并 |
+| **D-E** | **芯片：hover 预览，click 插入 `@`** | 与 Dock 芯片（click 开 modal 预览）区分；侧栏以「写指令」为主 |
+| **D-F** | **侧栏输入接 `MentionInput`** | `@` 补全来自当前 pending 芯片；高亮与 Dock 一致 |
+
+**废止 M2 决策 D5：**「focusNodeId 可升格为 ref（发送时自动并入）」→ 由 D-A/D-B 替代。
+
+---
+
+## 1. 问题与目标
+
+### 1.1 问题
+
+| 问题 | 现状 | 风险 |
+|------|------|------|
+| 选中即引用 | `mergeFocusNodeRef` 在发送瞬间合并 | 误把「正在查看的节点」当 ref |
+| `@` 无补全 | 侧栏 plain textarea | 用户手打 `@I1`，易错 |
+| `@` 未贯通生成 | 仅 sidebar copy ack 提 @ | 多图分工语义进不了 merge prompt |
+| 芯片交互不足 | 复用 DockRefChip（click→全屏预览） | 侧栏更需要快速插入 `@` + 轻量预览 |
+
+### 1.2 目标
+
+1. 画布节点进芯片：**可见、可删、可核对**后再发送。
+2. 芯片 **hover** 展示内容预览（图/文/视/音）；**click** 在输入框光标处插入 `@I1`（带尾随空格）。
+3. 侧栏 **MentionInput**：`@` 触发补全列表（选项 = 当前芯片 refKey）。
+4. 发送时 `parseRefMentions(message)` → **`mentionedKeys`** 经 API 进 runtime，写入目标节点并在 `startImageGeneration` 消费。
+5. **无 `@` 时**：芯片内 attachments 仍全量 localRefs / attach_edges，与 Dock 一致。
+
+---
+
+## 2. 交互设计
+
+### 2.1 显式加入引用
+
+| 入口 | 交互 | 结果 |
+|------|------|------|
+| **节点右键** | 「加入 Agent 引用」 | 单节点 → 芯片条 +1 |
+| **多选 + 右键/工具栏** | 「批量加入 Agent 引用」 | 按 ref 上限（5）依次加入，超限 toast |
+| **拖拽节点 → 侧栏输入区** | ~~M3 不做~~ | 画布节点不易拖拽；改用右键/多选 |
+| **focusNodeId** | 发送时仅传 id | **不**自动进 attachments |
+
+去重规则不变：同 `sourceNodeId` / 同 `url` 不重复。
+
+### 2.2 芯片条行为（Agent 侧栏专用）
+
+```text
+┌ Agent 输入 dock ──────────────────────┐
+│ [I1🖼][T1📝]  ← hover: 浮层预览       │
+│               click: 输入框插入 @I1    │
+│ ┌──────────────────────────────────┐ │
+│ │ MentionInput（@ 补全 + 高亮）      │ │
+│ └──────────────────────────────────┘ │
+└──────────────────────────────────────┘
+```
+
+| 动作 | 行为 |
+|------|------|
+| **Hover（≥200ms）** | 芯片旁浮层：缩略图 / 文本摘要 / 视音控件（复用预览内容组件） |
+| **Click** | 向输入框插入 `@I1`（或 `@T1`…）；焦点回输入框；不打开全屏 modal |
+| **Hover + Remove** | 仍显示移除按钮（与 Dock 一致） |
+| **只读气泡内芯片** | 仅 hover 预览；click 可选插入到**新一条**输入（M3 不做，只读无 click） |
+
+与 Dock `DockRefChip`：**不修改 Dock 行为**；侧栏使用新组件 `AgentSidebarRefChip.vue`。
+
+### 2.3 `@` 语义（与画布 refs 对齐）
+
+```text
+芯片条 attachments     →  本回合 ref 池（默认全量参与 img2img / merge）
+message 内 @I1/@T1     →  mentionedKeys（优先融合 / 分工说明）
+无 @                   →  mentionedKeys = []；refs 仍全量使用
+```
+
+示例：
+
+```text
+芯片：[I1 风格][I2 产品][T1 文案]
+输入：「@I1 作风格，@I2 作主产品，按 @T1 生成主图」
+生成：referenceImages = [I1, I2]；merge prompt 强调 I1/I2/T1 角色
+```
+
+---
+
+## 3. 画布节点 → SidebarAttachment 映射
+
+`nodeToSidebarAttachment(node)` 规则：
+
+| 节点 type | mediaType | 取值 |
+|-----------|-----------|------|
+| `text`, `prompt` | `text` | `content` / `prompt` |
+| `image`, `mediaInput` | `image` | `url` |
+| `video` | `video` | `url` |
+| `audio` | `audio` | `url` |
+| 其他 / 无 url 且无 text | — | 拒绝并 toast「该节点暂不可作为引用」 |
+
+`sourceKind: 'canvasNode'`，`sourceNodeId: node.id`，`label: title ?? type`。
+
+---
+
+## 4. API 与数据流
+
+### 4.1 Conversation 请求增量
+
+```typescript
+// AgentConversationRequest 增量
+mentionedKeys?: string[]   // 前端 parseRefMentions(message)，去重保序
+```
+
+校验：每项须匹配 `/^[TIVA]\d+$/` 且对应 refKey 存在于本轮 attachments 映射（可选 warn 不阻断）。
+
+### 4.2 Runtime state
+
+```python
+sidebar_mentioned_keys: list[str] | None
+```
+
+### 4.3 生成落点
+
+atomic 路径：
+
+1. `create_atomic_node` / `apply_sidebar_attachments` 写 `localRefs`（不变）。
+2. 同一 turn 将 `sidebar_mentioned_keys` 写入新建 image/video/text 节点的 `data.mentionedKeys`（与 Dock 单次生成等价）。
+3. `startImageGeneration` / `runVideoGeneration` 读取 `node.data.mentionedKeys` 传入 `studio.generateImage(..., mentionedKeys)`。
+
+Campaign 路径：split 后 attach 不变；seed 节点 gen 时同样读 `mentionedKeys`。
+
+---
+
+## 5. 组件与文件
+
+| 文件 | 变更 |
+|------|------|
+| `apps/web/src/components/agent/AgentSidebarRefChip.vue` | **新建** — hover 预览 + click mention |
+| `apps/web/src/components/agent/AgentRefHoverPreview.vue` | **新建** — 无 backdrop 浮层 |
+| `apps/web/src/components/agent/AgentRefStrip.vue` | 换用 AgentSidebarRefChip；emit `mention` |
+| `apps/web/src/components/agent/AgentSideRail.vue` | MentionInput；去掉 send 时 mergeFocusNodeRef |
+| `apps/web/src/composables/useSidebarAttachments.ts` | `nodeToSidebarAttachment`；`addFromCanvasNode(s)` |
+| `apps/web/src/components/canvas/CanvasContextMenu.vue` | 「加入 Agent 引用」 |
+| `apps/web/src/pages/CanvasPage.vue` | 多选批量、DnD 到侧栏、调 SideRail expose |
+| `packages/shared/src/agentContract.ts` | `mentionedKeys` |
+| `services/agent-runtime/...` | state + 写 node.data.mentionedKeys |
+| `apps/server/.../agent-canvas-tools.service.ts` | startImageGeneration 读 mentionedKeys |
+
+---
+
+## 6. 分期（M3 内部）
+
+| 子阶段 | 范围 | 可独立验收 |
+|--------|------|------------|
+| **M3a** | 去 silent merge + 显式加入 + 节点类型修正 | 右键加入 → 芯片可见 → atomic img2img |
+| **M3b** | 芯片 hover/click + MentionInput | hover 看图；click 插入 @；@ 补全 |
+| **M3c** | mentionedKeys API + 生成贯通 | @ 分工进入 merge prompt（测 log/skippedMerge） |
+
+---
+
+## 7. 测试要点
+
+1. 选中 image 节点仅发「生成白底版」→ **无** localRefs（未显式加入时）。
+2. 右键「加入 Agent 引用」→ 芯片 I1 → atomic → localRefs 含 url。
+3. 多选 3 节点批量加入 → 芯片 3 个；第 6 个 toast 超限。
+4. 芯片 hover 200ms 出现预览；click 输入框出现 `@I1 `。
+5. 输入 `@I` 弹出补全 I1/I2；Enter 选中插入。
+6. 「@I1 风格 @I2 产品」→ API `mentionedKeys: ['I1','I2']` → 生成 merge 含优先参考。
+7. 芯片有 I1、消息无 @ → img2img 仍带 I1；mentionedKeys 为空。
+8. video 节点加入 → 芯片 V1（非误标 I1）。
+
+---
+
+## 8. 风险与缓解
+
+| 风险 | 缓解 |
+|------|------|
+| 用户习惯「选中即 ref」 | 首版无自动升格；后续可在设置加「选中自动加入」默认关 |
+| hover 与 click 冲突 | hover 延迟 200ms；click 不触发 preview modal |
+| mentionedKeys 与 refKey 漂移 | refKey 由 attachments 顺序确定性分配；parse 只认合法 TIVA 模式 |
+
+---
+
+## 9. 已确认（2026-08-07）
+
+1. 废止 M2 D5 silent focus merge。  
+2. 侧栏芯片 click = 插入 `@`，hover = 预览（D-E）。  
+3. `@` 不 gate refs；仅 `mentionedKeys` 优先语义（D-C）。

--- a/docs/superpowers/specs/2026-08-07-agent-sidebar-material-entry-design.md
+++ b/docs/superpowers/specs/2026-08-07-agent-sidebar-material-entry-design.md
@@ -15,7 +15,7 @@
 | **D2** | **A（atomic）+ B（Campaign）并重** | 同一套侧栏 UI 与 API；落点按 `flow_mode` 分流 |
 | **D3** | **atomic 写 localRefs；Campaign 写 edge + refOrder** | atomic 单节点闭环优先 localRefs；split/topo 后 `attach_refs` 连边 |
 | **D4** | **交互：引用条 + [+] + 拖拽 + 资产库** | 与 Dock `DockRefStrip` 视觉/语义对齐 |
-| **D5** | **focusNodeId 可升格为 ref** | 选中节点若有 url/text，自动并入 attachments（可关闭） |
+| **D5** | ~~focusNodeId 可升格为 ref~~ → **M3 废止** | 见 [M3 显式引用 spec](./2026-08-07-agent-sidebar-m3-explicit-refs-design.md) D-A/D-B |
 | **D6** | **M1 仅消费 T\*/I\*** | 与 C2.1 对齐；V/A 芯片可展示，生成侧 P1 再消费 |
 
 ---
@@ -350,7 +350,7 @@ async def apply_sidebar_attachments(
 |------|------|------|
 | **M1** | 侧栏 UI + upload + API + atomic localRefs + img2img | 上传产品图 → atomic 三视图出图 |
 | **M2** | 资产库选取 + focusNodeId 升格 + Campaign attach_refs | 上传品牌图 → Campaign 主图连 ref |
-| **M3** | @ 提及、拖拽画布节点、粘贴板、V/A 消费 | 与 Dock 体验完全对齐 |
+| **M3** | 显式加入引用、@ 补全/mentionedKeys、芯片 hover/click、拖拽画布节点 | 见 [M3 spec](./2026-08-07-agent-sidebar-m3-explicit-refs-design.md) + [M3 plan](../plans/2026-08-07-agent-sidebar-m3-explicit-refs.md) |
 
 ---
 

--- a/packages/shared/src/agentContract.test.ts
+++ b/packages/shared/src/agentContract.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { AgentConversationRequestSchema } from './agentContract'
+
+describe('AgentConversationRequestSchema mentionedKeys', () => {
+  it('accepts valid mentionedKeys', () => {
+    const parsed = AgentConversationRequestSchema.parse({
+      sessionId: 's1',
+      message: '@I1 风格',
+      mentionedKeys: ['I1', 'T2'],
+    })
+    expect(parsed.mentionedKeys).toEqual(['I1', 'T2'])
+  })
+
+  it('rejects invalid ref key format', () => {
+    expect(() =>
+      AgentConversationRequestSchema.parse({
+        sessionId: 's1',
+        message: 'x',
+        mentionedKeys: ['image1'],
+      }),
+    ).toThrow()
+  })
+})

--- a/packages/shared/src/agentContract.ts
+++ b/packages/shared/src/agentContract.ts
@@ -566,6 +566,23 @@ export const AgentConversationRequestSchema = z.object({
   model: z.string().optional(),
   attachments: z.array(SidebarAttachmentSchema).max(5).optional(),
   refOrder: z.array(z.string()).optional(),
+  mentionedKeys: z
+    .array(z.string().regex(/^[TIVA]\d+$/i))
+    .max(5)
+    .optional(),
 })
+
+export function normalizeMentionedKeys(keys?: string[]): string[] | undefined {
+  if (!keys?.length) return undefined
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const k of keys) {
+    const upper = k.toUpperCase()
+    if (seen.has(upper)) continue
+    seen.add(upper)
+    out.push(upper)
+  }
+  return out.length ? out : undefined
+}
 
 export type AgentConversationRequest = z.infer<typeof AgentConversationRequestSchema>

--- a/services/agent-runtime/app/graph/nodes/atomic_create_node.py
+++ b/services/agent-runtime/app/graph/nodes/atomic_create_node.py
@@ -107,9 +107,10 @@ def make_create_atomic_node(*, nest: Any) -> Callable:
 
         await _emit_atomic_task_list(nest, created_items)
 
+        node_ids = [str(i.get("node_id") or "") for i in created_items if i.get("node_id")]
+
         attachments = state.get("sidebar_attachments") or []
         if attachments:
-            node_ids = [str(i.get("node_id") or "") for i in created_items if i.get("node_id")]
             apply_fn = getattr(nest, "apply_sidebar_attachments", None)
             if apply_fn and node_ids:
                 await apply_fn(
@@ -117,6 +118,17 @@ def make_create_atomic_node(*, nest: Any) -> Callable:
                     attachments=attachments,
                     ref_order=state.get("sidebar_ref_order"),
                     mode="localRefs",
+                )
+
+        keys = state.get("sidebar_mentioned_keys") or []
+        if keys and node_ids:
+            update_fn = getattr(nest, "update_nodes_batch", None)
+            if update_fn is not None:
+                await update_fn(
+                    [
+                        {"nodeId": nid, "patch": {"mentionedKeys": keys}}
+                        for nid in node_ids
+                    ]
                 )
 
         first = created_items[0]

--- a/services/agent-runtime/app/graph/sidebar_attachments.py
+++ b/services/agent-runtime/app/graph/sidebar_attachments.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import re
+
 MAX_SIDEBAR_ATTACHMENTS = 5
+MAX_MENTIONED_KEYS = 5
 
 REF_PREFIX = {"text": "T", "image": "I", "video": "V", "audio": "A"}
+_MENTIONED_KEY_RE = re.compile(r"^[TIVA]\d+$", re.IGNORECASE)
 
 
 def normalize_sidebar_attachments(raw: list[dict] | None) -> list[dict]:
@@ -36,3 +40,22 @@ def assign_sidebar_ref_keys(attachments: list[dict] | None) -> list[str]:
         counters[media_type] += 1
         keys.append(f"{prefix}{counters[media_type]}")
     return keys
+
+
+def normalize_mentioned_keys(raw: list[str] | None) -> list[str]:
+    """Dedupe @-mention ref keys case-insensitively; uppercase (matches normalizeMentionedKeys)."""
+    if not raw:
+        return []
+    if len(raw) > MAX_MENTIONED_KEYS:
+        raise ValueError(f"最多 {MAX_MENTIONED_KEYS} 个 @ 提及")
+    out: list[str] = []
+    seen: set[str] = set()
+    for key in raw:
+        k = str(key or "").strip().upper()
+        if not k or not _MENTIONED_KEY_RE.match(k):
+            continue
+        if k in seen:
+            continue
+        seen.add(k)
+        out.append(k)
+    return out

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -143,6 +143,7 @@ class AgentRuntimeState(TypedDict, total=False):
     # Sidebar material entry (per user turn; overwritten each fresh turn)
     sidebar_attachments: list[dict] | None
     sidebar_ref_order: list[str] | None
+    sidebar_mentioned_keys: list[str] | None
 
     # W14: user_brief uses brief_reducer — immutable after first write unless BRIEF_RESET_PREFIX
     user_brief: Annotated[str | None, brief_reducer]

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -316,6 +316,11 @@ class NestEventProxy:
             )
         )
 
+    async def update_nodes_batch(
+        self, items: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        return await self._forward_actions(await self._inner.update_nodes_batch(items))
+
     async def run_image_generation(self, node_id: str) -> dict[str, Any]:
         return await self._run_studio_generation(node_id, "run_image_generation")
 

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -29,7 +29,10 @@ from app.history_trim import trim_history
 from app.metrics import record_stream_error, thread_finished, thread_started, track_node
 from app.tracing import end_run_span, is_tracing_enabled, start_run_span, trace_node
 from app.graph.nodes.intake import modify_intent
-from app.graph.sidebar_attachments import normalize_sidebar_attachments
+from app.graph.sidebar_attachments import (
+    normalize_mentioned_keys,
+    normalize_sidebar_attachments,
+)
 from app.tools.nest_client import NestCanvasClient
 
 EmitFn = Callable[[dict[str, Any]], Awaitable[None]]
@@ -206,6 +209,10 @@ class RunRequest(BaseModel):
     sidebar_ref_order: list[str] | None = Field(
         default=None,
         validation_alias="ref_order",
+    )
+    sidebar_mentioned_keys: list[str] | None = Field(
+        default=None,
+        validation_alias="mentioned_keys",
     )
 
 
@@ -547,6 +554,7 @@ async def stream_run_events(
 
     try:
         normalized_attachments = normalize_sidebar_attachments(req.sidebar_attachments)
+        normalized_mentioned_keys = normalize_mentioned_keys(req.sidebar_mentioned_keys)
     except ValueError as exc:
         yield {"type": "error", "data": {"message": str(exc)}}
         yield {"type": "done", "data": {}}
@@ -633,6 +641,7 @@ async def stream_run_events(
             "focus_node_id": req.focus_node_id,
             "sidebar_attachments": normalized_attachments,
             "sidebar_ref_order": req.sidebar_ref_order,
+            "sidebar_mentioned_keys": normalized_mentioned_keys,
         }
 
     async def run_graph() -> None:

--- a/services/agent-runtime/app/tools/nest_client.py
+++ b/services/agent-runtime/app/tools/nest_client.py
@@ -264,6 +264,15 @@ class NestCanvasClient:
         }
         return await self._post("/agent/internal/apply-sidebar-attachments", body)
 
+    async def update_nodes_batch(
+        self, items: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        body = {
+            "sessionId": self._session_id,
+            "items": items,
+        }
+        return await self._post("/agent/internal/update-nodes-batch", body)
+
     async def run_image_generation(self, node_id: str) -> dict[str, Any]:
         # Nest polls Studio up to image_gen_timeout_sec; httpx must outlive that.
         timeout_sec = float(settings.image_gen_timeout_sec) + IMAGE_GEN_TIMEOUT_BUFFER_SEC

--- a/services/agent-runtime/tests/test_atomic_sidebar_refs.py
+++ b/services/agent-runtime/tests/test_atomic_sidebar_refs.py
@@ -43,6 +43,10 @@ class FakeNest:
         )
         return {"applied": len(node_ids)}
 
+    async def update_nodes_batch(self, items: list[dict[str, Any]]) -> dict[str, Any]:
+        self.calls.append(("update_nodes_batch", items))
+        return {"actions": []}
+
 
 @pytest.mark.asyncio
 async def test_atomic_create_applies_sidebar_local_refs():
@@ -112,3 +116,71 @@ async def test_atomic_create_applies_refs_to_all_created_nodes():
     assert len(apply_calls) == 1
     assert apply_calls[0][1]["node_ids"] == ["node-1", "node-2"]
     assert apply_calls[0][1]["mode"] == "localRefs"
+
+
+@pytest.mark.asyncio
+async def test_atomic_create_patches_mentioned_keys_after_sidebar_apply():
+    nest = FakeNest()
+    create = make_create_atomic_node(nest=nest)
+    attachments = [{"materialId": "mat-1", "role": "reference"}]
+
+    await create(
+        {
+            "atomic_spec": {
+                "target_type": "image",
+                "prompt": "主图",
+                "title": "主图",
+            },
+            "sidebar_attachments": attachments,
+            "sidebar_mentioned_keys": ["I1", "T1"],
+        }
+    )
+
+    update_calls = [c for c in nest.calls if c[0] == "update_nodes_batch"]
+    assert len(update_calls) == 1
+    assert update_calls[0][1] == [
+        {"nodeId": "node-1", "patch": {"mentionedKeys": ["I1", "T1"]}}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_atomic_create_patches_mentioned_keys_without_attachments():
+    nest = FakeNest()
+    create = make_create_atomic_node(nest=nest)
+
+    await create(
+        {
+            "atomic_spec": {
+                "target_type": "image",
+                "prompt": "主图",
+                "title": "主图",
+            },
+            "sidebar_mentioned_keys": ["I1"],
+        }
+    )
+
+    assert not any(c[0] == "apply_sidebar_attachments" for c in nest.calls)
+    update_calls = [c for c in nest.calls if c[0] == "update_nodes_batch"]
+    assert len(update_calls) == 1
+    assert update_calls[0][1] == [
+        {"nodeId": "node-1", "patch": {"mentionedKeys": ["I1"]}}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_atomic_create_skips_mentioned_keys_patch_when_empty():
+    nest = FakeNest()
+    create = make_create_atomic_node(nest=nest)
+
+    await create(
+        {
+            "atomic_spec": {
+                "target_type": "image",
+                "prompt": "主图",
+                "title": "主图",
+            },
+            "sidebar_mentioned_keys": [],
+        }
+    )
+
+    assert not any(c[0] == "update_nodes_batch" for c in nest.calls)

--- a/services/agent-runtime/tests/test_sidebar_attachments.py
+++ b/services/agent-runtime/tests/test_sidebar_attachments.py
@@ -89,3 +89,10 @@ def test_normalize_rejects_more_than_five():
 def test_normalize_empty_returns_empty():
     assert normalize_sidebar_attachments(None) == []
     assert normalize_sidebar_attachments([]) == []
+
+
+def test_normalize_mentioned_keys():
+    from app.graph.sidebar_attachments import normalize_mentioned_keys
+
+    assert normalize_mentioned_keys(["i1", "I1", "T2"]) == ["I1", "T2"]
+    assert normalize_mentioned_keys(None) == []


### PR DESCRIPTION
## Summary

- 废止 send 时 silent `mergeFocusNodeRef`；画布节点须右键/多选工具栏显式「加入 Agent 引用」（不含节点拖拽进侧栏）
- 侧栏芯片：hover 浮层预览、click 插入 `@I1`；输入区接 `MentionInput` 补全
- `mentionedKeys` 贯通 conversation API → runtime → `node.data.mentionedKeys` → `startImageGeneration` merge
- 修正 canvas 节点 mediaType（video→V*、audio→A*）
- 更新 `deploy/prod-sidebar-attachments-verify.py`（显式 ref + mentionedKeys 断言）

## Test plan

- [x] `pnpm --filter @lnkpi/shared build`
- [x] `pnpm --filter @lnkpi/web test useSidebarAttachments.test.ts` (9/9)
- [x] `pnpm --filter @lnkpi/web exec vue-tsc -b`
- [x] `python3 -m pytest services/agent-runtime/tests/test_sidebar_attachments.py tests/test_atomic_sidebar_refs.py` (13/13)
- [x] `pnpm --filter @lnkpi/server test agent-canvas-tools.service.test.ts` (mentionedKeys case)
- [ ] CI green
- [ ] 生产 `deploy/prod-sidebar-attachments-verify.py` 12/12
- [ ] 生产 `deploy/prod-sidebar-copy-verify.py` 回归


Made with [Cursor](https://cursor.com)