### PR TITLE
fix: BytePlus Seedance 2-0-260128 gateway profile routing

### DIFF
--- a/deploy/prod-pr174-verify.py
+++ b/deploy/prod-pr174-verify.py
@@ -361,7 +361,9 @@ def main() -> int:
             ref_wire3 = str(meta3.get("refWire") or "")
             record(
                 "Seedance refWire set",
-                "seedance" in ref_wire3.lower() or str(rec3.get("status")) in ("generating", "failed", "completed"),
+                ref_wire3.lower().startswith("apimart_")
+                or "seedance" in ref_wire3.lower()
+                or str(rec3.get("status")) in ("generating", "failed", "completed", "fallback_pending"),
                 f"refWire={ref_wire3 or '(empty)'} status={rec3.get('status')}",
             )
             record(

--- a/packages/agent/src/studio/generation-adapter.test.ts
+++ b/packages/agent/src/studio/generation-adapter.test.ts
@@ -204,6 +204,24 @@ describe('buildVideoProviderOptions', () => {
     expect(prompt).not.toContain('@Image10')
   })
 
+  it('resolves BYOK BytePlus base gateway hint to apimart_multimodal with mini variant', () => {
+    const bundle = buildVideoReferenceBundle([
+      { refKey: 'I1', mediaType: 'image', url: 'https://cdn/a.png' },
+      { refKey: 'V1', mediaType: 'video', url: 'https://cdn/v.mp4' },
+    ])
+    const r = buildVideoProviderOptions({
+      modelKey: 'doubao-seedance-2-0-260128',
+      gatewayModelHint: 'doubao-seedance-2-0-260128',
+      referenceBundle: bundle,
+      channelBaseUrl: 'https://api.apimart.ai/v1',
+    })
+    expect(r.meta.refWire).toBe('apimart_multimodal')
+    expect(r.model).toBe('doubao-seedance-2-0-260128')
+    expect(r.meta.gatewayModelId).toBe('doubao-seedance-2-0-260128')
+    expect(r.meta.variantTag).toBe('mini')
+    expect(r.providerOptions.referenceImages).toEqual(['https://cdn/a.png'])
+  })
+
   it('resolves BYOK fast gateway hint to apimart_multimodal with fast variant clamp', () => {
     const bundle = buildVideoReferenceBundle([
       { refKey: 'I1', mediaType: 'image', url: 'https://cdn/a.png' },

--- a/packages/shared/src/videoModelProfiles.test.ts
+++ b/packages/shared/src/videoModelProfiles.test.ts
@@ -109,6 +109,12 @@ describe('resolveSeedance20Gateway', () => {
   it('returns null for non-seedance models', () => {
     expect(resolveSeedance20Gateway('agnes-video-v2.0', 'agnes-video-v2.0')).toBeNull()
   })
+
+  it('maps BytePlus base id doubao-seedance-2-0-260128 to mini gateway', () => {
+    expect(
+      resolveSeedance20Gateway('doubao-seedance-2-0-260128', 'doubao-seedance-2-0-260128'),
+    ).toBe('doubao-seedance-2.0-mini')
+  })
 })
 
 describe('isSeedance1x', () => {
@@ -142,5 +148,16 @@ describe('resolveVideoModelProfile BYOK fast hint', () => {
     expect(p.refWire).toBe('apimart_multimodal')
     expect(p.gatewayModelId).toBe('doubao-seedance-2.0-fast')
     expect(p.variantTag).toBe('fast')
+  })
+
+  it('uses apimart_multimodal for BytePlus mini id while preserving upstream gatewayModelId', () => {
+    const p = resolveVideoModelProfile(
+      'doubao-seedance-2-0-260128',
+      'doubao-seedance-2-0-260128',
+      { channelBaseUrl: 'https://api.apimart.ai/v1' },
+    )
+    expect(p.refWire).toBe('apimart_multimodal')
+    expect(p.gatewayModelId).toBe('doubao-seedance-2-0-260128')
+    expect(p.variantTag).toBe('mini')
   })
 })

--- a/packages/shared/src/videoModelProfiles.ts
+++ b/packages/shared/src/videoModelProfiles.ts
@@ -60,6 +60,24 @@ export function isSeedance1x(gatewayModelId: string): boolean {
   return /^doubao-seedance-1[.-]/i.test(gatewayModelId)
 }
 
+/** BytePlus ModelArk ids use hyphens (2-0-260128); APIMart catalog uses dots (2.0-mini). */
+function inferSeedance20VariantFromDoubaoGateway(gatewayModelId: string): SeedanceVariantTag | null {
+  if (isSeedance1x(gatewayModelId)) return null
+  if (!/^doubao-seedance-2[.-]0/i.test(gatewayModelId)) return null
+
+  const lower = gatewayModelId.toLowerCase()
+  const exact = Object.values(SEEDANCE_20_GATEWAYS).find((gw) => gw.toLowerCase() === lower)
+  if (exact) return GATEWAY_TO_VARIANT[exact]
+
+  if (/-fast(?:$|[-_])/i.test(lower)) return 'fast'
+  if (/-face(?:$|[-_])/i.test(lower)) return 'face'
+  if (/-mini(?:$|[-_])/i.test(lower)) return 'mini'
+  if (/^doubao-seedance-2[.-]0$/i.test(gatewayModelId)) return 'standard'
+  // e.g. doubao-seedance-2-0-260128 (BytePlus base 2.0)
+  if (/^doubao-seedance-2-0-\d+$/i.test(gatewayModelId)) return 'mini'
+  return 'mini'
+}
+
 export function resolveSeedance20Gateway(
   modelKey: string,
   gatewayModelId: string,
@@ -72,12 +90,11 @@ export function resolveSeedance20Gateway(
   if (/^seedance-2\.0-fast$/i.test(modelKey)) return SEEDANCE_20_GATEWAYS.fast
   if (/^seedance-2\.0-face$/i.test(modelKey)) return SEEDANCE_20_GATEWAYS.face
   if (/^seedance-2\.0$/i.test(modelKey)) return SEEDANCE_20_GATEWAYS.standard
-  if (isSeedance1x(gatewayModelId)) return null
-  if (/^doubao-seedance-2\.0/i.test(gatewayModelId)) {
-    const exact = Object.values(SEEDANCE_20_GATEWAYS).find(
-      (gw) => gw.toLowerCase() === gatewayModelId.toLowerCase(),
-    )
-    return exact ?? null
+  if (isSeedance1x(gatewayModelId) || isSeedance1x(modelKey)) return null
+
+  for (const id of [gatewayModelId, modelKey]) {
+    const variant = inferSeedance20VariantFromDoubaoGateway(id)
+    if (variant) return SEEDANCE_20_GATEWAYS[variant]
   }
   return null
 }
@@ -141,7 +158,15 @@ export function resolveVideoModelProfile(
 ): VideoModelProfile {
   const seedanceGw = resolveSeedance20Gateway(modelKey, gatewayModelId)
   if (seedanceGw) {
-    return buildSeedance20Profile(seedanceGw)
+    const profile = buildSeedance20Profile(seedanceGw)
+    // BYOK channels may use upstream ids (e.g. doubao-seedance-2-0-260128) — keep for API calls.
+    if (
+      gatewayModelId.toLowerCase() !== seedanceGw.toLowerCase() &&
+      /^doubao-seedance-/i.test(gatewayModelId)
+    ) {
+      return { ...profile, gatewayModelId }
+    }
+    return profile
   }
 
   const gw = resolveVideoGatewayModelId(modelKey, gatewayModelId)


### PR DESCRIPTION
## Summary

- 识别 BytePlus ModelArk gateway id `doubao-seedance-2-0-260128`（连字符 `2-0`），映射到 mini variant + `apimart_multimodal`
- BYOK 出站保留原始 upstream id，profile/clamp 走 canonical mini
- 生产验证脚本接受 `apimart_*` refWire

## Root cause

`resolveSeedance20Gateway` 仅匹配 `doubao-seedance-2.0`（点号），生产 BYOK 通道使用 `doubao-seedance-2-0-260128`，导致 `legacy_prompt_tags`。

## Test plan

- [x] `videoModelProfiles.test.ts` 16/16
- [x] `generation-adapter.test.ts` 29/29
- [x] `pnpm build`
- [ ] CI green
- [ ] Deploy + prod verify (Seedance refWire)


Made with [Cursor](https://cursor.com)