### PR TITLE
fix(agent): persist sidebar mentionedKeys on atomic create

### DIFF
--- a/apps/server/src/agent/agent-canvas-tools.controller.ts
+++ b/apps/server/src/agent/agent-canvas-tools.controller.ts
@@ -203,6 +203,11 @@ class ApplySidebarAttachmentsDto {
 
   @IsString()
   mode!: 'localRefs' | 'attach_edges'
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  mentionedKeys?: string[]
 }
 
 class UpdateNodesBatchItemDto {
@@ -449,6 +454,7 @@ export class AgentCanvasToolsController {
       >[0]['attachments'],
       refOrder: dto.refOrder,
       mode: dto.mode,
+      mentionedKeys: dto.mentionedKeys,
     })
     return { code: 0, message: 'ok', data }
   }

--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -532,6 +532,7 @@ export class AgentCanvasToolsService {
     attachments: SidebarAttachment[]
     refOrder?: string[]
     mode: 'localRefs' | 'attach_edges'
+    mentionedKeys?: string[]
   }): Promise<{ actions: CanvasAction[]; sourceNodeIds: string[] }> {
     validateSidebarAttachments(input.attachments)
     const order = input.refOrder?.length
@@ -550,7 +551,14 @@ export class AgentCanvasToolsService {
         }))
       const actions: CanvasAction[] = input.nodeIds.map((nodeId) => ({
         type: 'update_node',
-        payload: { id: nodeId, data: { localRefs, refOrder: order } },
+        payload: {
+          id: nodeId,
+          data: {
+            localRefs,
+            refOrder: order,
+            ...(input.mentionedKeys?.length ? { mentionedKeys: input.mentionedKeys } : {}),
+          },
+        },
       }))
       await this.persist(input.sessionId, actions)
       return { actions, sourceNodeIds: [] }

--- a/apps/server/src/agent/agent-canvas-tools.sidebar.test.ts
+++ b/apps/server/src/agent/agent-canvas-tools.sidebar.test.ts
@@ -211,4 +211,33 @@ describe('AgentCanvasToolsService.applySidebarAttachments', () => {
     })
     expect(sessionUpdate).toHaveBeenCalled()
   })
+
+  it('localRefs mode writes mentionedKeys on target nodes', async () => {
+    canvas = {
+      nodes: [{ id: 'img-1', type: 'image', position: { x: 0, y: 0 }, data: {} }],
+      edges: [],
+    }
+    const oneAttachment: SidebarAttachment[] = [
+      {
+        id: 'ref-upload',
+        mediaType: 'image',
+        sourceKind: 'upload',
+        label: 'product.jpg',
+        url: 'https://cdn.example.com/product.jpg',
+      },
+    ]
+
+    const result = await svc.applySidebarAttachments({
+      sessionId: 's1',
+      nodeIds: ['img-1'],
+      attachments: oneAttachment,
+      mode: 'localRefs',
+      mentionedKeys: ['I1', 'T2'],
+    })
+
+    expect(result.actions[0].payload.data).toMatchObject({
+      mentionedKeys: ['I1', 'T2'],
+    })
+    expect(sessionUpdate).toHaveBeenCalled()
+  })
 })

--- a/services/agent-runtime/app/graph/nodes/atomic_create_node.py
+++ b/services/agent-runtime/app/graph/nodes/atomic_create_node.py
@@ -7,6 +7,7 @@ from typing import Any, Callable
 from langchain_core.messages import AIMessage
 
 from app.graph.sidebar_copy import format_atomic_create_progress
+from app.graph.sidebar_attachments import resolve_sidebar_mentioned_keys
 
 
 def _atomic_batch_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -110,26 +111,16 @@ def make_create_atomic_node(*, nest: Any) -> Callable:
         node_ids = [str(i.get("node_id") or "") for i in created_items if i.get("node_id")]
 
         attachments = state.get("sidebar_attachments") or []
