### PR TITLE
fix(agent): chip drag reorder, history reattach, dock parity

### DIFF
--- a/apps/web/src/components/agent/AgentRefStrip.vue
+++ b/apps/web/src/components/agent/AgentRefStrip.vue
@@ -1,17 +1,24 @@
 <script setup lang="ts">
 import type { SidebarAttachment } from '@lnkpi/shared'
 import AgentSidebarRefChip from '@/components/agent/AgentSidebarRefChip.vue'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import type { NodeRef } from '@/composables/useNodeRefs'
 
 const props = defineProps<{
   items: Array<{ attachment: SidebarAttachment; refKey: string }>
   removable?: boolean
+  /** History messages: click re-adds attachment to composer */
+  historyInteractive?: boolean
 }>()
 const emit = defineEmits<{
   remove: [id: string]
   mention: [refKey: string]
+  reattach: [attachment: SidebarAttachment]
+  reorder: [ids: string[]]
 }>()
+
+const dragRefId = ref<string | null>(null)
+const dragOverRefId = ref<string | null>(null)
 
 const refs = computed<NodeRef[]>(() =>
   props.items.map(({ attachment, refKey }) => ({
@@ -24,6 +31,64 @@ const refs = computed<NodeRef[]>(() =>
     payload: { url: attachment.url, text: attachment.text },
   })),
 )
+
+const canReorder = computed(() => props.removable !== false && props.items.length > 1)
+
+function onDragStart(refId: string, event: DragEvent) {
+  if (!canReorder.value) return
+  dragRefId.value = refId
+  dragOverRefId.value = null
+  if (event.dataTransfer) {
+    event.dataTransfer.effectAllowed = 'move'
+    event.dataTransfer.setData('text/plain', refId)
+  }
+}
+
+function onDragOver(refId: string, event: DragEvent) {
+  if (!canReorder.value) return
+  event.preventDefault()
+  if (event.dataTransfer) event.dataTransfer.dropEffect = 'move'
+  if (dragRefId.value && dragRefId.value !== refId) {
+    dragOverRefId.value = refId
+  }
+}
+
+function onDragLeave(refId: string) {
+  if (dragOverRefId.value === refId) dragOverRefId.value = null
+}
+
+function onDrop(targetRefId: string, event: DragEvent) {
+  if (!canReorder.value) return
+  event.preventDefault()
+  const sourceRefId = dragRefId.value ?? event.dataTransfer?.getData('text/plain')
+  dragRefId.value = null
+  dragOverRefId.value = null
+  if (!sourceRefId || sourceRefId === targetRefId) return
+
+  const ids = props.items.map((i) => i.attachment.id)
+  const from = ids.indexOf(sourceRefId)
+  const to = ids.indexOf(targetRefId)
+  if (from < 0 || to < 0) return
+
+  const next = [...ids]
+  next.splice(from, 1)
+  next.splice(to, 0, sourceRefId)
+  emit('reorder', next)
+}
+
+function onDragEnd() {
+  dragRefId.value = null
+  dragOverRefId.value = null
+}
+
+function onChipMention(refKey: string) {
+  if (props.historyInteractive) {
+    const item = props.items.find((i) => i.refKey === refKey)
+    if (item) emit('reattach', item.attachment)
+    return
+  }
+  emit('mention', refKey)
+}
 </script>
 
 <template>
@@ -33,10 +98,18 @@ const refs = computed<NodeRef[]>(() =>
         v-for="refItem in refs"
         :key="refItem.refId"
         :ref-item="refItem"
-        :clickable="removable !== false"
-        :class="{ 'agent-ref-strip__chip--readonly': !removable }"
+        :clickable="removable !== false || historyInteractive === true"
+        :draggable="canReorder"
+        :dragging="dragRefId === refItem.refId"
+        :drag-over="dragOverRefId === refItem.refId"
+        :class="{ 'agent-ref-strip__chip--readonly': !removable && !historyInteractive }"
         @remove="emit('remove', refItem.refId)"
-        @mention="emit('mention', $event)"
+        @mention="onChipMention"
+        @dragstart="onDragStart(refItem.refId, $event)"
+        @dragover="onDragOver(refItem.refId, $event)"
+        @dragleave="onDragLeave(refItem.refId)"
+        @drop="onDrop(refItem.refId, $event)"
+        @dragend="onDragEnd"
       />
     </div>
   </div>

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -61,6 +61,7 @@ import {
 import UniversalModelSelector from '@/components/canvas/UniversalModelSelector.vue'
 import { formatDuration as formatTraceDuration } from '@/components/agent/executionStepLabels'
 import { formatSessionTime, lastThreadStorageKey } from '@/utils/formatSessionTime'
+import { randomId } from '@/utils/randomId'
 import { ElMessage } from 'element-plus'
 
 interface AgentThreadRow {
@@ -105,10 +106,29 @@ function makeAttachmentItems(
   attachments: SidebarAttachment[] | undefined,
   refKeys: string[] | undefined,
 ) {
-  return (attachments ?? []).map((attachment, index) => ({
+  const list = attachments ?? []
+  const keys = refKeys?.length === list.length ? refKeys : assignRefKeysFor(list)
+  return list.map((attachment, index) => ({
     attachment,
-    refKey: refKeys?.[index] ?? attachment.id,
+    refKey: keys[index] ?? attachment.id,
   }))
+}
+
+function clearComposer() {
+  input.value = ''
+  sidebar.clear()
+}
+
+function reattachFromHistory(attachment: SidebarAttachment) {
+  if (sidebar.pendingAttachments.value.length >= SIDEBAR_ATTACHMENT_MAX) {
+    ElMessage.warning(`最多 ${SIDEBAR_ATTACHMENT_MAX} 个引用`)
+    return
+  }
+  sidebar.addFromPayload({ ...attachment, id: randomId() })
+  const keys = sidebar.assignRefKeys()
+  const idx = sidebar.pendingAttachments.value.length - 1
+  if (keys[idx]) insertRefMention(keys[idx])
+  nextTick(() => composerRef.value?.focus())
 }
 
 const pendingAttachmentItems = computed(() =>
@@ -341,6 +361,7 @@ async function selectThread(threadId: string) {
     historyOpen.value = false
     return
   }
+  clearComposer()
   agentThreadId.value = threadId
   localStorage.setItem(lastThreadStorageKey(props.sessionId), threadId)
   historyOpen.value = false
@@ -349,9 +370,11 @@ async function selectThread(threadId: string) {
   hasAtomicCheckpoint.value = false
   recoveredPhaseHint.value = null
   await loadHistory()
+  void refreshThreadCheckpoint()
 }
 
 async function bootstrapThread() {
+  clearComposer()
   agent.clear()
   const cached = localStorage.getItem(lastThreadStorageKey(props.sessionId))
   if (cached) {
@@ -361,6 +384,7 @@ async function bootstrapThread() {
     agentThreadId.value = list[0]?.id ?? createAgentThreadId(props.sessionId)
   }
   await loadHistory()
+  void refreshThreadCheckpoint()
   scrollToBottom()
 }
 
@@ -454,8 +478,8 @@ function startResize(event: MouseEvent) {
 }
 
 function newAgentSession() {
+  clearComposer()
   agent.clear()
-  input.value = ''
   taskProgress.value = emptyTaskProgress()
   interruptGate.value = null
   hasAtomicCheckpoint.value = false
@@ -1182,6 +1206,8 @@ defineExpose({
                   class="mt-2"
                   :items="makeAttachmentItems(msg.attachments, msg.attachmentRefKeys)"
                   :removable="false"
+                  history-interactive
+                  @reattach="reattachFromHistory"
                 />
                 <AgentCanvasOutputs
                   v-if="msg.role === 'assistant' && (assistantOutputsById.get(msg.id)?.length ?? 0) > 0"
@@ -1310,6 +1336,7 @@ defineExpose({
                 :removable="true"
                 @remove="sidebar.remove"
                 @mention="insertRefMention"
+                @reorder="sidebar.reorder"
               />
               <input
                 ref="fileInputRef"

--- a/apps/web/src/components/agent/AgentSidebarRefChip.vue
+++ b/apps/web/src/components/agent/AgentSidebarRefChip.vue
@@ -9,11 +9,19 @@ import type { DockNodeIconKind } from '@/components/canvas/dock-studio/shared/do
 const props = defineProps<{
   refItem: NodeRef
   clickable?: boolean
+  draggable?: boolean
+  dragging?: boolean
+  dragOver?: boolean
 }>()
 
 const emit = defineEmits<{
   mention: [refKey: string]
   remove: []
+  dragstart: [event: DragEvent]
+  dragover: [event: DragEvent]
+  dragleave: []
+  drop: [event: DragEvent]
+  dragend: []
 }>()
 
 const previewOpen = ref(false)
@@ -84,7 +92,10 @@ function onClick() {
       'is-stale': refItem.stale,
       'has-media': !!thumbUrl,
       'is-readonly': !clickable,
+      'is-dragging': dragging,
+      'is-drag-over': dragOver,
     }"
+    :draggable="draggable"
     :title="`${refItem.refKey} · ${refItem.label}`"
     role="button"
     tabindex="0"
@@ -92,6 +103,11 @@ function onClick() {
     @mouseleave="onLeave"
     @click="onClick"
     @keydown.enter.prevent="onClick"
+    @dragstart="emit('dragstart', $event)"
+    @dragover="emit('dragover', $event)"
+    @dragleave="emit('dragleave')"
+    @drop="emit('drop', $event)"
+    @dragend="emit('dragend')"
   >
     <span class="dock-ref-chip__key">{{ refItem.refKey }}</span>
 
@@ -161,6 +177,19 @@ function onClick() {
 
 .dock-ref-chip.is-readonly {
   cursor: default;
+}
+
+.dock-ref-chip.is-dragging {
+  opacity: 0.45;
+}
+
+.dock-ref-chip.is-drag-over {
+  border-color: var(--neo-accent-border);
+  background: var(--neo-accent-soft);
+}
+
+.dock-ref-chip:active[draggable='true'] {
+  cursor: grabbing;
 }
 
 .dock-ref-chip.is-stale {

--- a/apps/web/src/components/canvas/dock-studio/panels/AudioDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/AudioDockPanel.vue
@@ -63,6 +63,7 @@ const voiceSettings = ref<AudioVoiceSettings>({
 const modelVoices = computed(() => getModelEntry(catalogModelKeyFromValue(audioModel.value))?.voices)
 
 const speech = useSpeechRecognition()
+const promptSectionRef = ref<InstanceType<typeof DockPromptSection> | null>(null)
 const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
 const credits = computed(() => estimateAudioCredits())
 
@@ -153,6 +154,10 @@ function onRefReorder(refIds: string[]) {
 function onRefRemove(ref: NodeRef) {
   emit('removeRef', ref)
 }
+
+function onRefMention(refKey: string) {
+  promptSectionRef.value?.insertRefMention(refKey)
+}
 </script>
 
 <template>
@@ -161,9 +166,11 @@ function onRefRemove(ref: NodeRef) {
       :refs="refs ?? []"
       @reorder="onRefReorder"
       @remove="onRefRemove"
+      @mention="onRefMention"
     />
 
     <DockPromptSection
+      ref="promptSectionRef"
       :model-value="prompt"
       :mentions="mentions"
       placeholder="输入台词或旁白文本..."

--- a/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
@@ -52,6 +52,7 @@ const refInput = ref<HTMLInputElement | null>(null)
 const refUploading = ref(false)
 const refUploadProgress = ref(0)
 const refUploadError = ref('')
+const promptSectionRef = ref<InstanceType<typeof DockPromptSection> | null>(null)
 
 const speech = useSpeechRecognition()
 const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
@@ -106,6 +107,10 @@ function onRefReorder(refIds: string[]) {
 
 function onRefRemove(ref: NodeRef) {
   emit('removeRef', ref)
+}
+
+function onRefMention(refKey: string) {
+  promptSectionRef.value?.insertRefMention(refKey)
 }
 
 function syncFromNode() {
@@ -229,9 +234,11 @@ function clearReferenceImage() {
       :refs="stripRefs"
       @reorder="onRefReorder"
       @remove="onRefRemove"
+      @mention="onRefMention"
     />
 
     <DockPromptSection
+      ref="promptSectionRef"
       :model-value="prompt"
       :mentions="mentions"
       placeholder="描述画面内容，@ 引用节点..."

--- a/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
@@ -45,6 +45,7 @@ const prompt = ref('')
 const textModel = ref(getConfig('text').model)
 
 const speech = useSpeechRecognition()
+const promptSectionRef = ref<InstanceType<typeof DockPromptSection> | null>(null)
 const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
 const promptMode = computed(() => {
   const mode = props.node.data?.promptMode
@@ -140,6 +141,10 @@ function onRefReorder(refIds: string[]) {
 function onRefRemove(ref: NodeRef) {
   emit('removeRef', ref)
 }
+
+function onRefMention(refKey: string) {
+  promptSectionRef.value?.insertRefMention(refKey)
+}
 </script>
 
 <template>
@@ -148,9 +153,11 @@ function onRefRemove(ref: NodeRef) {
       :refs="textRefs"
       @reorder="onRefReorder"
       @remove="onRefRemove"
+      @mention="onRefMention"
     />
 
     <DockPromptSection
+      ref="promptSectionRef"
       :model-value="prompt"
       :mentions="mentions"
       placeholder="描述创作需求，生成结构化提示词..."

--- a/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
@@ -44,6 +44,7 @@ const textThinkingEffort = ref<'high' | 'max'>('high')
 const legacySeededForId = ref<string | null>(null)
 
 const speech = useSpeechRecognition()
+const promptSectionRef = ref<InstanceType<typeof DockPromptSection> | null>(null)
 const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
 const wordCount = computed(() => prompt.value.replace(/\s/g, '').length)
 const credits = computed(() => estimateTextCredits())
@@ -140,6 +141,10 @@ function onRefReorder(refIds: string[]) {
 function onRefRemove(ref: NodeRef) {
   emit('removeRef', ref)
 }
+
+function onRefMention(refKey: string) {
+  promptSectionRef.value?.insertRefMention(refKey)
+}
 </script>
 
 <template>
@@ -148,9 +153,11 @@ function onRefRemove(ref: NodeRef) {
       :refs="refs ?? []"
       @reorder="onRefReorder"
       @remove="onRefRemove"
+      @mention="onRefMention"
     />
 
     <DockPromptSection
+      ref="promptSectionRef"
       :model-value="prompt"
       :mentions="mentions"
       placeholder="输入脚本、旁白或品牌文案..."

--- a/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
@@ -53,6 +53,7 @@ const refUploadProgress = ref(0)
 const refUploadError = ref('')
 
 const speech = useSpeechRecognition()
+const promptSectionRef = ref<InstanceType<typeof DockPromptSection> | null>(null)
 const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
 const credits = computed(() => estimateVideoCredits(videoSettings.value.duration))
 
@@ -193,6 +194,10 @@ function onRefReorder(refIds: string[]) {
 function onRefRemove(ref: NodeRef) {
   emit('removeRef', ref)
 }
+
+function onRefMention(refKey: string) {
+  promptSectionRef.value?.insertRefMention(refKey)
+}
 </script>
 
 <template>
@@ -201,9 +206,11 @@ function onRefRemove(ref: NodeRef) {
       :refs="refs ?? []"
       @reorder="onRefReorder"
       @remove="onRefRemove"
+      @mention="onRefMention"
     />
 
     <DockPromptSection
+      ref="promptSectionRef"
       :model-value="prompt"
       :mentions="mentions"
       placeholder="描述视频内容，@ 引用节点..."

--- a/apps/web/src/components/canvas/dock-studio/shared/DockPromptSection.vue
+++ b/apps/web/src/components/canvas/dock-studio/shared/DockPromptSection.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import MentionInput, { type MentionOption } from '@/components/canvas/MentionInput.vue'
 
 defineProps<{
@@ -11,11 +12,22 @@ const emit = defineEmits<{
   'update:modelValue': [value: string]
   submit: []
 }>()
+
+const mentionInputRef = ref<InstanceType<typeof MentionInput> | null>(null)
+
+function insertRefMention(refKey: string) {
+  const token = `@${refKey} `
+  mentionInputRef.value?.insertText(token)
+  mentionInputRef.value?.focus()
+}
+
+defineExpose({ insertRefMention, focus: () => mentionInputRef.value?.focus() })
 </script>
 
 <template>
   <div class="prompt-input-section">
     <MentionInput
+      ref="mentionInputRef"
       :model-value="modelValue"
       :mentions="mentions ?? []"
       :placeholder="placeholder ?? '描述生成内容，@ 引用节点...'"

--- a/apps/web/src/components/canvas/dock-studio/shared/DockRefChip.vue
+++ b/apps/web/src/components/canvas/dock-studio/shared/DockRefChip.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from 'vue'
 import type { NodeRef, RefMediaType } from '@/composables/useNodeRefs'
 import DockTypeIcon from './DockTypeIcon.vue'
-import DockRefPreview from './DockRefPreview.vue'
+import AgentRefHoverPreview from '@/components/agent/AgentRefHoverPreview.vue'
 import { resolveMediaUrl } from '@/services/api-base'
 import type { DockNodeIconKind } from './dockIcons'
 
@@ -11,14 +11,24 @@ const props = defineProps<{
   draggable?: boolean
   dragging?: boolean
   dragOver?: boolean
+  /** When true, click inserts @refKey into prompt (agent-aligned). */
+  mentionable?: boolean
 }>()
 
 const emit = defineEmits<{
+  mention: [refKey: string]
   remove: []
+  dragstart: [event: DragEvent]
+  dragover: [event: DragEvent]
+  dragleave: []
+  drop: [event: DragEvent]
+  dragend: []
 }>()
 
 const previewOpen = ref(false)
 const previewPos = ref({ x: 0, y: 0 })
+const hoverTimer = ref<number | null>(null)
+const isHoveringPreview = ref(false)
 
 const MEDIA_ICON: Record<RefMediaType, DockNodeIconKind> = {
   text: 'text',
@@ -33,15 +43,48 @@ const thumbUrl = computed(() => {
   return raw ? resolveMediaUrl(raw) : ''
 })
 
+function clearHoverTimer() {
+  if (hoverTimer.value !== null) {
+    window.clearTimeout(hoverTimer.value)
+    hoverTimer.value = null
+  }
+}
+
+function onEnter(event: MouseEvent) {
+  clearHoverTimer()
+  previewPos.value = { x: event.clientX + 8, y: event.clientY + 8 }
+  hoverTimer.value = window.setTimeout(() => {
+    previewOpen.value = true
+  }, 200)
+}
+
+function onLeave() {
+  clearHoverTimer()
+  hoverTimer.value = window.setTimeout(() => {
+    if (!isHoveringPreview.value) previewOpen.value = false
+  }, 80)
+}
+
+function onPreviewEnter() {
+  clearHoverTimer()
+  isHoveringPreview.value = true
+}
+
+function onPreviewLeave() {
+  isHoveringPreview.value = false
+  previewOpen.value = false
+}
+
 function onRemoveClick(event: MouseEvent) {
   event.stopPropagation()
   emit('remove')
 }
 
-function onChipClick(event: MouseEvent) {
+function onClick() {
   if (props.refItem.stale) return
-  previewPos.value = { x: event.clientX + 8, y: event.clientY + 8 }
-  previewOpen.value = true
+  if (props.mentionable !== false) {
+    emit('mention', props.refItem.refKey)
+  }
 }
 </script>
 
@@ -58,8 +101,15 @@ function onChipClick(event: MouseEvent) {
     :title="`${refItem.refKey} · ${refItem.label}`"
     role="button"
     tabindex="0"
-    @click="onChipClick"
-    @keydown.enter.prevent="onChipClick($event as unknown as MouseEvent)"
+    @mouseenter="onEnter"
+    @mouseleave="onLeave"
+    @click="onClick"
+    @keydown.enter.prevent="onClick"
+    @dragstart="emit('dragstart', $event)"
+    @dragover="emit('dragover', $event)"
+    @dragleave="emit('dragleave')"
+    @drop="emit('drop', $event)"
+    @dragend="emit('dragend')"
   >
     <span class="dock-ref-chip__key">{{ refItem.refKey }}</span>
 
@@ -95,12 +145,13 @@ function onChipClick(event: MouseEvent) {
     </button>
   </div>
 
-  <DockRefPreview
+  <AgentRefHoverPreview
     v-if="previewOpen"
     :ref-item="refItem"
     :x="previewPos.x"
     :y="previewPos.y"
-    @close="previewOpen = false"
+    @mouseenter="onPreviewEnter"
+    @mouseleave="onPreviewLeave"
   />
 </template>
 
@@ -126,7 +177,7 @@ function onChipClick(event: MouseEvent) {
     opacity 0.15s ease;
 }
 
-.dock-ref-chip:active {
+.dock-ref-chip:active[draggable='true'] {
   cursor: grabbing;
 }
 
@@ -161,7 +212,6 @@ function onChipClick(event: MouseEvent) {
   pointer-events: none;
 }
 
-/* 缩略图上叠字时保持白字 + 阴影确保可读 */
 .dock-ref-chip.has-media .dock-ref-chip__key {
   color: rgba(255, 255, 255, 0.9);
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);

--- a/apps/web/src/components/canvas/dock-studio/shared/DockRefStrip.vue
+++ b/apps/web/src/components/canvas/dock-studio/shared/DockRefStrip.vue
@@ -10,6 +10,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   reorder: [refIds: string[]]
   remove: [ref: NodeRef]
+  mention: [refKey: string]
 }>()
 
 const dragRefId = ref<string | null>(null)
@@ -76,6 +77,7 @@ function onDragEnd() {
         @drop="onDrop(refItem.refId, $event)"
         @dragend="onDragEnd"
         @remove="emit('remove', refItem)"
+        @mention="emit('mention', $event)"
       />
     </div>
   </div>

--- a/apps/web/src/composables/useSidebarAttachments.ts
+++ b/apps/web/src/composables/useSidebarAttachments.ts
@@ -100,6 +100,13 @@ export function useSidebarAttachments() {
     pendingAttachments.value = pendingAttachments.value.filter((a) => a.id !== id)
   }
 
+  function reorder(ids: string[]) {
+    const byId = new Map(pendingAttachments.value.map((a) => [a.id, a]))
+    pendingAttachments.value = ids
+      .map((id) => byId.get(id))
+      .filter((a): a is SidebarAttachment => Boolean(a))
+  }
+
   function clear() {
     pendingAttachments.value = []
   }
@@ -129,5 +136,5 @@ export function useSidebarAttachments() {
     return { attachments: [...pendingAttachments.value], refOrder: refOrder.value }
   }
 
-  return { pendingAttachments, refOrder, addFromFile, addFromPayload, addFromCanvasNode, addFromCanvasNodes, remove, clear, toPayload, assignRefKeys }
+  return { pendingAttachments, refOrder, addFromFile, addFromPayload, addFromCanvasNode, addFromCanvasNodes, remove, reorder, clear, toPayload, assignRefKeys }
 }

--- a/services/agent-runtime/app/graph/atomic_intent.py
+++ b/services/agent-runtime/app/graph/atomic_intent.py
@@ -92,6 +92,12 @@ ATOMIC_REGENERATE_HINTS = tuple(_TAXONOMY.get("atomic_regenerate_hints") or (
     "再来一次",
     "再生成一次",
     "再跑一遍",
+    "重复上一次操作",
+    "重复上次",
+    "重复上一步",
+    "再来一遍",
+    "再做一次",
+    "重复上一操作",
 ))
 
 # Full-campaign phrases — atomic keyword substrings (e.g. 「图」in「出图」) must not hijack.
@@ -163,6 +169,10 @@ def _matches_regenerate_hints(text: str) -> bool:
 
 
 _REGENERATE_STRIP_PHRASES = (
+    "重复上一次操作",
+    "重复上一操作",
+    "重复上次",
+    "重复上一步",
     "重新生成一张",
     "重新生成",
     "再生成一张",
@@ -170,6 +180,8 @@ _REGENERATE_STRIP_PHRASES = (
     "再生成一遍",
     "再跑一次",
     "再来一次",
+    "再来一遍",
+    "再做一次",
     "再试一次",
     "再试",
     "重试",

--- a/services/agent-runtime/app/graph/l0_action.py
+++ b/services/agent-runtime/app/graph/l0_action.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from app.graph.planning_guard import ActionKind
 
 PRESERVE_MARKERS = ("不变", "保持", "维持", "沿用")
-TRANSFORM_VERBS = ("穿上", "换装", "替换", "融合", "上身")
+TRANSFORM_VERBS = ("穿上", "换装", "替换", "融合", "上身", "换上", "换穿", "试穿", "佩戴", "搭配")
 _REF_KEY_PATTERN = re.compile(r"@([ITVA]\d+)", re.IGNORECASE)
 
 

--- a/services/agent-runtime/app/graph/nodes/intake.py
+++ b/services/agent-runtime/app/graph/nodes/intake.py
@@ -11,9 +11,9 @@ from app.graph.state import BRIEF_RESET_PREFIX
 from app.skills.loader import discover_skills
 
 REGENERATE_NO_CHECKPOINT_CLARIFY = (
-    "当前对话还没有可重新生成的画布节点。"
-    "请先在同一会话里完成首次创作（例如「帮我生成一张蓝牙耳机主图」），"
-    "再说「重新生成一张」或「按刚才那个风格再生成一张」。"
+    "当前对话还没有可重新生成的画布节点（可能上一轮尚未成功完成）。"
+    "请先在同一会话里完成首次创作，或点击历史消息中的引用芯片重新加入 @I1 @I2 后再试；"
+    "也可以说「重新生成一张」或「按刚才那个风格再生成一张」。"
 )
 
 

--- a/services/agent-runtime/app/graph/route_decide.py
+++ b/services/agent-runtime/app/graph/route_decide.py
@@ -70,7 +70,9 @@ def _sidebar_img2img_signal(ctx: RouteContext) -> bool:
     keys = _image_mentioned_keys(ctx.get("mentioned_keys") or [])
     if not utterance:
         return False
-    has_transform = any(v in utterance for v in TRANSFORM_VERBS)
+    has_transform = any(v in utterance for v in TRANSFORM_VERBS) or (
+        len(keys) >= 2 and ("让" in utterance or "请" in utterance)
+    )
     if not has_transform and not has_preserve_intent(utterance):
         return False
     multi_ref = len(keys) >= 2 or utterance_has_multi_image_refs(utterance)

--- a/services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml
+++ b/services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml
@@ -121,6 +121,12 @@ atomic_regenerate_hints:
   - 再来一次
   - 再生成一次
   - 再跑一遍
+  - 重复上一次操作
+  - 重复上次
+  - 重复上一步
+  - 再来一遍
+  - 再做一次
+  - 重复上一操作
 
 orchestration:
   max_atomic_multi_items: 5

--- a/services/agent-runtime/tests/test_atomic_regenerate_intent.py
+++ b/services/agent-runtime/tests/test_atomic_regenerate_intent.py
@@ -10,6 +10,8 @@ def test_atomic_regenerate_positive():
     assert atomic_regenerate_intent("重新生成")
     assert atomic_regenerate_intent("重新生成一张")
     assert atomic_regenerate_intent("再来一次")
+    assert atomic_regenerate_intent("重复上一次操作")
+    assert atomic_regenerate_intent("重复上次")
 
 
 def test_regenerate_phrase_not_atomic_create():


### PR DESCRIPTION
## Summary
- Agent composer chips support drag-and-drop reorder (same behavior as canvas dock)
- Canvas dock chips: hover preview + click inserts `@refKey` into prompt (aligned with agent)
- History message chips: click to re-add attachment to composer and insert `@` reference
- Thread switch / new conversation clears composer pending chips and draft input
- Runtime: recognize「重复上一次操作」regenerate phrases; broaden img2img verbs (换上/试穿等)

## Test plan
- [x] pnpm build
- [x] pnpm --filter @lnkpi/web test (222/222)
- [x] pytest test_atomic_regenerate_intent.py
- [ ] Manual: agent chip drag, dock hover/click @, history chip reattach, new thread isolation
- [ ] deploy/prod-agent-thread-verify.py after merge


Made with [Cursor](https://cursor.com)