### PR TITLE
fix: lock Dock canvas image generation to single image

### DIFF
--- a/apps/web/src/components/canvas/ImageParamsSelector.vue
+++ b/apps/web/src/components/canvas/ImageParamsSelector.vue
@@ -120,12 +120,20 @@ function aspectRect(value: ImageAspectRatio) {
             :key="opt"
             type="button"
             class="neo-chip flex-1 rounded-md px-2 py-1 text-[10px]"
-            :class="count === opt ? 'is-on' : ''"
-            @click="emit('update:count', opt)"
+            :class="[
+              count === opt ? 'is-on' : '',
+              opt !== 1 ? 'cursor-not-allowed opacity-40' : '',
+            ]"
+            :disabled="opt !== 1"
+            :title="opt !== 1 ? '系统固定为单张；批量出图请使用 Agent 对话' : undefined"
+            @click="opt === 1 && emit('update:count', opt)"
           >
             ×{{ opt }}
           </button>
         </div>
+        <p class="mt-1.5 text-[10px] leading-4 text-[var(--neo-text-muted)]">
+          系统设定：单次原子生图固定 1 张；需多张请通过 Agent 批量创建节点。
+        </p>
       </div>
     </div>
   </div>

--- a/apps/web/src/components/canvas/ProviderConfigDialog.vue
+++ b/apps/web/src/components/canvas/ProviderConfigDialog.vue
@@ -69,7 +69,7 @@ const prefsDraft = reactive({
   defaultVideoModel: '',
   defaultTextModel: '',
   defaultAudioModel: '',
-  canvasImageCount: 3,
+  canvasImageCount: 1,
   defaultImageAspect: '16:9',
   defaultImageResolution: '1K',
   defaultVideoAspect: '16:9',
@@ -181,7 +181,7 @@ function hydrateFromBootstrap() {
     prefsDraft.defaultVideoModel = prefs.defaultVideoModel
     prefsDraft.defaultTextModel = prefs.defaultTextModel
     prefsDraft.defaultAudioModel = prefs.defaultAudioModel
-    prefsDraft.canvasImageCount = prefs.canvasImageCount
+    prefsDraft.canvasImageCount = 1
     prefsDraft.defaultImageAspect = prefs.defaultImageAspect || '16:9'
     prefsDraft.defaultImageResolution = prefs.defaultImageResolution || '1K'
     prefsDraft.defaultVideoAspect = prefs.defaultVideoAspect || DEFAULT_VIDEO_SETTINGS.aspectRatio
@@ -411,7 +411,7 @@ function buildPreferencesPayload(): ProviderPreferencesPublic {
     defaultVideoModel: prefsDraft.defaultVideoModel,
     defaultTextModel: prefsDraft.defaultTextModel,
     defaultAudioModel: prefsDraft.defaultAudioModel,
-    canvasImageCount: Math.max(1, Math.min(15, Math.floor(Number(prefsDraft.canvasImageCount) || 3))),
+    canvasImageCount: 1,
     defaultImageAspect: prefsDraft.defaultImageAspect || '16:9',
     defaultImageResolution: prefsDraft.defaultImageResolution || '1K',
     defaultVideoAspect: prefsDraft.defaultVideoAspect || DEFAULT_VIDEO_SETTINGS.aspectRatio,
@@ -734,17 +734,18 @@ function apiKeyPlaceholder(draft: ChannelDraft) {
         <!-- 生成偏好 -->
         <el-tab-pane label="生成偏好" name="preferences">
           <div class="grid gap-4 md:grid-cols-4">
-            <label class="block">
+            <label class="block opacity-80">
               <span class="mb-1 block text-[11px] text-[var(--neo-text-muted)]">画布默认生图张数</span>
               <el-input-number
-                v-model="prefsDraft.canvasImageCount"
+                :model-value="1"
                 :min="1"
-                :max="15"
+                :max="1"
+                disabled
                 class="!w-full"
                 controls-position="right"
               />
               <span class="mt-1 block text-[10px] leading-4 text-[var(--neo-text-muted)]">
-                新建画布生图和配置节点默认使用，单个节点仍可单独覆盖。Agent 自动出图会 clamp 到 1–4。
+                系统设定：单次原子生图固定 1 张。批量多图请通过 Agent 对话自动创建多个节点。
               </span>
             </label>
             <label class="block">

--- a/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
@@ -120,7 +120,10 @@ function syncFromNode() {
   imageAspect.value = (data.imageAspect as ImageAspectRatio | undefined) ?? '16:9'
   imageResolution.value = (data.imageResolution as ImageResolution | undefined) ?? '1K'
   const count = Number(data.imageCount ?? 1)
-  imageCount.value = (count === 2 || count === 4 ? count : 1) as ImageCount
+  imageCount.value = 1
+  if (count !== 1) {
+    syncField('imageCount', 1)
+  }
   referenceImageUrl.value = String(data.referenceImageUrl ?? '')
 }
 

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -842,7 +842,7 @@ function createNodeAt(type: DockNodeType, position: { x: number; y: number }) {
   const imageModel = getProviderConfig('image').model
   const videoModel = getProviderConfig('video').model
   const audioModel = getProviderConfig('audio').model
-  const imageCount = Math.max(1, Math.min(4, Math.round(Number(prefs?.canvasImageCount) || 1)))
+  const imageCount = 1
   const imageAspect = prefs?.defaultImageAspect || '16:9'
   const imageResolution = prefs?.defaultImageResolution || '1K'
   const videoSettings = {
@@ -1579,7 +1579,7 @@ async function createFileNodeAt(payload: MediaFilePayload, clientPos: { x: numbe
         imageModel: getProviderConfig('image').model,
         imageAspect: preferences.value?.defaultImageAspect || '16:9',
         imageResolution: preferences.value?.defaultImageResolution || '1K',
-        imageCount: Math.max(1, Math.min(4, Math.round(Number(preferences.value?.canvasImageCount) || 1))),
+        imageCount: 1,
       }, { position: resolveDropPosition(clientPos, 'image') })
       break
     case 'video':
@@ -1639,7 +1639,7 @@ function createUploadingMediaNodeAt(
         imageModel: getProviderConfig('image').model,
         imageAspect: preferences.value?.defaultImageAspect || '16:9',
         imageResolution: preferences.value?.defaultImageResolution || '1K',
-        imageCount: Math.max(1, Math.min(4, Math.round(Number(preferences.value?.canvasImageCount) || 1))),
+        imageCount: 1,
       }, { position: resolveDropPosition(clientPos, kind) })
     case 'video':
       return addNode('video', {


### PR DESCRIPTION
## Summary
- Dock 生图面板 ×2/×4 置灰不可选，并提示「系统固定单张；批量请走 Agent」
- 设置页「画布默认生图张数」禁用并固定为 1，保存偏好时写回 `canvasImageCount: 1`
- 新建/拖入生图节点默认 `imageCount: 1`；旧节点若仍为 2/4 打开 Dock 时自动写回 1

## Test plan
- [x] `pnpm build`
- [ ] Dock 生图：×2/×4 不可点击，×1 正常
- [ ] 设置 → 生成偏好：张数输入框禁用显示 1
- [ ] 新建生图节点 `imageCount` 为 1
- [ ] Agent 批量多图逻辑未改动


Made with [Cursor](https://cursor.com)