### PR TITLE
fix(agent): skill dock 自动默认 + img2img 澄清跟进

### DIFF
--- a/apps/server/src/agent/agent-skill-map.ts
+++ b/apps/server/src/agent/agent-skill-map.ts
@@ -1,8 +1,6 @@
+/** UI skill id → Runtime skill_id. Only ids listed in AGENT_SKILLS (web) should appear here. */
 export const SKILL_UI_TO_RUNTIME: Record<string, string | undefined> = {
   canvas: 'enterprise-marketing-campaign',
-  storyboard: undefined,
-  polish: undefined,
-  organize: undefined,
 }
 
 export function mapUiSkillId(uiSkillId?: string): string | undefined {

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -50,7 +50,11 @@ import { parseRefMentions } from '@/composables/useRefMentions'
 import MentionInput, { type MentionOption } from '@/components/canvas/MentionInput.vue'
 import { useClickOutside } from '@/composables/useClickOutside'
 import { useProviderBootstrap } from '@/composables/useProviderBootstrap'
-import { AGENT_SKILLS } from '@/constants/agentSkillMap'
+import {
+  AGENT_SKILLS,
+  agentInputPlaceholder,
+  getAgentSkill,
+} from '@/constants/agentSkillMap'
 import UniversalModelSelector from '@/components/canvas/UniversalModelSelector.vue'
 import { formatDuration as formatTraceDuration } from '@/components/agent/executionStepLabels'
 import { ElMessage } from 'element-plus'
@@ -250,9 +254,11 @@ const speech = useSpeechRecognition()
 const { preferences, load: loadProviderBootstrap } = useProviderBootstrap()
 const planningModel = ref(preferences.value?.defaultTextModel ?? '')
 
-/* ---- 技能选择 ---- */
-const activeSkillId = ref('canvas')
-const activeSkill = computed(() => AGENT_SKILLS.find((s) => s.id === activeSkillId.value) ?? AGENT_SKILLS[0])
+/* ---- 技能选择（显式 Skill；默认自动 / 平台路由） ---- */
+const activeSkillId = ref<string | null>(null)
+const activeSkill = computed(() => getAgentSkill(activeSkillId.value))
+const skillButtonLabel = computed(() => activeSkill.value?.label ?? '技能')
+const inputPlaceholder = computed(() => agentInputPlaceholder(activeSkill.value))
 const skillMenuOpen = ref(false)
 const skillMenuRef = ref<HTMLElement | null>(null)
 useClickOutside(skillMenuRef, () => {
@@ -535,7 +541,7 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
         message,
         threadId: agentThreadId.value,
         userDecision,
-        skillId: activeSkillId.value,
+        skillId: activeSkillId.value ?? undefined,
         model: planningModel.value || undefined,
         focusNodeId: props.selectedNodeId || undefined,
         attachments: attachments.length ? attachments : undefined,
@@ -1213,7 +1219,7 @@ defineExpose({
                 ref="composerRef"
                 v-model="input"
                 :mentions="mentionOptions"
-                :placeholder="`向${activeSkill.label}助手描述需求，Cmd/Ctrl + Enter 发送...`"
+                :placeholder="inputPlaceholder"
                 :disabled="agent.isStreaming"
                 @submit="send"
               />
@@ -1252,13 +1258,30 @@ defineExpose({
                       <path stroke-linecap="round" stroke-linejoin="round" d="M12 3l1.9 5.2L19 10l-5.1 1.8L12 17l-1.9-5.2L5 10l5.1-1.8L12 3z" />
                       <path stroke-linecap="round" stroke-linejoin="round" d="M19 15l.8 2.2L22 18l-2.2.8L19 21l-.8-2.2L16 18l2.2-.8L19 15z" />
                     </svg>
-                    <span class="max-w-[72px] truncate font-medium">{{ activeSkill.label }}</span>
+                    <span class="max-w-[72px] truncate font-medium">{{ skillButtonLabel }}</span>
                   </button>
                   <div
                     v-if="skillMenuOpen"
-                    class="neo-popover absolute bottom-full left-0 z-30 mb-1 w-[220px] rounded-xl py-1"
+                    class="neo-popover absolute bottom-full left-0 z-30 mb-1 w-[240px] rounded-xl py-1"
                     @click.stop
                   >
+                    <button
+                      type="button"
+                      class="neo-popover-item flex w-full items-start gap-2 px-3 py-2 text-left"
+                      :class="activeSkillId === null ? '!text-[var(--neo-accent-text)]' : ''"
+                      @click="activeSkillId = null; skillMenuOpen = false"
+                    >
+                      <span class="agent-skill-icon mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md">
+                        <svg viewBox="0 0 24 24" class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.75">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v3m0 12v3M3 12h3m12 0h3M5.6 5.6l2.1 2.1m8.6 8.6l2.1 2.1M5.6 18.4l2.1-2.1m8.6-8.6l2.1-2.1" />
+                        </svg>
+                      </span>
+                      <span class="min-w-0">
+                        <span class="text-xs font-medium">自动</span>
+                        <span class="block truncate text-[10px] opacity-60">平台路由，单张/图生图优先</span>
+                      </span>
+                    </button>
+                    <div class="mx-3 my-1 border-t border-[var(--neo-border)] opacity-40" />
                     <button
                       v-for="skill in AGENT_SKILLS"
                       :key="skill.id"
@@ -1268,27 +1291,16 @@ defineExpose({
                       @click="activeSkillId = skill.id; skillMenuOpen = false"
                     >
                       <span class="agent-skill-icon mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md">
-                        <svg v-if="skill.icon === 'canvas'" viewBox="0 0 24 24" class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.75">
+                        <svg viewBox="0 0 24 24" class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.75">
                           <rect x="3" y="3" width="7" height="7" rx="1.5" /><rect x="14" y="14" width="7" height="7" rx="1.5" /><path stroke-linecap="round" d="M10 6.5h5.5A1.5 1.5 0 0 1 17 8v6" />
-                        </svg>
-                        <svg v-else-if="skill.icon === 'storyboard'" viewBox="0 0 24 24" class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.75">
-                          <rect x="3" y="5" width="18" height="14" rx="2" /><path d="M3 10h18M9 10v9" />
-                        </svg>
-                        <svg v-else-if="skill.icon === 'polish'" viewBox="0 0 24 24" class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.75">
-                          <path stroke-linecap="round" stroke-linejoin="round" d="M14 4l6 6L8 22H2v-6L14 4z" /><path stroke-linecap="round" d="M11 7l6 6" />
-                        </svg>
-                        <svg v-else viewBox="0 0 24 24" class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.75">
-                          <path stroke-linecap="round" stroke-linejoin="round" d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z" />
                         </svg>
                       </span>
                       <span class="min-w-0">
-                        <span class="flex items-center gap-1.5">
-                          <span class="text-xs font-medium">{{ skill.label }}</span>
-                          <span v-if="!skill.ready" class="rounded px-1 py-px text-[9px] opacity-50 ring-1 ring-current">开发中</span>
-                        </span>
+                        <span class="text-xs font-medium">{{ skill.label }}</span>
                         <span class="block truncate text-[10px] opacity-60">{{ skill.desc }}</span>
                       </span>
                     </button>
+                    <p v-if="!AGENT_SKILLS.length" class="px-3 py-2 text-[10px] opacity-50">暂无已安装技能</p>
                   </div>
                 </div>
 

--- a/apps/web/src/constants/agentSkillMap.test.ts
+++ b/apps/web/src/constants/agentSkillMap.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AGENT_SKILLS,
+  agentInputPlaceholder,
+  getAgentSkill,
+} from './agentSkillMap'
+
+describe('agentSkillMap', () => {
+  it('lists only backend-connected skills', () => {
+    expect(AGENT_SKILLS.length).toBeGreaterThan(0)
+    for (const skill of AGENT_SKILLS) {
+      expect(skill.runtimeSkillId).toBeTruthy()
+    }
+  })
+
+  it('getAgentSkill returns undefined for auto mode', () => {
+    expect(getAgentSkill(null)).toBeUndefined()
+    expect(getAgentSkill(undefined)).toBeUndefined()
+    expect(getAgentSkill('')).toBeUndefined()
+  })
+
+  it('getAgentSkill resolves canvas', () => {
+    expect(getAgentSkill('canvas')?.runtimeSkillId).toBe('enterprise-marketing-campaign')
+  })
+
+  it('placeholder differs for auto vs skill', () => {
+    expect(agentInputPlaceholder(undefined)).toContain('@')
+    expect(agentInputPlaceholder(getAgentSkill('canvas'))).toContain('营销方案编排')
+  })
+})

--- a/apps/web/src/constants/agentSkillMap.ts
+++ b/apps/web/src/constants/agentSkillMap.ts
@@ -1,15 +1,35 @@
+/**
+ * Agent dock skills — only entries with Nest → Runtime mapping (see agent-skill-map.ts).
+ * Unconnected placeholders (分镜/润色/整理) are omitted until Skill packages exist.
+ */
+
 export interface AgentSkillDef {
   id: string
   label: string
   desc: string
-  icon: 'canvas' | 'storyboard' | 'polish' | 'organize'
-  runtimeSkillId: string | null
-  ready: boolean
+  /** Runtime skill directory name (validated by discover_skills). */
+  runtimeSkillId: string
 }
 
+/** Backend-connected skills shown in the Agent dock 「技能」 menu. */
 export const AGENT_SKILLS: AgentSkillDef[] = [
-  { id: 'canvas', label: '画布编排', desc: '创建节点与连线，驱动画布创作', icon: 'canvas', runtimeSkillId: 'enterprise-marketing-campaign', ready: true },
-  { id: 'storyboard', label: '分镜脚本', desc: '拆解剧情，生成分镜与镜头描述', icon: 'storyboard', runtimeSkillId: null, ready: false },
-  { id: 'polish', label: '提示词优化', desc: '润色扩写提示词，提升生成质量', icon: 'polish', runtimeSkillId: null, ready: false },
-  { id: 'organize', label: '素材整理', desc: '归纳画布素材，梳理创作结构', icon: 'organize', runtimeSkillId: null, ready: false },
+  {
+    id: 'canvas',
+    label: '营销方案编排',
+    desc: '多节点 Campaign 方案与画布拆分（enterprise-marketing-campaign）',
+    runtimeSkillId: 'enterprise-marketing-campaign',
+  },
 ]
+
+export function getAgentSkill(id: string | null | undefined): AgentSkillDef | undefined {
+  if (!id) return undefined
+  return AGENT_SKILLS.find((s) => s.id === id)
+}
+
+export const AGENT_INPUT_PLACEHOLDER_AUTO =
+  '描述需求，@ 引用素材，Cmd/Ctrl + Enter 发送…'
+
+export function agentInputPlaceholder(skill: AgentSkillDef | undefined): string {
+  if (!skill) return AGENT_INPUT_PLACEHOLDER_AUTO
+  return `已选技能「${skill.label}」— 描述编排需求，Cmd/Ctrl + Enter 发送…`
+}

--- a/services/agent-runtime/app/graph/atomic_clarify.py
+++ b/services/agent-runtime/app/graph/atomic_clarify.py
@@ -1,0 +1,35 @@
+"""Helpers for atomic parse clarify follow-ups (img2img affirmatives)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.graph.l0_action import TRANSFORM_VERBS, utterance_has_multi_image_refs
+
+_AFFIRMATIVE_EXACT = frozenset(
+    {"是的", "对", "好", "ok", "确认", "可以", "嗯", "行", "1", "要", "需要", "生成", "是", "对的"}
+)
+
+
+def pending_atomic_clarify(state: dict[str, Any]) -> dict[str, Any] | None:
+    ctx = state.get("clarify_context")
+    if isinstance(ctx, dict) and str(ctx.get("original_utterance") or "").strip():
+        return ctx
+    return None
+
+
+def is_affirmative_clarify_reply(text: str) -> bool:
+    raw = (text or "").strip()
+    if not raw or len(raw) > 16:
+        return False
+    lowered = raw.lower()
+    if lowered in _AFFIRMATIVE_EXACT:
+        return True
+    return any(k in raw for k in ("是的", "确认", "可以", "需要", "要生成"))
+
+
+def is_img2img_utterance(utterance: str) -> bool:
+    t = (utterance or "").strip()
+    if not t:
+        return False
+    return utterance_has_multi_image_refs(t) and any(v in t for v in TRANSFORM_VERBS)

--- a/services/agent-runtime/app/graph/clarify_reply.py
+++ b/services/agent-runtime/app/graph/clarify_reply.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
+from app.graph.atomic_clarify import is_affirmative_clarify_reply, is_img2img_utterance
 from app.graph.intent_parse_schema import IntentParseResult
 
 ClarifyReplyResult = IntentParseResult | Literal["none"]
@@ -94,6 +95,26 @@ def classify_clarify_reply(
             "confidence": 0.90,
             "needs_clarify": False,
             "reason": "clarify_reply_vision_text",
+        }
+
+    if is_affirmative_clarify_reply(raw) and is_img2img_utterance(original_utterance):
+        prompt = original_utterance.strip()
+        return {
+            "action": "generate",
+            "scope": "atomic",
+            "route": "atomic_create",
+            "structure": "single",
+            "items": [
+                {
+                    "target_type": "image",
+                    "title": prompt[:24],
+                    "prompt": prompt,
+                    "confirm_gate": False,
+                }
+            ],
+            "confidence": 0.94,
+            "needs_clarify": False,
+            "reason": "clarify_reply_img2img_confirm",
         }
 
     return "none"

--- a/services/agent-runtime/app/graph/nodes/atomic_parse.py
+++ b/services/agent-runtime/app/graph/nodes/atomic_parse.py
@@ -27,6 +27,7 @@ from app.graph.atomic_parse_util import (
     rule_parse_atomic,
 )
 from app.graph.atomic_intent import is_regenerate_new_variant
+from app.graph.atomic_clarify import is_img2img_utterance, pending_atomic_clarify
 from app.graph.clarify_reply import classify_clarify_reply
 from app.graph.intent_parse_llm import LLM_PARSE_TIMEOUT_SEC, llm_parse_intent
 from app.graph.intent_parse_schema import IntentParseResult, intent_result_to_parse_outcome
@@ -34,6 +35,18 @@ from app.graph.planning_guard import validate_llm_parse
 from app.tools.prompt_mode_taxonomy import resolve_prompt_mode
 
 logger = logging.getLogger(__name__)
+
+SIDEBAR_IMG2IMG_RULE_CONF = 0.95
+
+
+def _sidebar_img2img_fast_path(state: dict) -> bool:
+    decision = state.get("route_decision") if isinstance(state.get("route_decision"), dict) else {}
+    if decision.get("reason") == "sidebar_img2img_p1":
+        return True
+    ctx = state.get("route_context") if isinstance(state.get("route_context"), dict) else {}
+    utterance = str(ctx.get("utterance") or "")
+    keys = ctx.get("mentioned_keys") or []
+    return len(keys) >= 2 and is_img2img_utterance(utterance)
 
 
 def _latest_user_text(messages: list[Any]) -> str:
@@ -197,16 +210,23 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
             "atomic_spec": state.get("atomic_spec"),
         }
 
-        clarify_ctx = state.get("clarify_context") if isinstance(state.get("clarify_context"), dict) else None
-        if state.get("phase") == "clarify" and clarify_ctx:
+        clarify_ctx = pending_atomic_clarify(state)
+        if clarify_ctx:
             original = str(clarify_ctx.get("original_utterance") or "")
             question = str(clarify_ctx.get("clarify_question") or state.get("clarify_question") or "")
             classified = classify_clarify_reply(original, question, text, checkpoint=checkpoint)
             if classified != "none":
                 classified = _apply_prompt_mode_to_result(classified, original or text)
                 reason = str(classified.get("reason") or "")
-                validation_u = classified["items"][0]["prompt"] if reason == "clarify_reply_generate_image" else (original or text)
-                guard = None if reason == "clarify_reply_generate_image" else validate_llm_parse(classified, original or text)
+                validation_u = (
+                    classified["items"][0]["prompt"]
+                    if reason in ("clarify_reply_generate_image", "clarify_reply_img2img_confirm")
+                    else (original or text)
+                )
+                guard = None if reason in (
+                    "clarify_reply_generate_image",
+                    "clarify_reply_img2img_confirm",
+                ) else validate_llm_parse(classified, original or text)
                 outcome = guard or intent_result_to_parse_outcome(classified, validation_u)
                 _log_intent_parse(
                     source="clarify_reply",
@@ -215,6 +235,33 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
                     llm_result=classified,
                     guard_triggered=guard is not None,
                 )
+                patch = parse_outcome_to_state(
+                    outcome,
+                    canvas_context=parse_ctx,
+                    prior_spec=prior_spec,
+                    sidebar_attachments=sidebar_attachments,
+                )
+                patch.pop("clarify_context", None)
+                return patch
+
+        if _sidebar_img2img_fast_path(state):
+            parse_utterance = text
+            pending = pending_atomic_clarify(state)
+            if pending:
+                parse_utterance = str(pending.get("original_utterance") or text)
+            rule_items, _rule_conf = rule_parse_atomic(
+                parse_utterance,
+                canvas_summary=canvas_summary,
+                focus_node_id=focus_node_id,
+                parse_context=parse_ctx or None,
+            )
+            if rule_items:
+                outcome = outcome_from_rule_items(
+                    rule_items,
+                    confidence=SIDEBAR_IMG2IMG_RULE_CONF,
+                    reason="sidebar_img2img_rule_fast_path",
+                )
+                _log_intent_parse(source="rule", utterance=parse_utterance, outcome=outcome)
                 patch = parse_outcome_to_state(
                     outcome,
                     canvas_context=parse_ctx,

--- a/services/agent-runtime/app/graph/nodes/intake.py
+++ b/services/agent-runtime/app/graph/nodes/intake.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from app.graph.intent import marketing_intent, modify_intent, single_node_gen_intent
+from app.graph.atomic_clarify import is_affirmative_clarify_reply, pending_atomic_clarify
 from app.graph.route_context import assemble_route_context, latest_user_text
 from app.graph.route_decide import ROUTE_CLARIFY_ORCHESTRATION, decide_route
 from app.graph.state import BRIEF_RESET_PREFIX
@@ -49,6 +50,12 @@ def make_intake_node(skills_dir: Path) -> Callable:
 
         resolved_flow = flow_mode if flow_mode != "clarify_route" else "chat"
 
+        pending_clarify = pending_atomic_clarify(state)
+        if pending_clarify and is_affirmative_clarify_reply(text):
+            flow_mode = "atomic_create"
+            resolved_flow = "atomic_create"
+            skill_id = None
+
         out: dict[str, Any] = {
             "phase": "intake",
             "skill_id": skill_id,
@@ -64,6 +71,8 @@ def make_intake_node(skills_dir: Path) -> Callable:
         if resolved_flow in ("atomic_create", "atomic_regenerate"):
             out["split_manifest"] = []
             out["skill_id"] = None
+        if pending_clarify and is_affirmative_clarify_reply(text):
+            out["clarify_question"] = None
         if needs_regen_clarify:
             out["phase"] = "clarify"
             out["clarify_question"] = REGENERATE_NO_CHECKPOINT_CLARIFY

--- a/services/agent-runtime/tests/test_img2img_clarify_followup.py
+++ b/services/agent-runtime/tests/test_img2img_clarify_followup.py
@@ -1,0 +1,65 @@
+"""Img2img clarify follow-up regression tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from app.graph.builder import route_after_intake
+from app.graph.clarify_reply import classify_clarify_reply
+from app.graph.nodes.intake import make_intake_node
+
+IMG2IMG = "@I1 这个是女生，@I2 这个是产品，请让这个女生穿上这件衣服"
+
+
+@pytest.mark.asyncio
+async def test_intake_affirmative_after_atomic_clarify_stays_atomic():
+    skills = Path(__file__).resolve().parents[1] / "skills"
+    intake = make_intake_node(skills)
+    out = await intake(
+        {
+            "messages": [HumanMessage(content="是的")],
+            "requested_skill_id": "enterprise-marketing-campaign",
+            "skill_id": "enterprise-marketing-campaign",
+            "clarify_context": {
+                "original_utterance": IMG2IMG,
+                "clarify_question": "需要生成一张女生穿冲锋衣的图片吗？",
+            },
+            "clarify_question": "需要生成一张女生穿冲锋衣的图片吗？",
+        }
+    )
+    assert out["flow_mode"] == "atomic_create"
+    assert out.get("skill_id") is None
+    assert route_after_intake(out) == "parse_atomic_intent"
+
+
+def test_clarify_reply_yes_confirms_img2img():
+    result = classify_clarify_reply(IMG2IMG, "需要生成吗", "是的")
+    assert result != "none"
+    assert result["route"] == "atomic_create"
+    assert result["items"][0]["target_type"] == "image"
+    assert "穿上" in result["items"][0]["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_parse_skips_clarify_for_sidebar_img2img():
+    from app.graph.nodes.atomic_parse import make_parse_atomic_intent_node
+
+    node = make_parse_atomic_intent_node()
+    out = await node(
+        {
+            "messages": [HumanMessage(content=IMG2IMG)],
+            "sidebar_mentioned_keys": ["I1", "I2"],
+            "route_decision": {"reason": "sidebar_img2img_p1", "flow_mode": "atomic_create"},
+            "route_context": {
+                "utterance": IMG2IMG,
+                "mentioned_keys": ["I1", "I2"],
+                "sidebar_attachments": [],
+            },
+        }
+    )
+    assert out.get("phase") == "atomic_parse"
+    assert out.get("atomic_spec")
+    assert out.get("atomic_spec", {}).get("target_type") == "image"


### PR DESCRIPTION
## Summary
- Agent 底栏改为「技能」选择器：默认「自动」不传 skillId；仅展示已接入后端的 Skill（营销方案编排）
- 移除未接入占位项（分镜脚本/提示词优化/素材整理）
- Runtime：img2img 规则快速通道跳过 LLM 澄清；「是的」等确认回复保持 atomic；澄清跟进清除 skill 防止 Campaign 劫持

## Test plan
- [x] `pnpm build`
- [x] `pytest tests/test_img2img_clarify_followup.py` — 3 passed
- [x] `vitest agentSkillMap.test.ts` — 4 passed
- [ ] CI 全绿
- [ ] 部署后生产复测 img2img 用例


Made with [Cursor](https://cursor.com)