-        if attachments:
-            apply_fn = getattr(nest, "apply_sidebar_attachments", None)
-            if apply_fn and node_ids:
-                await apply_fn(
-                    node_ids=node_ids,
-                    attachments=attachments,
-                    ref_order=state.get("sidebar_ref_order"),
-                    mode="localRefs",
-                )
-
-        keys = state.get("sidebar_mentioned_keys") or []
-        if keys and node_ids:
-            update_fn = getattr(nest, "update_nodes_batch", None)
-            if update_fn is not None:
-                await update_fn(
-                    [
-                        {"nodeId": nid, "patch": {"mentionedKeys": keys}}
-                        for nid in node_ids
-                    ]
-                )
+        mentioned_keys = resolve_sidebar_mentioned_keys(state)
+        apply_fn = getattr(nest, "apply_sidebar_attachments", None)
+        if apply_fn and node_ids and (attachments or mentioned_keys):
+            await apply_fn(
+                node_ids=node_ids,
+                attachments=attachments,
+                ref_order=state.get("sidebar_ref_order"),
+                mode="localRefs",
+                mentioned_keys=mentioned_keys or None,
+            )
 
         first = created_items[0]
         msg = format_atomic_create_progress(first, count=len(created_items))

--- a/services/agent-runtime/app/graph/sidebar_attachments.py
+++ b/services/agent-runtime/app/graph/sidebar_attachments.py
@@ -7,6 +7,7 @@ MAX_MENTIONED_KEYS = 5
 
 REF_PREFIX = {"text": "T", "image": "I", "video": "V", "audio": "A"}
 _MENTIONED_KEY_RE = re.compile(r"^[TIVA]\d+$", re.IGNORECASE)
+_MENTIONED_KEY_IN_TEXT_RE = re.compile(r"@([TIVA]\d+)", re.IGNORECASE)
 
 
 def normalize_sidebar_attachments(raw: list[dict] | None) -> list[dict]:
@@ -40,6 +41,31 @@ def assign_sidebar_ref_keys(attachments: list[dict] | None) -> list[str]:
         counters[media_type] += 1
         keys.append(f"{prefix}{counters[media_type]}")
     return keys
+
+
+def parse_mentioned_keys_from_text(text: str) -> list[str]:
+    """Extract @I1-style keys from user message (matches web parseRefMentions)."""
+    if not text:
+        return []
+    raw: list[str] = []
+    for match in _MENTIONED_KEY_IN_TEXT_RE.finditer(text):
+        raw.append(match.group(1))
+    return normalize_mentioned_keys(raw)
+
+
+def resolve_sidebar_mentioned_keys(state: dict) -> list[str]:
+    """State keys first; fallback parse latest HumanMessage for @T1/@I1."""
+    keys = normalize_mentioned_keys(state.get("sidebar_mentioned_keys"))
+    if keys:
+        return keys
+    messages = state.get("messages") or []
+    for msg in reversed(messages):
+        content = getattr(msg, "content", None)
+        if isinstance(content, str) and content.strip():
+            parsed = parse_mentioned_keys_from_text(content)
+            if parsed:
+                return parsed
+    return []
 
 
 def normalize_mentioned_keys(raw: list[str] | None) -> list[str]:

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -306,6 +306,7 @@ class NestEventProxy:
         attachments: list[dict[str, Any]],
         ref_order: list[str] | None,
         mode: str,
+        mentioned_keys: list[str] | None = None,
     ) -> dict[str, Any]:
         return await self._forward_actions(
             await self._inner.apply_sidebar_attachments(
@@ -313,6 +314,7 @@ class NestEventProxy:
                 attachments=attachments,
                 ref_order=ref_order,
                 mode=mode,
+                mentioned_keys=mentioned_keys,
             )
         )
 

--- a/services/agent-runtime/app/tools/nest_client.py
+++ b/services/agent-runtime/app/tools/nest_client.py
@@ -254,6 +254,7 @@ class NestCanvasClient:
         attachments: list[dict],
         ref_order: list[str] | None,
         mode: str,
+        mentioned_keys: list[str] | None = None,
     ) -> dict[str, Any]:
         body = {
             "sessionId": self._session_id,
@@ -262,6 +263,8 @@ class NestCanvasClient:
             "refOrder": ref_order or [],
             "mode": mode,
         }
+        if mentioned_keys:
+            body["mentionedKeys"] = mentioned_keys
         return await self._post("/agent/internal/apply-sidebar-attachments", body)
 
     async def update_nodes_batch(

--- a/services/agent-runtime/tests/test_atomic_sidebar_refs.py
+++ b/services/agent-runtime/tests/test_atomic_sidebar_refs.py
@@ -29,6 +29,7 @@ class FakeNest:
         attachments: list[dict],
         ref_order: list[str] | None,
         mode: str,
+        mentioned_keys: list[str] | None = None,
     ) -> dict[str, Any]:
         self.calls.append(
             (
@@ -38,6 +39,7 @@ class FakeNest:
                     "attachments": attachments,
                     "ref_order": ref_order,
                     "mode": mode,
+                    "mentioned_keys": mentioned_keys,
                 },
             )
         )
