### PR TITLE
fix(agent): R0 slim intake — atomic-first, no implicit skill

### DIFF
--- a/deploy/prod-route-context-verify.py
+++ b/deploy/prod-route-context-verify.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Production smoke: platform route R0 — atomic-first, no implicit skill.
+
+Cases:
+  A) §1.1 img2img utterance without skillId → atomic_create (not 14-node campaign)
+  B) marketing utterance without skillId → clarify or chat (not campaign + implicit skill)
+  C) marketing with explicit skillId=canvas mapping → campaign allowed
+
+Usage:
+  python3 deploy/prod-route-context-verify.py
+  BASE_URL=http://119.29.173.89:8888 PHONE=... CODE=... python3 deploy/prod-route-context-verify.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import uuid
+from http.client import IncompleteRead
+from typing import Any
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+BASE = os.environ.get("BASE_URL", "http://119.29.173.89:8888").rstrip("/")
+API = f"{BASE}/api"
+PHONE = os.environ.get("PHONE", "17279698608")
+CODE = os.environ.get("CODE", "123456")
+SSE_TIMEOUT_SEC = float(os.environ.get("SSE_TIMEOUT_SEC", "120"))
+
+IMG2IMG_MSG = (
+    "@I1 这个是模特图，@I2 这个是产品图，让模特穿上这件衣服。"
+    "保持主图风格，背景，构图不变。"
+)
+
+PASS = FAIL = 0
+
+
+def record(case: str, ok: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if ok:
+        PASS += 1
+        icon = "✅"
+    else:
+        FAIL += 1
+        icon = "❌"
+    line = f"{icon} {case}"
+    if detail:
+        line += f" — {detail[:220]}"
+    print(line)
+
+
+def http(m: str, p: str, b: dict | None = None, t: str | None = None) -> Any:
+    h = {"Content-Type": "application/json", "Accept": "application/json"}
+    if t:
+        h["Authorization"] = f"Bearer {t}"
+    r = Request(f"{API}{p}", data=None if b is None else json.dumps(b).encode(), headers=h, method=m)
+    with urlopen(r, timeout=120) as resp:
+        return json.loads(resp.read())
+
+
+def sse_collect(
+    t: str,
+    sid: str,
+    msg: str,
+    tid: str,
+    *,
+    skill_id: str | None = None,
+    timeout: float = 120,
+) -> tuple[str, dict | None]:
+    body: dict[str, Any] = {"sessionId": sid, "message": msg, "threadId": tid}
+    if skill_id:
+        body["skillId"] = skill_id
+    h = {
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+        "Authorization": f"Bearer {t}",
+        "Idempotency-Key": f"ik_{uuid.uuid4().hex}",
+    }
+    r = Request(f"{API}/agent/chat/conversation", data=json.dumps(body).encode(), headers=h, method="POST")
+    parts: list[str] = []
+    thread_state_ev: dict | None = None
+    end = time.time() + timeout
+    with urlopen(r, timeout=timeout + 30) as resp:
+        buf = ""
+        while time.time() < end:
+            try:
+                chunk = resp.read(4096)
+            except IncompleteRead as exc:
+                if exc.partial:
+                    buf += exc.partial.decode(errors="replace")
+                break
+            if not chunk:
+                break
+            buf += chunk.decode(errors="replace")
+            while "\n\n" in buf:
+                block, buf = buf.split("\n\n", 1)
+                for line in block.splitlines():
+                    if not line.startswith("data:"):
+                        continue
+                    pl = line[5:].strip()
+                    if pl == "[DONE]":
+                        return "".join(parts), thread_state_ev
+                    try:
+                        ev = json.loads(pl)
+                    except json.JSONDecodeError:
+                        continue
+                    et = str(ev.get("type") or "")
+                    if et == "text_delta":
+                        parts.append(str((ev.get("data") or {}).get("text") or ""))
+                    if et == "thread_state":
+                        thread_state_ev = ev.get("data") if isinstance(ev.get("data"), dict) else None
+    return "".join(parts), thread_state_ev
+
+
+def thread_state(tok: str, tid: str) -> dict[str, Any]:
+    return http("GET", f"/agent/thread-state?threadId={quote(tid)}", t=tok).get("data") or {}
+
+
+def main() -> int:
+    print("=== prod route context verify (R0) ===")
+    tok = http("POST", "/auth/login", {"phone": PHONE, "code": CODE})["data"]["token"]
+
+    # Case A: img2img without skill
+    sid_a = http("POST", "/sessions", {"title": f"route-r0-img2img-{int(time.time())}"}, t=tok)["data"]["id"]
+    tid_a = f"rr0img_{uuid.uuid4().hex[:8]}"
+    text_a, _ = sse_collect(tok, sid_a, IMG2IMG_MSG, tid_a, timeout=SSE_TIMEOUT_SEC)
+    ts_a = thread_state(tok, tid_a)
+    flow_a = ts_a.get("flowMode") or ts_a.get("flow_mode")
+    bad_campaign = "拟定拆解约" in text_a and "14" in text_a
+    record(
+        "A img2img no skill → not 14-node campaign",
+        flow_a != "campaign" and not bad_campaign,
+        f"flow={flow_a} text={text_a[:120]}",
+    )
+    record(
+        "A img2img atomic or clarify",
+        flow_a in ("atomic_create", None) or "原子" in text_a or "单张" in text_a or ts_a.get("phase") == "clarify",
+        f"phase={ts_a.get('phase')}",
+    )
+
+    # Case B: marketing without skill
+    sid_b = http("POST", "/sessions", {"title": f"route-r0-mkt-{int(time.time())}"}, t=tok)["data"]["id"]
+    tid_b = f"rr0mkt_{uuid.uuid4().hex[:8]}"
+    text_b, _ = sse_collect(
+        tok,
+        sid_b,
+        "天猫蓝牙耳机详情页营销方案，主图白底",
+        tid_b,
+        timeout=SSE_TIMEOUT_SEC,
+    )
+    ts_b = thread_state(tok, tid_b)
+    flow_b = ts_b.get("flowMode") or ts_b.get("flow_mode")
+    record(
+        "B marketing no skill → not silent campaign",
+        flow_b != "campaign" or "Skill" in text_b or "编排" in text_b,
+        f"flow={flow_b} text={text_b[:120]}",
+    )
+
+    # Case C: explicit skill (canvas → enterprise-marketing-campaign)
+    sid_c = http("POST", "/sessions", {"title": f"route-r0-skill-{int(time.time())}"}, t=tok)["data"]["id"]
+    tid_c = f"rr0sk_{uuid.uuid4().hex[:8]}"
+    text_c, _ = sse_collect(
+        tok,
+        sid_c,
+        "天猫蓝牙耳机详情页营销方案",
+        tid_c,
+        skill_id="canvas",
+        timeout=SSE_TIMEOUT_SEC,
+    )
+    ts_c = thread_state(tok, tid_c)
+    flow_c = ts_c.get("flowMode") or ts_c.get("flow_mode")
+    record(
+        "C explicit skill → campaign path ok",
+        flow_c == "campaign" or "确认方案" in text_c or "采纳推荐" in text_c,
+        f"flow={flow_c} text={text_c[:120]}",
+    )
+
+    print(f"\n=== {PASS}/{PASS + FAIL} passed ===")
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/superpowers/plans/2026-08-07-platform-route-skill-boundary.md
+++ b/docs/superpowers/plans/2026-08-07-platform-route-skill-boundary.md
@@ -1,0 +1,627 @@
+# 平台路由减肥 + 原子化优先 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 对 Agent 平台做「减肥 + 结构重组」——废止隐式 Skill 绑定与 campaign 默认 fallback，抽出 `route_decide`，**优先把 atomic（含侧栏 img2img）路由建稳**；编排链路仅在用户**显式选 Skill** 时进入。
+
+**Architecture:** R0 在现有 `intake` 内止血（删隐式 skill、preserve 豁免、禁止 atomic 被 planning  silent 覆盖）；R1 新增 `route_context.py` + `route_decide.py`，`intake` 瘦身为 dispatcher；无 `requested_skill_id` 的营销/编排 utterance → `clarify_route`，不进 14 节点。R2+（orchestration 泛化、Skill 市场）**不在本计划**。
+
+**Tech Stack:** LangGraph (Python 3.11+), pytest, YAML eval sets, Nest `RunRequest.sidebar_attachments` / `sidebar_mentioned_keys`（已贯通）。
+
+**Spec:** [2026-08-07-platform-route-skill-boundary-design.md](../specs/2026-08-07-platform-route-skill-boundary-design.md)
+
+---
+
+## Global Constraints
+
+- Branch: `feat/platform-route-atomic-first` from `main` — **never push to main directly**.
+- Pre-PR: `cd services/agent-runtime && python -m pytest tests/test_route_decide.py tests/test_intake_gate.py tests/test_planning_guard_eval.py tests/test_atomic_orchestration.py tests/test_atomic_sidebar_refs.py -v` 全绿。
+- **本计划非目标：** Skill 市场 UI、`flow_mode=orchestration` 重命名、platform generic manifest、route_decide LLM shadow（属 R2 spec §11）。
+- eval gold **只增不删**；改 gold 须同步 spec §13 验收说明。
+- `flow_mode=campaign` **读路径保留**至 R2；新代码写 `campaign` 仅当 `requested_skill_id` 有效且 route_decide 判 orchestration。
+- Commit per task；R0、R1 可分两个 PR（R0 可先合并止血）。
+
+---
+
+## 实施策略（原子优先）
+
+```text
+优先级（高 → 低）
+  P1  atomic_create + sidebar img2img + preserve 短语
+  P2  atomic_regenerate / single_node（现有逻辑迁入 route_decide，行为不变）
+  P3  chat / clarify_route（替代 silent campaign）
+  P4  campaign（= 显式 skill + 编排 utterance，无 skill 则 clarify）
+```
+
+**减肥清单（intake 删除/禁止）：**
+
+| 删除项 | 原因 |
+|--------|------|
+| `marketing_intent → skill_id` | Skill 仅显式调用 |
+| `flow_mode = "campaign"` 默认值 | 原子平台不应默认最重链路 |
+| `single_node` 分支自动绑 `enterprise-marketing-campaign` | 与 atomic 正交 |
+| `orchestration_complexity_intent == campaign` silent 覆盖 `atomic_create` | 侧栏 P1 / preserve P5 优先 |
+| 无 skill 时 `resolved_flow else "campaign"` | 改为 chat 或 clarify |
+
+---
+
+## File Map
+
+| File | Action | Role |
+| --- | --- | --- |
+| `app/graph/l0_action.py` | **Create** | `detect_l0_action`, `has_preserve_intent` |
+| `app/graph/route_context.py` | **Create** | `RouteContext` TypedDict, `assemble_route_context(state)` |
+| `app/graph/route_decide.py` | **Create** | `decide_route(ctx) -> RouteDecision` |
+| `app/graph/planning_guard.py` | Modify | preserve 豁免 `has_planning_image_conflict` |
+| `app/graph/atomic_intent.py` | Modify | `resolve_intake_route` /consult route_decide；弱化 campaign override |
+| `app/graph/nodes/intake.py` | Modify | thin dispatcher：读 `route_decision` + 显式 skill |
+| `app/graph/nodes/clarify_route.py` | **Create** | 路由层 clarify（SSE 文案 + END） |
+| `app/graph/state.py` | Modify | `route_context`, `route_decision` 可选字段 |
+| `app/graph/builder.py` | Modify | `route_after_intake` 识别 `clarify_route` |
+| `skills/atomic-create/eval-route-set.yaml` | **Create** | atomic-first gold（≥20 cases MVP） |
+| `skills/atomic-create/eval-planning-guard-set.yaml` | Modify | + `pg-sidebar-01` |
+| `skills/atomic-create/eval-intent-regression.yaml` | Modify | + 生产 §1.1 case |
+| `tests/test_l0_action.py` | **Create** | preserve / plan 单测 |
+| `tests/test_route_decide.py` | **Create** | P1 sidebar img2img + 显式 skill 边界 |
+| `tests/test_eval_route_set.py` | **Create** | YAML gold runner |
+| `tests/test_intake_gate.py` | Modify | marketing 不再隐式绑 skill |
+| `tests/test_atomic_orchestration.py` | Modify | 无 skill → clarify；有 skill → campaign |
+| `deploy/prod-route-context-verify.py` | **Create** | 生产 §1.1 + sidebar fixture |
+| `docs/adr/p5-atomic-orchestration-boundary-adr.md` | Modify | 注记 R0/R1 override 修订（可选 R1 末 task） |
+
+**不修改（本计划）：** `apps/web` Dock UI（已传 `skillId`）；`enterprise-marketing-campaign` 包内容；`parse_atomic_intent` LLM 路径。
+
+---
+
+# Phase R0 — 止血 + 评测（1 PR）
+
+**PR 标题建议:** `fix(agent): slim intake — no implicit skill, preserve guard, atomic-first`
+
+---
+
+### Task 1: L0 preserve 检测
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/l0_action.py`
+- Create: `services/agent-runtime/tests/test_l0_action.py`
+
+**Interfaces:**
+- Produces: `has_preserve_intent(text: str) -> bool`, `detect_l0_action(text: str) -> ActionKind`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# tests/test_l0_action.py
+from app.graph.l0_action import detect_l0_action, has_preserve_intent
+
+PROD_CASE = (
+    "@I1 这个是模特图，@I2 这个是产品图，让模特穿上这件衣服。"
+    "保持主图风格，背景，构图不变。"
+)
+
+def test_preserve_prod_case():
+    assert has_preserve_intent(PROD_CASE)
+
+def test_preserve_blocks_planning_read():
+    assert detect_l0_action(PROD_CASE) in ("generate", "preserve")
+
+def test_plan_without_preserve():
+    u = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    assert detect_l0_action(u) == "plan"
+    assert not has_preserve_intent(u)
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+Run: `cd services/agent-runtime && python -m pytest tests/test_l0_action.py -v`
+
+- [ ] **Step 3: Implement**
+
+```python
+# app/graph/l0_action.py
+PRESERVE_MARKERS = ("不变", "保持", "维持", "沿用")
+TRANSFORM_VERBS = ("穿上", "换装", "替换", "融合", "上身")
+
+def has_preserve_intent(text: str) -> bool:
+    t = (text or "").strip()
+    return any(m in t for m in PRESERVE_MARKERS)
+
+def detect_l0_action(text: str) -> ActionKind:
+    from app.graph.planning_guard import detect_action, is_planning_intent
+    t = (text or "").strip()
+    if has_preserve_intent(t):
+        return "preserve"
+    return detect_action(t)  # plan | write | generate | ...
+```
+
+- [ ] **Step 4: Run test — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/agent-runtime/app/graph/l0_action.py services/agent-runtime/tests/test_l0_action.py
+git commit -m "feat(agent): L0 preserve intent detection"
+```
+
+---
+
+### Task 2: planning_guard preserve 豁免
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/planning_guard.py`
+- Modify: `services/agent-runtime/skills/atomic-create/eval-planning-guard-set.yaml`
+- Modify: `services/agent-runtime/tests/test_planning_guard_eval.py`（若需新 gold 字段）
+
+**Interfaces:**
+- Consumes: `has_preserve_intent` from `l0_action`
+- Produces: `has_planning_image_conflict` returns `False` when preserve + generate 语境
+
+- [ ] **Step 1: Add gold case `pg-sidebar-01`**
+
+```yaml
+  - id: pg-sidebar-01
+    utterance: "@I1 这个是模特图，@I2 这个是产品图，让模特穿上这件衣服。保持主图风格，背景，构图不变。"
+    gold: { route: atomic_create, complexity: atomic, planning_conflict: false }
+```
+
+- [ ] **Step 2: Extend eval runner for `planning_conflict: false`**
+
+在 `test_planning_guard_eval.py` 增加：
+
+```python
+from app.graph.planning_guard import has_planning_image_conflict
+
+if gold.get("planning_conflict") is False:
+    if has_planning_image_conflict(utterance):
+        mismatches.append(f"{case_id}: unexpected planning conflict")
+```
+
+- [ ] **Step 3: Patch `has_planning_image_conflict`**
+
+```python
+def has_planning_image_conflict(text: str) -> bool:
+    from app.graph.l0_action import has_preserve_intent
+    t = (text or "").strip()
+    if has_preserve_intent(t):
+        return False
+    # ... existing logic unchanged ...
+```
+
+- [ ] **Step 4: Run eval**
+
+Run: `cd services/agent-runtime && python -m pytest tests/test_planning_guard_eval.py tests/test_l0_action.py -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "fix(agent): planning guard skips preserve phrases"
+```
+
+---
+
+### Task 3: 废止 intake 隐式 Skill 绑定
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/nodes/intake.py`
+- Modify: `services/agent-runtime/tests/test_intake_gate.py`
+- Modify: `services/agent-runtime/tests/test_atomic_orchestration.py`
+
+**Interfaces:**
+- Produces: `skill_id` 仅当 `requested_skill_id in discover_skills()`
+
+- [ ] **Step 1: Update failing tests**
+
+```python
+# test_intake_gate.py — replace test_intake_marketing_sets_enterprise_skill
+@pytest.mark.asyncio
+async def test_intake_marketing_without_explicit_skill_sets_no_skill():
+    node = make_intake_node(SKILLS_DIR)
+    out = await node({
+        "messages": [HumanMessage(content="帮我设计一套卫生洁具的电商详情页营销方案")]
+    })
+    assert out.get("skill_id") is None
+
+@pytest.mark.asyncio
+async def test_intake_marketing_with_explicit_skill():
+    node = make_intake_node(SKILLS_DIR)
+    out = await node({
+        "messages": [HumanMessage(content="帮我设计一套卫生洁具的电商详情页营销方案")],
+        "requested_skill_id": "enterprise-marketing-campaign",
+    })
+    assert out.get("skill_id") == "enterprise-marketing-campaign"
+```
+
+```python
+# test_atomic_orchestration.py — revise campaign redirect tests
+@pytest.mark.asyncio
+async def test_intake_planning_without_skill_clarifies_or_chat():
+    intake = make_intake_node(skills)
+    u = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    out = await intake({"messages": [HumanMessage(content=u)]})
+    assert out.get("skill_id") is None
+    assert out["flow_mode"] in ("atomic_create", "chat") or out.get("phase") == "clarify"
+    assert out["flow_mode"] != "campaign" or out.get("skill_id")
+
+@pytest.mark.asyncio
+async def test_intake_planning_with_explicit_skill_enters_campaign():
+    intake = make_intake_node(skills)
+    u = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    out = await intake({
+        "messages": [HumanMessage(content=u)],
+        "requested_skill_id": "enterprise-marketing-campaign",
+    })
+    assert out["flow_mode"] == "campaign"
+    assert out.get("skill_id") == "enterprise-marketing-campaign"
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+Run: `python -m pytest tests/test_intake_gate.py tests/test_atomic_orchestration.py -v`
+
+- [ ] **Step 3: Slim `intake.py` skill block**
+
+删除 lines 43–48（`elif marketing_intent` 绑 skill）、lines 75–76（single_node 自动 skill）、lines 97–98（marketing 分支补 skill）。
+
+保留：
+
+```python
+skill_id: str | None = None
+if requested and requested in by_id:
+    skill_id = requested
+```
+
+- [ ] **Step 4: 禁止无 skill 时 resolved_flow 默认 campaign（临时，R1 由 route_decide 接管）**
+
+将 `flow_mode = "campaign"` 初值改为 `None`；`resolved_flow` 末尾：
+
+```python
+else:
+    resolved_flow = flow_mode or "chat"  # 非 atomic/single/regen 且无 skill → chat
+```
+
+营销分支 `elif marketing_intent(text) or ...` 改为 **仅当 `skill_id` 已设** 才写 `user_brief` 并 `flow_mode=campaign`；否则 `phase=clarify` + `ROUTE_CLARIFY_ORCHESTRATION` 文案（见 Task 4 常量）。
+
+- [ ] **Step 5: Run tests — expect PASS**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "fix(agent): remove implicit marketing skill binding"
+```
+
+---
+
+### Task 4: 禁止 orchestration silent 覆盖 atomic（临时规则）
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/nodes/intake.py`
+- Modify: `services/agent-runtime/app/graph/atomic_intent.py`（可选：文档注释）
+
+**Interfaces:**
+- Consumes: `has_preserve_intent`, sidebar keys（R0 仅 utterance 内 `@I` 计数）
+
+- [ ] **Step 1: Add helper in intake or l0_action**
+
+```python
+def _utterance_has_multi_image_refs(text: str) -> bool:
+    import re
+    keys = set(re.findall(r"@([ITVA]\d+)", text, flags=re.I))
+    image_keys = {k.upper() for k in keys if k.upper().startswith("I")}
+    return len(image_keys) >= 2
+```
+
+- [ ] **Step 2: Patch intake override block**
+
+```python
+from app.graph.l0_action import TRANSFORM_VERBS, has_preserve_intent
+
+# before: if orch == "campaign" and (is_atomic or is_variant_create):
+if orch == "campaign" and (is_atomic or is_variant_create):
+    t = text
+    img2img = _utterance_has_multi_image_refs(t) and any(v in t for v in TRANSFORM_VERBS)
+    if not (has_preserve_intent(t) or img2img):
+        is_atomic = False
+        ...
+```
+
+- [ ] **Step 3: Regression test for prod case**
+
+```python
+# tests/test_intake_gate.py
+@pytest.mark.asyncio
+async def test_intake_prod_img2img_case_atomic():
+    node = make_intake_node(SKILLS_DIR)
+    u = "@I1 这个是模特图，@I2 这个是产品图，让模特穿上这件衣服。保持主图风格，背景，构图不变。"
+    out = await node({"messages": [HumanMessage(content=u)]})
+    assert out["flow_mode"] == "atomic_create"
+    assert out.get("skill_id") is None
+```
+
+- [ ] **Step 4: Run full R0 pytest slice**
+
+Run: `python -m pytest tests/test_intake_gate.py tests/test_l0_action.py tests/test_planning_guard_eval.py -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "fix(agent): do not override atomic for img2img preserve utterances"
+```
+
+---
+
+### Task 5: eval-intent-regression + prod smoke stub
+
+**Files:**
+- Modify: `services/agent-runtime/skills/atomic-create/eval-intent-regression.yaml`
+- Create: `deploy/prod-route-context-verify.py`
+
+- [ ] **Step 1: Add regression entry**
+
+```yaml
+  - id: reg-2026-08-07-img2img-sidebar
+    utterance: "@I1 这个是模特图，@I2 这个是产品图，让模特穿上这件衣服。保持主图风格，背景，构图不变。"
+    gold: { flow_mode: atomic_create, skill_id: null }
+```
+
+- [ ] **Step 2: Create prod smoke（最小）**
+
+脚本断言：登录 → POST conversation（无 skillId）→ `thread-state.flowMode != campaign` 或 assistant 不含「拟定拆解约 14 个」。
+
+- [ ] **Step 3: Run locally against staging/prod if available**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add deploy/prod-route-context-verify.py services/agent-runtime/skills/atomic-create/eval-intent-regression.yaml
+git commit -m "test(agent): regression gold + prod route smoke for img2img case"
+```
+
+**R0 验收：** §1.1 生产 utterance 无 skill → `atomic_create`；隐式 `enterprise-marketing-campaign` 不再出现。
+
+---
+
+# Phase R1 — route_decide 结构 + 侧栏 Context（1 PR）
+
+**PR 标题建议:** `feat(agent): route_decide atomic-first with sidebar RouteContext`
+
+---
+
+### Task 6: RouteContext 组装
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/route_context.py`
+- Modify: `services/agent-runtime/app/graph/state.py`
+
+**Interfaces:**
+- Produces: `assemble_route_context(state: dict) -> RouteContext`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# tests/test_route_decide.py (start file)
+from app.graph.route_context import assemble_route_context
+
+def test_assemble_includes_sidebar_fields():
+    ctx = assemble_route_context({
+        "messages": [{"role": "user", "content": "@I1 @I2 穿上"}],
+        "sidebar_attachments": [{"kind": "image", "url": "https://x/a.jpg", "key": "I1"}],
+        "sidebar_mentioned_keys": ["I1", "I2"],
+        "requested_skill_id": "",
+    })
+    assert ctx["mentioned_keys"] == ["I1", "I2"]
+    assert len(ctx["sidebar_attachments"]) == 1
+```
+
+- [ ] **Step 2: Implement `route_context.py`**
+
+字段：`utterance`, `mentioned_keys`, `sidebar_attachments`, `focus_node_id`, `requested_skill_id`, `checkpoint`（atomic_node_id, user_brief, plan_draft）。
+
+- [ ] **Step 3: Add optional fields to `AgentRuntimeState` TypedDict**
+
+- [ ] **Step 4: Commit**
+
+---
+
+### Task 7: route_decide 核心（atomic-first 信号表）
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/route_decide.py`
+- Modify: `services/agent-runtime/tests/test_route_decide.py`
+
+**Interfaces:**
+- Produces: `decide_route(ctx: RouteContext) -> RouteDecision`
+
+- [ ] **Step 1: Write failing tests（P1–P6 MVP）**
+
+```python
+from app.graph.route_decide import decide_route
+from app.graph.route_context import assemble_route_context
+
+PROD = "@I1 这个是模特图，@I2 这个是产品图，让模特穿上这件衣服。保持主图风格，背景，构图不变。"
+
+def test_p1_sidebar_img2img_atomic():
+    ctx = assemble_route_context({
+        "messages": [{"role": "user", "content": PROD}],
+        "sidebar_mentioned_keys": ["I1", "I2"],
+        "sidebar_attachments": [
+            {"kind": "image", "url": "https://a/1.jpg"},
+            {"kind": "image", "url": "https://a/2.jpg"},
+        ],
+    })
+    d = decide_route(ctx)
+    assert d["flow_mode"] == "atomic_create"
+    assert d["reason"] == "sidebar_img2img_p1"
+    assert d["confidence"] >= 0.9
+
+def test_no_skill_marketing_clarify():
+    ctx = assemble_route_context({
+        "messages": [{"role": "user", "content": "天猫蓝牙耳机详情页营销方案"}],
+    })
+    d = decide_route(ctx)
+    assert d["flow_mode"] == "clarify_route"
+    assert "skill" in (d.get("clarify_question") or "").lower() or "出图" in d["clarify_question"]
+
+def test_explicit_skill_orchestration():
+    ctx = assemble_route_context({
+        "messages": [{"role": "user", "content": "详情页构图方案"}],
+        "requested_skill_id": "enterprise-marketing-campaign",
+    })
+    d = decide_route(ctx)
+    assert d["flow_mode"] == "campaign"
+```
+
+- [ ] **Step 2: Implement `decide_route` 优先级链**
+
+顺序：checkpoint regenerate → P1 sidebar img2img → P2 single_node → P4 atomic_create_intent → P5 preserve+generate → P3 plan（**仅 skill_id** → campaign，否则 clarify_route）→ P6 chat/clarify。
+
+- [ ] **Step 3: Run tests — PASS**
+
+- [ ] **Step 4: Commit**
+
+---
+
+### Task 8: intake 瘦身为 dispatcher
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/nodes/intake.py`
+- Modify: `services/agent-runtime/tests/test_intake_gate.py`
+
+**Interfaces:**
+- Consumes: `assemble_route_context`, `decide_route`
+- Produces: intake 输出 `route_decision`, `flow_mode`, `skill_id`, `phase`, `clarify_question`
+
+- [ ] **Step 1: Refactor intake body**
+
+```python
+ctx = assemble_route_context(state)
+decision = decide_route(ctx)
+flow_mode = decision["flow_mode"]
+# skill_id: only explicit requested
+skill_id = ctx["requested_skill_id"] if ctx["requested_skill_id"] in by_id else None
+if flow_mode == "clarify_route":
+    return {"phase": "clarify", "clarify_question": decision["clarify_question"], "flow_mode": "chat", ...}
+if flow_mode == "campaign":
+    assert skill_id  # invariant
+...
+```
+
+- [ ] **Step 2: Delete duplicated route logic**（`resolve_intake_route` 调用、`orch` override 块移入 `route_decide`）
+
+- [ ] **Step 3: Run full intake + route tests**
+
+- [ ] **Step 4: Commit**
+
+---
+
+### Task 9: clarify_route 节点 + builder 接线
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/nodes/clarify_route.py`
+- Modify: `services/agent-runtime/app/graph/builder.py`
+- Modify: `services/agent-runtime/tests/test_graph_routes.py`
+
+**Interfaces:**
+- Produces: `make_clarify_route_node()` → AIMessage + `phase=clarify` + END
+
+- [ ] **Step 1: Implement clarify_route node**（参考 `clarify_atomic_intent.py`，仅 SSE 文案，不写 brief）
+
+- [ ] **Step 2: Update `route_after_intake`**
+
+```python
+if state.get("phase") == "clarify" and state.get("route_clarify"):
+    return "clarify_route"
+```
+
+- [ ] **Step 3: Register node + edge to END**
+
+- [ ] **Step 4: Graph route unit test**
+
+- [ ] **Step 5: Commit**
+
+---
+
+### Task 10: eval-route-set.yaml + CI runner
+
+**Files:**
+- Create: `services/agent-runtime/skills/atomic-create/eval-route-set.yaml`
+- Create: `services/agent-runtime/tests/test_eval_route_set.py`
+
+- [ ] **Step 1: Author ≥20 gold cases**（类别：sidebar-img2img×5, preserve×3, atomic-generate×5, no-skill-marketing→clarify×3, explicit-skill-campaign×2, hello→chat×2）
+
+- [ ] **Step 2: Runner 调用 `decide_route(assemble_route_context(fixture))`**
+
+- [ ] **Step 3: CI green**
+
+Run: `python -m pytest tests/test_eval_route_set.py tests/test_route_decide.py -v`
+
+- [ ] **Step 4: Commit**
+
+---
+
+### Task 11: prod-route-context-verify 完整版
+
+**Files:**
+- Modify: `deploy/prod-route-context-verify.py`
+
+- [ ] **Step 1: Case A** — §1.1 utterance，无 skillId → `flowMode=atomic_create` 或 assistant 含「原子创作」
+
+- [ ] **Step 2: Case B** — 同 utterance + mock attachments（若 API 支持）→ atomic 节点创建
+
+- [ ] **Step 3: Case C** — 「详情页营销方案」无 skill → 不含 14 节点；含 clarify 或 chat
+
+- [ ] **Step 4: Case D** — 显式 skillId=canvas → campaign 可接受
+
+- [ ] **Step 5: Commit + 生产跑一遍记录 PASS**
+
+---
+
+### Task 12: ADR 注记 + spec 状态
+
+**Files:**
+- Modify: `docs/adr/p5-atomic-orchestration-boundary-adr.md`
+- Modify: `docs/superpowers/specs/2026-08-07-platform-route-skill-boundary-design.md`（状态 → Implemented R0/R1）
+
+- [ ] **Step 1: ADR 增加 Superseded部分**：规则 1 需 skill + 高置信 plan；无 skill 禁止 silent campaign
+
+- [ ] **Step 2: Spec §11 勾选 R0/R1 完成项**
+
+- [ ] **Step 3: Commit**
+
+---
+
+## Deferred（显式不在本计划）
+
+| 项 | Spec 阶段 | 原因 |
+|----|-----------|------|
+| `orchestration_gate` + generic manifest | R2 | 先 atomic 平台化 |
+| `campaign` → `orchestration` rename | R2 | 避免 checkpoint 震荡 |
+| route_decide LLM shadow | R2–R3 | 规则 + eval 先达标 |
+| Skill 市场 / 安装器 | R3 | 独立 spec |
+| 电商 Skill 产品包 | R4 | 样例 skill 仅显式调用 |
+
+---
+
+## Self-Review（plan ↔ spec）
+
+| Spec § | Task |
+|--------|------|
+| R-S1 路由与 Skill 正交 | Task 3, 7, 8 |
+| R-S2 废止隐式 skill | Task 3 |
+| R-S4 route_decide | Task 6–8 |
+| R-S5 clarify 非 campaign | Task 3, 7, 9 |
+| R-S6 侧栏 P1 | Task 7, 10, 11 |
+| R-S7 preserve | Task 1–2, 4, 7 |
+| §13 验收 1–5 | Task 4–5, 10–11 |
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-08-07-platform-route-skill-boundary.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven（推荐）** — 按 Task 1→12 分派 subagent，R0 PR 可先合并
+2. **Inline Execution** — 本会话用 executing-plans 连续执行 R0
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-08-07-platform-route-skill-boundary-design.md
+++ b/docs/superpowers/specs/2026-08-07-platform-route-skill-boundary-design.md
@@ -1,0 +1,474 @@
+# 平台路由与 Skill 边界 — 设计规格
+
+> 状态：**Draft**（2026-08-07）  
+> 动机：生产复测暴露 img2img 原子请求被误判为 Campaign 营销方案流；根因是 **平台 L1 路由** 与 **Skill 隐式绑定** 耦合，且样例 skill 被当作电商默认路径  
+> 前置：[2026-08-04-atomic-intent-hybrid-design.md](./2026-08-04-atomic-intent-hybrid-design.md)、[2026-08-05-intent-llm-structured-parse-design.md](./2026-08-05-intent-llm-structured-parse-design.md)、[2026-08-07-agent-sidebar-material-entry-design.md](./2026-08-07-agent-sidebar-material-entry-design.md)、[2026-08-03-agent-phase-c2-dock-model-skillid-design.md](./2026-08-03-agent-phase-c2-dock-model-skillid-design.md)  
+> 将 supersede：`docs/adr/p5-atomic-orchestration-boundary-adr.md` 规则 3（LLM 不改 L1）；Phase C2 §4.1 关键词启发式绑 skill  
+> 非范围：Skill 市场 UI、用户安装/卸载 API、斜杠唤起（R3+）；电商领域 skill 产品化内容（R4）
+
+| 字段 | 值 |
+|------|-----|
+| 文档版本 | v1.0 |
+| 创建日期 | 2026-08-07 |
+| 文档定位 | 将 **平台 Graph 路由** 与 **agentskills.io Skill 生态** 解耦；定义 `route_decide`、RouteContext、显式 Skill 调用契约 |
+
+---
+
+## 0. 决策摘要
+
+| # | 决策 | 说明 |
+|---|------|------|
+| **R-S1** | **平台路由与 Skill 选择正交** | `flow_mode` 由平台 `route_decide` 决定；`skill_id` **仅**在用户显式传入 `requested_skill_id` 时绑定 |
+| **R-S2** | **废止 intake 关键词隐式绑 skill** | 删除 `marketing_intent(text) → enterprise-marketing-campaign`；`MARKETING_HINTS` 不再驱动 skill 加载 |
+| **R-S3** | **`enterprise-marketing-campaign` 定位为验收样例** | 仅用于 LangGraph/manifest 格式参考；**不得**作为 production 默认 orchestration；电商最佳实践以可安装 Skill 交付 |
+| **R-S4** | **新增 `route_decide` 节点** | L0 Action + L1 `flow_mode` 在 **全量 RouteContext** 上决策；位于 Graph 分叉点之前 |
+| **R-S5** | **歧义默认 `clarify_route`，非 Campaign** | 低置信路由 → 侧栏追问；禁止 silent 进 14 节点 `await_confirm` |
+| **R-S6** | **侧栏 ref 参与 L1** | `mentionedKeys` + `sidebarAttachments` 为 P1 信号；双图 ref + 变换动词 → 优先 `atomic_create`（img2img） |
+| **R-S7** | **L0 `preserve` 修饰 `generate`** | 「保持构图/主图风格/背景不变」→ 禁止 `planning_guard` 触发 campaign override |
+| **R-S8** | **`flow_mode=campaign` 更名为 `orchestration`**（可选 R2） | 语义为平台多节点编排能力，不隐含任何 skill；过渡期允许 alias |
+
+---
+
+## 1. 背景与生产事件
+
+### 1.1 触发 case（2026-08-07 生产）
+
+用户输入：
+
+```text
+@I1 这个是模特图，@I2 这个是产品图，让模特穿上这件衣服。保持主图风格，背景，构图不变。
+```
+
+**期望：** `atomic_create` → img2img（@I1 + @I2）  
+**实际：** `flowMode=campaign` → `await_confirm` → 「拟定拆解约 14 个画布节点」
+
+### 1.2 双重误路由
+
+| 层 | 误判机制 | 性质 |
+|----|----------|------|
+| **平台 L1** | `has_planning_image_conflict`：`主图` + `构图` → planning；`resolve_intake_route` → campaign | **规则误判**（非 LLM） |
+| **Skill 绑定** | `marketing_intent("主图")` → 自动 `skill_id=enterprise-marketing-campaign` | **架构耦合**（用户未显式选 skill） |
+
+补充：`atomic_create_intent` 对该句为 **True**（含模特图/产品图），但被 L1 campaign override 覆盖；LLM structured parse **未参与**（仅在 `flow_mode=atomic_create` 后才进入 `parse_atomic_intent`）。
+
+### 1.3 设计债归纳
+
+当前 `intake.py` 将三件正交职责耦在一起：
+
+1. **L1 平台路由**（atomic / orchestration / single_node / chat）
+2. **Skill 选择**（应为用户显式安装/调用）
+3. **样例电商编排**（`enterprise-marketing-campaign` 14 节点 manifest）
+
+这与产品方向冲突：**Skill 是 agentskills.io 生态下用户可安装、显式调用的扩展**；平台 Graph 应提供与 Skill 无关的基础能力。
+
+---
+
+## 2. 目标与非目标
+
+### 2.1 目标
+
+1. **解耦**：平台 `flow_mode` 决策与 `skill_id` 绑定分离；唯一显式接口为 `requested_skill_id`。
+2. **Context-aware 路由**：`route_decide` 消费 utterance + 侧栏 ref + focus + canvas + checkpoint。
+3. **L0 Action 层**：区分 `plan` / `generate` / `preserve` / `regenerate` 等，消除 preservation 短语误触 planning guard。
+4. **Clarify 优先**：歧义 → `clarify_route`，不默认最重链路。
+5. **评测闭环**：新增 `eval-route-set.yaml` + skill 边界 case；CI 阻断回归。
+6. **渐进迁移**：R0 止血 → R1 平台路由 → R2 orchestration 泛化 → R3 Skill 生态 → R4 电商 Skill 产品化。
+
+### 2.2 非目标
+
+| 能力 | 说明 |
+|------|------|
+| Skill 市场 / 安装器 | R3+ 独立 spec |
+| 斜杠 `/skill-name` 唤起 | R3+ |
+| ReAct 无界 tool loop | 与 Loop Engineering L-P7 一致 |
+| 一次性修完所有 planning_guard 词表 | 系统性靠 L0 + RouteContext，非词表战争 |
+| 在本 spec 内重写 Campaign 14 节点产品 | 属 Skill 包内容 |
+
+---
+
+## 3. 目标架构
+
+### 3.1 两层模型
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│ 平台 Graph（内置，与 Skill 无关）                              │
+│  route_decide → flow_mode ∈ { atomic_create, atomic_regen,   │
+│    single_node, orchestration, chat, clarify_route }         │
+└─────────────────────────────────────────────────────────────┘
+                              │
+          requested_skill_id  │（显式，可选）
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Skill 生态（agentskills.io，用户安装 + 显式调用）               │
+│  SKILL.md + manifest + references + allowed-tools           │
+│  仅影响：manifest 模板 / few-shots / 领域 clarify 文案          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 3.2 Graph 拓扑（目标态）
+
+```mermaid
+flowchart TD
+    START --> CTX["assemble_route_context"]
+    CTX --> RD["route_decide\n(L0 + L1)"]
+    RD -->|confidence ≥ τ| FORK{flow_mode}
+    RD -->|confidence < τ| CL["clarify_route"]
+    CL --> RD
+    FORK -->|atomic_create| AG["atomic_create_gate"]
+    FORK -->|atomic_regenerate| RG["prepare_atomic_regenerate"]
+    FORK -->|single_node| SG["single_node_gate"]
+    FORK -->|orchestration| OG["orchestration_gate"]
+    FORK -->|chat| CH["chat"]
+    OG -->|requested_skill_id| LOAD["load_skill overlay"]
+    OG -->|no skill| GEN["platform generic manifest"]
+```
+
+**变更要点：**
+
+- `intake` 瘦身为 dispatcher：读 `route_decision`，不再内嵌 200 行规则 + 默认 campaign。
+- `orchestration_gate` 替代「Campaign = enterprise-marketing-campaign」硬编码。
+- `skill_id` 只在 `requested_skill_id` 校验通过时写入 state。
+
+### 3.3 四层意图模型（修订）
+
+在 [Hybrid Spec §2](./2026-08-04-atomic-intent-hybrid-design.md) 基础上增加 **L0**，并将 L1 决策点前移：
+
+| 层 | 职责 | 决策点 |
+|----|------|--------|
+| **L0 Action** | plan \| write \| generate \| preserve \| regenerate \| confirm \| cancel | `route_decide` |
+| **L1 Route** | flow_mode（平台） | `route_decide` |
+| **L2 Structure** | single \| multi | `parse_atomic_intent` / orchestration plan |
+| **L3 Modality** | image \| text \| video \| audio \| prompt | parse |
+| **L4 Extract** | title, prompt per item | parse |
+
+**修订 I-1（supersede Hybrid §2.1）：**
+
+- L1 **可以**在 `route_decide` 使用 LLM（shadow → prod），但 **仅允许降 complexity**（orchestration → atomic）或 **clarify**；**禁止** silent 升档至 orchestration。
+- L2–L4 仍在 subgraph 内；与现 `atomic_parse` 对齐。
+- `planning_guard` 角色：**veto / clarify**，不再是 silent campaign override。
+
+---
+
+## 4. RouteContext 契约
+
+### 4.1 数据结构
+
+```typescript
+/** 平台路由唯一输入；与 atomic_parse context packet 字段对齐，避免双栈 */
+interface RouteContext {
+  utterance: string
+  mentionedKeys?: string[]           // @I1 @I2，来自侧栏 M3
+  sidebarAttachments?: SidebarAttachment[]
+  focusNodeId?: string
+  canvasSummary?: string
+  checkpoint?: {
+    atomicNodeId?: string
+    atomicSpec?: Record<string, unknown>
+    flowModePrev?: string
+    userBrief?: string
+    planDraft?: string
+  }
+  requestedSkillId?: string          // UI Dock / API 显式传入；P0 最高优先级
+  requestedFlowMode?: never          // 预留：不在 MVP 开放
+}
+```
+
+Runtime state 注入：`assemble_route_context` 在 `intake` 之前或作为 `intake` 第一步，从 `RunRequest` + checkpoint 组装。
+
+### 4.2 信号优先级表
+
+| 优先级 | 信号 | L1 倾向 | 备注 |
+|--------|------|---------|------|
+| **P0** | `requestedSkillId` 有效 | 不单独决定 flow_mode；与 utterance 联合 | Skill **不**强制 orchestration；见 §4.3 |
+| **P1** | `mentionedKeys.length ≥ 2` + image refs + 变换动词（穿上/替换/融合/换装） | `atomic_create` | img2img 强信号 |
+| **P2** | `focusNodeId` + `single_node_gen_intent` | `single_node` | 现有逻辑保留 |
+| **P3** | L0=`plan` + 详情页/多模块/分镜≥4 | `orchestration` 或 `clarify_route` | 无 skill 时 clarify 优先 |
+| **P4** | L0=`generate` + 单资产 | `atomic_create` | |
+| **P5** | L0=`preserve` + L0=`generate` | `atomic_create`；**禁止** planning_guard campaign | |
+| **P6** | 其余 / 低置信 | `clarify_route` | **禁止** 默认 orchestration |
+
+变换动词词表（MVP，可扩展）：`穿上`、`换装`、`替换`、`融合`、`上身`、`try-on`、`virtual try-on`（英文可选）。
+
+### 4.3 Skill 与 flow_mode 关系
+
+| 场景 | flow_mode | skill_id |
+|------|-----------|----------|
+| 用户只发 utterance，无 skill | 由 P1–P6 决定 | `null` |
+| 用户 Dock 选 skill + utterance | 由 route_decide 决定；skill 提供 manifest overlay | `requestedSkillId` |
+| utterance 像 orchestration 但未选 skill | `clarify_route`：「单张出图 vs 多节点编排？是否选用已安装 Skill？」 | `null` |
+| 用户选 skill +  utterance 与 skill 能力明显冲突 | `clarify_route`（skill 内 clarify 模板） | 保留 requested |
+
+**禁止：**
+
+- 根据 utterance 关键词自动 `discover_skills()[0]` 或绑定 `enterprise-marketing-campaign`。
+- Skill 的 SKILL.md `description` 被 runtime 解析用于 L1 路由（仅用于市场检索 / 用户选择 UI）。
+
+---
+
+## 5. L0 Action 与 Planning Guard 修订
+
+### 5.1 L0 分类
+
+```python
+ActionKind = Literal[
+    "plan", "write", "generate", "preserve",
+    "regenerate", "confirm", "cancel", "unknown"
+]
+```
+
+**preserve 检测（MVP 规则）：**
+
+- 短语：`不变`、`保持`、`维持`、`沿用`、`same composition`、`keep style`
+- 与 planning verb 共现时的语义：**preserve 修饰 generate**，不是 plan
+
+示例：
+
+| utterance 片段 | L0 | planning_guard |
+|----------------|-----|----------------|
+| 「详情页的构图**方案**」 | plan | 可触发 orchestration/clarify |
+| 「保持**构图不变**」 | preserve + generate | **不触发** |
+| 「保持**主图**风格」 | preserve + generate | **不触发**；**不**触发 marketing_intent 绑 skill |
+
+### 5.2 planning_guard 角色变更
+
+| 现状（B 阶段） | 目标态 |
+|----------------|--------|
+| intake 内 `has_planning_image_conflict` → 直接 campaign | 输出 `guard_veto: planning_image_conflict` → `clarify_route` 或 cap confidence |
+| 覆盖 `atomic_create_intent=True` | **禁止 silent override**；至多 clarify |
+
+`validate_llm_parse` 保留：LLM 判 generate 但 guard 冲突 → clarify（现有 Phase C 设计）。
+
+### 5.3 marketing_intent 废止范围
+
+- **删除**：`marketing_intent` → 设置 `skill_id`、作为 orchestration 主触发器。
+- **保留（可选）**：作为 `route_decide` 弱特征之一，权重低于 P1 侧栏信号；不得单独触发 orchestration。
+- **删除**：`MARKETING_HINTS` 中「主图」作为独立 campaign 触发词（电商语义留给 Skill description）。
+
+---
+
+## 6. Loop Engineering：clarify_route
+
+### 6.1 触发条件
+
+- `route_decide.confidence < CLARIFY_THRESHOLD`（默认 0.70，与 atomic parse 对齐）
+- P3 命中但无 `requestedSkillId`
+- planning_guard veto 且 utterance 非显式 generate
+
+### 6.2 用户可见文案（MVP）
+
+**img2img 歧义（无 skill）：**
+
+```text
+你是要：
+1）单张图生图（使用 @I1 @I2 做换装/融合）；
+2）完整多节点编排（需选用已安装的编排 Skill）；
+3）其他（请补充）。
+回复 1 / 2 / 3。
+```
+
+**preservation + 电商词：**
+
+```text
+听起来像在原图基础上直接出图。请确认是要「单张图生图」，还是「完整详情页编排方案」？
+回复「出图」或「方案」。
+```
+
+### 6.3 终止与回路
+
+- 用户回复 → 重新 `assemble_route_context` + `route_decide`（L-P4 HITL = Adjust）
+- `clarify_route` **不得**写入 `user_brief` 或进入 `await_confirm` 14 节点门
+
+---
+
+## 7. Skill 生态契约（agentskills.io）
+
+### 7.1 样例 skill 定位
+
+`enterprise-marketing-campaign`：
+
+| 属性 | 值 |
+|------|-----|
+| 用途 | LangGraph 验收、manifest 格式参考、CI fixture |
+| 生产默认 | **否** |
+| 隐式加载 | **禁止**（R0 起） |
+| SKILL.md description | 仅供文档；runtime 不 parse 路由 |
+
+### 7.2 显式调用路径
+
+| 入口 | 字段 | 校验 |
+|------|------|------|
+| Agent Dock skill 选择 | `ConversationDto.skillId` → `mapUiSkillId` → `requested_skill_id` | `discover_skills()` 存在 |
+| 未来：斜杠 / 市场安装 | 同 `requested_skill_id` | 同上 |
+| 无效 skill id | `skill_id=null`；不 fallback 到样例 skill | 现有 test 保留并扩展 |
+
+### 7.3 orchestration_gate 与 skill overlay
+
+```text
+orchestration_gate:
+  if requested_skill_id:
+    manifest = load_skill(skill_id).canvas_manifest
+    prompts  = skill body + references
+  else:
+    manifest = platform_generic_manifest   # R2：最小 3–5 节点或纯 plan-only
+  → confirm_gate → split → topo → gen
+```
+
+电商「14 节点天猫详情页」等最佳实践 = **用户安装的领域 Skill**，不是平台内置。
+
+---
+
+## 8. 与现有组件的映射
+
+| 现有 | 目标 | 阶段 |
+|------|------|------|
+| `intake.py` 规则 + 默认 campaign | `assemble_route_context` + `route_decide` + thin `intake` | R1 |
+| `marketing_intent` → skill | 删除；仅 `requested_skill_id` | R0 |
+| `flow_mode=campaign` | `orchestration`（alias 兼容） | R2 |
+| `atomic_parse` LLM shadow | 扩展到 `route_decide` shadow | R2–R3 |
+| `eval-planning-guard-set.yaml` | 增加 preserve 负例 + sidebar fixture | R0–R1 |
+| `agent-skill-map.ts` `canvas→enterprise-marketing-campaign` | Dock 选「画布编排」→ 显式 skill；未选则不绑 | R0 |
+| P5 ADR 规则 1 | 修订：orchestration override 需高置信 + 无 P1 img2img | R1 |
+| P5 ADR 规则 3 | 修订：LLM 可参与 L1，仅降档/clarify | R2 |
+
+---
+
+## 9. 数据契约增量
+
+### 9.1 State 字段
+
+```python
+# AgentRuntimeState 增量
+route_context: RouteContext | None          # 组装后快照，供日志
+route_decision: RouteDecision | None        # route_decide 输出
+
+class RouteDecision(TypedDict):
+    flow_mode: Literal[
+        "atomic_create", "atomic_regenerate",
+        "single_node", "orchestration", "chat", "clarify_route"
+    ]
+    l0_action: ActionKind
+    confidence: float
+    reason: str                               # 机器可读，如 sidebar_img2img_p1
+    clarify_question: str | None
+    guard_veto: str | None                    # planning_image_conflict 等
+```
+
+### 9.2 与 skill_id 的关系
+
+```python
+# intake 输出（修订）
+skill_id: str | None   # 仅当 requested_skill_id 校验通过
+flow_mode: str         # 来自 route_decision，不再默认 campaign
+```
+
+---
+
+## 10. Harness Engineering
+
+### 10.1 新增评测集
+
+**`eval-route-set.yaml`**（建议 ≥40 cases）：
+
+| 类别 | 示例 | gold |
+|------|------|------|
+| sidebar-img2img | `@I1 模特 @I2 产品，穿上，保持构图不变` + attachments fixture | atomic_create, skill_id=null |
+| preserve | `保持主图风格、背景、构图不变，生成换装图` | atomic_create, guard 不触发 |
+| plan-orchestration | `详情页构图方案` | orchestration 或 clarify；skill_id=null |
+| explicit-skill | 同上 + requestedSkillId | orchestration + skill_id |
+| no-skill-no-implicit | `天猫蓝牙耳机详情页` | clarify 或 chat；**禁止** skill_id=enterprise-marketing-campaign |
+| hello | `你好` | chat, skill_id=null |
+
+**扩展 `eval-planning-guard-set.yaml`：**
+
+- pg-sidebar-01：`@I1 模特 @I2 产品，穿上，保持主图风格构图不变` → route=atomic_create, planning_conflict=false
+
+### 10.2 CI 与生产 smoke
+
+| 门禁 | 命令 / 文件 |
+|------|-------------|
+| 单元 | `pytest tests/test_route_decide.py tests/test_planning_guard_eval.py` |
+| 路由 gold | `tests/test_eval_route_set.py` |
+| Skill 边界 | `tests/test_intake_gate.py` 修订：marketing 不再绑 skill |
+| 生产 | `deploy/prod-route-context-verify.py`（新）；含 utterance + mock attachments |
+
+### 10.3 Shadow 路径
+
+1. R1：`route_decide` 并行 rule vs LLM，log `route_shadow_diff`
+2. 达标：agreement ≥95% + eval-route 全绿
+3. R3：`INTENT_LLM_PARSE=true` 管 L0+L1；planning_guard 仅 veto
+
+---
+
+## 11. 分阶段交付
+
+### R0 — 止血（1–2 天）
+
+- [ ] 删除 `marketing_intent → skill_id` 隐式绑定
+- [ ] `has_planning_image_conflict`：preserve 短语豁免
+- [ ] gold case pg-sidebar-01 + CI
+- [ ] 文档：样例 skill 非 production 默认（本 spec §7.1）
+
+**验收：** 生产复测 utterance（§1.1）在无 skill 时 **不得** 出现 14 节点 await_confirm；应 atomic 或 clarify。
+
+### R1 — 平台路由（约 1 周）
+
+- [ ] `RouteContext` 组装；Nest → Runtime 已有 attachments/mentionedKeys 贯通
+- [ ] `route_decide` 节点 + P1 侧栏信号表
+- [ ] thin `intake`；默认 flow 非 campaign
+- [ ] `eval-route-set.yaml` v1
+
+### R2 — Orchestration 泛化（约 2 周）
+
+- [ ] `orchestration_gate` + platform generic manifest
+- [ ] `flow_mode` campaign → orchestration alias
+- [ ] `route_decide` LLM shadow
+- [ ] 修订 P5 ADR
+
+### R3 — Skill 生态（独立 spec）
+
+- [ ] 安装/发现/版本；Dock 展示已安装 skills
+- [ ] 斜杠唤起；Skill 市场检索
+
+### R4 — 电商 Skill 产品化
+
+- [ ] 独立「天猫详情页」「服装换装」等 skill 包
+- [ ] 样例 skill 移入 `_samples/` 或文档-only
+
+---
+
+## 12. 风险与迁移
+
+| 风险 | 缓解 |
+|------|------|
+| 去掉隐式 skill 后，老用户习惯「说主图就进方案」 | clarify_route 引导；Dock 明示选 skill |
+| 规则 → LLM 切换回归 | shadow + eval-route 门禁 |
+| `campaign` 改名破坏 checkpoint | state alias：`campaign` ↔ `orchestration` 读兼容 |
+| 侧栏 P1 误杀纯文案 multi-ref | P1 要求 image ref + 变换动词 |
+
+---
+
+## 13. 验收标准（R0+R1 合并）
+
+1. §1.1 生产 case 在无 `requestedSkillId` 时：`flow_mode ∈ {atomic_create, clarify_route}`，**never** orchestration + 14 节点。
+2. 同 case 带 `mentionedKeys: ['I1','I2']` + 两图 attachments：`flow_mode=atomic_create`，`skill_id=null`。
+3. 「帮我做天猫详情页营销方案」无 skill：`skill_id=null`；orchestration 或 clarify，**不**自动 enterprise-marketing-campaign。
+4. Dock 显式选 skill：`skill_id=requested`，flow 由 route_decide 与 utterance 联合决定。
+5. `eval-route-set` + `eval-planning-guard-set` CI 全绿。
+
+---
+
+## 14. 参考
+
+- 生产复现 thread：`rdbg_202df83a`（`flowMode=campaign`，2026-08-07）
+- 代码：`services/agent-runtime/app/graph/nodes/intake.py`、`planning_guard.py`、`atomic_intent.py`
+- agentskills.io：Runtime `discover_skills` / `SKILL.md` frontmatter
+- 侧栏 M3：[2026-08-07-agent-sidebar-m3-explicit-refs-design.md](./2026-08-07-agent-sidebar-m3-explicit-refs-design.md)
+
+---
+
+## 15. 变更记录
+
+| 版本 | 日期 | 说明 |
+|------|------|------|
+| v1.0 | 2026-08-07 | 初稿：平台路由 vs Skill 边界、route_decide、RouteContext、分阶段 R0–R4 |

--- a/services/agent-runtime/app/graph/l0_action.py
+++ b/services/agent-runtime/app/graph/l0_action.py
@@ -1,0 +1,43 @@
+"""L0 action hints — preserve vs plan vs generate (platform routing)."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.graph.planning_guard import ActionKind
+
+PRESERVE_MARKERS = ("不变", "保持", "维持", "沿用")
+TRANSFORM_VERBS = ("穿上", "换装", "替换", "融合", "上身")
+_REF_KEY_PATTERN = re.compile(r"@([ITVA]\d+)", re.IGNORECASE)
+
+
+def has_preserve_intent(text: str) -> bool:
+    t = (text or "").strip()
+    if not t:
+        return False
+    return any(m in t for m in PRESERVE_MARKERS)
+
+
+def utterance_has_multi_image_refs(text: str) -> bool:
+    t = (text or "").strip()
+    if not t:
+        return False
+    image_keys = {
+        m.group(1).upper()
+        for m in _REF_KEY_PATTERN.finditer(t)
+        if m.group(1).upper().startswith("I")
+    }
+    return len(image_keys) >= 2
+
+
+def detect_l0_action(text: str) -> "ActionKind":
+    from app.graph.planning_guard import detect_action
+
+    t = (text or "").strip()
+    if not t:
+        return "unknown"
+    if has_preserve_intent(t):
+        return "preserve"
+    return detect_action(t)

--- a/services/agent-runtime/app/graph/nodes/intake.py
+++ b/services/agent-runtime/app/graph/nodes/intake.py
@@ -11,6 +11,11 @@ from app.graph.atomic_intent import (
     resolve_intake_route,
 )
 from app.graph.intent import marketing_intent, modify_intent, single_node_gen_intent  # re-export for tests
+from app.graph.l0_action import (
+    TRANSFORM_VERBS,
+    has_preserve_intent,
+    utterance_has_multi_image_refs,
+)
 from app.graph.state import BRIEF_RESET_PREFIX
 from app.skills.loader import discover_skills
 
@@ -18,6 +23,14 @@ REGENERATE_NO_CHECKPOINT_CLARIFY = (
     "当前对话还没有可重新生成的画布节点。"
     "请先在同一会话里完成首次创作（例如「帮我生成一张蓝牙耳机主图」），"
     "再说「重新生成一张」或「按刚才那个风格再生成一张」。"
+)
+
+ROUTE_CLARIFY_ORCHESTRATION = (
+    "听起来像多节点编排或营销方案需求。请确认：\n"
+    "1）单张/图生图原子出图；\n"
+    "2）完整编排（请在侧栏选用已安装的 Skill）；\n"
+    "3）其他说明。\n"
+    "回复 1 / 2 / 3。"
 )
 
 
@@ -30,6 +43,14 @@ def latest_user_text(messages: list[Any]) -> str:
     return ""
 
 
+def _should_skip_atomic_campaign_override(text: str) -> bool:
+    t = (text or "").strip()
+    if not t:
+        return False
+    img2img = utterance_has_multi_image_refs(t) and any(v in t for v in TRANSFORM_VERBS)
+    return has_preserve_intent(t) or img2img
+
+
 def make_intake_node(skills_dir: Path) -> Callable:
     async def intake(state: dict) -> dict:
         text = latest_user_text(state.get("messages") or [])
@@ -37,15 +58,8 @@ def make_intake_node(skills_dir: Path) -> Callable:
         requested = str(state.get("requested_skill_id") or "").strip()
         by_id = {e.skill_id: e for e in entries}
         skill_id: str | None = None
-        flow_mode = "campaign"
         if requested and requested in by_id:
             skill_id = requested
-        elif marketing_intent(text):
-            preferred = "enterprise-marketing-campaign"
-            if preferred in by_id:
-                skill_id = preferred
-            elif entries:
-                skill_id = entries[0].skill_id
 
         existing_brief = state.get("user_brief")
         existing_plan = state.get("plan_draft")
@@ -54,7 +68,7 @@ def make_intake_node(skills_dir: Path) -> Callable:
         is_single_node = route == "single_node"
         is_atomic = route == "atomic_create"
         is_modify = bool(
-            existing_brief and existing_plan and modify_intent(text) and not is_single_node and not is_atomic
+            existing_brief and existing_plan and modify_intent(text) and not is_single_node
         )
         has_atomic_checkpoint = (
             bool(str(state.get("atomic_node_id") or "").strip())
@@ -62,56 +76,65 @@ def make_intake_node(skills_dir: Path) -> Callable:
         )
         is_variant_create = has_atomic_checkpoint and is_regenerate_new_variant(text)
         needs_regen_clarify = not has_atomic_checkpoint and regenerate_phrase_intent(text)
+        needs_route_clarify = False
         orch = orchestration_complexity_intent(text)
         if orch == "campaign" and (is_atomic or is_variant_create):
-            is_atomic = False
-            is_variant_create = False
-            route = "campaign"
+            if not _should_skip_atomic_campaign_override(text):
+                is_atomic = False
+                is_variant_create = False
+                route = "campaign"
+
+        flow_mode: str | None = None
+        mode = "create"
+        proposed_brief: str | None = None
 
         if is_single_node:
-            mode = "create"
             proposed_brief = None
             flow_mode = "single_node"
-            if not skill_id and "enterprise-marketing-campaign" in by_id:
-                skill_id = "enterprise-marketing-campaign"
         elif has_atomic_checkpoint and atomic_regenerate_intent(text):
-            mode = "create"
             proposed_brief = None
             flow_mode = "atomic_regenerate"
             skill_id = None
         elif needs_regen_clarify:
-            mode = "create"
-            proposed_brief = None
-            flow_mode = "atomic_create"
-            skill_id = None
-        elif is_atomic or is_variant_create:
-            mode = "create"
             proposed_brief = None
             flow_mode = "atomic_create"
             skill_id = None
         elif is_modify:
             mode = "modify"
             proposed_brief = None  # reducer keeps existing brief
-        elif marketing_intent(text) or (orch == "campaign" and route == "campaign"):
-            mode = "create"
-            if not skill_id and "enterprise-marketing-campaign" in by_id:
-                skill_id = "enterprise-marketing-campaign"
+            flow_mode = "campaign"
+        elif skill_id and (
+            marketing_intent(text) or route == "campaign" or orch == "campaign"
+        ):
             if existing_brief and not modify_intent(text):
                 proposed_brief = BRIEF_RESET_PREFIX + text
             else:
                 proposed_brief = text
-        else:
-            mode = "create"
+            flow_mode = "campaign"
+        elif is_atomic or is_variant_create:
             proposed_brief = None
+            flow_mode = "atomic_create"
+            skill_id = None
+        elif marketing_intent(text) or (orch == "campaign" and route == "campaign"):
+            if skill_id:
+                if existing_brief and not modify_intent(text):
+                    proposed_brief = BRIEF_RESET_PREFIX + text
+                else:
+                    proposed_brief = text
+                flow_mode = "campaign"
+            else:
+                needs_route_clarify = True
+                proposed_brief = None
+                flow_mode = "chat"
+        else:
+            proposed_brief = None
+            flow_mode = "chat"
 
         resolved_flow = (
             flow_mode
-            if is_single_node
-            or is_atomic
-            or is_variant_create
-            or flow_mode == "atomic_regenerate"
+            if flow_mode in ("single_node", "atomic_create", "atomic_regenerate", "campaign")
             or needs_regen_clarify
-            else "campaign"
+            else "chat"
         )
 
         out: dict[str, Any] = {
@@ -129,6 +152,9 @@ def make_intake_node(skills_dir: Path) -> Callable:
         if needs_regen_clarify:
             out["phase"] = "clarify"
             out["clarify_question"] = REGENERATE_NO_CHECKPOINT_CLARIFY
+        elif needs_route_clarify:
+            out["phase"] = "clarify"
+            out["clarify_question"] = ROUTE_CLARIFY_ORCHESTRATION
         if focus_node_id:
             out["focus_node_id"] = focus_node_id
         if proposed_brief is not None:

--- a/services/agent-runtime/app/graph/planning_guard.py
+++ b/services/agent-runtime/app/graph/planning_guard.py
@@ -87,8 +87,12 @@ def is_explicit_generation_intent(text: str) -> bool:
 
 def has_planning_image_conflict(text: str) -> bool:
     """True when planning + ecommerce hero/detail assets without explicit generation."""
+    from app.graph.l0_action import has_preserve_intent
+
     t = (text or "").strip()
-    if not t or is_explicit_generation_intent(t):
+    if not t or has_preserve_intent(t):
+        return False
+    if is_explicit_generation_intent(t):
         return False
     if detect_action(t) == "write":
         return False

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -94,6 +94,7 @@ class AgentRuntimeState(TypedDict, total=False):
         "error",
     ]
     skill_id: str | None
+    requested_skill_id: str | None  # explicit Dock/API skill; intake reads each turn
     thread_id: str
     session_id: str
     user_id: str

--- a/services/agent-runtime/skills/atomic-create/eval-intent-regression.yaml
+++ b/services/agent-runtime/skills/atomic-create/eval-intent-regression.yaml
@@ -124,3 +124,9 @@ cases:
     utterance: 帮我生成一个模特人物图
     gold:
       multi_item_count: null
+
+  - id: reg-2026-08-07-img2img-sidebar
+    utterance: "@I1 这个是模特图，@I2 这个是产品图，让模特穿上这件衣服。保持主图风格，背景，构图不变。"
+    gold:
+      flow_mode: atomic_create
+      skill_id: null

--- a/services/agent-runtime/skills/atomic-create/eval-planning-guard-set.yaml
+++ b/services/agent-runtime/skills/atomic-create/eval-planning-guard-set.yaml
@@ -108,3 +108,7 @@ cases:
   - id: pg-ctrl-05
     utterance: 生成一个模特人物图
     gold: { route: atomic_create, target_type: image, complexity: atomic, min_confidence: 0.88 }
+
+  - id: pg-sidebar-01
+    utterance: "@I1 这个是模特图，@I2 这个是产品图，让模特穿上这件衣服。保持主图风格，背景，构图不变。"
+    gold: { route: atomic_create, complexity: atomic, planning_conflict: false }

--- a/services/agent-runtime/tests/test_atomic_intent_regression.py
+++ b/services/agent-runtime/tests/test_atomic_intent_regression.py
@@ -77,3 +77,12 @@ def test_multi_parse_regression(regression_cases: list[dict], case_id: str):
 def test_multi_parse_negative(regression_cases: list[dict]):
     case = next(c for c in regression_cases if c["id"] == "multi-neg-01")
     assert parse_atomic_multi_items(case["utterance"]) is None
+
+
+@pytest.mark.asyncio
+async def test_intake_regression_img2img_no_implicit_skill(regression_cases: list[dict]):
+    case = next(c for c in regression_cases if c["id"] == "reg-2026-08-07-img2img-sidebar")
+    intake = make_intake_node(SKILLS_DIR)
+    out = await intake({"messages": [HumanMessage(content=case["utterance"])]})
+    assert out["flow_mode"] == case["gold"]["flow_mode"]
+    assert out.get("skill_id") is case["gold"]["skill_id"]

--- a/services/agent-runtime/tests/test_atomic_orchestration.py
+++ b/services/agent-runtime/tests/test_atomic_orchestration.py
@@ -16,6 +16,8 @@ from app.graph.atomic_parse_schema import MAX_ATOMIC_MULTI_ITEMS, validate_parse
 from app.graph.nodes.intake import make_intake_node
 from app.graph.subgraphs.atomic_create_gate import route_after_atomic_create
 
+SKILLS_DIR = Path(__file__).resolve().parents[1] / "skills"
+
 EVAL_PATH = (
     Path(__file__).resolve().parents[1]
     / "skills"
@@ -76,19 +78,41 @@ def test_mixed_modal_routes_to_confirm():
 
 
 @pytest.mark.asyncio
-async def test_intake_planning_detail_page_redirects_to_campaign(tmp_path: Path):
-    skills = Path(__file__).resolve().parents[1] / "skills"
-    intake = make_intake_node(skills)
+async def test_intake_planning_without_skill_clarifies_or_chat():
+    intake = make_intake_node(SKILLS_DIR)
     u = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
     out = await intake({"messages": [HumanMessage(content=u)]})
-    assert out["flow_mode"] == "campaign"
-    assert out.get("skill_id") is not None
+    assert out.get("skill_id") is None
+    assert out["flow_mode"] in ("atomic_create", "chat") or out.get("phase") == "clarify"
+    assert out["flow_mode"] != "campaign" or out.get("skill_id")
 
 
 @pytest.mark.asyncio
-async def test_intake_storyboard_redirects_to_campaign(tmp_path: Path):
-    skills = Path(__file__).resolve().parents[1] / "skills"
-    intake = make_intake_node(skills)
-    out = await intake({"messages": [HumanMessage(content="帮我生成12个分镜镜头")]})
+async def test_intake_planning_with_explicit_skill_enters_campaign():
+    intake = make_intake_node(SKILLS_DIR)
+    u = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    out = await intake({
+        "messages": [HumanMessage(content=u)],
+        "requested_skill_id": "enterprise-marketing-campaign",
+    })
     assert out["flow_mode"] == "campaign"
-    assert out.get("skill_id") is not None
+    assert out.get("skill_id") == "enterprise-marketing-campaign"
+
+
+@pytest.mark.asyncio
+async def test_intake_storyboard_without_skill_does_not_enter_campaign():
+    intake = make_intake_node(SKILLS_DIR)
+    out = await intake({"messages": [HumanMessage(content="帮我生成12个分镜镜头")]})
+    assert out.get("skill_id") is None
+    assert out["flow_mode"] != "campaign" or out.get("skill_id")
+
+
+@pytest.mark.asyncio
+async def test_intake_storyboard_with_explicit_skill_enters_campaign():
+    intake = make_intake_node(SKILLS_DIR)
+    out = await intake({
+        "messages": [HumanMessage(content="帮我生成12个分镜镜头")],
+        "requested_skill_id": "enterprise-marketing-campaign",
+    })
+    assert out["flow_mode"] == "campaign"
+    assert out.get("skill_id") == "enterprise-marketing-campaign"

--- a/services/agent-runtime/tests/test_graph_plan_split.py
+++ b/services/agent-runtime/tests/test_graph_plan_split.py
@@ -158,6 +158,7 @@ async def test_confirm_then_split_creates_image_skeletons():
             "session_id": "session-1",
             "thread_id": "thread-confirm-1",
             "user_id": "user-1",
+            "requested_skill_id": "enterprise-marketing-campaign",
         },
         config,
     )
@@ -226,6 +227,7 @@ async def test_revise_returns_to_plan():
             "session_id": "session-2",
             "thread_id": "thread-revise-1",
             "user_id": "user-1",
+            "requested_skill_id": "enterprise-marketing-campaign",
         },
         config,
     )
@@ -262,6 +264,7 @@ async def test_await_confirm_none_emits_tip_message():
             "session_id": "session-none-tip",
             "thread_id": "thread-none-tip-1",
             "user_id": "user-1",
+            "requested_skill_id": "enterprise-marketing-campaign",
         },
         config,
     )

--- a/services/agent-runtime/tests/test_intake_gate.py
+++ b/services/agent-runtime/tests/test_intake_gate.py
@@ -49,7 +49,7 @@ async def test_intake_invalid_requested_skill_falls_back_to_chat():
 
 
 @pytest.mark.asyncio
-async def test_intake_marketing_sets_enterprise_skill():
+async def test_intake_marketing_without_explicit_skill_sets_no_skill():
     node = make_intake_node(SKILLS_DIR)
     out = await node(
         {
@@ -58,18 +58,34 @@ async def test_intake_marketing_sets_enterprise_skill():
             ]
         }
     )
+    assert out.get("skill_id") is None
+    assert out.get("phase") == "clarify"
+
+
+@pytest.mark.asyncio
+async def test_intake_marketing_with_explicit_skill():
+    node = make_intake_node(SKILLS_DIR)
+    out = await node(
+        {
+            "messages": [
+                HumanMessage(content="帮我设计一套卫生洁具的电商详情页营销方案")
+            ],
+            "requested_skill_id": "enterprise-marketing-campaign",
+        }
+    )
     assert out.get("skill_id") == "enterprise-marketing-campaign"
+    assert out["flow_mode"] == "campaign"
 
 
 @pytest.mark.asyncio
 async def test_intake_first_turn_create_mode_locks_brief():
-    # 修复 P0-1/P0-3：首轮营销需求 → mode=create + brief 锁定
     node = make_intake_node(SKILLS_DIR)
     out = await node(
         {
             "messages": [
                 HumanMessage(content="帮我做一套洁具详情页营销方案并出图")
-            ]
+            ],
+            "requested_skill_id": "enterprise-marketing-campaign",
         }
     )
     assert out["mode"] == "create"
@@ -103,6 +119,7 @@ async def test_intake_new_product_request_resets_brief_to_create_mode():
             "messages": [
                 HumanMessage(content="帮我做一套运动鞋详情页营销方案并出图")
             ],
+            "requested_skill_id": "enterprise-marketing-campaign",
             "user_brief": "帮我做一套洁具详情页营销方案",
             "plan_draft": "# 洁具详情页方案\n## 定位...",
         }
@@ -125,3 +142,15 @@ async def test_modify_intent_detects_changelog_keywords():
     assert modify_intent("改拓扑")
     assert not modify_intent("帮我做一套运动鞋详情页")
     assert not modify_intent("确认方案")
+
+
+@pytest.mark.asyncio
+async def test_intake_prod_img2img_case_atomic():
+    node = make_intake_node(SKILLS_DIR)
+    u = (
+        "@I1 这个是模特图，@I2 这个是产品图，让模特穿上这件衣服。"
+        "保持主图风格，背景，构图不变。"
+    )
+    out = await node({"messages": [HumanMessage(content=u)]})
+    assert out["flow_mode"] == "atomic_create"
+    assert out.get("skill_id") is None

--- a/services/agent-runtime/tests/test_l0_action.py
+++ b/services/agent-runtime/tests/test_l0_action.py
@@ -1,0 +1,32 @@
+from app.graph.l0_action import (
+    detect_l0_action,
+    has_preserve_intent,
+    utterance_has_multi_image_refs,
+)
+
+PROD_CASE = (
+    "@I1 这个是模特图，@I2 这个是产品图，让模特穿上这件衣服。"
+    "保持主图风格，背景，构图不变。"
+)
+
+
+def test_preserve_prod_case():
+    assert has_preserve_intent(PROD_CASE)
+
+
+def test_preserve_blocks_planning_read():
+    assert detect_l0_action(PROD_CASE) == "preserve"
+
+
+def test_plan_without_preserve():
+    u = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
+    assert detect_l0_action(u) == "plan"
+    assert not has_preserve_intent(u)
+
+
+def test_multi_image_refs_from_utterance():
+    assert utterance_has_multi_image_refs(PROD_CASE)
+
+
+def test_single_image_ref_not_multi():
+    assert not utterance_has_multi_image_refs("按 @I1 风格生成主图")

--- a/services/agent-runtime/tests/test_planning_guard_eval.py
+++ b/services/agent-runtime/tests/test_planning_guard_eval.py
@@ -15,6 +15,7 @@ from app.graph.atomic_intent import (
 )
 from app.graph.atomic_parse_schema import validate_parse_result
 from app.graph.atomic_parse_util import rule_parse_confidence
+from app.graph.planning_guard import has_planning_image_conflict
 
 EVAL_PATH = (
     Path(__file__).resolve().parents[1]
@@ -81,5 +82,9 @@ def test_eval_planning_guard_gold(planning_cases: list[dict]):
                 mismatches.append(f"{case_id}: expected clarify, got {out['kind']}")
             elif gold.get("reason") and out.get("reason") != gold["reason"]:
                 mismatches.append(f"{case_id}: reason {out.get('reason')} != {gold['reason']}")
+
+        if gold.get("planning_conflict") is False:
+            if has_planning_image_conflict(utterance):
+                mismatches.append(f"{case_id}: unexpected planning conflict")
 
     assert not mismatches, "\n".join(mismatches)


### PR DESCRIPTION
## Summary

- 废止 `marketing_intent` 隐式绑定 `enterprise-marketing-campaign`；Skill 仅通过 Dock/API 显式 `requested_skill_id` 加载
- 新增 L0 `preserve` 检测 + planning guard 豁免，修复生产 img2img case（`@I1/@I2` 换装 +「保持构图不变」）被误判为 14 节点 Campaign
- intake 默认 fallback 改为 `chat`/`clarify_route`，无 skill 时不 silent 进 campaign
- State 增加 `requested_skill_id`，保证 Graph 全链路可传显式 skill
- 新增 spec/plan、`pg-sidebar-01` gold、`eval-intent-regression` 条目、`deploy/prod-route-context-verify.py`

## Test plan

- [x] `cd services/agent-runtime && python3 -m pytest tests/test_l0_action.py tests/test_planning_guard_eval.py tests/test_intake_gate.py tests/test_atomic_orchestration.py tests/test_atomic_intent_regression.py tests/test_graph_plan_split.py tests/test_atomic_sidebar_refs.py -v` (48 passed)
- [ ] CI green
- [ ] 合并后：`python3 deploy/prod-route-context-verify.py` 生产复测

## 后续

R1 PR：`route_decide` + `RouteContext` + 侧栏 P1 信号（见 plan Task 6–12）


Made with [Cursor](https://cursor.com)