### PR TITLE
fix: normalize APIMart video URL array in task result

### DIFF
--- a/packages/agent/src/tools/video-provider.test.ts
+++ b/packages/agent/src/tools/video-provider.test.ts
@@ -111,6 +111,29 @@ describe('ApimartVideoProvider', () => {
     expect(url).toBe('https://cdn/v.mp4')
     expect(JSON.parse(String(fetchMock.mock.calls[0][1].body)).image_urls).toBeUndefined()
   })
+
+  it('normalizes apimart result.url when returned as string array', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: [{ task_id: 'task_arr' }] }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: {
+            status: 'completed',
+            result: {
+              url: [
+                'https://getapib.org/video/9998213808887624-db838584-132d-48ee-a487-440a1a26f801-video_task_01KZGMCY3V95MGPWVY46C3NWF3.mp4',
+              ],
+            },
+          },
+        }),
+      })
+    const provider = new ApimartVideoProvider('key', 'https://api.apimart.ai/v1', 0, 30_000)
+    const { url } = await provider.generate('hello', { model: 'doubao-seedance-2.0-mini', duration: 5 })
+    expect(url).toBe(
+      'https://getapib.org/video/9998213808887624-db838584-132d-48ee-a487-440a1a26f801-video_task_01KZGMCY3V95MGPWVY46C3NWF3.mp4',
+    )
+  })
 })
 
 describe('resolveVideoParams', () => {

--- a/packages/agent/src/tools/video-provider.ts
+++ b/packages/agent/src/tools/video-provider.ts
@@ -176,15 +176,26 @@ function extractApimartTaskId(json: unknown): string | undefined {
   return (first as { task_id?: string })?.task_id
 }
 
+function pickFirstUrl(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim()) return value.trim()
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const picked = pickFirstUrl(item)
+      if (picked) return picked
+    }
+  }
+  return undefined
+}
+
 function extractApimartVideoUrl(data: unknown): string | undefined {
   const result = (data as {
-    result?: { video_url?: string; url?: string; videos?: Array<{ url?: string }> }
+    result?: { video_url?: unknown; url?: unknown; videos?: Array<{ url?: unknown }> }
   }).result
   return (
-    result?.video_url ??
-    result?.url ??
-    result?.videos?.[0]?.url ??
-    (data as { url?: string }).url
+    pickFirstUrl(result?.video_url) ??
+    pickFirstUrl(result?.url) ??
+    pickFirstUrl(result?.videos?.[0]?.url) ??
+    pickFirstUrl((data as { url?: unknown }).url)
   )
 }
 


### PR DESCRIPTION
## Summary

- APIMart 任务完成时 `result.url` 可能返回 `string[]`（与图片侧一致），导致 Prisma `url` 字段类型错误、BYOK 误判失败
- 新增 `pickFirstUrl`，与 `extractApimartImageUrls` 对齐，归一化为单个 string
- 作用于所有走 `ApimartVideoProvider` 的路径（BYOK / 平台 env 指向 APIMart）

## Root cause

生产任务 `cmskbyebh001apc01qmjrb2v0`：上游已成功出片，落库时 `url: ["https://getapib.org/video/..."]` 触发 Prisma 校验失败。

## Test plan

- [x] `video-provider.test.ts` 14/14
- [x] `pnpm build`
- [ ] CI green
- [ ] Deploy


Made with [Cursor](https://cursor.com)