### PR TITLE
feat(agent): canvas control surface PR-B graph P1

### DIFF
--- a/apps/server/src/agent/agent-canvas-tools.controller.ts
+++ b/apps/server/src/agent/agent-canvas-tools.controller.ts
@@ -74,6 +74,23 @@ class BatchNodeItemDto {
   @IsOptional()
   @IsString()
   imageAspect?: string
+
+  @IsOptional()
+  videoSettings?: {
+    aspectRatio?: string
+    duration?: number
+    resolution?: string
+    crop?: string
+    generateAudio?: boolean
+  }
+
+  @IsOptional()
+  @IsString()
+  videoMode?: string
+
+  @IsOptional()
+  @IsString()
+  referenceImageUrl?: string
 }
 
 class AddNodesBatchDto {

--- a/apps/server/src/agent/agent-canvas-tools.service.test.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.test.ts
@@ -424,6 +424,8 @@ describe('AgentCanvasToolsService', () => {
       'center',
       undefined,
       { sessionId: 's1', nodeId: 'vid-1' },
+      undefined,
+      undefined,
     )
     expect(result.status).toBe('completed')
     expect(result.url).toBe('https://cdn.example/vid.mp4')
@@ -468,7 +470,85 @@ describe('AgentCanvasToolsService', () => {
       'center',
       'https://example.com/node-ref.png',
       { sessionId: 's1', nodeId: 'vid-1' },
+      undefined,
+      undefined,
     )
+  })
+
+  it('runVideoGeneration passes videoMode and generateAudio from node data', async () => {
+    canvas = {
+      nodes: [
+        {
+          id: 'vid-1',
+          type: 'video',
+          position: { x: 0, y: 0 },
+          data: {
+            prompt: '产品展示视频',
+            status: 'draft',
+            videoMode: 'image_to_video',
+            videoSettings: {
+              aspectRatio: '9:16',
+              duration: 4,
+              resolution: '1080p',
+              crop: 'center',
+              generateAudio: false,
+            },
+          },
+        },
+      ],
+      edges: [],
+    }
+    getGeneration.mockResolvedValue({
+      id: 'gen-v1',
+      status: 'completed',
+      url: 'https://cdn.example/vid.mp4',
+    })
+    await svc.runVideoGeneration({
+      sessionId: 's1',
+      userId: 'u1',
+      nodeId: 'vid-1',
+    })
+    expect(generateVideo).toHaveBeenCalledWith(
+      'u1',
+      '产品展示视频',
+      'platform::user-default-video',
+      4,
+      '9:16',
+      expect.any(Array),
+      undefined,
+      '1080p',
+      'center',
+      undefined,
+      { sessionId: 's1', nodeId: 'vid-1' },
+      'image_to_video',
+      false,
+    )
+  })
+
+  it('addNodesBatch merges explicit video P6 overrides onto video skeleton', async () => {
+    const result = await svc.addNodesBatch({
+      sessionId: 's1',
+      userId: 'u1',
+      items: [
+        {
+          key: 'show_video',
+          title: '视频',
+          targetType: 'video',
+          videoSettings: { duration: 4, generateAudio: false },
+          videoMode: 'image_to_video',
+          referenceImageUrl: 'https://cdn.example/ref.png',
+        },
+      ],
+    })
+    expect(result.nodes).toHaveLength(1)
+    const videoNode = canvas.nodes.find((n) => n.type === 'video')
+    expect(videoNode?.data.videoSettings).toMatchObject({
+      duration: 4,
+      generateAudio: false,
+      aspectRatio: '9:16',
+    })
+    expect(videoNode?.data.videoMode).toBe('image_to_video')
+    expect(videoNode?.data.referenceImageUrl).toBe('https://cdn.example/ref.png')
   })
 
   it('runTextGeneration calls Studio and writes content', async () => {

--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -345,6 +345,15 @@ export class AgentCanvasToolsService {
       position?: { x: number; y: number }
       pipeline?: string
       imageAspect?: string
+      videoSettings?: {
+        aspectRatio?: string
+        duration?: number
+        resolution?: string
+        crop?: string
+        generateAudio?: boolean
+      }
+      videoMode?: string
+      referenceImageUrl?: string
     }>
     stage?: boolean
   }): Promise<{ nodes: Array<{ key: string; nodeId: string }>; actions: CanvasAction[] }> {
@@ -374,6 +383,15 @@ export class AgentCanvasToolsService {
       }
       if (item.pipeline) nodeData.pipeline = item.pipeline
       if (item.imageAspect) nodeData.imageAspect = item.imageAspect
+      if (item.videoSettings && typeof item.videoSettings === 'object') {
+        const base =
+          nodeData.videoSettings && typeof nodeData.videoSettings === 'object'
+            ? (nodeData.videoSettings as Record<string, unknown>)
+            : {}
+        nodeData.videoSettings = { ...base, ...item.videoSettings }
+      }
+      if (item.videoMode) nodeData.videoMode = item.videoMode
+      if (item.referenceImageUrl) nodeData.referenceImageUrl = item.referenceImageUrl
       actions.push({
         type: 'add_node',
         payload: {
@@ -916,6 +934,12 @@ export class AgentCanvasToolsService {
       const model = pickString(node.data?.videoModel, prefs.defaultVideoModel) || undefined
       const referenceImageUrl =
         String(node.data?.referenceImageUrl ?? '').trim() || undefined
+      const videoMode =
+        String(node.data?.videoMode ?? '').trim() || undefined
+      const generateAudio =
+        typeof settings.generateAudio === 'boolean'
+          ? settings.generateAudio
+          : undefined
 
       const record = await this.studio.generateVideo(
         input.userId,
@@ -929,6 +953,8 @@ export class AgentCanvasToolsService {
         crop,
         referenceImageUrl,
         { sessionId: input.sessionId, nodeId: input.nodeId },
+        videoMode,
+        generateAudio,
       )
 
       const recordId = record.id

--- a/services/agent-runtime/app/graph/atomic_intent.py
+++ b/services/agent-runtime/app/graph/atomic_intent.py
@@ -63,6 +63,7 @@ PROMPT_EXPLICIT_KEYWORDS = tuple(_TAXONOMY.get("prompt_explicit_keywords") or (
 ))
 
 VIDEO_KEYWORDS = ("视频", "短片", "短视频", "15s", "15秒", "30s", "30秒")
+_VIDEO_DURATION_RE = re.compile(r"(\d+)\s*(?:秒|s)", re.IGNORECASE)
 AUDIO_KEYWORDS = ("配音", "旁白", "音频", "语音")
 # Avoid bare 「图」— it matches campaign phrases like 「确认出图」.
 IMAGE_KEYWORDS = ("海报", "banner", "视觉", "主图", "白底", "场景图", "产品图", "人物图", "风图")
@@ -440,6 +441,17 @@ def confirm_gate_for_type(target_type: AtomicTargetType) -> bool:
     return target_type in ("video", "audio")
 
 
+def infer_video_duration(text: str) -> int | None:
+    match = _VIDEO_DURATION_RE.search(text or "")
+    if not match:
+        return None
+    try:
+        duration = int(match.group(1))
+    except ValueError:
+        return None
+    return max(4, min(15, duration))
+
+
 def build_atomic_spec(text: str) -> dict[str, Any]:
     """Build atomic_spec from raw user utterance."""
     utterance = (text or "").strip()
@@ -455,6 +467,10 @@ def build_atomic_spec(text: str) -> dict[str, Any]:
         spec["pipeline"] = TURNAROUND_PIPELINE
         spec["imageAspect"] = TURNAROUND_ASPECT_RATIO
         spec["resolutionBump"] = True
+    if target_type == "video":
+        duration = infer_video_duration(utterance)
+        if duration is not None:
+            spec["videoSettings"] = {"duration": duration}
     return spec
 
 

--- a/services/agent-runtime/app/graph/atomic_parse_schema.py
+++ b/services/agent-runtime/app/graph/atomic_parse_schema.py
@@ -29,7 +29,35 @@ class AtomicParseItem(TypedDict, total=False):
     resolutionBump: bool
     promptMode: str
     prompt_mode: str
+    videoSettings: dict[str, Any]
+    videoMode: str
+    referenceImageUrl: str
 
+
+def _clamp_video_duration(value: Any) -> int | None:
+    try:
+        duration = int(value)
+    except (TypeError, ValueError):
+        return None
+    return max(4, min(15, duration))
+
+
+def _normalize_video_settings(raw: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    out: dict[str, Any] = {}
+    if raw.get("aspectRatio"):
+        out["aspectRatio"] = str(raw["aspectRatio"])
+    duration = _clamp_video_duration(raw.get("duration"))
+    if duration is not None:
+        out["duration"] = duration
+    if raw.get("resolution"):
+        out["resolution"] = str(raw["resolution"])
+    if raw.get("crop"):
+        out["crop"] = str(raw["crop"])
+    if raw.get("generateAudio") is not None:
+        out["generateAudio"] = bool(raw["generateAudio"])
+    return out or None
 
 class AtomicParseSuccess(TypedDict):
     kind: Literal["success"]
@@ -75,6 +103,13 @@ def _normalize_item(raw: dict[str, Any]) -> AtomicParseItem | None:
     pm = raw.get("promptMode") or raw.get("prompt_mode")
     if pm:
         item["promptMode"] = str(pm)
+    video_settings = _normalize_video_settings(raw.get("videoSettings"))
+    if video_settings:
+        item["videoSettings"] = video_settings
+    if raw.get("videoMode"):
+        item["videoMode"] = str(raw["videoMode"])
+    if raw.get("referenceImageUrl"):
+        item["referenceImageUrl"] = str(raw["referenceImageUrl"])
     return item  # type: ignore[return-value]
 
 

--- a/services/agent-runtime/app/graph/nodes/atomic_create_node.py
+++ b/services/agent-runtime/app/graph/nodes/atomic_create_node.py
@@ -32,6 +32,21 @@ def _atomic_batch_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
                     if item.get("imageAspect")
                     else {}
                 ),
+                **(
+                    {"videoSettings": item["videoSettings"]}
+                    if item.get("videoSettings")
+                    else {}
+                ),
+                **(
+                    {"videoMode": item["videoMode"]}
+                    if item.get("videoMode")
+                    else {}
+                ),
+                **(
+                    {"referenceImageUrl": item["referenceImageUrl"]}
+                    if item.get("referenceImageUrl")
+                    else {}
+                ),
             }
         )
     return batch

--- a/services/agent-runtime/app/tools/definitions.py
+++ b/services/agent-runtime/app/tools/definitions.py
@@ -78,6 +78,16 @@ class SaveNodeAssetInput(BaseModel):
     label: str | None = Field(default=None, description="Optional asset label override")
 
 
+class ApplySidebarAttachmentsInput(BaseModel):
+    node_ids: list[str] = Field(description="Target canvas node ids")
+    attachments: list[dict[str, Any]] = Field(description="Sidebar attachment payloads")
+    ref_order: list[str] | None = Field(default=None, description="Attachment id order")
+    mode: str = Field(description="localRefs or attach_edges")
+    mentioned_keys: list[str] | None = Field(
+        default=None, description="Explicit @I1-style mention keys"
+    )
+
+
 class ListGenerationTasksInput(BaseModel):
     type: str | None = Field(default=None, description="Optional filter: image, video, etc.")
 
@@ -167,6 +177,21 @@ def _all_tool_specs(client: NestCanvasClient) -> list[tuple[str, StructuredTool]
 
     async def focus_node(node_id: str) -> dict:
         return {"ok": True, "canvasCommands": [{"type": "focus_node", "nodeId": node_id}]}
+
+    async def apply_sidebar_attachments(
+        node_ids: list[str],
+        attachments: list[dict[str, Any]],
+        mode: str,
+        ref_order: list[str] | None = None,
+        mentioned_keys: list[str] | None = None,
+    ) -> dict:
+        return await client.apply_sidebar_attachments(
+            node_ids=node_ids,
+            attachments=attachments,
+            ref_order=ref_order,
+            mode=mode,
+            mentioned_keys=mentioned_keys,
+        )
 
     specs: list[tuple[str, StructuredTool]] = [
         (
@@ -354,6 +379,15 @@ def _all_tool_specs(client: NestCanvasClient) -> list[tuple[str, StructuredTool]
                 name="focus_node",
                 description="Pan/zoom the canvas viewport to a node (UI command)",
                 args_schema=NodeIdInput,
+            ),
+        ),
+        (
+            "apply_sidebar_attachments",
+            StructuredTool.from_function(
+                coroutine=apply_sidebar_attachments,
+                name="apply_sidebar_attachments",
+                description="Write sidebar attachments onto canvas nodes (localRefs or ref edges)",
+                args_schema=ApplySidebarAttachmentsInput,
             ),
         ),
     ]

--- a/services/agent-runtime/app/tools/tool_registry.py
+++ b/services/agent-runtime/app/tools/tool_registry.py
@@ -35,6 +35,7 @@ EXPLORE_TOOL_NAMES = frozenset({
     "save_node_to_asset_library",
     "introduce_nodes_to_agent",
     "apply_asset_to_node",
+    "apply_sidebar_attachments",
     "focus_node",
 })
 

--- a/services/agent-runtime/tests/test_atomic_create_intent.py
+++ b/services/agent-runtime/tests/test_atomic_create_intent.py
@@ -100,6 +100,12 @@ def test_turnaround_prompt_with_hint_word_not_pipeline():
     assert "pipeline" not in spec
 
 
+def test_build_atomic_spec_infers_video_duration():
+    spec = build_atomic_spec("帮我做一个15秒产品展示视频")
+    assert spec["target_type"] == "video"
+    assert spec.get("videoSettings") == {"duration": 15}
+
+
 def test_atomic_create_intent_negative_campaign():
     assert not atomic_create_intent("帮我做一套天猫蓝牙耳机详情页营销方案")
     assert atomic_create_intent("帮我生成一个模特人物图")

--- a/services/agent-runtime/tests/test_atomic_create_subgraph.py
+++ b/services/agent-runtime/tests/test_atomic_create_subgraph.py
@@ -90,6 +90,31 @@ async def test_create_atomic_node_then_image_gen():
 
 
 @pytest.mark.asyncio
+async def test_create_atomic_node_passes_video_p6_fields():
+    nest = FakeNest()
+    create = make_create_atomic_node(nest=nest)
+    spec = {
+        "target_type": "video",
+        "prompt": "产品展示",
+        "title": "产品展示",
+        "confirm_gate": True,
+        "videoSettings": {"duration": 4, "aspectRatio": "9:16", "generateAudio": False},
+        "videoMode": "image_to_video",
+        "referenceImageUrl": "https://cdn.example/ref.png",
+    }
+    await create({"atomic_spec": spec})
+    batch_call = next(c for c in nest.calls if c[0] == "add_nodes_batch")
+    item = batch_call[1][0]
+    assert item["videoSettings"] == {
+        "duration": 4,
+        "aspectRatio": "9:16",
+        "generateAudio": False,
+    }
+    assert item["videoMode"] == "image_to_video"
+    assert item["referenceImageUrl"] == "https://cdn.example/ref.png"
+
+
+@pytest.mark.asyncio
 async def test_text_atomic_gen_direct():
     nest = FakeNest()
     create = make_create_atomic_node(nest=nest)

--- a/services/agent-runtime/tests/test_atomic_parse_schema.py
+++ b/services/agent-runtime/tests/test_atomic_parse_schema.py
@@ -63,6 +63,39 @@ def test_validate_video_confirm_gate_default():
     assert out["items"][0]["confirm_gate"] is True
 
 
+def test_validate_preserves_video_p6_fields():
+    out = validate_parse_result(
+        {
+            "items": [
+                {
+                    "target_type": "video",
+                    "prompt": "产品展示",
+                    "title": "产品展示",
+                    "confirm_gate": True,
+                    "videoSettings": {
+                        "duration": 4,
+                        "aspectRatio": "9:16",
+                        "generateAudio": False,
+                    },
+                    "videoMode": "image_to_video",
+                    "referenceImageUrl": "https://cdn.example/ref.png",
+                }
+            ],
+            "confidence": 0.95,
+        },
+        utterance="做一个4秒竖屏视频",
+    )
+    assert out["kind"] == "success"
+    item = out["items"][0]
+    assert item.get("videoSettings") == {
+        "duration": 4,
+        "aspectRatio": "9:16",
+        "generateAudio": False,
+    }
+    assert item.get("videoMode") == "image_to_video"
+    assert item.get("referenceImageUrl") == "https://cdn.example/ref.png"
+
+
 def test_validate_preserves_turnaround_pipeline_fields():
     out = validate_parse_result(
         {

--- a/services/agent-runtime/tests/test_explore_tools.py
+++ b/services/agent-runtime/tests/test_explore_tools.py
@@ -11,6 +11,7 @@ def test_explore_tools_exclude_generation():
     names = {t.name for t in tools}
     assert "get_canvas_summary" in names
     assert "cancel_generation" in names
+    assert "apply_sidebar_attachments" in names
     assert "run_image_generation" not in names
     assert "add_nodes_batch" not in names
     assert names <= EXPLORE_TOOL_NAMES


### PR DESCRIPTION
## Summary
- 将 `apply_sidebar_attachments` 纳入 explore 白名单与 StructuredTool 绑定
- atomic create 贯通 video P6 参数（duration/aspectRatio/generateAudio/videoMode/referenceImageUrl）
- `runVideoGeneration` 对齐 studio 路径，传递 `videoMode` 与 `generateAudio`

## Test plan
- [x] pytest: explore + atomic parse/create/orchestration (63 passed)
- [x] vitest: agent-canvas-tools.service.test.ts (38 passed)
- [x] pnpm build


Made with [Cursor](https://cursor.com)