@@ -136,11 +138,10 @@ async def test_atomic_create_patches_mentioned_keys_after_sidebar_apply():
         }
     )
 
-    update_calls = [c for c in nest.calls if c[0] == "update_nodes_batch"]
-    assert len(update_calls) == 1
-    assert update_calls[0][1] == [
-        {"nodeId": "node-1", "patch": {"mentionedKeys": ["I1", "T1"]}}
-    ]
+    apply_calls = [c for c in nest.calls if c[0] == "apply_sidebar_attachments"]
+    assert len(apply_calls) == 1
+    assert apply_calls[0][1]["mentioned_keys"] == ["I1", "T1"]
+    assert not any(c[0] == "update_nodes_batch" for c in nest.calls)
 
 
 @pytest.mark.asyncio
@@ -159,12 +160,34 @@ async def test_atomic_create_patches_mentioned_keys_without_attachments():
         }
     )
 
-    assert not any(c[0] == "apply_sidebar_attachments" for c in nest.calls)
-    update_calls = [c for c in nest.calls if c[0] == "update_nodes_batch"]
-    assert len(update_calls) == 1
-    assert update_calls[0][1] == [
-        {"nodeId": "node-1", "patch": {"mentionedKeys": ["I1"]}}
-    ]
+    apply_calls = [c for c in nest.calls if c[0] == "apply_sidebar_attachments"]
+    assert len(apply_calls) == 1
+    assert apply_calls[0][1]["mentioned_keys"] == ["I1"]
+    assert apply_calls[0][1]["attachments"] == []
+
+
+@pytest.mark.asyncio
+async def test_atomic_create_parses_mentioned_keys_from_user_message():
+    from langchain_core.messages import HumanMessage
+
+    nest = FakeNest()
+    create = make_create_atomic_node(nest=nest)
+    attachments = [{"materialId": "mat-1"}]
+
+    await create(
+        {
+            "atomic_spec": {
+                "target_type": "image",
+                "prompt": "主图",
+                "title": "主图",
+            },
+            "sidebar_attachments": attachments,
+            "messages": [HumanMessage(content="按 @I1 风格生成主图")],
+        }
+    )
+
+    apply_calls = [c for c in nest.calls if c[0] == "apply_sidebar_attachments"]
+    assert apply_calls[0][1]["mentioned_keys"] == ["I1"]
 
 
 @pytest.mark.asyncio
@@ -183,4 +206,5 @@ async def test_atomic_create_skips_mentioned_keys_patch_when_empty():
         }
     )
 
+    assert not any(c[0] == "apply_sidebar_attachments" for c in nest.calls)
     assert not any(c[0] == "update_nodes_batch" for c in nest.calls)

--- a/services/agent-runtime/tests/test_sidebar_attachments.py
+++ b/services/agent-runtime/tests/test_sidebar_attachments.py
@@ -96,3 +96,10 @@ def test_normalize_mentioned_keys():
 
     assert normalize_mentioned_keys(["i1", "I1", "T2"]) == ["I1", "T2"]
     assert normalize_mentioned_keys(None) == []
+
+
+def test_parse_mentioned_keys_from_text():
+    from app.graph.sidebar_attachments import parse_mentioned_keys_from_text
+
+    assert parse_mentioned_keys_from_text("按 @I1 风格，@T2 文案") == ["I1", "T2"]
+    assert parse_mentioned_keys_from_text("无提及") == []


### PR DESCRIPTION
## Summary

- 将 `mentionedKeys` 与 `localRefs` 在同一 `apply_sidebar_attachments` persist 中写入（修复生产 11/12 中 node.data.mentionedKeys 为空）
- `atomic_create_node` 增加从用户消息解析 `@I1` 的 fallback（API state 缺失时仍写入）

## Test plan

- [x] pytest sidebar + atomic refs (15/15)
- [x] vitest agent-canvas-tools.sidebar (4/4)
- [ ] CI green
- [ ] 生产 `prod-sidebar-attachments-verify.py` 12/12


Made with [Cursor](https://cursor.com)