### PR TITLE
feat(agent): canvas control surface P0+P1 explore and harness (PR-A)

### DIFF
--- a/apps/server/src/agent/agent-canvas-tools.controller.ts
+++ b/apps/server/src/agent/agent-canvas-tools.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Inject, Post, UseGuards } from '@nestjs/common'
-import { IsArray, IsBoolean, IsOptional, IsString, ValidateNested } from 'class-validator'
+import { IsArray, IsBoolean, IsIn, IsOptional, IsString, ValidateNested } from 'class-validator'
 import { Type } from 'class-transformer'
 import { AgentCanvasToolsService } from './agent-canvas-tools.service'
 import { AgentInternalGuard } from './agent-internal.guard'
@@ -258,6 +258,101 @@ class WaitImageGenerationDto {
 
   @IsString()
   generationRecordId!: string
+}
+
+class GenerationLifecycleDto {
+  @IsString()
+  sessionId!: string
+
+  @IsString()
+  userId!: string
+
+  @IsOptional()
+  @IsString()
+  generationRecordId?: string
+
+  @IsOptional()
+  @IsString()
+  nodeId?: string
+}
+
+class SessionUserDto {
+  @IsString()
+  sessionId!: string
+
+  @IsString()
+  userId!: string
+}
+
+class ListGenerationTasksDto {
+  @IsString()
+  sessionId!: string
+
+  @IsString()
+  userId!: string
+
+  @IsOptional()
+  @IsString()
+  type?: string
+}
+
+class UserOnlyDto {
+  @IsString()
+  userId!: string
+}
+
+class ListPublicAssetsDto {
+  @IsOptional()
+  @IsIn(['image', 'video', 'audio'])
+  kind?: 'image' | 'video' | 'audio'
+
+  @IsOptional()
+  @IsString()
+  search?: string
+}
+
+class SaveNodeAssetDto {
+  @IsString()
+  sessionId!: string
+
+  @IsString()
+  userId!: string
+
+  @IsString()
+  nodeId!: string
+
+  @IsOptional()
+  @IsString()
+  label?: string
+}
+
+class IntroduceNodesDto {
+  @IsString()
+  sessionId!: string
+
+  @IsString()
+  userId!: string
+
+  @IsArray()
+  @IsString({ each: true })
+  nodeIds!: string[]
+}
+
+class ApplyAssetToNodeDto {
+  @IsString()
+  sessionId!: string
+
+  @IsString()
+  userId!: string
+
+  @IsString()
+  nodeId!: string
+
+  @IsString()
+  assetId!: string
+
+  @IsIn(['user', 'public'])
+  source!: 'user' | 'public'
 }
 
 class SaveAgentMessageDto {
@@ -524,6 +619,66 @@ export class AgentCanvasToolsController {
   @Post('get-generation-status')
   async getGenerationStatus(@Body() dto: SessionNodeDto) {
     const data = await this.tools.getGenerationStatus(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('get-generation-diagnostic')
+  async getGenerationDiagnostic(@Body() dto: GenerationLifecycleDto) {
+    const data = await this.tools.getGenerationDiagnostic(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('cancel-generation')
+  async cancelGeneration(@Body() dto: GenerationLifecycleDto) {
+    const data = await this.tools.cancelGeneration(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('confirm-platform-fallback')
+  async confirmPlatformFallback(@Body() dto: GenerationLifecycleDto) {
+    const data = await this.tools.confirmPlatformFallback(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('cancel-platform-fallback')
+  async cancelPlatformFallback(@Body() dto: GenerationLifecycleDto) {
+    const data = await this.tools.cancelPlatformFallback(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('list-generation-tasks')
+  async listGenerationTasks(@Body() dto: ListGenerationTasksDto) {
+    const data = await this.tools.listGenerationTasks(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('list-user-assets')
+  async listUserAssets(@Body() dto: UserOnlyDto) {
+    const data = await this.tools.listUserAssets(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('list-public-assets')
+  async listPublicAssets(@Body() dto: ListPublicAssetsDto) {
+    const data = await this.tools.listPublicAssets(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('save-node-to-asset-library')
+  async saveNodeToAssetLibrary(@Body() dto: SaveNodeAssetDto) {
+    const data = await this.tools.saveNodeToAssetLibrary(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('introduce-nodes-to-agent')
+  async introduceNodesToAgent(@Body() dto: IntroduceNodesDto) {
+    const data = await this.tools.introduceNodesToAgent(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('apply-asset-to-node')
+  async applyAssetToNode(@Body() dto: ApplyAssetToNodeDto) {
+    const data = await this.tools.applyAssetToNode(dto)
     return { code: 0, message: 'ok', data }
   }
 

--- a/apps/server/src/agent/agent-canvas-tools.service.test.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.test.ts
@@ -22,6 +22,11 @@ describe('AgentCanvasToolsService', () => {
   const generateAudio = vi.fn()
   const expandPromptContent = vi.fn()
   const getGeneration = vi.fn()
+  const cancelGenerationStudio = vi.fn()
+  const getGenerationDiagnostic = vi.fn()
+  const confirmPlatformFallback = vi.fn()
+  const cancelPlatformFallback = vi.fn()
+  const listGenerations = vi.fn()
 
   const defaultPrefs = {
     userId: 'u1',
@@ -89,6 +94,30 @@ describe('AgentCanvasToolsService', () => {
       status: 'completed',
       url: 'https://cdn.example/audio.mp3',
     })
+    cancelGenerationStudio.mockResolvedValue({ id: 'rec-1', status: 'failed' })
+    getGenerationDiagnostic.mockResolvedValue({
+      errorCode: 'upstream',
+      userMessage: '上游失败',
+      providerSnippet: '',
+    })
+    confirmPlatformFallback.mockResolvedValue({
+      id: 'rec-1',
+      status: 'completed',
+      url: 'https://cdn.example/fallback.png',
+    })
+    cancelPlatformFallback.mockResolvedValue({ id: 'rec-1', status: 'failed' })
+    listGenerations.mockResolvedValue([
+      {
+        id: 'g1',
+        type: 'image',
+        status: 'completed',
+        prompt: 'test',
+        url: 'https://cdn/x.png',
+        nodeId: 'img-1',
+        sessionId: 's1',
+        createdAt: new Date('2026-08-08T00:00:00Z'),
+      },
+    ])
 
     // Serialize concurrent $transaction callbacks.
     // serializable / read-committed TX chain would queue concurrent
@@ -121,7 +150,20 @@ describe('AgentCanvasToolsService', () => {
         },
         {
           provide: StudioService,
-          useValue: { generateImage, generateVideo, generateText, generatePrompt, generateAudio, getGeneration, expandPromptContent },
+          useValue: {
+            generateImage,
+            generateVideo,
+            generateText,
+            generatePrompt,
+            generateAudio,
+            getGeneration,
+            expandPromptContent,
+            cancelGeneration: cancelGenerationStudio,
+            getGenerationDiagnostic,
+            confirmPlatformFallback,
+            cancelPlatformFallback,
+            listGenerations,
+          },
         },
       ],
     }).compile()
@@ -1026,6 +1068,95 @@ describe('AgentCanvasToolsService', () => {
           }),
         }),
       )
+    })
+  })
+
+  describe('generation lifecycle', () => {
+    beforeEach(() => {
+      canvas = {
+        nodes: [
+          {
+            id: 'img-1',
+            type: 'image',
+            position: { x: 0, y: 0 },
+            data: {
+              prompt: 'test',
+              status: 'generating',
+              generationRecordId: 'rec-1',
+            },
+          },
+        ],
+        edges: [],
+      }
+    })
+
+    it('cancelGeneration resolves record from node and patches canvas', async () => {
+      const result = await svc.cancelGeneration({
+        sessionId: 's1',
+        userId: 'u1',
+        nodeId: 'img-1',
+      })
+      expect(cancelGenerationStudio).toHaveBeenCalledWith('u1', 'rec-1')
+      expect(result.status).toBe('cancelled')
+      expect(canvas.nodes[0].data.status).toBe('error')
+      expect(canvas.nodes[0].data.errorMessage).toBe('已取消')
+    })
+
+    it('getGenerationDiagnostic delegates to studio', async () => {
+      const d = await svc.getGenerationDiagnostic({
+        sessionId: 's1',
+        userId: 'u1',
+        generationRecordId: 'rec-1',
+      })
+      expect(getGenerationDiagnostic).toHaveBeenCalledWith('u1', 'rec-1')
+      expect(d.userMessage).toBe('上游失败')
+    })
+  })
+
+  describe('P1 explore harness', () => {
+    beforeEach(() => {
+      canvas = {
+        nodes: [
+          {
+            id: 'img-1',
+            type: 'image',
+            position: { x: 0, y: 0 },
+            data: {
+              title: '主图',
+              url: 'https://cdn.example/img.png',
+              status: 'completed',
+            },
+          },
+          {
+            id: 'txt-1',
+            type: 'text',
+            position: { x: 0, y: 0 },
+            data: { content: '文案内容', title: '文案' },
+          },
+        ],
+        edges: [],
+      }
+    })
+
+    it('listGenerationTasks delegates to studio', async () => {
+      const result = await svc.listGenerationTasks({
+        sessionId: 's1',
+        userId: 'u1',
+      })
+      expect(listGenerations).toHaveBeenCalledWith('u1', undefined, 's1')
+      expect(result.tasks).toHaveLength(1)
+      expect(result.tasks[0].nodeId).toBe('img-1')
+    })
+
+    it('introduceNodesToAgent builds attachments and canvasCommands', async () => {
+      const result = await svc.introduceNodesToAgent({
+        sessionId: 's1',
+        userId: 'u1',
+        nodeIds: ['img-1', 'txt-1', 'missing'],
+      })
+      expect(result.attachments).toHaveLength(2)
+      expect(result.skipped).toEqual(['missing'])
+      expect(result.canvasCommands[0]?.type).toBe('introduce_nodes')
     })
   })
 })

--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -1,4 +1,4 @@
-import { ConflictException, ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common'
+import { BadRequestException, ConflictException, ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common'
 import { applyCanvasActions } from '@lnkpi/agent'
 import {
   resolveNodeRefs,
@@ -12,6 +12,7 @@ import {
   validateSidebarAttachments,
 } from '@lnkpi/shared'
 import { PrismaService } from '../prisma/prisma.service'
+import { PUBLIC_ASSETS } from '../assets/public-assets.data'
 import { StudioService, type StudioRefInput } from '../studio/studio.service'
 
 const GRID_X = 280
@@ -61,6 +62,39 @@ function nodeTitle(node: CanvasNode): string {
 
 function nodeStatus(node: CanvasNode): string {
   return String(node.data?.status ?? 'draft')
+}
+
+function nodeToAgentAttachment(node: CanvasNode): SidebarAttachment | null {
+  const data = node.data ?? {}
+  const url = String(data.url ?? '').trim()
+  const text = String(data.content ?? data.prompt ?? '').trim()
+  if (!url && !text) return null
+
+  const t = String(node.type ?? '')
+  let mediaType: SidebarAttachment['mediaType'] = 'image'
+  if (t === 'text' || t === 'prompt') mediaType = 'text'
+  else if (t === 'video') mediaType = 'video'
+  else if (t === 'audio') mediaType = 'audio'
+  else if (t === 'image' || t === 'mediaInput') mediaType = 'image'
+  else if (text && !url) mediaType = 'text'
+  else if (!url) return null
+
+  return {
+    id: `agent-ref-${node.id}`,
+    mediaType,
+    sourceKind: 'canvasNode',
+    label: nodeTitle(node) || node.id,
+    url: url || undefined,
+    text: text || undefined,
+    sourceNodeId: node.id,
+  }
+}
+
+function assetKindFromNodeType(type: string): 'image' | 'video' | 'audio' | null {
+  if (type === 'image' || type === 'mediaInput') return 'image'
+  if (type === 'video') return 'video'
+  if (type === 'audio') return 'audio'
+  return null
 }
 
 function toStudioRefs(node: CanvasNode, canvas: CanvasData): StudioRefInput[] {
@@ -1206,11 +1240,313 @@ export class AgentCanvasToolsService {
   async getGenerationStatus(input: {
     sessionId: string
     nodeId: string
-  }): Promise<{ status: string; url?: string }> {
+  }): Promise<{ status: string; url?: string; generationRecordId?: string }> {
     const node = await this.getNode(input)
     const status = nodeStatus(node)
     const url = typeof node.data?.url === 'string' && node.data.url ? node.data.url : undefined
-    return url ? { status, url } : { status }
+    const generationRecordId =
+      typeof node.data?.generationRecordId === 'string' && node.data.generationRecordId
+        ? node.data.generationRecordId
+        : undefined
+    return generationRecordId
+      ? { status, url, generationRecordId }
+      : url
+        ? { status, url }
+        : { status }
+  }
+
+  private generationRecordIdFromNode(node: CanvasNode): string | undefined {
+    const id = node.data?.generationRecordId
+    return typeof id === 'string' && id.trim() ? id.trim() : undefined
+  }
+
+  private async resolveGenerationRecord(input: {
+    sessionId: string
+    userId: string
+    generationRecordId?: string
+    nodeId?: string
+  }): Promise<{ recordId: string; nodeId?: string }> {
+    const direct = input.generationRecordId?.trim()
+    if (direct) {
+      return { recordId: direct, nodeId: input.nodeId }
+    }
+    if (!input.nodeId) {
+      throw new BadRequestException('需要提供 generationRecordId 或 nodeId')
+    }
+    const node = await this.getNode({ sessionId: input.sessionId, nodeId: input.nodeId })
+    const recordId = this.generationRecordIdFromNode(node)
+    if (!recordId) {
+      throw new NotFoundException('节点无关联的生成记录')
+    }
+    return { recordId, nodeId: input.nodeId }
+  }
+
+  async getGenerationDiagnostic(input: {
+    sessionId: string
+    userId: string
+    generationRecordId?: string
+    nodeId?: string
+  }) {
+    const { recordId } = await this.resolveGenerationRecord(input)
+    return this.studio.getGenerationDiagnostic(input.userId, recordId)
+  }
+
+  async cancelGeneration(input: {
+    sessionId: string
+    userId: string
+    generationRecordId?: string
+    nodeId?: string
+  }): Promise<{ status: string; generationRecordId: string; actions: CanvasAction[] }> {
+    const { recordId, nodeId } = await this.resolveGenerationRecord(input)
+    await this.studio.cancelGeneration(input.userId, recordId)
+    const actions: CanvasAction[] = []
+    if (nodeId) {
+      actions.push({
+        type: 'update_node',
+        payload: {
+          id: nodeId,
+          data: { status: 'error', errorMessage: '已取消' },
+        },
+      })
+      await this.persist(input.sessionId, actions)
+    }
+    return { status: 'cancelled', generationRecordId: recordId, actions }
+  }
+
+  async confirmPlatformFallback(input: {
+    sessionId: string
+    userId: string
+    generationRecordId?: string
+    nodeId?: string
+  }): Promise<{
+    status: string
+    generationRecordId: string
+    url?: string
+    actions: CanvasAction[]
+  }> {
+    const { recordId, nodeId } = await this.resolveGenerationRecord(input)
+    const record = await this.studio.confirmPlatformFallback(input.userId, recordId)
+    const actions: CanvasAction[] = []
+    const url = typeof record.url === 'string' && record.url ? record.url : undefined
+    if (nodeId) {
+      const patch: Record<string, unknown> = {
+        status: record.status === 'completed' ? 'completed' : record.status,
+        generationRecordId: recordId,
+      }
+      if (url) patch.url = url
+      if (record.status === 'failed') {
+        patch.errorMessage = '平台回退失败'
+      }
+      actions.push({
+        type: 'update_node',
+        payload: { id: nodeId, data: patch },
+      })
+      await this.persist(input.sessionId, actions)
+    }
+    return {
+      status: record.status,
+      generationRecordId: recordId,
+      url,
+      actions,
+    }
+  }
+
+  async cancelPlatformFallback(input: {
+    sessionId: string
+    userId: string
+    generationRecordId?: string
+    nodeId?: string
+  }): Promise<{ status: string; generationRecordId: string; actions: CanvasAction[] }> {
+    const { recordId, nodeId } = await this.resolveGenerationRecord(input)
+    await this.studio.cancelPlatformFallback(input.userId, recordId)
+    const actions: CanvasAction[] = []
+    if (nodeId) {
+      actions.push({
+        type: 'update_node',
+        payload: {
+          id: nodeId,
+          data: { status: 'error', errorMessage: '已拒绝平台回退' },
+        },
+      })
+      await this.persist(input.sessionId, actions)
+    }
+    return { status: 'failed', generationRecordId: recordId, actions }
+  }
+
+  async listGenerationTasks(input: {
+    sessionId: string
+    userId: string
+    type?: string
+  }): Promise<{
+    tasks: Array<{
+      id: string
+      type: string
+      status: string
+      prompt: string
+      url?: string | null
+      nodeId?: string | null
+      sessionId?: string | null
+      createdAt: Date
+    }>
+  }> {
+    await this.loadOwnedSession(input.sessionId, input.userId)
+    const rows = await this.studio.listGenerations(input.userId, input.type, input.sessionId)
+    return {
+      tasks: rows.map((row) => ({
+        id: row.id,
+        type: row.type,
+        status: row.status,
+        prompt: row.prompt,
+        url: row.url,
+        nodeId: row.nodeId,
+        sessionId: row.sessionId,
+        createdAt: row.createdAt,
+      })),
+    }
+  }
+
+  async listUserAssets(input: { userId: string }): Promise<{
+    items: Array<{
+      id: string
+      url: string
+      label: string
+      kind: string
+      sourceNodeId?: string | null
+      createdAt: Date
+    }>
+  }> {
+    const items = await this.prisma.userAsset.findMany({
+      where: { userId: input.userId },
+      orderBy: { createdAt: 'desc' },
+      take: 500,
+    })
+    return { items }
+  }
+
+  async listPublicAssets(input?: {
+    kind?: 'image' | 'video' | 'audio'
+    search?: string
+  }): Promise<{ items: typeof PUBLIC_ASSETS }> {
+    let items = PUBLIC_ASSETS
+    if (input?.kind) {
+      items = items.filter((item) => item.kind === input.kind)
+    }
+    if (input?.search) {
+      const q = input.search.toLowerCase()
+      items = items.filter((item) => item.label.toLowerCase().includes(q))
+    }
+    return { items }
+  }
+
+  async saveNodeToAssetLibrary(input: {
+    sessionId: string
+    userId: string
+    nodeId: string
+    label?: string
+  }): Promise<{ assetId: string; url: string; kind: string }> {
+    await this.loadOwnedSession(input.sessionId, input.userId)
+    const node = await this.getNode({ sessionId: input.sessionId, nodeId: input.nodeId })
+    const kind = assetKindFromNodeType(String(node.type ?? ''))
+    const url = String(node.data?.url ?? '').trim()
+    if (!kind || !url) {
+      throw new BadRequestException('节点缺少可保存的媒体 URL')
+    }
+    const item = await this.prisma.userAsset.upsert({
+      where: { userId_url: { userId: input.userId, url } },
+      create: {
+        userId: input.userId,
+        kind,
+        url,
+        label: input.label?.trim() || nodeTitle(node) || node.id,
+        sourceNodeId: node.id,
+      },
+      update: {
+        label: input.label?.trim() || nodeTitle(node) || node.id,
+        kind,
+        sourceNodeId: node.id,
+      },
+    })
+    return { assetId: item.id, url: item.url, kind: item.kind }
+  }
+
+  async introduceNodesToAgent(input: {
+    sessionId: string
+    userId: string
+    nodeIds: string[]
+  }): Promise<{
+    attachments: SidebarAttachment[]
+    skipped: string[]
+    canvasCommands: Array<{ type: string; attachments: SidebarAttachment[] }>
+  }> {
+    await this.loadOwnedSession(input.sessionId, input.userId)
+    const attachments: SidebarAttachment[] = []
+    const skipped: string[] = []
+    for (const nodeId of input.nodeIds) {
+      try {
+        const node = await this.getNode({ sessionId: input.sessionId, nodeId })
+        const att = nodeToAgentAttachment(node)
+        if (att) attachments.push(att)
+        else skipped.push(nodeId)
+      } catch {
+        skipped.push(nodeId)
+      }
+    }
+    const canvasCommands =
+      attachments.length > 0
+        ? [{ type: 'introduce_nodes', attachments }]
+        : []
+    return { attachments, skipped, canvasCommands }
+  }
+
+  async applyAssetToNode(input: {
+    sessionId: string
+    userId: string
+    nodeId: string
+    assetId: string
+    source: 'user' | 'public'
+  }): Promise<{ actions: CanvasAction[]; canvasCommands: Array<{ type: string; nodeId: string }> }> {
+    await this.loadOwnedSession(input.sessionId, input.userId)
+    let url = ''
+    let label = ''
+    let kind: 'image' | 'video' | 'audio' | null = null
+    if (input.source === 'user') {
+      const asset = await this.prisma.userAsset.findFirst({
+        where: { id: input.assetId, userId: input.userId },
+      })
+      if (!asset) throw new NotFoundException('资产不存在')
+      url = asset.url
+      label = asset.label
+      kind = asset.kind as 'image' | 'video' | 'audio'
+    } else {
+      const asset = PUBLIC_ASSETS.find((item) => item.id === input.assetId)
+      if (!asset) throw new NotFoundException('公共资产不存在')
+      url = asset.url
+      label = asset.label
+      kind = asset.kind
+    }
+    const node = await this.getNode({ sessionId: input.sessionId, nodeId: input.nodeId })
+    const nodeKind = assetKindFromNodeType(String(node.type ?? ''))
+    if (!nodeKind || nodeKind !== kind) {
+      throw new BadRequestException('资产类型与节点类型不匹配')
+    }
+    const actions: CanvasAction[] = [
+      {
+        type: 'update_node',
+        payload: {
+          id: input.nodeId,
+          data: {
+            url,
+            status: 'completed',
+            label: label || nodeTitle(node),
+          },
+        },
+      },
+    ]
+    await this.persist(input.sessionId, actions)
+    return {
+      actions,
+      canvasCommands: [{ type: 'focus_node', nodeId: input.nodeId }],
+    }
   }
 
   async getAgentMessages(input: {

--- a/apps/server/src/agent/agent-runtime.client.ts
+++ b/apps/server/src/agent/agent-runtime.client.ts
@@ -6,8 +6,7 @@ export interface RuntimeRunInput {
   userId: string
   message: string
   threadId?: string
-  /** W5 修复：用户结构化决策（confirm/revise/...），用于触发 agent-runtime 的
-   *  Command(resume=user_decision) 精确恢复 interrupt，避免重跑 route_entry→intake 卡死 */
+  /** W5：用户结构化决策；runtime 通过 aupdate_state 恢复 interrupt_before gate */
   userDecision?: 'confirm' | 'revise' | 'replan' | 'confirm_gen' | 'topo_revise' | 'node_revise'
   /** Runtime skill id after UI→runtime mapping */
   skillId?: string
@@ -137,8 +136,7 @@ export class AgentRuntimeClient {
         user_id: input.userId,
         message: input.message,
         thread_id: input.threadId ?? input.sessionId,
-        // W5 修复：把结构化决策转发给 agent-runtime
-        // 与 RunRequest.user_decision 字段对应，触发 Command(resume=...) 恢复 interrupt
+        // W5：转发 user_decision，供 interrupt_before gate 恢复（见 hitl_resume.py）
         user_decision: input.userDecision,
         skill_id: input.skillId,
         llm_model: input.llmModel,

--- a/apps/server/src/agent/agent.controller.ts
+++ b/apps/server/src/agent/agent.controller.ts
@@ -58,7 +58,7 @@ class ConversationDto {
   @IsString()
   threadId?: string
 
-  /** W5 修复：用户结构化决策（确认/修改/换方向），用于触发 Command(resume=...) 精确恢复 interrupt。
+  /** W5：用户结构化决策（确认/修改/换方向），写入 state 后恢复 interrupt_before gate。
    *  文本消息（"1"/"2"/"确认方案"等）也能走兼容分支，但显式传值更可靠。 */
   @IsOptional()
   @IsIn(['confirm', 'revise', 'replan', 'confirm_gen', 'topo_revise', 'node_revise'])

--- a/apps/server/src/agent/agent.service.ts
+++ b/apps/server/src/agent/agent.service.ts
@@ -329,7 +329,7 @@ export class AgentService {
       // 新建对话应换 thread，避免 MemorySaver 把旧 await_confirm 状态续上
       threadId: threadId?.trim() || sessionId,
       // W5 修复：把前端结构化决策（按钮点击）传给 agent-runtime
-      // 让它走 Command(resume=...) 精确恢复 interrupt，不再重跑 route_entry→intake
+      // interrupt_before 恢复：注入 user_decision 后 astream(None)，不再重跑 intake
       userDecision,
       skillId: runtimeSkillId,
       llmModel,

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -567,7 +567,7 @@ async function send() {
 
   const message = input.value.trim()
   input.value = ''
-  // W5 修复：手动输入若匹配确认/修改关键词，也带上 userDecision 触发 Command(resume=...)
+  // W5：手动输入若匹配确认/修改关键词，带上 userDecision，供 interrupt_before gate 恢复
   await sendMessage(message, mapPresetToDecision(message))
 }
 
@@ -583,7 +583,7 @@ async function sendPreset(text: string) {
   }
   input.value = ''
   // W5 修复：按钮选择是结构化决策（confirm/revise），需显式传递 userDecision
-  // 否则后端 Command(resume=...) 不会触发，流程会卡在 await_confirm
+  // 否则后端 interrupt_before 恢复（aupdate_state + astream(None)）拿不到 userDecision，会卡在 await_confirm
   const decision = mapPresetToDecision(text)
   await sendMessage(text.trim(), decision)
 }
@@ -925,6 +925,25 @@ function handleEvent(event: { type: string; data: unknown }) {
     case 'explore':
       agent.trackExplore(event.data as Parameters<typeof agent.trackExplore>[0])
       break
+    case 'canvas_command': {
+      const cmd = event.data as {
+        type: string
+        nodeId?: string
+        nodeIds?: string[]
+        attachments?: SidebarAttachment[]
+      }
+      if (cmd.type === 'focus_node' && cmd.nodeId) {
+        emit('focusNode', cmd.nodeId)
+      } else if (cmd.type === 'focus_nodes' && cmd.nodeIds?.length) {
+        emit('focusAll', cmd.nodeIds)
+      } else if (cmd.type === 'introduce_nodes' && cmd.attachments?.length) {
+        for (const att of cmd.attachments) {
+          if (sidebar.pendingAttachments.value.length >= SIDEBAR_ATTACHMENT_MAX) break
+          sidebar.addFromPayload(att)
+        }
+      }
+      break
+    }
     case 'task_list':
     case 'task_update':
     case 'task_summary': {

--- a/docs/superpowers/plans/2026-08-08-agent-canvas-control-surface.md
+++ b/docs/superpowers/plans/2026-08-08-agent-canvas-control-surface.md
@@ -1,0 +1,146 @@
+# Agent 画布控制面（Hybrid A）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development`（推荐）或 `superpowers:executing-plans` 按 Task 执行。步骤用 `- [ ]` 跟踪。
+>
+> **Spec SSOT:** `docs/superpowers/specs/2026-08-08-agent-canvas-control-surface-design.md`（v1.2）
+
+**Goal:** Agent 通过 explore 子图 + Harness Tool + `canvas_command` SSE，驱动画布读/轻写/生命周期，高成本生成仍走 Graph。
+
+**Architecture:** 三通道 — Harness Tool（数据）/ LangGraph Command（仅 fan-out）/ `canvas_command` SSE（UI）。explore 白名单见 `tool_registry.py`。
+
+**Tech Stack:** Python agent-runtime（LangGraph）、Nest Harness internal API、Vue AgentSideRail SSE。
+
+## Global Constraints
+
+- CS-4：explore **禁止** `run_*_generation`、`remove_*`、batch topology tools
+- CS-9：LangGraph `Command` **仅** gen_scheduler Send；HITL 用 `interrupt_before` + `aupdate_state`
+- Harness SSOT：`/agent/internal/*`；TS `CANVAS_TOOLS` deprecated（P4 移除 mock）
+- 每个 PR **仅**包含本 Task 文件；禁止混入无关 UI（Seedream/ImageParams 等）
+
+---
+
+## SDD 阶段与 PR 切分
+
+| PR | Wave | 范围 | 状态 |
+|----|------|------|------|
+| **PR-A** | P0 + P1 Harness/SSE | explore、lifecycle、tasks/assets、canvas_command | **代码就绪，待 commit** |
+| **PR-B** | P1 Graph | atomic P6、mixed confirm、sidebar explore bind | 未开始 |
+| **PR-C** | P2 | layout、duplicate、upload/export、group/ungroup | 未开始 |
+| **PR-D** | P3–P4 | 精修、trace、undo command、TS 降级 | 未开始 |
+
+---
+
+## PR-A — 已完成实现（待提交）
+
+### Task A1: Tool registry + explore 子图（P0）
+
+**Files:**
+- Create: `services/agent-runtime/app/tools/tool_registry.py`
+- Create: `services/agent-runtime/app/graph/nodes/explore.py`
+- Create: `services/agent-runtime/app/graph/canvas_commands.py`
+- Modify: `services/agent-runtime/app/tools/definitions.py`
+- Modify: `services/agent-runtime/app/graph/builder.py`, `route_decide.py`, `runs.py`
+
+- [x] explore allowlist + `build_explore_tools()`
+- [x] `route_decide` → `explore_canvas`
+- [x] 测试：`test_explore_tools.py`, `test_route_decide_explore.py`
+
+### Task A2: Lifecycle Harness（P0）
+
+**Files:**
+- Modify: `apps/server/src/agent/agent-canvas-tools.service.ts`, `.controller.ts`
+- Modify: `services/agent-runtime/app/tools/nest_client.py`
+
+- [x] cancel / diagnostic / platform fallback internal API
+- [x] 测试：`agent-canvas-tools.service.test.ts` lifecycle block
+
+### Task A3: P1 read/write Harness + explore bind
+
+**Files:** 同上 service/controller/definitions/nest_client/tool_registry
+
+- [x] `list_generation_tasks`, `list_*_assets`, `save_node_to_asset_library`
+- [x] `introduce_nodes_to_agent`, `apply_asset_to_node`, `focus_node`（UI tool）
+- [x] `canvas_command` SSE + AgentSideRail handler
+- [x] HITL 注释修正（非 LangGraph Command(resume)）
+
+### Task A4: 规格文档
+
+- [x] Spec v1.2（UI 对照 + LangGraph Command 边界）
+- [x] 本 Plan（SDD 格式）
+
+### Task A5: 验证（PR-A gate）
+
+```bash
+cd services/agent-runtime && python3 -m pytest \
+  tests/test_canvas_commands.py tests/test_explore_tools.py \
+  tests/test_route_decide_explore.py tests/test_nest_client.py \
+  tests/test_route_decide.py -q
+# Expected: 31 passed
+
+cd apps/server && npm test -- agent-canvas-tools.service.test.ts --run
+# Expected: 36 passed
+```
+
+- [x] 2026-08-08 验证通过（31 + 36 passed）
+
+### Task A6: Commit PR-A（**待用户确认**）
+
+**Stage 范围（仅 PR-A）：**
+
+```
+docs/superpowers/specs/2026-08-08-agent-canvas-control-surface-design.md
+docs/superpowers/plans/2026-08-08-agent-canvas-control-surface.md
+services/agent-runtime/app/** (explore, tool_registry, canvas_commands, …)
+services/agent-runtime/tests/test_*explore* test_canvas_commands test_nest_client
+apps/server/src/agent/agent-canvas-tools.*
+apps/server/src/agent/agent-runtime.client.ts
+apps/server/src/agent/agent.controller.ts
+apps/server/src/agent/agent.service.ts
+apps/web/src/components/agent/AgentSideRail.vue
+packages/agent/src/tools/canvas-tools.ts
+```
+
+**排除：** `ImageParamsSelector.vue`, `ProviderConfigDialog.vue`, `ImageDockPanel.vue`, `CanvasPage.vue`（若非本 feature 改动）
+
+- [ ] `git add` 上述路径
+- [ ] `git commit -m "feat(agent): canvas control surface P0+P1 explore and harness"`
+- [ ] `git push -u origin feat/agent-canvas-control-surface`
+- [ ] `gh pr create`（mydev-github-workflow）
+
+---
+
+## PR-B — P1 Graph 剩余（下一 Session）
+
+### Task B1: `apply_sidebar_attachments` 纳入 explore
+
+- [ ] definitions + tool_registry + nest 已有 → 加入 EXPLORE_TOOL_NAMES
+- [ ] 测试：explore bind 含该 tool
+
+### Task B2: atomic video P6 参数贯通
+
+- [ ] `atomic_create_gate` 读取 video P6 字段
+- [ ] 测试 + prod verify 扩展
+
+### Task B3: mixed 模态 confirm + lifecycle 双路径
+
+- [ ] material vs studio record 归一
+- [ ] 见 spec §1.4
+
+---
+
+## PR-C / PR-D
+
+见 Spec §1.1–§1.5 能力矩阵；P2 布局/复制/上传，P3 精修，P4 trace/undo/TS 降级。
+
+---
+
+## 能力速查
+
+| UI 操作 | Wave | 形态 |
+|---------|------|------|
+| 任务列表 | P1 ✅ | `list_generation_tasks` |
+| 定位 | P1 ✅ | `canvas_command` focus_node |
+| 资产/引入 Agent | P1 ✅ | Harness + SSE |
+| 小地图/布局 | P2 | `get_canvas_layout` |
+| 分组/整理 | P2–P3 | graph_batch |
+| 撤销 | P4 | `canvas_command` undo |

--- a/docs/superpowers/specs/2026-08-08-agent-canvas-control-surface-design.md
+++ b/docs/superpowers/specs/2026-08-08-agent-canvas-control-surface-design.md
@@ -1,0 +1,273 @@
+# Agent 画布控制面 — Hybrid 设计规格
+
+> 状态：**Accepted**（2026-08-08，v1.2 增补 LangGraph Command 边界）  
+> 方案：**A — Hybrid**（延续 ADR-003 / P5）  
+> 目标：Agent 可驱动画布 **Tool 级原语 + 原子能力 + 编排**，不将高成本生成 ReAct 化
+
+| 字段 | 值 |
+|------|-----|
+| 文档版本 | v1.2 |
+| 关联 | ADR-003、P5 atomic-orchestration-boundary、2026-08-07 platform-route-skill-boundary |
+
+---
+
+## 0. 决策摘要
+
+| # | 决策 |
+|---|------|
+| **CS-1** | Harness SSOT：`NestCanvasClient` + `/agent/internal/*`；StructuredTool 为可选 LLM 绑定层 |
+| **CS-2** | **atomic / campaign / single_node** 保持 LangGraph 确定性子图，不 bind 生成类 tools |
+| **CS-3** | 新增 **`explore_canvas` 流**：`bind_tools` 仅 **读 + 轻写 + 生成生命周期** |
+| **CS-4** | **禁止** explore 调用 `run_*_generation`、destructive `remove_*`、批量拓扑 |
+| **CS-5** | TS `CANVAS_TOOLS` 标记 deprecated；runtime 降级改调 Nest API（P4） |
+| **CS-6** | Tool 分层见 §0.4 |
+| **CS-7** | **三通道模型**：Harness Tool（改画布数据） / Client Command（改视口与本地 UI） / Graph-only（批量、destructive、gen） |
+| **CS-8** | 用户本地 **Undo 栈** 不纳入 Harness；Agent 通过 **`canvas_command` SSE** 或文案说明，不伪造服务端 undo |
+| **CS-9** | **LangGraph `Command`** 仅用于 **图内控制流**（动态路由 / Send fan-out）；画布副作用、UI 操作 **不得** 用 Command 承载 |
+
+### 0.2 三种「Command」命名空间（勿混用）
+
+| 名称 | 载体 | 作用域 | 典型 |
+|------|------|--------|------|
+| **LangGraph `Command`** | Python `langgraph.types.Command` | **Graph 运行时**内部 | `Command(goto=[Send("gen_node", ...)])` |
+| **Harness Tool** | Nest `/agent/internal/*` + StructuredTool | **画布/资产/任务数据** | `get_node`, `remove_nodes` |
+| **`canvas_command` SSE** | NDJSON `type: canvas_command` | **浏览器 UI** | `focus_node`, `undo` |
+
+---
+
+## 0.3 LangGraph `Command` — 纳入 / 不纳入
+
+> 参考：`hitl_resume.py`（HITL 恢复）、`gen_scheduler.py`（Send fan-out）
+
+LangGraph 有两种 interrupt；本项目 **HITL 用 `interrupt_before`**，恢复走 `aupdate_state` + `ainvoke(None)`，**不是** `Command(resume=...)`。
+
+| LangGraph `Command` 用法 | 是否采用 | 说明 |
+|--------------------------|----------|------|
+| `Command(goto=[Send(...)])` | ✅ **已用** | `gen_scheduler` 并行 fan-out → `gen_node` |
+| `Command(update=..., goto=...)` | ✅ **已用** | scheduler 合并 cascade 状态后路由 |
+| `Command(goto=["collect_gen"])` | ✅ **已用** | 生成调度结束 |
+| `Command(resume=...)` | ❌ **不用**（HITL） | 仅适用于节点内 `interrupt()`；本项目 gate 用 `interrupt_before` |
+| `Command` 驱动 Nest 画布 API | ❌ **禁止** | 副作用走 Tool，保持可测试 / 可追踪 |
+| `Command` 驱动前端定位/撤销 | ❌ **禁止** | 走 `canvas_command` SSE |
+
+**应纳入 LangGraph `Command` 的（仅图内控制流）：**
+
+| 场景 | 节点/边 | Wave |
+|------|---------|------|
+| Campaign 生成并行调度 | `gen_scheduler` → `Send("gen_node")` | 已有 |
+| 调度完成收口 | `gen_scheduler` → `collect_gen` | 已有 |
+| 未来：多 explore 轮次子图（若从单节点升级为子图） | 可选 `Command(goto="explore_tool_loop")` | 待定 |
+| 未来：动态选子图（atomic vs campaign 运行时分支） | 条件边优先；仅 fan-out 用 Command | 非优先 |
+
+**不得纳入 LangGraph `Command` 的（改走 Tool 或 SSE）：**
+
+| 用户/产品能力 | 正确通道 |
+|---------------|----------|
+| 读任务/节点/资产/布局 | Harness **Tool** |
+| 改 prompt、复制、上传、存资产库 | Harness **Tool** |
+| 分组、整理布局、批量加节点 | Harness **Tool**（graph_batch；graph 节点内调用） |
+| 删除节点 | Harness **Tool**（destructive） |
+| 取消生成 / 平台回退 | Harness **Tool**（lifecycle） |
+| 定位节点、撤销、打开精修面板 | **`canvas_command` SSE** |
+| HITL「确认出图 / 确认拓扑」 | **`interrupt_before` + state 注入**（非 Command） |
+
+**HITL 恢复（易与 Command 混淆）：**
+
+```
+用户点「确认」→ Nest 带 user_decision → runs.py
+  → prepare_interrupt_resume()  # aupdate_state(messages, user_decision)
+  → graph.astream(None)         # 继续 interrupt_before 之后的路径
+```
+
+前端注释里的 `Command(resume=...)` 为历史/泛化表述；**生产路径以 `hitl_resume.py` 为准**。
+
+---
+
+### 0.4 Tool 分层
+
+| Tier | 含义 | explore bind | 典型 |
+|------|------|--------------|------|
+| `read` | 只读查询 | ✅ | summary、layout、任务列表 |
+| `write_light` | 单节点/小范围写 | ✅ | set_prompt、duplicate、存资产库 |
+| `lifecycle` | 生成任务状态机 | ✅ | cancel、fallback confirm |
+| `graph_batch` | 批量拓扑/布局 | ❌ | group、grid layout、add_nodes_batch |
+| `gen` | 计费生成 | ❌ | run_*_generation |
+| `destructive` | 不可逆删除 | ❌ | remove_nodes |
+| `export` | 导出/下载 | ✅（返回 URL） | export_media_package |
+| `ui_command` | 前端执行 | N/A（SSE） | focus_node、undo |
+
+---
+
+## 1. 能力矩阵
+
+### 1.1 Tool 层 — explore 可 bind（P0 已落地 + 规划）
+
+| Tool | Tier | Wave | 说明 |
+|------|------|------|------|
+| `get_canvas_summary` | read | **P0** | 节点 id/type/title/status |
+| `get_node` | read | **P0** | 单节点快照 |
+| `get_generation_status` | read | **P0** | **单节点**当前生成态（≠ 任务列表） |
+| `get_generation_diagnostic` | read | **P0** | 失败/回退诊断 |
+| `set_node_prompt` / `set_node_content` | write_light | **P0** | 轻量编辑 |
+| `attach_refs` | write_light | **P0** | 参考边 |
+| `upsert_prompt_node` | write_light | **P0** | 创建/更新 prompt 节点 |
+| `cancel_generation` | lifecycle | **P0** | |
+| `confirm_platform_fallback` | lifecycle | **P0** | |
+| `cancel_platform_fallback` | lifecycle | **P0** | |
+| `list_generation_tasks` | read | P1 | 对应 UI【任务】=`listGenerations(sessionId)` |
+| `list_user_assets` / `list_public_assets` | read | P1 | 对应 UI【资产】 |
+| `save_node_to_asset_library` | write_light | P1 | 节点「存入资产库」 |
+| `apply_asset_to_node` | write_light | P1 | 资产拖入/应用到节点 |
+| `apply_sidebar_attachments` | write_light | P1 | 侧栏附件写画布 |
+| `introduce_nodes_to_agent` | write_light | P1 | 节点内容引入 Agent 上下文（见 §1.5） |
+| `get_canvas_layout` | read | P2 | 含 position/size，小地图语义 |
+| `get_node`（扩展） | read | P2 | 返回 `position`、`parentNode` |
+| `duplicate_node` | write_light | P2 | 复制节点 |
+| `optimize_prompt` | read | P2 | 提示词优化 proxy |
+| `upload_media_to_canvas` | write_light | P2 | 上传并创建/更新媒体节点 |
+| `export_media_package` | export | P2 | 打包下载（返回 stream-download URL） |
+| `group_nodes` / `ungroup_node` | graph_batch | P2 | 分组/解组（explore 不 bind，见 §1.2） |
+| `arrange_nodes_grid` | graph_batch | P3 | 整理布局（grid） |
+| `run_icon_refine` 等 | gen | P3+ | 图标精修/抠图/inpaint（Graph-only） |
+| `get_image_edit_capabilities` | read | P3 | 精修能力探测 |
+
+### 1.2 仅 Graph / campaign（非 explore bind）
+
+| 能力 | Tier | 流 | Wave |
+|------|------|-----|------|
+| `run_*_generation` 五模态 | gen | atomic / single / campaign | P0 |
+| `add_nodes_batch` + atomic parse | graph_batch | atomic_create | P0 |
+| `connect_nodes` / topo / stage | graph_batch | campaign | P0 |
+| `remove_nodes` / `remove_edges` | destructive | campaign（HITL） | P0 |
+| `group_nodes` / `ungroup_node` | graph_batch | campaign 或专用 layout 子图 | P2 |
+| `arrange_nodes_grid` | graph_batch | campaign layout 步 | P3 |
+| mixed 模态 confirm | — | atomic_create | P1 |
+| Scene Composer / video composition | gen | campaign P3 | P3 |
+
+### 1.3 Client Command（SSE `canvas_command`，非 Harness POST）
+
+| Command | 对应 UI | Wave | 说明 |
+|---------|---------|------|------|
+| `focus_node` | 【任务】定位、输出卡定位 | P1 | `selectOnlyNode` + `fitView` |
+| `focus_nodes` | 多选定位 | P1 | |
+| `undo` / `redo` | 撤销/重做 | P4 | 转发到 `useCanvasUndoStack`；仅本地会话栈 |
+| `set_minimap_state` | 小地图展开 | — | **非目标**（纯 UI 偏好） |
+| `open_image_editor` | 精修面板 | P3 | 精修入口，实际改动画布走 Harness |
+
+### 1.4 原子能力完善（Graph）
+
+| 项 | Wave |
+|----|------|
+| P6 video 参数 atomic 贯通 | P1 |
+| platform Seedance catalog | P1 |
+| mixed 模态 confirm | P1 |
+| material/studio lifecycle 归一 | P1 |
+
+### 1.5 UI 功能 ↔ 能力对照表
+
+| 画布 UI | 现有实现（前端/服务端） | Agent 能力 | Tier | Wave |
+|---------|-------------------------|------------|------|------|
+| 【任务】列表/排队/进行中 | `studioApi.listGenerations(sessionId)` | `list_generation_tasks` | read | P1 |
+| 【任务】单节点状态 | 节点 `data.status` | `get_generation_status(nodeId)` | read | **P0** |
+| 【任务】失败诊断 | `getGenerationDiagnostic` | `get_generation_diagnostic` | read | **P0** |
+| 【任务】定位 | `handleHistoryLocate` → `focusNodeById` | `focus_node` **Command** + read layout | ui_command | P1 |
+| 【资产】我的/公共列表 | `assetsApi.listMine/listPublic` | `list_user_assets` / `list_public_assets` | read | P1 |
+| 【资产】应用到节点 | `handleAssetApply` | `apply_asset_to_node` | write_light | P1 |
+| 【资产】存入资产库 | `saveAssetToLibrary` | `save_node_to_asset_library` | write_light | P1 |
+| 【小地图】节点分布 | `minimapNodeList`（nodes+position） | `get_canvas_layout` | read | P2 |
+| 【小地图】点击跳转 | `fitView` | `focus_node` Command | ui_command | P1 |
+| 多选 **分组** | `createGroupFromNodes` | `group_nodes` | graph_batch | P2 |
+| **解组** | `ungroupNodes` | `ungroup_node` | graph_batch | P2 |
+| **整理布局** | `layoutNodesInGrid` | `arrange_nodes_grid` | graph_batch | P3 |
+| **上传** | `uploadApi` + 创建节点 | `upload_media_to_canvas` | write_light | P2 |
+| **下载** / 打包 | `downloadMediaFile/Package` | `export_media_package` | export | P2 |
+| **复制节点** | 右键 duplicate | `duplicate_node` | write_light | P2 |
+| **删除节点** | `handleDeleteSelection` | `remove_nodes`（已有 internal） | destructive | P0 graph |
+| **撤销** | `useCanvasUndoStack` 本地栈 | `undo` Command 或说明不可远程 undo | ui_command | P4 |
+| **节点引入 Agent** | `addFromCanvasNodes` → 侧栏附件 | `introduce_nodes_to_agent` | write_light | P1 |
+| 图标/图像 **精修** | `openImageEditor` + apply | `open_image_editor` Command + `run_icon_refine` Graph | gen | P3+ |
+
+#### 1.5.1 【任务】与 `get_generation_status` 的关系
+
+- **`get_generation_status`**：回答「**这个节点现在**什么状态」（generating / completed / url）。
+- **`list_generation_tasks`**：回答「**本会话有哪些生成记录**」（历史重试、排队、fallback_pending 全量）。
+- 二者互补，不能互相替代。
+
+#### 1.5.2 节点引入 Agent
+
+用户选中节点 →「加入对话」本质是把节点媒体/文本变成 **Agent 侧栏附件**（`SidebarAttachment`，`sourceKind: canvasNode`）。
+
+Harness 路径：
+
+1. **P1** `introduce_nodes_to_agent(nodeIds)` → 内部组装 attachments + 写入 thread 下轮 `sidebar_attachments`（或调用已有 `apply_sidebar_attachments` 的只读变体）。
+2. explore 读路径：`get_node` 已可让 Agent 引用内容；引入 Agent 是 **写 Agent 上下文**，不是改画布。
+
+#### 1.5.3 撤销
+
+- Undo 栈在浏览器内存 + `Session.canvasData` 持久化之间：**仅用户编辑**入栈（`persistUserEdit` / `canvasUndo.commitAfterChange`）。
+- Agent 通过 Harness 改画布 **不自动**进入用户 Undo 栈（除非 P4 统一「Agent 编辑也 commit 一条 undo snapshot」）。
+- **P4 可选**：Agent 编辑后 push 一条 undo 快照；`undo` Command 仍走客户端栈。
+
+#### 1.5.4 删除 vs explore
+
+- `remove_nodes` 已在 Harness（**P0**），归属 **destructive + campaign graph**（需 HITL/confirm）。
+- explore **禁止** bind，避免 ReAct 误删。
+
+---
+
+## 2. 路由
+
+```
+intake → route_decide
+  ├─ atomic_* / single_node → 现有子图
+  ├─ skill → campaign
+  ├─ explore_canvas → explore 节点 (bind_tools)
+  └─ else → chat（纯对话，无 tools）
+```
+
+**explore 信号：** 画布/节点/任务/资产/布局 **查询或轻量编辑**，且 **非** atomic_create / single_node / 营销编排。
+
+---
+
+## 3. explore 节点行为
+
+1. 拉取 `get_canvas_summary` 注入 system context  
+2. `llm.bind_tools(build_explore_tools(client))`  
+3. 有界 tool loop（≤3 轮）  
+4. 返回 `AIMessage` + 可选 `explore_summary` SSE  
+5. **P1+** 若需定位：SSE 附带 `canvas_command: { type: 'focus_node', nodeId }`
+
+---
+
+## 4. 基础设施
+
+| 项 | Wave |
+|----|------|
+| `tool_registry.py` tier + explore allowlist | **P0** |
+| `trace_tool` 覆盖 explore | P4 |
+| `canvas_command` SSE schema（focus/undo/open_editor） | P1 / P4 |
+| 错误归一化 `AgentToolError` → 用户文案 | P4 |
+| Agent 编辑是否入 Undo 栈（产品决策） | P4 |
+
+---
+
+## 5. 非目标
+
+- Full ReAct 驱动所有画布 mutation  
+- 将 atomic_create 拆成 tool 链  
+- Agent 远程操作用户 **小地图展开状态**、grid 颜色等 viewport 偏好  
+- Skill 市场 UI（R3+）  
+- 服务端全局 Undo（替代客户端 Cmd+Z）
+
+---
+
+## 6. 产品演进：精修 / 图标编辑
+
+| 能力 | 建议归属 |
+|------|----------|
+| 打开精修面板 | Client Command |
+| 参数级（crop、尺寸、风格 preset） | explore `write_light` 或 atomic 单步 |
+| 单次 inpaint/outpaint/去背景 | **Graph gen** `run_icon_refine`（计费+confirm） |
+| 多版迭代 + 排版 | campaign 子图闭环 |
+
+判断：**改数据 → Tool；改视口/面板 → Command；高成本/confirm → Graph。**

--- a/packages/agent/src/tools/canvas-tools.ts
+++ b/packages/agent/src/tools/canvas-tools.ts
@@ -1,5 +1,9 @@
 import type { AgentToolDefinition } from '../types'
 
+/**
+ * @deprecated Runtime 生产路径使用 Nest `/agent/internal/*` + agent-runtime StructuredTool。
+ * 保留仅为 TS Agent 包降级 mock；新能力请加到 agent-canvas-tools Harness。
+ */
 export const CANVAS_TOOLS: AgentToolDefinition[] = [
   {
     name: 'create_shot',

--- a/services/agent-runtime/app/graph/builder.py
+++ b/services/agent-runtime/app/graph/builder.py
@@ -10,6 +10,7 @@ from langgraph.graph import END, START, StateGraph
 
 from app.graph.nodes.apply_sidebar_refs import make_apply_sidebar_refs_node
 from app.graph.nodes.chat import make_chat_node
+from app.graph.nodes.explore import make_explore_node
 from app.graph.nodes.done import make_done_node
 from app.graph.nodes.clarify_route import make_clarify_route_node
 from app.graph.nodes.intake import make_intake_node
@@ -35,6 +36,8 @@ def route_after_intake(state: AgentRuntimeState) -> str:
         return "parse_atomic_intent"
     if state.get("skill_id"):
         return "decide_plan_mode"
+    if state.get("flow_mode") == "explore_canvas":
+        return "explore"
     return "chat"
 
 
@@ -61,6 +64,7 @@ def build_agent_graph(
     graph.add_node("intake", make_intake_node(skills_path))
     graph.add_node("clarify_route", make_clarify_route_node())
     graph.add_node("chat", make_chat_node(llm=llm))
+    graph.add_node("explore", make_explore_node(llm=llm, nest=nest))
     graph.add_node("split", make_split_node(nest=nest, skills_dir=skills_path))
     graph.add_node("apply_sidebar_refs", make_apply_sidebar_refs_node(nest=nest))
     graph.add_node("done", make_done_node(nest=nest))
@@ -83,9 +87,11 @@ def build_agent_graph(
             "clarify_route": "clarify_route",
             "decide_plan_mode": "decide_plan_mode",
             "chat": "chat",
+            "explore": "explore",
         },
     )
     graph.add_edge("chat", END)
+    graph.add_edge("explore", END)
     graph.add_edge("clarify_route", END)
     graph.add_edge("write_plan_node", "split")
     graph.add_conditional_edges(

--- a/services/agent-runtime/app/graph/canvas_commands.py
+++ b/services/agent-runtime/app/graph/canvas_commands.py
@@ -1,0 +1,18 @@
+"""Extract client-side canvas commands from Harness tool results."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def extract_canvas_commands(result: Any) -> list[dict[str, Any]]:
+    if not isinstance(result, dict):
+        return []
+    raw = result.get("canvasCommands") or result.get("canvas_commands")
+    if not isinstance(raw, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for item in raw:
+        if isinstance(item, dict) and item.get("type"):
+            out.append(item)
+    return out

--- a/services/agent-runtime/app/graph/nodes/explore.py
+++ b/services/agent-runtime/app/graph/nodes/explore.py
@@ -1,0 +1,106 @@
+"""Explore canvas path — bind_tools for read / light-write / lifecycle only."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+from app.graph.canvas_commands import extract_canvas_commands
+from app.tools.definitions import build_explore_tools
+
+MAX_EXPLORE_TOOL_ROUNDS = 3
+
+_EXPLORE_SYSTEM = (
+    "你是 lnkpi 画布探索助手。用简洁中文回答。"
+    "可通过工具读取画布节点、查询生成状态、取消任务或处理平台回退。"
+    "不要调用 run_*_generation；用户要出图/生成视频时，提示其直接描述创作需求。"
+    "\n\n当前画布摘要：\n{summary}"
+)
+
+
+def _latest_user_text(messages: list[Any]) -> str:
+    for msg in reversed(messages or []):
+        role = getattr(msg, "type", None) or (msg.get("role") if isinstance(msg, dict) else None)
+        content = getattr(msg, "content", None) or (msg.get("content") if isinstance(msg, dict) else "")
+        if role in ("human", "user") and content:
+            return str(content)
+    return ""
+
+
+def _serialize_tool_result(result: Any) -> str:
+    if isinstance(result, str):
+        return result
+    try:
+        return json.dumps(result, ensure_ascii=False, default=str)
+    except Exception:
+        return str(result)
+
+
+def make_explore_node(*, llm: Any, nest: Any) -> Callable:
+    async def explore(state: dict) -> dict:
+        tools = build_explore_tools(nest)
+        tools_by_name = {t.name: t for t in tools}
+        llm_bound = llm.bind_tools(tools)
+
+        try:
+            summary = await nest.get_canvas_summary()
+        except Exception:
+            summary = {"error": "无法拉取画布摘要"}
+
+        user_text = _latest_user_text(state.get("messages") or []) or "看看画布状态"
+        convo: list[Any] = [
+            SystemMessage(content=_EXPLORE_SYSTEM.format(summary=_serialize_tool_result(summary))),
+            HumanMessage(content=user_text),
+        ]
+
+        final_reply = ""
+        canvas_commands: list[dict[str, Any]] = []
+        for _ in range(MAX_EXPLORE_TOOL_ROUNDS):
+            ai = await llm_bound.ainvoke(convo)
+            tool_calls = getattr(ai, "tool_calls", None) or []
+            if not tool_calls:
+                final_reply = str(getattr(ai, "content", "") or "").strip()
+                break
+
+            convo.append(ai)
+            for tc in tool_calls:
+                name = tc.get("name") if isinstance(tc, dict) else getattr(tc, "name", "")
+                args = tc.get("args") if isinstance(tc, dict) else getattr(tc, "args", {})
+                tool_call_id = tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", "")
+                tool = tools_by_name.get(name)
+                if tool is None:
+                    result: Any = {"error": f"unknown tool: {name}"}
+                else:
+                    try:
+                        result = await tool.ainvoke(args or {})
+                    except Exception as exc:
+                        result = {"error": str(exc)}
+                for cmd in extract_canvas_commands(result):
+                    if cmd not in canvas_commands:
+                        canvas_commands.append(cmd)
+                convo.append(
+                    ToolMessage(
+                        content=_serialize_tool_result(result),
+                        tool_call_id=str(tool_call_id or name),
+                    )
+                )
+        else:
+            final_reply = str(getattr(convo[-1], "content", "") or "").strip()
+
+        if not final_reply:
+            final_reply = "已查询画布信息。如需继续操作，请说明具体节点或任务。"
+
+        out: dict[str, Any] = {
+            "phase": "done",
+            "skill_id": None,
+            "user_decision": "none",
+            "messages": [AIMessage(content=final_reply)],
+            "explore_summary": summary if isinstance(summary, dict) else None,
+        }
+        if canvas_commands:
+            out["canvas_commands"] = canvas_commands
+        return out
+
+    return explore

--- a/services/agent-runtime/app/graph/route_decide.py
+++ b/services/agent-runtime/app/graph/route_decide.py
@@ -37,6 +37,7 @@ RouteFlowMode = Literal[
     "atomic_regenerate",
     "single_node",
     "campaign",
+    "explore_canvas",
     "chat",
     "clarify_route",
 ]
@@ -63,6 +64,27 @@ def _image_attachment_count(attachments: list[dict]) -> int:
 
 def _image_mentioned_keys(keys: list[str]) -> list[str]:
     return [k for k in keys if k.upper().startswith("I")]
+
+
+def _explore_canvas_signal(ctx: RouteContext) -> bool:
+    utterance = str(ctx.get("utterance") or "").strip()
+    if not utterance:
+        return False
+    if atomic_create_intent(utterance) or single_node_gen_intent(utterance):
+        return False
+    if regenerate_phrase_intent(utterance) or atomic_regenerate_intent(utterance):
+        return False
+    if marketing_intent(utterance):
+        return False
+    nouns = ("画布", "节点", "分镜", "canvas", "生成状态", "生成任务", "任务状态")
+    verbs = ("看看", "有哪些", "列出", "查询", "检查", "状态", "什么情况", "怎么样")
+    lifecycle = any(
+        k in utterance
+        for k in ("取消生成", "平台回退", "fallback", "诊断", "失败原因")
+    )
+    has_noun = any(n in utterance for n in nouns)
+    has_verb = any(v in utterance for v in verbs)
+    return lifecycle or (has_noun and has_verb)
 
 
 def _sidebar_img2img_signal(ctx: RouteContext) -> bool:
@@ -212,6 +234,17 @@ def decide_route(ctx: RouteContext, *, valid_skill_ids: set[str] | None = None) 
             "reason": "empty_utterance",
             "clarify_question": None,
             "guard_veto": None,
+            "is_modify": False,
+        }
+
+    if _explore_canvas_signal(ctx):
+        return {
+            "flow_mode": "explore_canvas",
+            "l0_action": l0,
+            "confidence": 0.85,
+            "reason": "explore_canvas_intent",
+            "clarify_question": None,
+            "guard_veto": guard_veto,
             "is_modify": False,
         }
 

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -695,6 +695,11 @@ async def stream_run_events(
                         explore = delta.get("explore_summary")
                         if isinstance(explore, dict):
                             await emit({"type": "explore", "data": explore})
+                        commands = delta.get("canvas_commands")
+                        if isinstance(commands, list):
+                            for cmd in commands:
+                                if isinstance(cmd, dict) and cmd.get("type"):
+                                    await emit({"type": "canvas_command", "data": cmd})
                         thinking = delta.get("thinking_summary")
                         if thinking and settings.agent_thinking_ui:
                             await emit(

--- a/services/agent-runtime/app/tools/definitions.py
+++ b/services/agent-runtime/app/tools/definitions.py
@@ -11,6 +11,7 @@ from app.tools.prompt_templates import (
     UPSERT_PROMPT_NODE_PROMPT_FIELD,
     upsert_prompt_node_tool_description,
 )
+from app.tools.tool_registry import EXPLORE_TOOL_NAMES, is_explore_tool
 
 
 class UpsertPromptNodeInput(BaseModel):
@@ -21,6 +22,15 @@ class UpsertPromptNodeInput(BaseModel):
 
 class NodeIdInput(BaseModel):
     node_id: str = Field(description="Canvas node id")
+
+
+class GenerationRecordInput(BaseModel):
+    generation_record_id: str | None = Field(
+        default=None, description="Studio generation record id"
+    )
+    node_id: str | None = Field(
+        default=None, description="Canvas node id (resolves generationRecordId from node data)"
+    )
 
 
 class AddNodesBatchInput(BaseModel):
@@ -38,16 +48,48 @@ class SetNodePromptInput(BaseModel):
     prompt: str = Field(description="Updated prompt text")
 
 
+class SetNodeContentInput(BaseModel):
+    node_id: str = Field(description="Canvas node id")
+    content: str = Field(description="Updated node content text")
+
+
 class AttachRefsInput(BaseModel):
     node_id: str = Field(description="Target node id")
     ref_order: list[str] = Field(description="Ordered reference node ids")
 
 
-def build_canvas_tools(client: NestCanvasClient) -> list[StructuredTool]:
-    """Build LangChain tools with session/user injected via the Nest client."""
+class IntroduceNodesInput(BaseModel):
+    node_ids: list[str] = Field(description="Canvas node ids to add as agent sidebar refs")
+
+
+class ListPublicAssetsInput(BaseModel):
+    kind: str | None = Field(default=None, description="Filter: image, video, or audio")
+    search: str | None = Field(default=None, description="Label search substring")
+
+
+class ApplyAssetInput(BaseModel):
+    node_id: str = Field(description="Target canvas node id")
+    asset_id: str = Field(description="User or public asset id")
+    source: str = Field(description="user or public")
+
+
+class SaveNodeAssetInput(BaseModel):
+    node_id: str = Field(description="Canvas node with media to save")
+    label: str | None = Field(default=None, description="Optional asset label override")
+
+
+class ListGenerationTasksInput(BaseModel):
+    type: str | None = Field(default=None, description="Optional filter: image, video, etc.")
+
+
+def _all_tool_specs(client: NestCanvasClient) -> list[tuple[str, StructuredTool]]:
+    """Return (name, tool) pairs for registry filtering."""
 
     async def upsert_prompt_node(prompt: str, content: str, node_id: str | None = None) -> dict:
         return await client.upsert_prompt_node(prompt=prompt, content=content, node_id=node_id)
+
+    async def get_canvas_summary() -> dict:
+        return await client.get_canvas_summary()
 
     async def get_node(node_id: str) -> dict:
         return await client.get_node(node_id)
@@ -61,6 +103,9 @@ def build_canvas_tools(client: NestCanvasClient) -> list[StructuredTool]:
     async def set_node_prompt(node_id: str, prompt: str) -> dict:
         return await client.set_node_prompt(node_id, prompt)
 
+    async def set_node_content(node_id: str, content: str) -> dict:
+        return await client.set_node_content(node_id, content)
+
     async def attach_refs(node_id: str, ref_order: list[str]) -> dict:
         return await client.attach_refs(node_id, ref_order)
 
@@ -70,53 +115,261 @@ def build_canvas_tools(client: NestCanvasClient) -> list[StructuredTool]:
     async def get_generation_status(node_id: str) -> dict:
         return await client.get_generation_status(node_id)
 
-    return [
-        StructuredTool.from_function(
-            coroutine=upsert_prompt_node,
-            name="upsert_prompt_node",
-            description=upsert_prompt_node_tool_description(),
-            args_schema=UpsertPromptNodeInput,
+    async def get_generation_diagnostic(
+        generation_record_id: str | None = None, node_id: str | None = None
+    ) -> dict:
+        return await client.get_generation_diagnostic(
+            generation_record_id=generation_record_id, node_id=node_id
+        )
+
+    async def cancel_generation(
+        generation_record_id: str | None = None, node_id: str | None = None
+    ) -> dict:
+        return await client.cancel_generation(
+            generation_record_id=generation_record_id, node_id=node_id
+        )
+
+    async def confirm_platform_fallback(
+        generation_record_id: str | None = None, node_id: str | None = None
+    ) -> dict:
+        return await client.confirm_platform_fallback(
+            generation_record_id=generation_record_id, node_id=node_id
+        )
+
+    async def cancel_platform_fallback(
+        generation_record_id: str | None = None, node_id: str | None = None
+    ) -> dict:
+        return await client.cancel_platform_fallback(
+            generation_record_id=generation_record_id, node_id=node_id
+        )
+
+    async def list_generation_tasks(type: str | None = None) -> dict:
+        return await client.list_generation_tasks(type=type)
+
+    async def list_user_assets() -> dict:
+        return await client.list_user_assets()
+
+    async def list_public_assets(kind: str | None = None, search: str | None = None) -> dict:
+        return await client.list_public_assets(kind=kind, search=search)
+
+    async def save_node_to_asset_library(
+        node_id: str, label: str | None = None
+    ) -> dict:
+        return await client.save_node_to_asset_library(node_id=node_id, label=label)
+
+    async def introduce_nodes_to_agent(node_ids: list[str]) -> dict:
+        return await client.introduce_nodes_to_agent(node_ids=node_ids)
+
+    async def apply_asset_to_node(node_id: str, asset_id: str, source: str) -> dict:
+        return await client.apply_asset_to_node(
+            node_id=node_id, asset_id=asset_id, source=source
+        )
+
+    async def focus_node(node_id: str) -> dict:
+        return {"ok": True, "canvasCommands": [{"type": "focus_node", "nodeId": node_id}]}
+
+    specs: list[tuple[str, StructuredTool]] = [
+        (
+            "upsert_prompt_node",
+            StructuredTool.from_function(
+                coroutine=upsert_prompt_node,
+                name="upsert_prompt_node",
+                description=upsert_prompt_node_tool_description(),
+                args_schema=UpsertPromptNodeInput,
+            ),
         ),
-        StructuredTool.from_function(
-            coroutine=get_node,
-            name="get_node",
-            description="Fetch a canvas node snapshot by id",
-            args_schema=NodeIdInput,
+        (
+            "get_canvas_summary",
+            StructuredTool.from_function(
+                coroutine=get_canvas_summary,
+                name="get_canvas_summary",
+                description="List canvas nodes with id, type, title, status for exploration",
+            ),
         ),
-        StructuredTool.from_function(
-            coroutine=add_nodes_batch,
-            name="add_nodes_batch",
-            description="Add multiple canvas nodes in one batch",
-            args_schema=AddNodesBatchInput,
+        (
+            "get_node",
+            StructuredTool.from_function(
+                coroutine=get_node,
+                name="get_node",
+                description="Fetch a canvas node snapshot by id",
+                args_schema=NodeIdInput,
+            ),
         ),
-        StructuredTool.from_function(
-            coroutine=connect_nodes,
-            name="connect_nodes",
-            description="Connect canvas nodes with directed edges",
-            args_schema=ConnectNodesInput,
+        (
+            "add_nodes_batch",
+            StructuredTool.from_function(
+                coroutine=add_nodes_batch,
+                name="add_nodes_batch",
+                description="Add multiple canvas nodes in one batch",
+                args_schema=AddNodesBatchInput,
+            ),
         ),
-        StructuredTool.from_function(
-            coroutine=set_node_prompt,
-            name="set_node_prompt",
-            description="Update the prompt text on an existing node",
-            args_schema=SetNodePromptInput,
+        (
+            "connect_nodes",
+            StructuredTool.from_function(
+                coroutine=connect_nodes,
+                name="connect_nodes",
+                description="Connect canvas nodes with directed edges",
+                args_schema=ConnectNodesInput,
+            ),
         ),
-        StructuredTool.from_function(
-            coroutine=attach_refs,
-            name="attach_refs",
-            description="Attach ordered reference nodes to a target node",
-            args_schema=AttachRefsInput,
+        (
+            "set_node_prompt",
+            StructuredTool.from_function(
+                coroutine=set_node_prompt,
+                name="set_node_prompt",
+                description="Update the prompt text on an existing node",
+                args_schema=SetNodePromptInput,
+            ),
         ),
-        StructuredTool.from_function(
-            coroutine=run_image_generation,
-            name="run_image_generation",
-            description="Run image generation for a canvas node and wait for completion",
-            args_schema=NodeIdInput,
+        (
+            "set_node_content",
+            StructuredTool.from_function(
+                coroutine=set_node_content,
+                name="set_node_content",
+                description="Update the content text on an existing node",
+                args_schema=SetNodeContentInput,
+            ),
         ),
-        StructuredTool.from_function(
-            coroutine=get_generation_status,
-            name="get_generation_status",
-            description="Poll image generation status for a canvas node",
-            args_schema=NodeIdInput,
+        (
+            "attach_refs",
+            StructuredTool.from_function(
+                coroutine=attach_refs,
+                name="attach_refs",
+                description="Attach ordered reference nodes to a target node",
+                args_schema=AttachRefsInput,
+            ),
+        ),
+        (
+            "run_image_generation",
+            StructuredTool.from_function(
+                coroutine=run_image_generation,
+                name="run_image_generation",
+                description="Run image generation for a canvas node and wait for completion",
+                args_schema=NodeIdInput,
+            ),
+        ),
+        (
+            "get_generation_status",
+            StructuredTool.from_function(
+                coroutine=get_generation_status,
+                name="get_generation_status",
+                description="Poll generation status for a canvas node",
+                args_schema=NodeIdInput,
+            ),
+        ),
+        (
+            "get_generation_diagnostic",
+            StructuredTool.from_function(
+                coroutine=get_generation_diagnostic,
+                name="get_generation_diagnostic",
+                description="Fetch failure/fallback diagnostic for a generation record or node",
+                args_schema=GenerationRecordInput,
+            ),
+        ),
+        (
+            "cancel_generation",
+            StructuredTool.from_function(
+                coroutine=cancel_generation,
+                name="cancel_generation",
+                description="Cancel an in-progress generation by record id or node id",
+                args_schema=GenerationRecordInput,
+            ),
+        ),
+        (
+            "confirm_platform_fallback",
+            StructuredTool.from_function(
+                coroutine=confirm_platform_fallback,
+                name="confirm_platform_fallback",
+                description="Confirm platform fallback billing and retry after BYOK failure",
+                args_schema=GenerationRecordInput,
+            ),
+        ),
+        (
+            "cancel_platform_fallback",
+            StructuredTool.from_function(
+                coroutine=cancel_platform_fallback,
+                name="cancel_platform_fallback",
+                description="Decline platform fallback and mark generation failed",
+                args_schema=GenerationRecordInput,
+            ),
+        ),
+        (
+            "list_generation_tasks",
+            StructuredTool.from_function(
+                coroutine=list_generation_tasks,
+                name="list_generation_tasks",
+                description="List generation records for the current session (task panel)",
+                args_schema=ListGenerationTasksInput,
+            ),
+        ),
+        (
+            "list_user_assets",
+            StructuredTool.from_function(
+                coroutine=list_user_assets,
+                name="list_user_assets",
+                description="List assets in the user's asset library",
+            ),
+        ),
+        (
+            "list_public_assets",
+            StructuredTool.from_function(
+                coroutine=list_public_assets,
+                name="list_public_assets",
+                description="List platform public assets",
+                args_schema=ListPublicAssetsInput,
+            ),
+        ),
+        (
+            "save_node_to_asset_library",
+            StructuredTool.from_function(
+                coroutine=save_node_to_asset_library,
+                name="save_node_to_asset_library",
+                description="Save a canvas node's media URL to the user asset library",
+                args_schema=SaveNodeAssetInput,
+            ),
+        ),
+        (
+            "introduce_nodes_to_agent",
+            StructuredTool.from_function(
+                coroutine=introduce_nodes_to_agent,
+                name="introduce_nodes_to_agent",
+                description="Add canvas node content to agent sidebar context",
+                args_schema=IntroduceNodesInput,
+            ),
+        ),
+        (
+            "apply_asset_to_node",
+            StructuredTool.from_function(
+                coroutine=apply_asset_to_node,
+                name="apply_asset_to_node",
+                description="Apply a user or public asset URL to a compatible canvas node",
+                args_schema=ApplyAssetInput,
+            ),
+        ),
+        (
+            "focus_node",
+            StructuredTool.from_function(
+                coroutine=focus_node,
+                name="focus_node",
+                description="Pan/zoom the canvas viewport to a node (UI command)",
+                args_schema=NodeIdInput,
+            ),
         ),
     ]
+    return specs
+
+
+def build_explore_tools(client: NestCanvasClient) -> list[StructuredTool]:
+    """Tools bindable in explore sub-graph (read + light write + lifecycle)."""
+    return [tool for name, tool in _all_tool_specs(client) if name in EXPLORE_TOOL_NAMES]
+
+
+def build_canvas_tools(client: NestCanvasClient) -> list[StructuredTool]:
+    """All canvas tools — used by tests and future graph tool nodes."""
+    return [tool for _, tool in _all_tool_specs(client)]
+
+
+def build_graph_only_tools(client: NestCanvasClient) -> list[StructuredTool]:
+    """Generation / destructive tools reserved for deterministic graph paths."""
+    return [tool for name, tool in _all_tool_specs(client) if not is_explore_tool(name)]

--- a/services/agent-runtime/app/tools/nest_client.py
+++ b/services/agent-runtime/app/tools/nest_client.py
@@ -342,6 +342,139 @@ class NestCanvasClient:
             {"sessionId": self._session_id, "nodeId": node_id},
         )
 
+    def _lifecycle_body(
+        self,
+        *,
+        generation_record_id: str | None = None,
+        node_id: str | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "sessionId": self._session_id,
+            "userId": self._user_id,
+        }
+        if generation_record_id:
+            body["generationRecordId"] = generation_record_id
+        if node_id:
+            body["nodeId"] = node_id
+        return body
+
+    async def get_generation_diagnostic(
+        self,
+        *,
+        generation_record_id: str | None = None,
+        node_id: str | None = None,
+    ) -> dict[str, Any]:
+        return await self._post(
+            "/agent/internal/get-generation-diagnostic",
+            self._lifecycle_body(
+                generation_record_id=generation_record_id, node_id=node_id
+            ),
+        )
+
+    async def cancel_generation(
+        self,
+        *,
+        generation_record_id: str | None = None,
+        node_id: str | None = None,
+    ) -> dict[str, Any]:
+        return await self._post(
+            "/agent/internal/cancel-generation",
+            self._lifecycle_body(
+                generation_record_id=generation_record_id, node_id=node_id
+            ),
+        )
+
+    async def confirm_platform_fallback(
+        self,
+        *,
+        generation_record_id: str | None = None,
+        node_id: str | None = None,
+    ) -> dict[str, Any]:
+        timeout_sec = float(settings.image_gen_timeout_sec) + IMAGE_GEN_TIMEOUT_BUFFER_SEC
+        return await self._post(
+            "/agent/internal/confirm-platform-fallback",
+            self._lifecycle_body(
+                generation_record_id=generation_record_id, node_id=node_id
+            ),
+            timeout=timeout_sec,
+        )
+
+    async def cancel_platform_fallback(
+        self,
+        *,
+        generation_record_id: str | None = None,
+        node_id: str | None = None,
+    ) -> dict[str, Any]:
+        return await self._post(
+            "/agent/internal/cancel-platform-fallback",
+            self._lifecycle_body(
+                generation_record_id=generation_record_id, node_id=node_id
+            ),
+        )
+
+    async def list_generation_tasks(
+        self, *, type: str | None = None
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "sessionId": self._session_id,
+            "userId": self._user_id,
+        }
+        if type:
+            body["type"] = type
+        return await self._post("/agent/internal/list-generation-tasks", body)
+
+    async def list_user_assets(self) -> dict[str, Any]:
+        return await self._post(
+            "/agent/internal/list-user-assets",
+            {"userId": self._user_id},
+        )
+
+    async def list_public_assets(
+        self, *, kind: str | None = None, search: str | None = None
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {}
+        if kind:
+            body["kind"] = kind
+        if search:
+            body["search"] = search
+        return await self._post("/agent/internal/list-public-assets", body)
+
+    async def save_node_to_asset_library(
+        self, *, node_id: str, label: str | None = None
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "sessionId": self._session_id,
+            "userId": self._user_id,
+            "nodeId": node_id,
+        }
+        if label:
+            body["label"] = label
+        return await self._post("/agent/internal/save-node-to-asset-library", body)
+
+    async def introduce_nodes_to_agent(self, *, node_ids: list[str]) -> dict[str, Any]:
+        return await self._post(
+            "/agent/internal/introduce-nodes-to-agent",
+            {
+                "sessionId": self._session_id,
+                "userId": self._user_id,
+                "nodeIds": node_ids,
+            },
+        )
+
+    async def apply_asset_to_node(
+        self, *, node_id: str, asset_id: str, source: str
+    ) -> dict[str, Any]:
+        return await self._post(
+            "/agent/internal/apply-asset-to-node",
+            {
+                "sessionId": self._session_id,
+                "userId": self._user_id,
+                "nodeId": node_id,
+                "assetId": asset_id,
+                "source": source,
+            },
+        )
+
     async def get_agent_messages(self, *, thread_id: str) -> list[dict[str, Any]]:
         """Load conversation history for one thread (Nest single-writer)."""
         return await self._post(

--- a/services/agent-runtime/app/tools/tool_registry.py
+++ b/services/agent-runtime/app/tools/tool_registry.py
@@ -1,0 +1,88 @@
+"""Tool tier registry — SSOT for explore vs graph-only tools (Hybrid A)."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ToolTier(str, Enum):
+    READ = "read"
+    WRITE_LIGHT = "write_light"
+    LIFECYCLE = "lifecycle"
+    GEN = "gen"
+    DESTRUCTIVE = "destructive"
+    GRAPH_BATCH = "graph_batch"
+    EXPORT = "export"
+    # ui_command: focus_node, undo — not in TOOL_TIERS; see design spec §1.3
+
+
+# Explore sub-graph explicit allowlist (CS-4: no gen, no batch topology).
+EXPLORE_TOOL_NAMES = frozenset({
+    "get_canvas_summary",
+    "get_node",
+    "get_generation_status",
+    "get_generation_diagnostic",
+    "set_node_prompt",
+    "set_node_content",
+    "attach_refs",
+    "upsert_prompt_node",
+    "cancel_generation",
+    "confirm_platform_fallback",
+    "cancel_platform_fallback",
+    "list_generation_tasks",
+    "list_user_assets",
+    "list_public_assets",
+    "save_node_to_asset_library",
+    "introduce_nodes_to_agent",
+    "apply_asset_to_node",
+    "focus_node",
+})
+
+TOOL_TIERS: dict[str, ToolTier] = {
+    "get_canvas_summary": ToolTier.READ,
+    "get_node": ToolTier.READ,
+    "get_generation_status": ToolTier.READ,
+    "get_generation_diagnostic": ToolTier.READ,
+    "set_node_prompt": ToolTier.WRITE_LIGHT,
+    "set_node_content": ToolTier.WRITE_LIGHT,
+    "attach_refs": ToolTier.WRITE_LIGHT,
+    "upsert_prompt_node": ToolTier.WRITE_LIGHT,
+    "apply_sidebar_attachments": ToolTier.WRITE_LIGHT,
+    "cancel_generation": ToolTier.LIFECYCLE,
+    "confirm_platform_fallback": ToolTier.LIFECYCLE,
+    "cancel_platform_fallback": ToolTier.LIFECYCLE,
+    "list_generation_tasks": ToolTier.READ,
+    "list_user_assets": ToolTier.READ,
+    "list_public_assets": ToolTier.READ,
+    "save_node_to_asset_library": ToolTier.WRITE_LIGHT,
+    "apply_asset_to_node": ToolTier.WRITE_LIGHT,
+    "introduce_nodes_to_agent": ToolTier.WRITE_LIGHT,
+    "get_canvas_layout": ToolTier.READ,
+    "duplicate_node": ToolTier.WRITE_LIGHT,
+    "upload_media_to_canvas": ToolTier.WRITE_LIGHT,
+    "export_media_package": ToolTier.EXPORT,
+    "optimize_prompt": ToolTier.READ,
+    "group_nodes": ToolTier.GRAPH_BATCH,
+    "ungroup_node": ToolTier.GRAPH_BATCH,
+    "arrange_nodes_grid": ToolTier.GRAPH_BATCH,
+    "run_icon_refine": ToolTier.GEN,
+    "get_image_edit_capabilities": ToolTier.READ,
+    "add_nodes_batch": ToolTier.GRAPH_BATCH,
+    "connect_nodes": ToolTier.GRAPH_BATCH,
+    "update_nodes_batch": ToolTier.GRAPH_BATCH,
+    "run_image_generation": ToolTier.GEN,
+    "run_video_generation": ToolTier.GEN,
+    "run_text_generation": ToolTier.GEN,
+    "run_prompt_generation": ToolTier.GEN,
+    "run_audio_generation": ToolTier.GEN,
+    "start_image_generation": ToolTier.GEN,
+    "wait_image_generation": ToolTier.GEN,
+    "remove_nodes": ToolTier.DESTRUCTIVE,
+    "remove_edges": ToolTier.DESTRUCTIVE,
+}
+
+GRAPH_ONLY_TOOL_NAMES = frozenset(TOOL_TIERS.keys()) - EXPLORE_TOOL_NAMES
+
+
+def is_explore_tool(name: str) -> bool:
+    return name in EXPLORE_TOOL_NAMES

--- a/services/agent-runtime/tests/test_canvas_commands.py
+++ b/services/agent-runtime/tests/test_canvas_commands.py
@@ -1,0 +1,14 @@
+from app.graph.canvas_commands import extract_canvas_commands
+
+
+def test_extract_canvas_commands_from_harness_result():
+    result = {
+        "attachments": [],
+        "canvasCommands": [{"type": "focus_node", "nodeId": "n1"}],
+    }
+    assert extract_canvas_commands(result) == [{"type": "focus_node", "nodeId": "n1"}]
+
+
+def test_extract_ignores_invalid():
+    assert extract_canvas_commands("x") == []
+    assert extract_canvas_commands({"canvasCommands": [{"bad": 1}]}) == []

--- a/services/agent-runtime/tests/test_explore_tools.py
+++ b/services/agent-runtime/tests/test_explore_tools.py
@@ -1,0 +1,25 @@
+from app.tools.definitions import build_explore_tools, build_graph_only_tools
+from app.tools.tool_registry import EXPLORE_TOOL_NAMES, GRAPH_ONLY_TOOL_NAMES
+
+
+class _FakeClient:
+    pass
+
+
+def test_explore_tools_exclude_generation():
+    tools = build_explore_tools(_FakeClient())  # type: ignore[arg-type]
+    names = {t.name for t in tools}
+    assert "get_canvas_summary" in names
+    assert "cancel_generation" in names
+    assert "run_image_generation" not in names
+    assert "add_nodes_batch" not in names
+    assert names <= EXPLORE_TOOL_NAMES
+
+
+def test_graph_only_includes_generation():
+    tools = build_graph_only_tools(_FakeClient())  # type: ignore[arg-type]
+    names = {t.name for t in tools}
+    assert "run_image_generation" in names
+    assert "get_canvas_summary" not in names
+    assert "add_nodes_batch" in names
+    assert names <= GRAPH_ONLY_TOOL_NAMES

--- a/services/agent-runtime/tests/test_nest_client.py
+++ b/services/agent-runtime/tests/test_nest_client.py
@@ -60,6 +60,19 @@ def nest_client(captured):
             )
         if path.endswith("/get-generation-status"):
             return httpx.Response(200, json=_ok({"status": "completed", "url": "https://cdn.example/img.png"}))
+        if path.endswith("/get-canvas-summary"):
+            return httpx.Response(200, json=_ok({"nodes": [{"id": "n1", "type": "image"}]}))
+        if path.endswith("/get-generation-diagnostic"):
+            return httpx.Response(200, json=_ok({"errorCode": "upstream", "userMessage": "失败"}))
+        if path.endswith("/cancel-generation"):
+            return httpx.Response(200, json=_ok({"status": "cancelled", "generationRecordId": "rec-1", "actions": []}))
+        if path.endswith("/confirm-platform-fallback"):
+            return httpx.Response(
+                200,
+                json=_ok({"status": "completed", "generationRecordId": "rec-1", "url": "https://cdn/x.png", "actions": []}),
+            )
+        if path.endswith("/cancel-platform-fallback"):
+            return httpx.Response(200, json=_ok({"status": "failed", "generationRecordId": "rec-1", "actions": []}))
         return httpx.Response(404, json={"code": 404, "message": "not found"})
 
     transport = httpx.MockTransport(handler)
@@ -293,3 +306,21 @@ def test_build_canvas_tools_upsert_prompt_node_has_template_in_schema(nest_clien
     content_desc = schema["properties"]["content"]["description"]
     assert "character_turnaround" in content_desc
     assert any(t in content_desc for t in CHARACTER_TURNAROUND_TRIGGERS[:3])
+
+
+@pytest.mark.asyncio
+async def test_cancel_generation_lifecycle(nest_client, captured):
+    result = await nest_client.cancel_generation(node_id="n1")
+    assert result["status"] == "cancelled"
+    req = _last(captured)
+    assert req["json"]["nodeId"] == "n1"
+    assert req["json"]["sessionId"] == SESSION_ID
+
+
+@pytest.mark.asyncio
+async def test_get_generation_diagnostic(nest_client, captured):
+    result = await nest_client.get_generation_diagnostic(generation_record_id="rec-1")
+    assert result["errorCode"] == "upstream"
+    req = _last(captured)
+    assert req["json"]["generationRecordId"] == "rec-1"
+

--- a/services/agent-runtime/tests/test_route_decide_explore.py
+++ b/services/agent-runtime/tests/test_route_decide_explore.py
@@ -1,0 +1,27 @@
+from app.graph.route_context import assemble_route_context
+from app.graph.route_decide import decide_route
+
+
+def test_explore_canvas_intent():
+    ctx = assemble_route_context({
+        "messages": [{"role": "user", "content": "看看画布上有哪些节点，状态怎么样？"}],
+    })
+    d = decide_route(ctx)
+    assert d["flow_mode"] == "explore_canvas"
+    assert d["reason"] == "explore_canvas_intent"
+
+
+def test_explore_not_when_atomic_create():
+    ctx = assemble_route_context({
+        "messages": [{"role": "user", "content": "帮我在画布上生成一张产品主图"}],
+    })
+    d = decide_route(ctx)
+    assert d["flow_mode"] != "explore_canvas"
+
+
+def test_explore_lifecycle_diagnostic():
+    ctx = assemble_route_context({
+        "messages": [{"role": "user", "content": "查一下这个生成任务的失败诊断"}],
+    })
+    d = decide_route(ctx)
+    assert d["flow_mode"] == "explore_canvas"


### PR DESCRIPTION
## Summary

- **Hybrid A 控制面 PR-A**：explore 子图 + `tool_registry` SSOT + 生成 lifecycle Harness API
- **P1 Harness**：`list_generation_tasks`、资产列表/应用/存库、`introduce_nodes_to_agent`
- **`canvas_command` SSE**：`focus_node` / `introduce_nodes` 前端 handler
- **规格**：Spec v1.2（三通道 Tool / LangGraph Command / canvas_command SSE）+ SDD Plan

## Test plan

- [x] `python3 -m pytest tests/test_canvas_commands.py tests/test_explore_tools.py tests/test_route_decide_explore.py tests/test_nest_client.py tests/test_route_decide.py -q` → 31 passed
- [x] `npm test -- agent-canvas-tools.service.test.ts --run` → 36 passed
- [x] `pnpm build` → pass
- [ ] CI green
- [ ] 合并后可选：explore 流手动冒烟（「看看画布有哪些节点」）

## 后续 PR

- **PR-B**：P1 Graph 剩余（atomic P6、mixed confirm、sidebar explore bind）
- **PR-C/D**：P2 layout/duplicate、P3–P4 trace/undo


Made with [Cursor](https://cursor.com)