### PR TITLE
fix: 中文文件名下载 500（Content-Disposition）

### DIFF
--- a/apps/server/src/media/media.service.test.ts
+++ b/apps/server/src/media/media.service.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 import { Test } from '@nestjs/testing'
 import {
   collectUrlsFromCanvasData,
+  contentDispositionAttachment,
   MediaService,
   sanitizeFilename,
 } from './media.service'
@@ -118,5 +119,22 @@ describe('MediaService.resolveDownloadSource', () => {
 describe('sanitizeFilename', () => {
   it('strips unsafe characters from basename', () => {
     expect(sanitizeFilename('a/b?c*.png')).toBe('b_c_.png')
+  })
+})
+
+describe('contentDispositionAttachment', () => {
+  it('keeps filename= ASCII-only for CJK names', () => {
+    const header = contentDispositionAttachment('让模特换上产品图.png')
+    expect(header).toMatch(/^attachment; filename="[^"]+"; filename\*=UTF-8''/)
+    expect(header).toContain(encodeURIComponent('让模特换上产品图.png'))
+    const quoted = header.match(/filename="([^"]*)"/)?.[1] ?? ''
+    expect(quoted).toMatch(/^[\x20-\x7E]+$/)
+    expect(quoted).not.toBe('')
+  })
+
+  it('preserves ASCII filename in filename=', () => {
+    expect(contentDispositionAttachment('product-shot.png')).toBe(
+      'attachment; filename="product-shot.png"; filename*=UTF-8\'\'product-shot.png',
+    )
   })
 })

--- a/apps/server/src/media/media.service.ts
+++ b/apps/server/src/media/media.service.ts
@@ -220,9 +220,12 @@ export function mimeFromExt(fileName: string): string | undefined {
   }
 }
 
+/** RFC 5987: `filename=` must be ASCII; CJK and symbols go in `filename*=` only. */
 export function contentDispositionAttachment(filename: string): string {
   const safe = sanitizeFilename(filename)
-  return `attachment; filename="${safe}"; filename*=UTF-8''${encodeURIComponent(safe)}`
+  const asciiFallback =
+    safe.replace(/[^\x20-\x7E]/g, '_').replace(/["\\]/g, '_').trim() || 'download.bin'
+  return `attachment; filename="${asciiFallback}"; filename*=UTF-8''${encodeURIComponent(safe)}`
 }
 
 export async function openDownloadStream(

--- a/apps/web/src/composables/useCanvasMedia.ts
+++ b/apps/web/src/composables/useCanvasMedia.ts
@@ -161,7 +161,15 @@ export async function downloadMediaFile(
     headers: { Authorization: `Bearer ${token}` },
   })
   if (!res.ok) {
-    ElMessage.warning('下载失败，链接可能已过期，请稍后重试')
+    if (res.status === 401) {
+      ElMessage.warning('登录已过期，请重新登录后再下载')
+    } else if (res.status === 403) {
+      ElMessage.warning('无权下载该文件，请刷新画布后重试')
+    } else if (res.status >= 500) {
+      ElMessage.warning('下载服务异常，请稍后重试')
+    } else {
+      ElMessage.warning('下载失败，链接可能已过期，请稍后重试')
+    }
     return
   }
   triggerDownload(await res.blob(), filename)


### PR DESCRIPTION
## Summary
- 修复画布节点 hover 下载、资产库预览下载在中文 prompt/label 文件名时返回 HTTP 500 的问题
- 根因：`Content-Disposition: filename="中文.png"` 含非 ASCII，Node.js `setHeader` 抛错
- 改为 `filename=` ASCII fallback + RFC 5987 `filename*=UTF-8''...` 保留中文下载名
- 前端区分 401/403/500 下载错误提示

## Test plan
- [x] `vitest run src/media/media.service.test.ts`（9 passed）
- [ ] 生产部署后：画布节点 hover 下载含中文 prompt 的图片
- [ ] 生产部署后：资产库预览下载含中文 label 的条目


Made with [Cursor](https://cursor.com)