### PR TITLE
fix: agent history refresh + batch color variant intake

### DIFF
--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -40,6 +40,8 @@ import { phaseHintFromInterrupt } from '@/components/agent/executionStepLabels'
 import {
   buildIdempotencyKey,
   createAgentThreadId,
+  persistActiveThreadId,
+  resolveBootstrapThreadId,
   shouldPollRuntimeHealth,
   checkRuntimeHealthViaNest,
   RUNTIME_UNREACHABLE_SNIPPET,
@@ -161,7 +163,7 @@ const lastAssistantMessageId = computed(() =>
 function isLiveTurnMessage(msg: AgentStreamMessage): boolean {
   if (msg.role !== 'assistant') return false
   if (msg.id !== lastAssistantMessageId.value) return false
-  return Boolean(msg.streaming) || showTaskCard.value || Boolean(msg.executionTrace)
+  return Boolean(msg.streaming) || Boolean(msg.executionTrace) || showTaskCard.value
 }
 
 function canvasOutputsForMessage(msg: AgentStreamMessage) {
@@ -363,7 +365,7 @@ async function selectThread(threadId: string) {
   }
   clearComposer()
   agentThreadId.value = threadId
-  localStorage.setItem(lastThreadStorageKey(props.sessionId), threadId)
+  persistActiveThreadId(props.sessionId, threadId)
   historyOpen.value = false
   taskProgress.value = emptyTaskProgress()
   interruptGate.value = null
@@ -376,13 +378,27 @@ async function selectThread(threadId: string) {
 async function bootstrapThread() {
   clearComposer()
   agent.clear()
+  taskProgress.value = emptyTaskProgress()
   const cached = localStorage.getItem(lastThreadStorageKey(props.sessionId))
-  if (cached) {
-    agentThreadId.value = cached
-  } else {
-    const list = await fetchThreads()
-    agentThreadId.value = list[0]?.id ?? createAgentThreadId(props.sessionId)
-  }
+  const list = await fetchThreads()
+  agentThreadId.value = await resolveBootstrapThreadId(props.sessionId, {
+    cachedThreadId: cached,
+    threads: list,
+    messageCountFor: async (threadId) => {
+      try {
+        const res = await fetch(
+          apiUrl(
+            `/api/agent/chat/user/messages?sessionId=${encodeURIComponent(props.sessionId)}&threadId=${encodeURIComponent(threadId)}`,
+          ),
+        )
+        const json = await res.json()
+        return Array.isArray(json.data) ? json.data.length : 0
+      } catch {
+        return 0
+      }
+    },
+  })
+  persistActiveThreadId(props.sessionId, agentThreadId.value)
   await loadHistory()
   void refreshThreadCheckpoint()
   scrollToBottom()
@@ -485,7 +501,7 @@ function newAgentSession() {
   hasAtomicCheckpoint.value = false
   recoveredPhaseHint.value = null
   agentThreadId.value = createAgentThreadId(props.sessionId)
-  localStorage.setItem(lastThreadStorageKey(props.sessionId), agentThreadId.value)
+  persistActiveThreadId(props.sessionId, agentThreadId.value)
   ElMessage.info('已新建对话')
 }
 
@@ -510,16 +526,21 @@ async function refreshThreadCheckpoint() {
 
 async function loadHistory() {
   agent.clear()
+  taskProgress.value = emptyTaskProgress()
   try {
     const res = await fetch(
       apiUrl(
         `/api/agent/chat/user/messages?sessionId=${encodeURIComponent(props.sessionId)}&threadId=${encodeURIComponent(agentThreadId.value)}`,
       ),
     )
+    if (!res.ok) {
+      ElMessage.warning('对话历史加载失败，请检查网络后刷新')
+      return
+    }
     const json = await res.json()
     if (json.data?.length) agent.loadHistory(json.data)
   } catch {
-    // ignore
+    ElMessage.warning('对话历史加载失败，请检查网络后刷新')
   }
   scrollToBottom()
 }
@@ -542,7 +563,7 @@ async function send() {
     auth.openLogin()
     return
   }
-  localStorage.setItem(lastThreadStorageKey(props.sessionId), agentThreadId.value)
+  persistActiveThreadId(props.sessionId, agentThreadId.value)
 
   const message = input.value.trim()
   input.value = ''
@@ -603,7 +624,8 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
     return
   }
 
-  localStorage.setItem(lastThreadStorageKey(props.sessionId), agentThreadId.value)
+  persistActiveThreadId(props.sessionId, agentThreadId.value)
+  taskProgress.value = emptyTaskProgress()
 
   const { attachments: pendingAttachments } = sidebar.toPayload()
   const attachments = pendingAttachments

--- a/apps/web/src/components/agent/streamRecovery.test.ts
+++ b/apps/web/src/components/agent/streamRecovery.test.ts
@@ -4,15 +4,62 @@ import {
   buildIdempotencyKey,
   createAgentThreadId,
   randomThreadSuffix,
+  resolveBootstrapThreadId,
+  persistActiveThreadId,
   shouldPollRuntimeHealth,
   checkRuntimeHealthViaNest,
   isStreamStale,
   STREAM_STALE_MS,
 } from './streamRecovery'
+import { lastThreadStorageKey } from '@/utils/formatSessionTime'
 
 vi.mock('@/services/api-base', () => ({
   apiUrl: (path: string) => `http://localhost:5100${path.startsWith('/') ? path : `/${path}`}`,
 }))
+
+describe('resolveBootstrapThreadId', () => {
+  it('prefers cached thread when it has messages', async () => {
+    const id = await resolveBootstrapThreadId('sess1', {
+      cachedThreadId: 'sess1:cached',
+      threads: [{ id: 'sess1:other' }],
+      messageCountFor: async (tid) => (tid === 'sess1:cached' ? 3 : 0),
+    })
+    expect(id).toBe('sess1:cached')
+  })
+
+  it('falls back to first non-empty thread when cached is empty', async () => {
+    const id = await resolveBootstrapThreadId('sess1', {
+      cachedThreadId: 'sess1:empty',
+      threads: [{ id: 'sess1:empty' }, { id: 'sess1:busy' }],
+      messageCountFor: async (tid) => (tid === 'sess1:busy' ? 5 : 0),
+    })
+    expect(id).toBe('sess1:busy')
+  })
+
+  it('creates new thread when nothing has messages', async () => {
+    vi.stubGlobal('crypto', { randomUUID: () => 'new-thread' })
+    const id = await resolveBootstrapThreadId('sess1', {
+      cachedThreadId: null,
+      threads: [],
+      messageCountFor: async () => 0,
+    })
+    expect(id).toBe('sess1:new-thread')
+  })
+})
+
+describe('persistActiveThreadId', () => {
+  it('writes localStorage key', () => {
+    const store: Record<string, string> = {}
+    vi.stubGlobal('localStorage', {
+      setItem: (k: string, v: string) => {
+        store[k] = v
+      },
+      getItem: (k: string) => store[k] ?? null,
+    })
+    persistActiveThreadId('sess-abc', 'sess-abc:tid1')
+    expect(store[lastThreadStorageKey('sess-abc')]).toBe('sess-abc:tid1')
+  })
+})
 
 describe('randomThreadSuffix', () => {
   afterEach(() => {

--- a/apps/web/src/components/agent/streamRecovery.ts
+++ b/apps/web/src/components/agent/streamRecovery.ts
@@ -1,4 +1,5 @@
 import { apiUrl } from '@/services/api-base'
+import { lastThreadStorageKey } from '@/utils/formatSessionTime'
 import { randomId } from '@/utils/randomId'
 
 /**
@@ -29,6 +30,39 @@ export function randomThreadSuffix(): string {
 /** Build a session-scoped agent thread id (never reuse `:main`). */
 export function createAgentThreadId(sessionId: string): string {
   return `${sessionId}:${randomThreadSuffix()}`
+}
+
+/**
+ * Pick thread to restore after canvas refresh.
+ * Avoids blank UI when localStorage points at an empty thread (e.g. after「新建对话」).
+ */
+export async function resolveBootstrapThreadId(
+  sessionId: string,
+  opts: {
+    cachedThreadId: string | null
+    threads: Array<{ id: string }>
+    messageCountFor: (threadId: string) => Promise<number>
+  },
+): Promise<string> {
+  const { cachedThreadId, threads, messageCountFor } = opts
+
+  if (cachedThreadId) {
+    const cachedCount = await messageCountFor(cachedThreadId)
+    if (cachedCount > 0) return cachedThreadId
+  }
+
+  for (const th of threads) {
+    const count = await messageCountFor(th.id)
+    if (count > 0) return th.id
+  }
+
+  if (cachedThreadId) return cachedThreadId
+  if (threads[0]?.id) return threads[0].id
+  return createAgentThreadId(sessionId)
+}
+
+export function persistActiveThreadId(sessionId: string, threadId: string) {
+  localStorage.setItem(lastThreadStorageKey(sessionId), threadId)
 }
 
 /** Generate an idempotency key for POST /api/agent/chat/conversation. */

--- a/services/agent-runtime/app/graph/atomic_intent.py
+++ b/services/agent-runtime/app/graph/atomic_intent.py
@@ -295,6 +295,12 @@ def _has_prompt_explicit(text: str) -> bool:
     return False
 
 
+_BATCH_IMAGE_COUNT = re.compile(
+    r"(?:生成|做|来)\s*([一二三四五六七八九十两\d]+)\s*张|"
+    r"([一二三四五六七八九十两\d]+)\s*张(?:图|图片)",
+)
+
+
 def atomic_create_intent(text: str) -> bool:
     """True when user wants a single-shot create-and-generate flow."""
     lowered = (text or "").strip().lower()
@@ -310,6 +316,12 @@ def atomic_create_intent(text: str) -> bool:
         return True
     if _has_prompt_explicit(text):
         return True
+    batch_m = _BATCH_IMAGE_COUNT.search(text or "")
+    if batch_m:
+        token = batch_m.group(1) or batch_m.group(2) or ""
+        count = _parse_orch_count(token)
+        if count is not None and count >= 2:
+            return True
     if any(h in lowered for h in ATOMIC_CREATE_HINTS):
         return True
     if any(h in text for h in TEXT_DEFAULT_KEYWORDS):

--- a/services/agent-runtime/app/graph/atomic_parse_util.py
+++ b/services/agent-runtime/app/graph/atomic_parse_util.py
@@ -208,6 +208,20 @@ def parse_atomic_multi_items(utterance: str) -> list[dict[str, Any]] | None:
             labels = _split_atomic_item_labels(colon_m.group(1))
 
     if not labels or len(labels) < 2:
+        variant_markers = ("不同颜色", "多种颜色", "各色", "不同风格", "多种风格", "不同款式")
+        has_variant = any(m in t for m in variant_markers)
+        has_ref = bool(re.search(r"@I\d|参考|参照|这张图|这个图", t, re.IGNORECASE))
+        if expected is not None and expected >= 2 and (has_variant or has_ref):
+            base = re.sub(r"^@I\d+\s*[，,]?\s*", "", t).strip()
+            return [
+                {
+                    "target_type": "image",
+                    "prompt": f"{base}（变体 {i + 1}/{expected}）".strip(),
+                    "title": f"变体{i + 1}",
+                    "confirm_gate": False,
+                }
+                for i in range(expected)
+            ]
         return None
     if expected is not None and expected != len(labels):
         return None

--- a/services/agent-runtime/tests/test_atomic_parse_util.py
+++ b/services/agent-runtime/tests/test_atomic_parse_util.py
@@ -64,6 +64,42 @@ def test_parse_atomic_multi_items_not_single_image():
     assert parse_atomic_multi_items("帮我生成一个模特人物图") is None
 
 
+def test_parse_atomic_multi_items_color_variants_with_ref():
+    from app.graph.atomic_parse_util import parse_atomic_multi_items
+
+    utterance = "@I1 ，参考这个图，生成7中不同颜色的7张图"
+    items = parse_atomic_multi_items(utterance)
+    assert items is not None
+    assert len(items) == 7
+    assert all(i["target_type"] == "image" for i in items)
+    assert "变体 1/7" in items[0]["prompt"]
+
+
+def test_atomic_create_intent_batch_image_count():
+    from app.graph.atomic_intent import atomic_create_intent
+
+    assert atomic_create_intent("@I1 ，参考这个图，生成7中不同颜色的7张图")
+    assert atomic_create_intent("生成3张场景图")
+    assert not atomic_create_intent("今天天气不错")
+
+
+def test_intake_routes_batch_color_variants_to_atomic():
+    from app.graph.nodes.intake import make_intake_node
+    from langchain_core.messages import HumanMessage
+    from pathlib import Path
+
+    skills_dir = Path(__file__).resolve().parents[1] / "skills"
+    intake = make_intake_node(skills_dir)
+    utterance = "@I1 ，参考这个图，生成7中不同颜色的7张图"
+
+    import asyncio
+
+    out = asyncio.get_event_loop().run_until_complete(
+        intake({"messages": [HumanMessage(content=utterance)]})
+    )
+    assert out["flow_mode"] == "atomic_create"
+
+
 def test_build_atomic_spec_enriched_uses_clean_prompt():
     spec = build_atomic_spec_enriched("帮我生成一个模特人物图")
     assert spec["target_type"] == "image"


### PR DESCRIPTION
## Summary
- Fix canvas refresh loading blank agent sidebar when localStorage points to an empty thread (`resolveBootstrapThreadId` fallback + persist active thread).
- Clear stale `taskProgress` on new turns and history load so chat rounds no longer show prior「成功 1」.
- Route batch image requests like「@I1 参考这个图，生成7种不同颜色的7张图」to `atomic_create` (7 variant items) instead of default chat.

## Test plan
- [x] `pnpm build`
- [x] `pytest services/agent-runtime/tests/test_atomic_parse_util.py` (21 passed)
- [x] `vitest streamRecovery.test.ts` (18 passed)
- [ ] Production: `deploy/prod-agent-thread-verify.py`
- [ ] Production: batch color variant SSE routes to atomic_create on session `cmsg9wz5k00c4ny01jx792a3z`


Made with [Cursor](https://cursor.com)