### PR TITLE
feat(agent): canvas control surface PR-C/D (P1-P4 harness + explore tools)

### DIFF
--- a/apps/server/src/agent/agent-canvas-tools.controller.ts
+++ b/apps/server/src/agent/agent-canvas-tools.controller.ts
@@ -372,6 +372,95 @@ class ApplyAssetToNodeDto {
   source!: 'user' | 'public'
 }
 
+class DuplicateNodeDto {
+  @IsString()
+  sessionId!: string
+
+  @IsString()
+  userId!: string
+
+  @IsString()
+  nodeId!: string
+
+  @IsOptional()
+  offset?: { x: number; y: number }
+}
+
+class UploadMediaToCanvasDto {
+  @IsString()
+  sessionId!: string
+
+  @IsString()
+  userId!: string
+
+  @IsString()
+  url!: string
+
+  @IsIn(['image', 'video', 'audio'])
+  mediaType!: 'image' | 'video' | 'audio'
+
+  @IsOptional()
+  @IsString()
+  title?: string
+
+  @IsOptional()
+  position?: { x: number; y: number }
+}
+
+class ExportMediaPackageDto {
+  @IsString()
+  sessionId!: string
+
+  @IsString()
+  userId!: string
+
+  @IsArray()
+  @IsString({ each: true })
+  nodeIds!: string[]
+}
+
+class GroupNodesDto {
+  @IsString()
+  sessionId!: string
+
+  @IsString()
+  userId!: string
+
+  @IsArray()
+  @IsString({ each: true })
+  nodeIds!: string[]
+
+  @IsOptional()
+  @IsString()
+  title?: string
+}
+
+class UngroupNodeDto {
+  @IsString()
+  sessionId!: string
+
+  @IsString()
+  userId!: string
+
+  @IsString()
+  groupId!: string
+}
+
+class ArrangeNodesGridDto {
+  @IsString()
+  sessionId!: string
+
+  @IsString()
+  userId!: string
+
+  @IsArray()
+  @IsString({ each: true })
+  nodeIds!: string[]
+
+  @IsOptional()
+  gap?: number
+}
+
 class SaveAgentMessageDto {
   @IsString()
   sessionId!: string
@@ -696,6 +785,54 @@ export class AgentCanvasToolsController {
   @Post('apply-asset-to-node')
   async applyAssetToNode(@Body() dto: ApplyAssetToNodeDto) {
     const data = await this.tools.applyAssetToNode(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('get-canvas-layout')
+  async getCanvasLayout(@Body() dto: SessionOnlyDto) {
+    const data = await this.tools.getCanvasLayout(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('duplicate-node')
+  async duplicateNode(@Body() dto: DuplicateNodeDto) {
+    const data = await this.tools.duplicateNode(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('upload-media-to-canvas')
+  async uploadMediaToCanvas(@Body() dto: UploadMediaToCanvasDto) {
+    const data = await this.tools.uploadMediaToCanvas(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('export-media-package')
+  async exportMediaPackage(@Body() dto: ExportMediaPackageDto) {
+    const data = await this.tools.exportMediaPackage(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('group-nodes')
+  async groupNodes(@Body() dto: GroupNodesDto) {
+    const data = await this.tools.groupNodes(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('ungroup-node')
+  async ungroupNode(@Body() dto: UngroupNodeDto) {
+    const data = await this.tools.ungroupNode(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('arrange-nodes-grid')
+  async arrangeNodesGrid(@Body() dto: ArrangeNodesGridDto) {
+    const data = await this.tools.arrangeNodesGrid(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('get-image-edit-capabilities')
+  async getImageEditCapabilities(@Body() dto: SessionNodeDto) {
+    const data = await this.tools.getImageEditCapabilities(dto)
     return { code: 0, message: 'ok', data }
   }
 

--- a/apps/server/src/agent/agent-canvas-tools.service.test.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.test.ts
@@ -5,6 +5,7 @@ import { Test } from '@nestjs/testing'
 import type { CanvasData } from '@lnkpi/shared'
 import { PrismaService } from '../prisma/prisma.service'
 import { StudioService } from '../studio/studio.service'
+import { MaterialService } from '../canvas/material.service'
 import { AgentCanvasToolsService } from './agent-canvas-tools.service'
 
 const emptyCanvas = (): CanvasData => ({ nodes: [], edges: [] })
@@ -26,7 +27,12 @@ describe('AgentCanvasToolsService', () => {
   const getGenerationDiagnostic = vi.fn()
   const confirmPlatformFallback = vi.fn()
   const cancelPlatformFallback = vi.fn()
+  const cancelPlatformFallbackMaterial = vi.fn()
   const listGenerations = vi.fn()
+  const cancelGenerationMaterial = vi.fn()
+  const getMaterialDiagnostic = vi.fn()
+  const confirmPlatformFallbackMaterial = vi.fn()
+  const materialFindFirst = vi.fn()
 
   const defaultPrefs = {
     userId: 'u1',
@@ -106,6 +112,18 @@ describe('AgentCanvasToolsService', () => {
       url: 'https://cdn.example/fallback.png',
     })
     cancelPlatformFallback.mockResolvedValue({ id: 'rec-1', status: 'failed' })
+    cancelGenerationMaterial.mockResolvedValue({ id: 'mat-1', status: 'failed' })
+    getMaterialDiagnostic.mockResolvedValue({
+      errorCode: 'upstream',
+      userMessage: '素材生成失败',
+    })
+    confirmPlatformFallbackMaterial.mockResolvedValue({
+      id: 'mat-1',
+      status: 'completed',
+      url: 'https://cdn.example/mat.png',
+    })
+    cancelPlatformFallbackMaterial.mockResolvedValue({ id: 'mat-1', status: 'failed' })
+    materialFindFirst.mockResolvedValue(null)
     listGenerations.mockResolvedValue([
       {
         id: 'g1',
@@ -145,6 +163,7 @@ describe('AgentCanvasToolsService', () => {
           useValue: {
             session: { findUnique: sessionFindUnique, update: sessionUpdate },
             userAiPreferences: { findUnique: prefsFindUnique },
+            material: { findFirst: materialFindFirst },
             $transaction,
           },
         },
@@ -163,6 +182,15 @@ describe('AgentCanvasToolsService', () => {
             confirmPlatformFallback,
             cancelPlatformFallback,
             listGenerations,
+          },
+        },
+        {
+          provide: MaterialService,
+          useValue: {
+            cancelGeneration: cancelGenerationMaterial,
+            getMaterialDiagnostic,
+            confirmPlatformFallback: confirmPlatformFallbackMaterial,
+            cancelPlatformFallback: cancelPlatformFallbackMaterial,
           },
         },
       ],
@@ -1191,6 +1219,51 @@ describe('AgentCanvasToolsService', () => {
       expect(getGenerationDiagnostic).toHaveBeenCalledWith('u1', 'rec-1')
       expect(d.userMessage).toBe('上游失败')
     })
+
+    it('cancelGeneration routes material records to MaterialService', async () => {
+      canvas = {
+        nodes: [
+          {
+            id: 'img-mat',
+            type: 'image',
+            position: { x: 0, y: 0 },
+            data: { materialId: 'mat-1', status: 'generating' },
+          },
+        ],
+        edges: [],
+      }
+      const result = await svc.cancelGeneration({
+        sessionId: 's1',
+        userId: 'u1',
+        nodeId: 'img-mat',
+      })
+      expect(cancelGenerationMaterial).toHaveBeenCalledWith('u1', 'mat-1')
+      expect(cancelGenerationStudio).not.toHaveBeenCalled()
+      expect(result.recordKind).toBe('material')
+      expect(result.status).toBe('cancelled')
+    })
+
+    it('getGenerationDiagnostic routes material records to MaterialService', async () => {
+      canvas = {
+        nodes: [
+          {
+            id: 'img-mat',
+            type: 'image',
+            position: { x: 0, y: 0 },
+            data: { materialId: 'mat-1' },
+          },
+        ],
+        edges: [],
+      }
+      const d = await svc.getGenerationDiagnostic({
+        sessionId: 's1',
+        userId: 'u1',
+        nodeId: 'img-mat',
+      })
+      expect(getMaterialDiagnostic).toHaveBeenCalledWith('u1', 'mat-1')
+      expect(getGenerationDiagnostic).not.toHaveBeenCalled()
+      expect(d.userMessage).toBe('素材生成失败')
+    })
   })
 
   describe('P1 explore harness', () => {
@@ -1237,6 +1310,33 @@ describe('AgentCanvasToolsService', () => {
       expect(result.attachments).toHaveLength(2)
       expect(result.skipped).toEqual(['missing'])
       expect(result.canvasCommands[0]?.type).toBe('introduce_nodes')
+    })
+
+    it('getCanvasLayout returns node positions and sizes', async () => {
+      const layout = await svc.getCanvasLayout({ sessionId: 's1' })
+      expect(layout.nodes).toHaveLength(2)
+      expect(layout.nodes[0]?.id).toBe('img-1')
+      expect(layout.nodes[0]?.size.w).toBeGreaterThan(0)
+    })
+
+    it('duplicateNode clones node and focuses copy', async () => {
+      const result = await svc.duplicateNode({
+        sessionId: 's1',
+        userId: 'u1',
+        nodeId: 'img-1',
+      })
+      expect(result.nodeId).not.toBe('img-1')
+      expect(canvas.nodes).toHaveLength(3)
+      expect(result.canvasCommands[0]?.type).toBe('focus_node')
+    })
+
+    it('getImageEditCapabilities reports image node support', async () => {
+      const caps = await svc.getImageEditCapabilities({
+        sessionId: 's1',
+        nodeId: 'img-1',
+      })
+      expect(caps.canEdit).toBe(true)
+      expect(caps.supportedModes).toContain('inpaint')
     })
   })
 })

--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -13,7 +13,15 @@ import {
 } from '@lnkpi/shared'
 import { PrismaService } from '../prisma/prisma.service'
 import { PUBLIC_ASSETS } from '../assets/public-assets.data'
+import { MaterialService } from '../canvas/material.service'
 import { StudioService, type StudioRefInput } from '../studio/studio.service'
+import {
+  createGroupFromNodes,
+  getNodeSize,
+  layoutNodesInGrid,
+  type LayoutNode,
+  ungroupNode,
+} from './canvas-layout.util'
 
 const GRID_X = 280
 const GRID_Y = 220
@@ -238,6 +246,7 @@ export class AgentCanvasToolsService {
   constructor(
     @Inject(PrismaService) private readonly prisma: PrismaService,
     @Inject(StudioService) private readonly studio: StudioService,
+    @Inject(MaterialService) private readonly material: MaterialService,
   ) {}
 
   private async loadAccountGenPrefs(userId: string): Promise<AccountGenPrefs> {
@@ -1266,23 +1275,35 @@ export class AgentCanvasToolsService {
   async getGenerationStatus(input: {
     sessionId: string
     nodeId: string
-  }): Promise<{ status: string; url?: string; generationRecordId?: string }> {
+  }): Promise<{
+    status: string
+    url?: string
+    generationRecordId?: string
+    materialId?: string
+    recordKind?: 'studio' | 'material'
+  }> {
     const node = await this.getNode(input)
     const status = nodeStatus(node)
     const url = typeof node.data?.url === 'string' && node.data.url ? node.data.url : undefined
-    const generationRecordId =
-      typeof node.data?.generationRecordId === 'string' && node.data.generationRecordId
-        ? node.data.generationRecordId
-        : undefined
-    return generationRecordId
-      ? { status, url, generationRecordId }
-      : url
-        ? { status, url }
-        : { status }
+    const generationRecordId = this.generationRecordIdFromNode(node)
+    const materialId = this.materialIdFromNode(node)
+    const recordKind = generationRecordId ? 'studio' : materialId ? 'material' : undefined
+    return {
+      status,
+      url,
+      generationRecordId,
+      materialId,
+      recordKind,
+    }
   }
 
   private generationRecordIdFromNode(node: CanvasNode): string | undefined {
     const id = node.data?.generationRecordId
+    return typeof id === 'string' && id.trim() ? id.trim() : undefined
+  }
+
+  private materialIdFromNode(node: CanvasNode): string | undefined {
+    const id = node.data?.materialId
     return typeof id === 'string' && id.trim() ? id.trim() : undefined
   }
 
@@ -1291,20 +1312,35 @@ export class AgentCanvasToolsService {
     userId: string
     generationRecordId?: string
     nodeId?: string
-  }): Promise<{ recordId: string; nodeId?: string }> {
+  }): Promise<{ recordId: string; recordKind: 'studio' | 'material'; nodeId?: string }> {
     const direct = input.generationRecordId?.trim()
     if (direct) {
-      return { recordId: direct, nodeId: input.nodeId }
+      try {
+        await this.studio.getGeneration(input.userId, direct)
+        return { recordId: direct, recordKind: 'studio', nodeId: input.nodeId }
+      } catch {
+        const material = await this.prisma.material.findFirst({
+          where: { id: direct, shot: { session: { userId: input.userId } } },
+        })
+        if (material) {
+          return { recordId: direct, recordKind: 'material', nodeId: input.nodeId }
+        }
+        throw new NotFoundException('生成记录不存在')
+      }
     }
     if (!input.nodeId) {
       throw new BadRequestException('需要提供 generationRecordId 或 nodeId')
     }
     const node = await this.getNode({ sessionId: input.sessionId, nodeId: input.nodeId })
-    const recordId = this.generationRecordIdFromNode(node)
-    if (!recordId) {
-      throw new NotFoundException('节点无关联的生成记录')
+    const studioId = this.generationRecordIdFromNode(node)
+    if (studioId) {
+      return { recordId: studioId, recordKind: 'studio', nodeId: input.nodeId }
     }
-    return { recordId, nodeId: input.nodeId }
+    const materialId = this.materialIdFromNode(node)
+    if (materialId) {
+      return { recordId: materialId, recordKind: 'material', nodeId: input.nodeId }
+    }
+    throw new NotFoundException('节点无关联的生成记录')
   }
 
   async getGenerationDiagnostic(input: {
@@ -1313,7 +1349,10 @@ export class AgentCanvasToolsService {
     generationRecordId?: string
     nodeId?: string
   }) {
-    const { recordId } = await this.resolveGenerationRecord(input)
+    const { recordId, recordKind } = await this.resolveGenerationRecord(input)
+    if (recordKind === 'material') {
+      return this.material.getMaterialDiagnostic(input.userId, recordId)
+    }
     return this.studio.getGenerationDiagnostic(input.userId, recordId)
   }
 
@@ -1322,9 +1361,18 @@ export class AgentCanvasToolsService {
     userId: string
     generationRecordId?: string
     nodeId?: string
-  }): Promise<{ status: string; generationRecordId: string; actions: CanvasAction[] }> {
-    const { recordId, nodeId } = await this.resolveGenerationRecord(input)
-    await this.studio.cancelGeneration(input.userId, recordId)
+  }): Promise<{
+    status: string
+    generationRecordId: string
+    recordKind: 'studio' | 'material'
+    actions: CanvasAction[]
+  }> {
+    const { recordId, recordKind, nodeId } = await this.resolveGenerationRecord(input)
+    if (recordKind === 'material') {
+      await this.material.cancelGeneration(input.userId, recordId)
+    } else {
+      await this.studio.cancelGeneration(input.userId, recordId)
+    }
     const actions: CanvasAction[] = []
     if (nodeId) {
       actions.push({
@@ -1336,7 +1384,12 @@ export class AgentCanvasToolsService {
       })
       await this.persist(input.sessionId, actions)
     }
-    return { status: 'cancelled', generationRecordId: recordId, actions }
+    return {
+      status: 'cancelled',
+      generationRecordId: recordId,
+      recordKind,
+      actions,
+    }
   }
 
   async confirmPlatformFallback(input: {
@@ -1347,18 +1400,23 @@ export class AgentCanvasToolsService {
   }): Promise<{
     status: string
     generationRecordId: string
+    recordKind: 'studio' | 'material'
     url?: string
     actions: CanvasAction[]
   }> {
-    const { recordId, nodeId } = await this.resolveGenerationRecord(input)
-    const record = await this.studio.confirmPlatformFallback(input.userId, recordId)
+    const { recordId, recordKind, nodeId } = await this.resolveGenerationRecord(input)
+    const record =
+      recordKind === 'material'
+        ? await this.material.confirmPlatformFallback(input.userId, recordId)
+        : await this.studio.confirmPlatformFallback(input.userId, recordId)
     const actions: CanvasAction[] = []
     const url = typeof record.url === 'string' && record.url ? record.url : undefined
     if (nodeId) {
       const patch: Record<string, unknown> = {
         status: record.status === 'completed' ? 'completed' : record.status,
-        generationRecordId: recordId,
       }
+      if (recordKind === 'studio') patch.generationRecordId = recordId
+      if (recordKind === 'material') patch.materialId = recordId
       if (url) patch.url = url
       if (record.status === 'failed') {
         patch.errorMessage = '平台回退失败'
@@ -1372,6 +1430,7 @@ export class AgentCanvasToolsService {
     return {
       status: record.status,
       generationRecordId: recordId,
+      recordKind,
       url,
       actions,
     }
@@ -1382,9 +1441,18 @@ export class AgentCanvasToolsService {
     userId: string
     generationRecordId?: string
     nodeId?: string
-  }): Promise<{ status: string; generationRecordId: string; actions: CanvasAction[] }> {
-    const { recordId, nodeId } = await this.resolveGenerationRecord(input)
-    await this.studio.cancelPlatformFallback(input.userId, recordId)
+  }): Promise<{
+    status: string
+    generationRecordId: string
+    recordKind: 'studio' | 'material'
+    actions: CanvasAction[]
+  }> {
+    const { recordId, recordKind, nodeId } = await this.resolveGenerationRecord(input)
+    if (recordKind === 'material') {
+      await this.material.cancelPlatformFallback(input.userId, recordId)
+    } else {
+      await this.studio.cancelPlatformFallback(input.userId, recordId)
+    }
     const actions: CanvasAction[] = []
     if (nodeId) {
       actions.push({
@@ -1396,7 +1464,7 @@ export class AgentCanvasToolsService {
       })
       await this.persist(input.sessionId, actions)
     }
-    return { status: 'failed', generationRecordId: recordId, actions }
+    return { status: 'failed', generationRecordId: recordId, recordKind, actions }
   }
 
   async listGenerationTasks(input: {
@@ -1572,6 +1640,212 @@ export class AgentCanvasToolsService {
     return {
       actions,
       canvasCommands: [{ type: 'focus_node', nodeId: input.nodeId }],
+    }
+  }
+
+  async getCanvasLayout(input: { sessionId: string }): Promise<{
+    nodes: Array<{
+      id: string
+      type: string
+      title: string
+      status: string
+      position: { x: number; y: number }
+      size: { w: number; h: number }
+      parentNode?: string
+    }>
+  }> {
+    const { canvas } = await this.loadSession(input.sessionId)
+    const nodes = (canvas.nodes as LayoutNode[]).map((node) => {
+      const { w, h } = getNodeSize(node)
+      return {
+        id: node.id,
+        type: String(node.type ?? ''),
+        title: nodeTitle(node),
+        status: nodeStatus(node),
+        position: node.position,
+        size: { w, h },
+        ...(node.parentNode ? { parentNode: node.parentNode } : {}),
+      }
+    })
+    return { nodes }
+  }
+
+  async duplicateNode(input: {
+    sessionId: string
+    userId: string
+    nodeId: string
+    offset?: { x: number; y: number }
+  }): Promise<{ nodeId: string; actions: CanvasAction[]; canvasCommands: Array<{ type: string; nodeId: string }> }> {
+    await this.loadOwnedSession(input.sessionId, input.userId)
+    const source = await this.getNode({ sessionId: input.sessionId, nodeId: input.nodeId })
+    const offset = input.offset ?? { x: 40, y: 40 }
+    const nodeType = String(source.type ?? 'image') as NodeType
+    const newId = nextNodeId(nodeType)
+    const cloned = JSON.parse(JSON.stringify(source.data ?? {})) as Record<string, unknown>
+    delete cloned.generationRecordId
+    delete cloned.materialId
+    cloned.status = 'draft'
+    const actions: CanvasAction[] = [
+      {
+        type: 'add_node',
+        payload: {
+          id: newId,
+          nodeType,
+          position: {
+            x: source.position.x + offset.x,
+            y: source.position.y + offset.y,
+          },
+          data: cloned,
+        },
+      },
+    ]
+    await this.persist(input.sessionId, actions)
+    return {
+      nodeId: newId,
+      actions,
+      canvasCommands: [{ type: 'focus_node', nodeId: newId }],
+    }
+  }
+
+  async uploadMediaToCanvas(input: {
+    sessionId: string
+    userId: string
+    url: string
+    mediaType: 'image' | 'video' | 'audio'
+    title?: string
+    position?: { x: number; y: number }
+  }): Promise<{ nodeId: string; actions: CanvasAction[] }> {
+    await this.loadOwnedSession(input.sessionId, input.userId)
+    const { canvas } = await this.loadSession(input.sessionId)
+    const nodeType = input.mediaType === 'image' ? 'mediaInput' : input.mediaType
+    const nodeId = nextNodeId(nodeType)
+    const position =
+      input.position ?? {
+        x: 80 + (canvas.nodes.length % 4) * GRID_X,
+        y: 80 + Math.floor(canvas.nodes.length / 4) * GRID_Y,
+      }
+    const actions: CanvasAction[] = [
+      {
+        type: 'add_node',
+        payload: {
+          id: nodeId,
+          nodeType: nodeType as NodeType,
+          position,
+          data: {
+            title: input.title?.trim() || '上传媒体',
+            url: input.url.trim(),
+            status: 'completed',
+          },
+        },
+      },
+    ]
+    await this.persist(input.sessionId, actions)
+    return { nodeId, actions }
+  }
+
+  async exportMediaPackage(input: {
+    sessionId: string
+    userId: string
+    nodeIds: string[]
+  }): Promise<{
+    manifest: {
+      exportedAt: string
+      count: number
+      items: Array<{ nodeId: string; url: string; fileName: string; downloadPath: string }>
+    }
+  }> {
+    await this.loadOwnedSession(input.sessionId, input.userId)
+    const { canvas } = await this.loadSession(input.sessionId)
+    const idSet = new Set(input.nodeIds)
+    const items: Array<{ nodeId: string; url: string; fileName: string; downloadPath: string }> = []
+    for (const node of canvas.nodes) {
+      if (!idSet.has(node.id)) continue
+      const url = String(node.data?.url ?? '').trim()
+      if (!url) continue
+      const ext = url.includes('.mp4') ? 'mp4' : url.includes('.mp3') ? 'mp3' : 'png'
+      const fileName = `${nodeTitle(node) || node.id}.${ext}`.replace(/[^\w\u4e00-\u9fff.-]+/g, '_')
+      const params = new URLSearchParams({
+        url,
+        filename: fileName,
+        sessionId: input.sessionId,
+      })
+      items.push({
+        nodeId: node.id,
+        url,
+        fileName,
+        downloadPath: `/api/media/stream-download?${params.toString()}`,
+      })
+    }
+    return {
+      manifest: {
+        exportedAt: new Date().toISOString(),
+        count: items.length,
+        items,
+      },
+    }
+  }
+
+  async groupNodes(input: {
+    sessionId: string
+    userId: string
+    nodeIds: string[]
+    title?: string
+  }): Promise<{ groupId: string; actions: CanvasAction[] }> {
+    await this.loadOwnedSession(input.sessionId, input.userId)
+    const { canvas } = await this.loadSession(input.sessionId)
+    const before = canvas.nodes as LayoutNode[]
+    const result = createGroupFromNodes(before, input.nodeIds, input.title)
+    if (!result) throw new BadRequestException('至少需要 2 个可分组节点')
+    await this.persistLayoutNodes(input.sessionId, result.nodes)
+    return { groupId: result.groupId, actions: [] }
+  }
+
+  async ungroupNode(input: {
+    sessionId: string
+    userId: string
+    groupId: string
+  }): Promise<{ actions: CanvasAction[] }> {
+    await this.loadOwnedSession(input.sessionId, input.userId)
+    const { canvas } = await this.loadSession(input.sessionId)
+    const before = canvas.nodes as LayoutNode[]
+    const after = ungroupNode(before, input.groupId)
+    await this.persistLayoutNodes(input.sessionId, after)
+    return { actions: [] }
+  }
+
+  async arrangeNodesGrid(input: {
+    sessionId: string
+    userId: string
+    nodeIds: string[]
+    gap?: number
+  }): Promise<{ actions: CanvasAction[] }> {
+    await this.loadOwnedSession(input.sessionId, input.userId)
+    const { canvas } = await this.loadSession(input.sessionId)
+    const before = canvas.nodes as LayoutNode[]
+    const after = layoutNodesInGrid(before, input.nodeIds, input.gap ?? 40)
+    await this.persistLayoutNodes(input.sessionId, after)
+    return { actions: [] }
+  }
+
+  async getImageEditCapabilities(input: {
+    sessionId: string
+    nodeId: string
+  }): Promise<{
+    canEdit: boolean
+    nodeType: string
+    hasUrl: boolean
+    supportedModes: string[]
+  }> {
+    const node = await this.getNode({ sessionId: input.sessionId, nodeId: input.nodeId })
+    const nodeType = String(node.type ?? '')
+    const url = String(node.data?.url ?? '').trim()
+    const isImageLike = nodeType === 'image' || nodeType === 'mediaInput'
+    const canEdit = isImageLike && Boolean(url)
+    return {
+      canEdit,
+      nodeType,
+      hasUrl: Boolean(url),
+      supportedModes: canEdit ? ['crop', 'inpaint', 'outpaint', 'remove_bg'] : [],
     }
   }
 
@@ -1973,6 +2247,33 @@ export class AgentCanvasToolsService {
       return
     }
     await this.persist(sessionId, actions)
+  }
+
+  /**
+   * Replace canvas nodes for layout operations (group/ungroup/grid) that need
+   * parentNode/style fields not supported by applyCanvasActions.
+   */
+  private async persistLayoutNodes(sessionId: string, nodes: LayoutNode[]): Promise<CanvasData> {
+    await this.expireStaleStage(sessionId)
+    return this.prisma.$transaction(async (tx) => {
+      const session = await tx.session.findUnique({
+        where: { id: sessionId },
+        select: { canvasData: true, stagedActions: true },
+      })
+      if (!session) throw new NotFoundException('会话不存在')
+      if (session.stagedActions) {
+        throw new ConflictException(
+          'Canvas has staged actions pending commit; call commitStage or rollbackStage first',
+        )
+      }
+      const current = parseCanvas(session.canvasData)
+      const updated: CanvasData = { ...current, nodes: nodes as CanvasNode[] }
+      await tx.session.update({
+        where: { id: sessionId },
+        data: { canvasData: JSON.stringify(updated) },
+      })
+      return updated
+    })
   }
 
   /**

--- a/apps/server/src/agent/agent-canvas-tools.sidebar.test.ts
+++ b/apps/server/src/agent/agent-canvas-tools.sidebar.test.ts
@@ -4,6 +4,7 @@ import { Test } from '@nestjs/testing'
 import type { CanvasData, SidebarAttachment } from '@lnkpi/shared'
 import { PrismaService } from '../prisma/prisma.service'
 import { StudioService } from '../studio/studio.service'
+import { MaterialService } from '../canvas/material.service'
 import { AgentCanvasToolsService } from './agent-canvas-tools.service'
 
 const emptyCanvas = (): CanvasData => ({ nodes: [], edges: [] })
@@ -59,6 +60,15 @@ describe('AgentCanvasToolsService.applySidebarAttachments', () => {
             generateAudio: vi.fn(),
             getGeneration: vi.fn(),
             expandPromptContent: vi.fn(),
+          },
+        },
+        {
+          provide: MaterialService,
+          useValue: {
+            cancelGeneration: vi.fn(),
+            getMaterialDiagnostic: vi.fn(),
+            confirmPlatformFallback: vi.fn(),
+            cancelPlatformFallback: vi.fn(),
           },
         },
       ],

--- a/apps/server/src/agent/canvas-layout.util.ts
+++ b/apps/server/src/agent/canvas-layout.util.ts
@@ -1,0 +1,220 @@
+import type { CanvasNode } from '@lnkpi/shared'
+
+export const GROUP_PADDING = 80
+
+export type LayoutNode = CanvasNode & {
+  parentNode?: string
+  style?: Record<string, unknown> | string
+  extent?: string
+  expandParent?: boolean
+  draggable?: boolean
+  selectable?: boolean
+  zIndex?: number
+  dimensions?: { width?: number; height?: number }
+}
+
+const NODE_SIZES: Record<string, { w: number; h: number }> = {
+  text: { w: 280, h: 160 },
+  image: { w: 280, h: 280 },
+  video: { w: 280, h: 280 },
+  audio: { w: 280, h: 140 },
+  sceneComposer: { w: 280, h: 280 },
+  shot: { w: 280, h: 280 },
+  mediaInput: { w: 280, h: 280 },
+  videoComposition: { w: 280, h: 200 },
+  worldModel: { w: 280, h: 280 },
+  group: { w: 280, h: 160 },
+  prompt: { w: 280, h: 120 },
+}
+
+function parseStyleSize(style: LayoutNode['style']): { w?: number; h?: number } {
+  if (!style || typeof style === 'string') return {}
+  const width = style.width
+  const height = style.height
+  const w =
+    typeof width === 'number'
+      ? width
+      : typeof width === 'string'
+        ? Number.parseFloat(width)
+        : undefined
+  const h =
+    typeof height === 'number'
+      ? height
+      : typeof height === 'string'
+        ? Number.parseFloat(height)
+        : undefined
+  return { w: Number.isFinite(w) ? w : undefined, h: Number.isFinite(h) ? h : undefined }
+}
+
+export function getNodeSize(node: LayoutNode): { w: number; h: number } {
+  const type = String(node.type ?? '')
+  const fallback = NODE_SIZES[type] ?? { w: 280, h: 160 }
+  const fromStyle = parseStyleSize(node.style)
+  return {
+    w: node.dimensions?.width ?? fromStyle.w ?? fallback.w,
+    h: node.dimensions?.height ?? fromStyle.h ?? fallback.h,
+  }
+}
+
+export function getAbsolutePosition(node: LayoutNode, nodes: LayoutNode[]): { x: number; y: number } {
+  let x = node.position.x
+  let y = node.position.y
+  let parentId = node.parentNode
+  while (parentId) {
+    const parent = nodes.find((n) => n.id === parentId)
+    if (!parent) break
+    x += parent.position.x
+    y += parent.position.y
+    parentId = parent.parentNode
+  }
+  return { x, y }
+}
+
+function countGroups(nodes: LayoutNode[]): number {
+  return nodes.filter((n) => n.type === 'group').length
+}
+
+export function createGroupFromNodes(
+  nodes: LayoutNode[],
+  selectedIds: string[],
+  groupTitle?: string,
+): { nodes: LayoutNode[]; groupId: string } | null {
+  const eligible = selectedIds
+    .map((id) => nodes.find((n) => n.id === id))
+    .filter((n): n is LayoutNode => Boolean(n && n.type !== 'group' && !n.parentNode))
+  if (eligible.length < 2) return null
+
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+  for (const node of eligible) {
+    const abs = getAbsolutePosition(node, nodes)
+    const { w, h } = getNodeSize(node)
+    minX = Math.min(minX, abs.x)
+    minY = Math.min(minY, abs.y)
+    maxX = Math.max(maxX, abs.x + w)
+    maxY = Math.max(maxY, abs.y + h)
+  }
+
+  const groupId = `group-${Date.now()}`
+  const groupX = minX - GROUP_PADDING
+  const groupY = minY - GROUP_PADDING
+  const groupW = maxX - minX + GROUP_PADDING * 2
+  const groupH = maxY - minY + GROUP_PADDING * 2
+
+  const next: LayoutNode[] = nodes.map((n) => ({
+    ...n,
+    data: { ...(n.data ?? {}) },
+  }))
+
+  next.push({
+    id: groupId,
+    type: 'group',
+    position: { x: groupX, y: groupY },
+    style: { width: groupW, height: groupH },
+    data: {
+      title: groupTitle ?? `分组 ${countGroups(next)}`,
+      childIds: eligible.map((n) => n.id),
+    },
+    draggable: true,
+    selectable: true,
+    zIndex: 0,
+  } as LayoutNode)
+
+  for (const node of eligible) {
+    const abs = getAbsolutePosition(node, nodes)
+    const idx = next.findIndex((n) => n.id === node.id)
+    if (idx < 0) continue
+    next[idx] = {
+      ...next[idx]!,
+      parentNode: groupId,
+      extent: 'parent',
+      expandParent: true,
+      draggable: true,
+      selectable: true,
+      position: { x: abs.x - groupX, y: abs.y - groupY },
+      zIndex: 1,
+    }
+  }
+
+  return { nodes: next, groupId }
+}
+
+function getGroupChildIds(nodes: LayoutNode[], groupId: string): string[] {
+  const group = nodes.find((n) => n.id === groupId)
+  const fromData = group?.data?.childIds
+  if (Array.isArray(fromData) && fromData.length) {
+    return fromData.map(String)
+  }
+  return nodes.filter((n) => n.parentNode === groupId).map((n) => n.id)
+}
+
+export function ungroupNode(nodes: LayoutNode[], groupId: string): LayoutNode[] {
+  const childIdSet = new Set(getGroupChildIds(nodes, groupId))
+  const next: LayoutNode[] = []
+  for (const node of nodes) {
+    if (node.id === groupId) continue
+    if (node.parentNode === groupId || childIdSet.has(node.id)) {
+      const abs = getAbsolutePosition(node, nodes)
+      const { parentNode: _p, extent: _e, expandParent: _x, ...rest } = node
+      next.push({
+        ...rest,
+        position: { x: abs.x, y: abs.y },
+        zIndex: undefined,
+      })
+      continue
+    }
+    next.push({ ...node })
+  }
+  return next
+}
+
+function updateNodePosition(nodes: LayoutNode[], id: string, pos: { x: number; y: number }) {
+  const idx = nodes.findIndex((n) => n.id === id)
+  if (idx >= 0) {
+    nodes[idx] = { ...nodes[idx]!, position: pos }
+  }
+}
+
+export function layoutNodesInGrid(
+  nodes: LayoutNode[],
+  selectedIds: string[],
+  gap = 40,
+): LayoutNode[] {
+  const selected = new Set(selectedIds)
+  const targets = nodes.filter((n) => selected.has(n.id) && n.type !== 'group')
+  if (targets.length < 2) return nodes
+
+  const cols = Math.ceil(Math.sqrt(targets.length))
+  let minX = Infinity
+  let minY = Infinity
+  for (const node of targets) {
+    const abs = getAbsolutePosition(node, nodes)
+    minX = Math.min(minX, abs.x)
+    minY = Math.min(minY, abs.y)
+  }
+
+  const next = nodes.map((n) => ({ ...n }))
+  let idx = 0
+  for (const node of targets) {
+    const col = idx % cols
+    const row = Math.floor(idx / cols)
+    const { w, h } = getNodeSize(node)
+    const newAbsX = minX + col * (w + gap)
+    const newAbsY = minY + row * (h + gap)
+
+    if (node.parentNode) {
+      const parent = next.find((p) => p.id === node.parentNode)
+      const parentAbs = parent ? getAbsolutePosition(parent, next) : { x: 0, y: 0 }
+      updateNodePosition(next, node.id, {
+        x: newAbsX - parentAbs.x,
+        y: newAbsY - parentAbs.y,
+      })
+    } else {
+      updateNodePosition(next, node.id, { x: newAbsX, y: newAbsY })
+    }
+    idx += 1
+  }
+  return next
+}

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -89,6 +89,9 @@ const emit = defineEmits<{
   turnComplete: []
   focusNode: [nodeId: string]
   focusAll: [nodeIds: string[]]
+  undo: []
+  redo: []
+  openImageEditor: [nodeId: string]
   expandedChange: [expanded: boolean]
 }>()
 
@@ -936,6 +939,12 @@ function handleEvent(event: { type: string; data: unknown }) {
         emit('focusNode', cmd.nodeId)
       } else if (cmd.type === 'focus_nodes' && cmd.nodeIds?.length) {
         emit('focusAll', cmd.nodeIds)
+      } else if (cmd.type === 'undo') {
+        emit('undo')
+      } else if (cmd.type === 'redo') {
+        emit('redo')
+      } else if (cmd.type === 'open_image_editor' && cmd.nodeId) {
+        emit('openImageEditor', cmd.nodeId)
       } else if (cmd.type === 'introduce_nodes' && cmd.attachments?.length) {
         for (const att of cmd.attachments) {
           if (sidebar.pendingAttachments.value.length >= SIDEBAR_ATTACHMENT_MAX) break

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -2021,6 +2021,27 @@ useCanvasKeyboard({
   },
 })
 
+function handleAgentUndo() {
+  if (canvasUndo.undo()) void saveCanvas()
+}
+
+function handleAgentRedo() {
+  if (canvasUndo.redo()) void saveCanvas()
+}
+
+function handleAgentOpenImageEditor(nodeId: string) {
+  const node = findNodeById(nodeId)
+  if (!node || (node.type !== 'image' && node.type !== 'mediaInput')) return
+  const data = node.data as Record<string, unknown>
+  const url = String(data.url ?? '').trim()
+  if (!url) return
+  canvasEditor.openImageEditor({
+    nodeId: node.id,
+    url,
+    prompt: data.prompt as string | undefined,
+  })
+}
+
 function patchSelectedNode(patch: Record<string, unknown>) {
   if (!editorNode.value) return
   debouncedNodePatch.patchNode(editorNode.value.id, patch)
@@ -2805,6 +2826,9 @@ onMounted(() => {
         @turn-complete="handleAgentTurnComplete"
         @focus-node="focusNodeById"
         @focus-all="focusNodesByIds"
+        @undo="handleAgentUndo"
+        @redo="handleAgentRedo"
+        @open-image-editor="handleAgentOpenImageEditor"
       />
     </div>
 

--- a/services/agent-runtime/app/graph/nodes/explore.py
+++ b/services/agent-runtime/app/graph/nodes/explore.py
@@ -7,6 +7,7 @@ from typing import Any, Callable
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
+from app.errors import AgentToolError, from_exception
 from app.graph.canvas_commands import extract_canvas_commands
 from app.tools.definitions import build_explore_tools
 
@@ -75,8 +76,20 @@ def make_explore_node(*, llm: Any, nest: Any) -> Callable:
                 else:
                     try:
                         result = await tool.ainvoke(args or {})
+                    except AgentToolError as exc:
+                        err = exc.error
+                        result = {
+                            "error": err["message"],
+                            "error_type": err["error_type"],
+                            "retry_hint": err.get("retry_hint"),
+                        }
                     except Exception as exc:
-                        result = {"error": str(exc)}
+                        err = from_exception(str(name), exc)
+                        result = {
+                            "error": err["message"],
+                            "error_type": err["error_type"],
+                            "retry_hint": err.get("retry_hint"),
+                        }
                 for cmd in extract_canvas_commands(result):
                     if cmd not in canvas_commands:
                         canvas_commands.append(cmd)

--- a/services/agent-runtime/app/tools/definitions.py
+++ b/services/agent-runtime/app/tools/definitions.py
@@ -88,8 +88,44 @@ class ApplySidebarAttachmentsInput(BaseModel):
     )
 
 
+class FocusNodesInput(BaseModel):
+    node_ids: list[str] = Field(description="Canvas node ids to focus in viewport")
+
+
+class DuplicateNodeInput(BaseModel):
+    node_id: str = Field(description="Source canvas node id to duplicate")
+
+
+class UploadMediaInput(BaseModel):
+    url: str = Field(description="Public media URL to attach")
+    media_type: str = Field(description="image, video, or audio")
+    title: str | None = Field(default=None, description="Optional node title")
+
+
+class ExportMediaInput(BaseModel):
+    node_ids: list[str] = Field(description="Node ids whose media URLs to export")
+
+
+class GroupNodesInput(BaseModel):
+    node_ids: list[str] = Field(description="At least two node ids to group")
+    title: str | None = Field(default=None, description="Optional group title")
+
+
+class UngroupNodeInput(BaseModel):
+    group_id: str = Field(description="Group node id to dissolve")
+
+
+class ArrangeNodesGridInput(BaseModel):
+    node_ids: list[str] = Field(description="Node ids to arrange in a grid")
+    gap: int | None = Field(default=None, description="Grid gap in pixels")
+
+
 class ListGenerationTasksInput(BaseModel):
     type: str | None = Field(default=None, description="Optional filter: image, video, etc.")
+
+
+class OpenImageEditorInput(BaseModel):
+    node_id: str = Field(description="Image node id to open in the refine editor")
 
 
 def _all_tool_specs(client: NestCanvasClient) -> list[tuple[str, StructuredTool]]:
@@ -177,6 +213,49 @@ def _all_tool_specs(client: NestCanvasClient) -> list[tuple[str, StructuredTool]
 
     async def focus_node(node_id: str) -> dict:
         return {"ok": True, "canvasCommands": [{"type": "focus_node", "nodeId": node_id}]}
+
+    async def focus_nodes(node_ids: list[str]) -> dict:
+        return {"ok": True, "canvasCommands": [{"type": "focus_nodes", "nodeIds": node_ids}]}
+
+    async def undo() -> dict:
+        return {"ok": True, "canvasCommands": [{"type": "undo"}]}
+
+    async def redo() -> dict:
+        return {"ok": True, "canvasCommands": [{"type": "redo"}]}
+
+    async def open_image_editor(node_id: str) -> dict:
+        return {
+            "ok": True,
+            "canvasCommands": [{"type": "open_image_editor", "nodeId": node_id}],
+        }
+
+    async def get_canvas_layout() -> dict:
+        return await client.get_canvas_layout()
+
+    async def duplicate_node(node_id: str) -> dict:
+        return await client.duplicate_node(node_id=node_id)
+
+    async def upload_media_to_canvas(
+        url: str, media_type: str, title: str | None = None
+    ) -> dict:
+        return await client.upload_media_to_canvas(
+            url=url, media_type=media_type, title=title
+        )
+
+    async def export_media_package(node_ids: list[str]) -> dict:
+        return await client.export_media_package(node_ids=node_ids)
+
+    async def group_nodes(node_ids: list[str], title: str | None = None) -> dict:
+        return await client.group_nodes(node_ids=node_ids, title=title)
+
+    async def ungroup_node(group_id: str) -> dict:
+        return await client.ungroup_node(group_id=group_id)
+
+    async def arrange_nodes_grid(node_ids: list[str], gap: int | None = None) -> dict:
+        return await client.arrange_nodes_grid(node_ids=node_ids, gap=gap)
+
+    async def get_image_edit_capabilities(node_id: str) -> dict:
+        return await client.get_image_edit_capabilities(node_id=node_id)
 
     async def apply_sidebar_attachments(
         node_ids: list[str],
@@ -388,6 +467,111 @@ def _all_tool_specs(client: NestCanvasClient) -> list[tuple[str, StructuredTool]
                 name="apply_sidebar_attachments",
                 description="Write sidebar attachments onto canvas nodes (localRefs or ref edges)",
                 args_schema=ApplySidebarAttachmentsInput,
+            ),
+        ),
+        (
+            "focus_nodes",
+            StructuredTool.from_function(
+                coroutine=focus_nodes,
+                name="focus_nodes",
+                description="Pan/zoom the canvas viewport to multiple nodes (UI command)",
+                args_schema=FocusNodesInput,
+            ),
+        ),
+        (
+            "undo",
+            StructuredTool.from_function(
+                coroutine=undo,
+                name="undo",
+                description="Undo the last local canvas edit (client undo stack)",
+            ),
+        ),
+        (
+            "redo",
+            StructuredTool.from_function(
+                coroutine=redo,
+                name="redo",
+                description="Redo the last undone canvas edit (client undo stack)",
+            ),
+        ),
+        (
+            "open_image_editor",
+            StructuredTool.from_function(
+                coroutine=open_image_editor,
+                name="open_image_editor",
+                description="Open the image refine editor for a node (UI command)",
+                args_schema=OpenImageEditorInput,
+            ),
+        ),
+        (
+            "get_canvas_layout",
+            StructuredTool.from_function(
+                coroutine=get_canvas_layout,
+                name="get_canvas_layout",
+                description="List canvas node positions, sizes, and group hierarchy",
+            ),
+        ),
+        (
+            "duplicate_node",
+            StructuredTool.from_function(
+                coroutine=duplicate_node,
+                name="duplicate_node",
+                description="Clone a canvas node with offset position",
+                args_schema=DuplicateNodeInput,
+            ),
+        ),
+        (
+            "upload_media_to_canvas",
+            StructuredTool.from_function(
+                coroutine=upload_media_to_canvas,
+                name="upload_media_to_canvas",
+                description="Add a media node from a public URL",
+                args_schema=UploadMediaInput,
+            ),
+        ),
+        (
+            "export_media_package",
+            StructuredTool.from_function(
+                coroutine=export_media_package,
+                name="export_media_package",
+                description="Export downloadable URLs for node media",
+                args_schema=ExportMediaInput,
+            ),
+        ),
+        (
+            "get_image_edit_capabilities",
+            StructuredTool.from_function(
+                coroutine=get_image_edit_capabilities,
+                name="get_image_edit_capabilities",
+                description="Check whether a node supports image refine modes",
+                args_schema=NodeIdInput,
+            ),
+        ),
+        (
+            "group_nodes",
+            StructuredTool.from_function(
+                coroutine=group_nodes,
+                name="group_nodes",
+                description="Wrap nodes in a group container (graph batch)",
+                args_schema=GroupNodesInput,
+            ),
+        ),
+        (
+            "ungroup_node",
+            StructuredTool.from_function(
+                coroutine=ungroup_node,
+                name="ungroup_node",
+                description="Dissolve a group node and restore child positions",
+                args_schema=UngroupNodeInput,
+            ),
+        ),
+        (
+            "arrange_nodes_grid",
+            StructuredTool.from_function(
+                coroutine=arrange_nodes_grid,
+                name="arrange_nodes_grid",
+                description="Arrange nodes in a grid layout (graph batch)",
+                args_schema=ArrangeNodesGridInput,
             ),
         ),
     ]

--- a/services/agent-runtime/app/tools/nest_client.py
+++ b/services/agent-runtime/app/tools/nest_client.py
@@ -475,6 +475,87 @@ class NestCanvasClient:
             },
         )
 
+    async def get_canvas_layout(self) -> dict[str, Any]:
+        return await self._post(
+            "/agent/internal/get-canvas-layout",
+            {"sessionId": self._session_id},
+        )
+
+    async def duplicate_node(self, *, node_id: str) -> dict[str, Any]:
+        return await self._post(
+            "/agent/internal/duplicate-node",
+            {
+                "sessionId": self._session_id,
+                "userId": self._user_id,
+                "nodeId": node_id,
+            },
+        )
+
+    async def upload_media_to_canvas(
+        self,
+        *,
+        url: str,
+        media_type: str,
+        title: str | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "sessionId": self._session_id,
+            "userId": self._user_id,
+            "url": url,
+            "mediaType": media_type,
+        }
+        if title:
+            body["title"] = title
+        return await self._post("/agent/internal/upload-media-to-canvas", body)
+
+    async def export_media_package(self, *, node_ids: list[str]) -> dict[str, Any]:
+        return await self._post(
+            "/agent/internal/export-media-package",
+            {
+                "sessionId": self._session_id,
+                "userId": self._user_id,
+                "nodeIds": node_ids,
+            },
+        )
+
+    async def group_nodes(self, *, node_ids: list[str], title: str | None = None) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "sessionId": self._session_id,
+            "userId": self._user_id,
+            "nodeIds": node_ids,
+        }
+        if title:
+            body["title"] = title
+        return await self._post("/agent/internal/group-nodes", body)
+
+    async def ungroup_node(self, *, group_id: str) -> dict[str, Any]:
+        return await self._post(
+            "/agent/internal/ungroup-node",
+            {
+                "sessionId": self._session_id,
+                "userId": self._user_id,
+                "groupId": group_id,
+            },
+        )
+
+    async def arrange_nodes_grid(
+        self, *, node_ids: list[str], gap: int | None = None
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "sessionId": self._session_id,
+            "userId": self._user_id,
+            "nodeIds": node_ids,
+        }
+        if gap is not None:
+            body["gap"] = gap
+        return await self._post("/agent/internal/arrange-nodes-grid", body)
+
+    async def get_image_edit_capabilities(self, *, node_id: str) -> dict[str, Any]:
+        return await self._post(
+            "/agent/internal/get-image-edit-capabilities",
+            {"sessionId": self._session_id, "nodeId": node_id},
+        )
+
     async def get_agent_messages(self, *, thread_id: str) -> list[dict[str, Any]]:
         """Load conversation history for one thread (Nest single-writer)."""
         return await self._post(

--- a/services/agent-runtime/app/tools/tool_registry.py
+++ b/services/agent-runtime/app/tools/tool_registry.py
@@ -37,6 +37,15 @@ EXPLORE_TOOL_NAMES = frozenset({
     "apply_asset_to_node",
     "apply_sidebar_attachments",
     "focus_node",
+    "focus_nodes",
+    "get_canvas_layout",
+    "duplicate_node",
+    "upload_media_to_canvas",
+    "export_media_package",
+    "get_image_edit_capabilities",
+    "undo",
+    "redo",
+    "open_image_editor",
 })
 
 TOOL_TIERS: dict[str, ToolTier] = {

--- a/services/agent-runtime/tests/test_explore_tools.py
+++ b/services/agent-runtime/tests/test_explore_tools.py
@@ -12,8 +12,14 @@ def test_explore_tools_exclude_generation():
     assert "get_canvas_summary" in names
     assert "cancel_generation" in names
     assert "apply_sidebar_attachments" in names
+    assert "focus_nodes" in names
+    assert "get_canvas_layout" in names
+    assert "duplicate_node" in names
+    assert "undo" in names
+    assert "open_image_editor" in names
     assert "run_image_generation" not in names
     assert "add_nodes_batch" not in names
+    assert "group_nodes" not in names
     assert names <= EXPLORE_TOOL_NAMES
 
 


### PR DESCRIPTION
## Summary
- **PR-C (P1+P2)**: Material/studio lifecycle routing by `recordKind`; Nest harness for canvas layout, duplicate, upload, export, group/ungroup/grid, and image-edit capabilities (`canvas-layout.util.ts`).
- **PR-D (P3–P4 partial)**: agent-runtime explore tools (`focus_nodes`, layout/duplicate/upload/export, `undo`/`redo`, `open_image_editor`); `AgentToolError` normalization in explore loop; frontend `canvas_command` handlers for undo/redo/image editor.

## Test plan
- [x] `pnpm build`
- [x] `vitest run apps/server/src/agent/agent-canvas-tools.service.test.ts` (43/43)
- [x] `pytest services/agent-runtime/tests/test_explore_tools.py` (2/2)
- [ ] CI green
- [ ] Post-merge: `deploy/prod-atomic-confirm-gate-verify.py`
- [ ] Post-merge: `deploy/prod-sidebar-attachments-verify.py`

## Out of scope (follow-up PR)
- CS-5: remove TS `CANVAS_TOOLS` fallback → Nest API / explicit runtime-unavailable error
- `run_icon_refine` graph gen


Made with [Cursor](https://cursor.com)