### PR TITLE
feat(agent): canvas layout workflow harness

### DIFF
--- a/apps/server/src/agent/agent-canvas-tools.controller.ts
+++ b/apps/server/src/agent/agent-canvas-tools.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Inject, Post, UseGuards } from '@nestjs/common'
-import { IsArray, IsBoolean, IsIn, IsOptional, IsString, ValidateNested } from 'class-validator'
+import { IsArray, IsBoolean, IsIn, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator'
 import { Type } from 'class-transformer'
 import { AgentCanvasToolsService } from './agent-canvas-tools.service'
 import { AgentInternalGuard } from './agent-internal.guard'
@@ -461,6 +461,41 @@ class ArrangeNodesGridDto {
   gap?: number
 }
 
+class MoveNodeItemDto {
+  @IsString()
+  nodeId!: string
+
+  @IsNumber()
+  x!: number
+
+  @IsNumber()
+  y!: number
+}
+
+class MoveNodesDto {
+  @IsString()
+  sessionId!: string
+
+  @IsString()
+  userId!: string
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => MoveNodeItemDto)
+  items!: MoveNodeItemDto[]
+}
+
+class ApplyLayoutOpsDto {
+  @IsString()
+  sessionId!: string
+
+  @IsString()
+  userId!: string
+
+  @IsArray()
+  ops!: Array<Record<string, unknown>>
+}
+
 class SaveAgentMessageDto {
   @IsString()
   sessionId!: string
@@ -827,6 +862,22 @@ export class AgentCanvasToolsController {
   @Post('arrange-nodes-grid')
   async arrangeNodesGrid(@Body() dto: ArrangeNodesGridDto) {
     const data = await this.tools.arrangeNodesGrid(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('move-nodes')
+  async moveNodes(@Body() dto: MoveNodesDto) {
+    const data = await this.tools.moveNodes(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('apply-layout-ops')
+  async applyLayoutOps(@Body() dto: ApplyLayoutOpsDto) {
+    const data = await this.tools.applyLayoutOps({
+      sessionId: dto.sessionId,
+      userId: dto.userId,
+      ops: dto.ops as Parameters<AgentCanvasToolsService['applyLayoutOps']>[0]['ops'],
+    })
     return { code: 0, message: 'ok', data }
   }
 

--- a/apps/server/src/agent/agent-canvas-tools.service.test.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.test.ts
@@ -1317,6 +1317,8 @@ describe('AgentCanvasToolsService', () => {
       expect(layout.nodes).toHaveLength(2)
       expect(layout.nodes[0]?.id).toBe('img-1')
       expect(layout.nodes[0]?.size.w).toBeGreaterThan(0)
+      expect(layout.nodes[0]?.absolutePosition).toEqual(layout.nodes[0]?.position)
+      expect(layout.groups).toEqual([])
     })
 
     it('duplicateNode clones node and focuses copy', async () => {
@@ -1337,6 +1339,97 @@ describe('AgentCanvasToolsService', () => {
       })
       expect(caps.canEdit).toBe(true)
       expect(caps.supportedModes).toContain('inpaint')
+    })
+  })
+
+  describe('P2 layout harness', () => {
+    beforeEach(() => {
+      canvas = {
+        nodes: [
+          { id: 'img-1', type: 'image', position: { x: 100, y: 100 }, data: { title: 'A' } },
+          { id: 'txt-1', type: 'text', position: { x: 420, y: 160 }, data: { title: 'B' } },
+          { id: 'vid-1', type: 'video', position: { x: 760, y: 80 }, data: { title: 'C' } },
+        ],
+        edges: [],
+      }
+    })
+
+    it('groupNodes persists a group with child parentNode links', async () => {
+      vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
+      const result = await svc.groupNodes({
+        sessionId: 's1',
+        userId: 'u1',
+        nodeIds: ['img-1', 'txt-1'],
+        title: 'Block A',
+      })
+      expect(result.groupId).toBe('group-1700000000000')
+      const group = canvas.nodes.find((n) => n.id === result.groupId)
+      expect(group?.type).toBe('group')
+      expect(group?.data?.title).toBe('Block A')
+      expect(canvas.nodes.find((n) => n.id === 'img-1')?.parentNode).toBe(result.groupId)
+      expect(canvas.nodes.find((n) => n.id === 'txt-1')?.parentNode).toBe(result.groupId)
+      vi.restoreAllMocks()
+    })
+
+    it('ungroupNode restores flat coordinates and removes the group node', async () => {
+      vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
+      const grouped = await svc.groupNodes({
+        sessionId: 's1',
+        userId: 'u1',
+        nodeIds: ['img-1', 'txt-1'],
+      })
+      await svc.ungroupNode({
+        sessionId: 's1',
+        userId: 'u1',
+        groupId: grouped.groupId,
+      })
+      expect(canvas.nodes.some((n) => n.id === grouped.groupId)).toBe(false)
+      expect(canvas.nodes.find((n) => n.id === 'img-1')?.position).toEqual({ x: 100, y: 100 })
+      expect(canvas.nodes.find((n) => n.id === 'txt-1')?.position).toEqual({ x: 420, y: 160 })
+      expect(canvas.nodes.find((n) => n.id === 'img-1')?.parentNode).toBeUndefined()
+      vi.restoreAllMocks()
+    })
+
+    it('arrangeNodesGrid repositions selected nodes on canvas', async () => {
+      await svc.arrangeNodesGrid({
+        sessionId: 's1',
+        userId: 'u1',
+        nodeIds: ['img-1', 'txt-1', 'vid-1'],
+        gap: 20,
+      })
+      const img = canvas.nodes.find((n) => n.id === 'img-1')
+      const txt = canvas.nodes.find((n) => n.id === 'txt-1')
+      const vid = canvas.nodes.find((n) => n.id === 'vid-1')
+      expect(img?.position).toEqual({ x: 100, y: 80 })
+      expect(txt?.position.x).toBe(100 + 280 + 20)
+      expect(vid?.position.y).toBeGreaterThan(img!.position.y)
+    })
+
+    it('moveNodes updates absolute coordinates', async () => {
+      await svc.moveNodes({
+        sessionId: 's1',
+        userId: 'u1',
+        items: [{ nodeId: 'img-1', x: 300, y: 400 }],
+      })
+      expect(canvas.nodes.find((n) => n.id === 'img-1')?.position).toEqual({ x: 300, y: 400 })
+    })
+
+    it('applyLayoutOps runs group then grid atomically', async () => {
+      vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_001)
+      const result = await svc.applyLayoutOps({
+        sessionId: 's1',
+        userId: 'u1',
+        ops: [
+          { op: 'group', nodeIds: ['img-1', 'txt-1'], title: 'Workflow block' },
+          { op: 'move', items: [{ nodeId: 'vid-1', x: 900, y: 900 }] },
+        ],
+      })
+      expect(result.results).toHaveLength(2)
+      expect(result.results[0]?.op).toBe('group')
+      expect(result.layout.groups).toHaveLength(1)
+      expect(canvas.nodes.find((n) => n.id === 'img-1')?.parentNode).toBeTruthy()
+      expect(canvas.nodes.find((n) => n.id === 'vid-1')?.position).toEqual({ x: 900, y: 900 })
+      vi.restoreAllMocks()
     })
   })
 })

--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -16,9 +16,15 @@ import { PUBLIC_ASSETS } from '../assets/public-assets.data'
 import { MaterialService } from '../canvas/material.service'
 import { StudioService, type StudioRefInput } from '../studio/studio.service'
 import {
+  applyLayoutOps,
   createGroupFromNodes,
+  getAbsolutePosition,
   getNodeSize,
   layoutNodesInGrid,
+  moveNodes,
+  summarizeLayoutGroups,
+  type CanvasLayoutOp,
+  type CanvasLayoutOpResult,
   type LayoutNode,
   ungroupNode,
 } from './canvas-layout.util'
@@ -1650,12 +1656,21 @@ export class AgentCanvasToolsService {
       title: string
       status: string
       position: { x: number; y: number }
+      absolutePosition: { x: number; y: number }
       size: { w: number; h: number }
       parentNode?: string
     }>
+    groups: Array<{
+      id: string
+      title: string
+      childIds: string[]
+      position: { x: number; y: number }
+      size: { w: number; h: number }
+    }>
   }> {
     const { canvas } = await this.loadSession(input.sessionId)
-    const nodes = (canvas.nodes as LayoutNode[]).map((node) => {
+    const layoutNodes = canvas.nodes as LayoutNode[]
+    const nodes = layoutNodes.map((node) => {
       const { w, h } = getNodeSize(node)
       return {
         id: node.id,
@@ -1663,11 +1678,12 @@ export class AgentCanvasToolsService {
         title: nodeTitle(node),
         status: nodeStatus(node),
         position: node.position,
+        absolutePosition: getAbsolutePosition(node, layoutNodes),
         size: { w, h },
         ...(node.parentNode ? { parentNode: node.parentNode } : {}),
       }
     })
-    return { nodes }
+    return { nodes, groups: summarizeLayoutGroups(layoutNodes) }
   }
 
   async duplicateNode(input: {
@@ -1825,6 +1841,46 @@ export class AgentCanvasToolsService {
     const after = layoutNodesInGrid(before, input.nodeIds, input.gap ?? 40)
     await this.persistLayoutNodes(input.sessionId, after)
     return { actions: [] }
+  }
+
+  async moveNodes(input: {
+    sessionId: string
+    userId: string
+    items: Array<{ nodeId: string; x: number; y: number }>
+  }): Promise<{ movedNodeIds: string[]; actions: CanvasAction[] }> {
+    await this.loadOwnedSession(input.sessionId, input.userId)
+    const { canvas } = await this.loadSession(input.sessionId)
+    const before = canvas.nodes as LayoutNode[]
+    const { nodes: after, movedIds } = moveNodes(before, input.items)
+    if (!movedIds.length) {
+      throw new BadRequestException('未找到可移动的节点')
+    }
+    await this.persistLayoutNodes(input.sessionId, after)
+    return { movedNodeIds: movedIds, actions: [] }
+  }
+
+  async applyLayoutOps(input: {
+    sessionId: string
+    userId: string
+    ops: CanvasLayoutOp[]
+  }): Promise<{
+    results: CanvasLayoutOpResult[]
+    layout: Awaited<ReturnType<AgentCanvasToolsService['getCanvasLayout']>>
+    actions: CanvasAction[]
+  }> {
+    await this.loadOwnedSession(input.sessionId, input.userId)
+    const { canvas } = await this.loadSession(input.sessionId)
+    const before = canvas.nodes as LayoutNode[]
+    let after: LayoutNode[]
+    let results: CanvasLayoutOpResult[]
+    try {
+      ;({ nodes: after, results } = applyLayoutOps(before, input.ops))
+    } catch (err) {
+      throw new BadRequestException(err instanceof Error ? err.message : '布局操作失败')
+    }
+    await this.persistLayoutNodes(input.sessionId, after)
+    const layout = await this.getCanvasLayout({ sessionId: input.sessionId })
+    return { results, layout, actions: [] }
   }
 
   async getImageEditCapabilities(input: {

--- a/apps/server/src/agent/canvas-layout.util.test.ts
+++ b/apps/server/src/agent/canvas-layout.util.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  applyLayoutOps,
+  createGroupFromNodes,
+  getAbsolutePosition,
+  getNodeSize,
+  layoutNodesInGrid,
+  moveNodes,
+  type LayoutNode,
+  ungroupNode,
+} from './canvas-layout.util'
+
+function node(
+  id: string,
+  type: string,
+  x: number,
+  y: number,
+  extra: Partial<LayoutNode> = {},
+): LayoutNode {
+  return {
+    id,
+    type,
+    position: { x, y },
+    data: {},
+    ...extra,
+  }
+}
+
+describe('canvas-layout.util', () => {
+  describe('getNodeSize', () => {
+    it('uses type defaults', () => {
+      expect(getNodeSize(node('a', 'image', 0, 0))).toEqual({ w: 280, h: 280 })
+      expect(getNodeSize(node('b', 'prompt', 0, 0))).toEqual({ w: 280, h: 120 })
+      expect(getNodeSize(node('c', 'unknown', 0, 0))).toEqual({ w: 280, h: 160 })
+    })
+
+    it('prefers dimensions over style and type defaults', () => {
+      const sized = node('a', 'image', 0, 0, {
+        dimensions: { width: 400, height: 300 },
+        style: { width: 100, height: 100 },
+      })
+      expect(getNodeSize(sized)).toEqual({ w: 400, h: 300 })
+    })
+
+    it('parses numeric style sizes', () => {
+      const styled = node('a', 'text', 0, 0, {
+        style: { width: 320, height: 180 },
+      })
+      expect(getNodeSize(styled)).toEqual({ w: 320, h: 180 })
+    })
+
+    it('parses string style sizes', () => {
+      const styled = node('a', 'text', 0, 0, {
+        style: { width: '360px', height: '200' },
+      })
+      expect(getNodeSize(styled)).toEqual({ w: 360, h: 200 })
+    })
+  })
+
+  describe('getAbsolutePosition', () => {
+    it('returns position for root nodes', () => {
+      const nodes = [node('a', 'image', 100, 50)]
+      expect(getAbsolutePosition(nodes[0]!, nodes)).toEqual({ x: 100, y: 50 })
+    })
+
+    it('accumulates parent offsets for nested groups', () => {
+      const nodes = [
+        node('g1', 'group', 200, 100),
+        node('a', 'image', 40, 30, { parentNode: 'g1' }),
+        node('g2', 'group', 10, 20, { parentNode: 'g1' }),
+        node('b', 'text', 5, 5, { parentNode: 'g2' }),
+      ]
+      expect(getAbsolutePosition(nodes[1]!, nodes)).toEqual({ x: 240, y: 130 })
+      expect(getAbsolutePosition(nodes[3]!, nodes)).toEqual({ x: 215, y: 125 })
+    })
+
+    it('stops when parent chain is broken', () => {
+      const orphan = node('a', 'image', 10, 20, { parentNode: 'missing' })
+      expect(getAbsolutePosition(orphan, [orphan])).toEqual({ x: 10, y: 20 })
+    })
+  })
+
+  describe('createGroupFromNodes', () => {
+    beforeEach(() => {
+      vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('returns null when fewer than two eligible nodes', () => {
+      const nodes = [node('a', 'image', 0, 0)]
+      expect(createGroupFromNodes(nodes, ['a'])).toBeNull()
+      expect(createGroupFromNodes(nodes, ['missing', 'a'])).toBeNull()
+    })
+
+    it('ignores nodes already in a group or group nodes', () => {
+      const nodes = [
+        node('a', 'image', 0, 0),
+        node('b', 'text', 300, 0, { parentNode: 'existing-group' }),
+        node('g', 'group', 0, 0),
+      ]
+      expect(createGroupFromNodes(nodes, ['a', 'b'])).toBeNull()
+      expect(createGroupFromNodes(nodes, ['a', 'g'])).toBeNull()
+    })
+
+    it('wraps nodes in a padded group with relative child positions', () => {
+      const nodes = [
+        node('a', 'image', 100, 100),
+        node('b', 'text', 420, 160),
+      ]
+
+      const result = createGroupFromNodes(nodes, ['a', 'b'], 'Campaign block')
+      expect(result).not.toBeNull()
+
+      const { groupId, nodes: next } = result!
+      expect(groupId).toBe('group-1700000000000')
+
+      const group = next.find((n) => n.id === groupId)
+      expect(group?.type).toBe('group')
+      expect(group?.data?.title).toBe('Campaign block')
+      expect(group?.style).toEqual({ width: 760, height: 440 })
+      expect(group?.position).toEqual({ x: 20, y: 20 })
+
+      const childA = next.find((n) => n.id === 'a')
+      const childB = next.find((n) => n.id === 'b')
+      expect(childA?.parentNode).toBe(groupId)
+      expect(childB?.parentNode).toBe(groupId)
+      expect(childA?.position).toEqual({ x: 80, y: 80 })
+      expect(childB?.position).toEqual({ x: 400, y: 140 })
+    })
+  })
+
+  describe('ungroupNode', () => {
+    it('dissolves group and restores absolute positions for children', () => {
+      const grouped = createGroupFromNodes(
+        [node('a', 'image', 50, 80), node('b', 'text', 360, 120)],
+        ['a', 'b'],
+      )
+      expect(grouped).not.toBeNull()
+
+      const ungrouped = ungroupNode(grouped!.nodes, grouped!.groupId)
+      expect(ungrouped.some((n) => n.id === grouped!.groupId)).toBe(false)
+      expect(ungrouped.find((n) => n.id === 'a')?.position).toEqual({ x: 50, y: 80 })
+      expect(ungrouped.find((n) => n.id === 'b')?.position).toEqual({ x: 360, y: 120 })
+      expect(ungrouped.find((n) => n.id === 'a')?.parentNode).toBeUndefined()
+    })
+
+    it('uses childIds from group data when present', () => {
+      const nodes: LayoutNode[] = [
+        {
+          id: 'g1',
+          type: 'group',
+          position: { x: 0, y: 0 },
+          data: { childIds: ['a'] },
+        },
+        node('a', 'image', 25, 35, { parentNode: 'g1', extent: 'parent' }),
+        node('b', 'text', 500, 500),
+      ]
+
+      const ungrouped = ungroupNode(nodes, 'g1')
+      expect(ungrouped.find((n) => n.id === 'a')?.position).toEqual({ x: 25, y: 35 })
+      expect(ungrouped.find((n) => n.id === 'b')?.position).toEqual({ x: 500, y: 500 })
+    })
+  })
+
+  describe('layoutNodesInGrid', () => {
+    it('returns input unchanged when fewer than two layout targets', () => {
+      const nodes = [node('a', 'image', 10, 10)]
+      expect(layoutNodesInGrid(nodes, ['a'])).toBe(nodes)
+      expect(layoutNodesInGrid(nodes, ['a', 'missing'])).toBe(nodes)
+    })
+
+    it('ignores group nodes in the selection', () => {
+      const nodes = [
+        node('a', 'image', 0, 0),
+        node('g', 'group', 100, 100),
+      ]
+      expect(layoutNodesInGrid(nodes, ['a', 'g'])).toBe(nodes)
+    })
+
+    it('arranges root nodes in a sqrt grid anchored at selection bounding-box origin', () => {
+      const nodes = [
+        node('a', 'image', 200, 100),
+        node('b', 'text', 500, 300),
+        node('c', 'video', 800, 50),
+        node('d', 'prompt', 900, 900),
+      ]
+
+      const next = layoutNodesInGrid(nodes, ['a', 'b', 'c', 'd'], 20)
+      const byId = Object.fromEntries(next.map((n) => [n.id, n.position]))
+
+      // Anchor = min absolute x/y across selected nodes (c.y=50 is the top edge).
+      expect(byId.a).toEqual({ x: 200, y: 50 })
+      expect(byId.b).toEqual({ x: 200 + 280 + 20, y: 50 })
+      expect(byId.c).toEqual({ x: 200, y: 50 + 280 + 20 })
+      expect(byId.d).toEqual({ x: 200 + 280 + 20, y: 50 + 120 + 20 })
+    })
+
+    it('updates relative positions for nodes inside a parent group', () => {
+      const grouped = createGroupFromNodes(
+        [node('a', 'image', 0, 0), node('b', 'text', 400, 0), node('c', 'video', 0, 400)],
+        ['a', 'b', 'c'],
+      )
+      expect(grouped).not.toBeNull()
+
+      const next = layoutNodesInGrid(grouped!.nodes, ['a', 'b', 'c'], 10)
+      const group = next.find((n) => n.id === grouped!.groupId)!
+      const groupAbs = getAbsolutePosition(group, next)
+
+      for (const id of ['a', 'b', 'c']) {
+        const child = next.find((n) => n.id === id)!
+        const abs = getAbsolutePosition(child, next)
+        expect(child.parentNode).toBe(grouped!.groupId)
+        expect(child.position.x).toBe(abs.x - groupAbs.x)
+        expect(child.position.y).toBe(abs.y - groupAbs.y)
+      }
+
+      const absA = getAbsolutePosition(next.find((n) => n.id === 'a')!, next)
+      const absB = getAbsolutePosition(next.find((n) => n.id === 'b')!, next)
+      expect(absB.x - absA.x).toBe(280 + 10)
+    })
+  })
+
+  describe('moveNodes', () => {
+    it('moves root nodes to absolute coordinates', () => {
+      const nodes = [node('a', 'image', 0, 0), node('b', 'text', 200, 200)]
+      const { nodes: next, movedIds } = moveNodes(nodes, [
+        { nodeId: 'a', x: 500, y: 600 },
+      ])
+      expect(movedIds).toEqual(['a'])
+      expect(next.find((n) => n.id === 'a')?.position).toEqual({ x: 500, y: 600 })
+      expect(next.find((n) => n.id === 'b')?.position).toEqual({ x: 200, y: 200 })
+    })
+
+    it('converts absolute coordinates to parent-relative positions', () => {
+      vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
+      const grouped = createGroupFromNodes(
+        [node('a', 'image', 100, 100), node('b', 'text', 400, 100)],
+        ['a', 'b'],
+      )!
+      const { nodes: next } = moveNodes(grouped.nodes, [{ nodeId: 'a', x: 300, y: 300 }])
+      const child = next.find((n) => n.id === 'a')!
+      const abs = getAbsolutePosition(child, next)
+      expect(abs).toEqual({ x: 300, y: 300 })
+      vi.restoreAllMocks()
+    })
+  })
+
+  describe('applyLayoutOps', () => {
+    beforeEach(() => {
+      vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('chains group, grid, and ungroup', () => {
+      const base = [node('a', 'image', 0, 0), node('b', 'text', 400, 0), node('c', 'video', 0, 400)]
+      const { nodes, results } = applyLayoutOps(base, [
+        { op: 'group', nodeIds: ['a', 'b'], title: 'Pair' },
+        { op: 'arrange_grid', nodeIds: ['c'], gap: 20 },
+        { op: 'move', items: [{ nodeId: 'c', x: 800, y: 800 }] },
+      ])
+      expect(results.map((r) => r.op)).toEqual(['group', 'arrange_grid', 'move'])
+      expect(nodes.some((n) => n.type === 'group')).toBe(true)
+      expect(nodes.find((n) => n.id === 'c')?.position).toEqual({ x: 800, y: 800 })
+
+      const group = nodes.find((n) => n.type === 'group')!
+      const ungrouped = applyLayoutOps(nodes, [{ op: 'ungroup', groupId: group.id }])
+      expect(ungrouped.results[0]?.op).toBe('ungroup')
+      expect(ungrouped.nodes.some((n) => n.id === group.id)).toBe(false)
+    })
+  })
+})

--- a/apps/server/src/agent/canvas-layout.util.ts
+++ b/apps/server/src/agent/canvas-layout.util.ts
@@ -218,3 +218,111 @@ export function layoutNodesInGrid(
   }
   return next
 }
+
+export type CanvasLayoutOp =
+  | { op: 'group'; nodeIds: string[]; title?: string }
+  | { op: 'ungroup'; groupId: string }
+  | { op: 'arrange_grid'; nodeIds: string[]; gap?: number }
+  | { op: 'move'; items: Array<{ nodeId: string; x: number; y: number }> }
+
+export type CanvasLayoutOpResult =
+  | { op: 'group'; groupId: string; nodeIds: string[] }
+  | { op: 'ungroup'; groupId: string; nodeIds: string[] }
+  | { op: 'arrange_grid'; nodeIds: string[] }
+  | { op: 'move'; nodeIds: string[] }
+
+/** Move nodes by absolute canvas coordinates (converts to parent-relative when nested). */
+export function moveNodes(
+  nodes: LayoutNode[],
+  items: Array<{ nodeId: string; x: number; y: number }>,
+): { nodes: LayoutNode[]; movedIds: string[] } {
+  const next = nodes.map((n) => ({ ...n, data: { ...(n.data ?? {}) } }))
+  const movedIds: string[] = []
+  for (const item of items) {
+    const idx = next.findIndex((n) => n.id === item.nodeId)
+    if (idx < 0) continue
+    const node = next[idx]!
+    let position = { x: item.x, y: item.y }
+    if (node.parentNode) {
+      const parent = next.find((n) => n.id === node.parentNode)
+      if (parent) {
+        const parentAbs = getAbsolutePosition(parent, next)
+        position = {
+          x: item.x - parentAbs.x,
+          y: item.y - parentAbs.y,
+        }
+      }
+    }
+    next[idx] = { ...node, position }
+    movedIds.push(item.nodeId)
+  }
+  return { nodes: next, movedIds }
+}
+
+/** Apply ordered layout ops on an in-memory node list (no persistence). */
+export function applyLayoutOps(
+  nodes: LayoutNode[],
+  ops: CanvasLayoutOp[],
+): { nodes: LayoutNode[]; results: CanvasLayoutOpResult[] } {
+  let current = nodes.map((n) => ({ ...n, data: { ...(n.data ?? {}) } }))
+  const results: CanvasLayoutOpResult[] = []
+
+  for (const op of ops) {
+    switch (op.op) {
+      case 'group': {
+        const grouped = createGroupFromNodes(current, op.nodeIds, op.title)
+        if (!grouped) {
+          throw new Error(`group requires at least 2 eligible nodes: ${op.nodeIds.join(', ')}`)
+        }
+        current = grouped.nodes
+        results.push({ op: 'group', groupId: grouped.groupId, nodeIds: op.nodeIds })
+        break
+      }
+      case 'ungroup': {
+        const childIds = getGroupChildIds(current, op.groupId)
+        current = ungroupNode(current, op.groupId)
+        results.push({ op: 'ungroup', groupId: op.groupId, nodeIds: childIds })
+        break
+      }
+      case 'arrange_grid': {
+        current = layoutNodesInGrid(current, op.nodeIds, op.gap ?? 40)
+        results.push({ op: 'arrange_grid', nodeIds: op.nodeIds })
+        break
+      }
+      case 'move': {
+        const moved = moveNodes(current, op.items)
+        current = moved.nodes
+        results.push({ op: 'move', nodeIds: moved.movedIds })
+        break
+      }
+      default: {
+        const _exhaustive: never = op
+        throw new Error(`unknown layout op: ${JSON.stringify(_exhaustive)}`)
+      }
+    }
+  }
+
+  return { nodes: current, results }
+}
+
+export function summarizeLayoutGroups(nodes: LayoutNode[]): Array<{
+  id: string
+  title: string
+  childIds: string[]
+  position: { x: number; y: number }
+  size: { w: number; h: number }
+}> {
+  return nodes
+    .filter((n) => n.type === 'group')
+    .map((group) => {
+      const childIds = getGroupChildIds(nodes, group.id)
+      const { w, h } = getNodeSize(group)
+      return {
+        id: group.id,
+        title: String(group.data?.title ?? '分组'),
+        childIds,
+        position: group.position,
+        size: { w, h },
+      }
+    })
+}

--- a/services/agent-runtime/app/tools/definitions.py
+++ b/services/agent-runtime/app/tools/definitions.py
@@ -128,6 +128,25 @@ class OpenImageEditorInput(BaseModel):
     node_id: str = Field(description="Image node id to open in the refine editor")
 
 
+class MoveNodeItemInput(BaseModel):
+    node_id: str = Field(description="Canvas node id")
+    x: float = Field(description="Absolute canvas X coordinate")
+    y: float = Field(description="Absolute canvas Y coordinate")
+
+
+class MoveNodesInput(BaseModel):
+    items: list[MoveNodeItemInput] = Field(description="Nodes to move by absolute coordinates")
+
+
+class ApplyLayoutOpsInput(BaseModel):
+    ops: list[dict[str, Any]] = Field(
+        description=(
+            "Ordered layout ops: group, ungroup, arrange_grid, move "
+            "(see canvas layout workflow harness)"
+        )
+    )
+
+
 def _all_tool_specs(client: NestCanvasClient) -> list[tuple[str, StructuredTool]]:
     """Return (name, tool) pairs for registry filtering."""
 
@@ -253,6 +272,20 @@ def _all_tool_specs(client: NestCanvasClient) -> list[tuple[str, StructuredTool]
 
     async def arrange_nodes_grid(node_ids: list[str], gap: int | None = None) -> dict:
         return await client.arrange_nodes_grid(node_ids=node_ids, gap=gap)
+
+    async def move_nodes(items: list[dict[str, Any]]) -> dict:
+        normalized = [
+            {
+                "nodeId": str(item.get("node_id") or item.get("nodeId") or ""),
+                "x": float(item["x"]),
+                "y": float(item["y"]),
+            }
+            for item in items
+        ]
+        return await client.move_nodes(items=normalized)
+
+    async def apply_layout_ops(ops: list[dict[str, Any]]) -> dict:
+        return await client.apply_layout_ops(ops=ops)
 
     async def get_image_edit_capabilities(node_id: str) -> dict:
         return await client.get_image_edit_capabilities(node_id=node_id)
@@ -572,6 +605,26 @@ def _all_tool_specs(client: NestCanvasClient) -> list[tuple[str, StructuredTool]
                 name="arrange_nodes_grid",
                 description="Arrange nodes in a grid layout (graph batch)",
                 args_schema=ArrangeNodesGridInput,
+            ),
+        ),
+        (
+            "move_nodes",
+            StructuredTool.from_function(
+                coroutine=move_nodes,
+                name="move_nodes",
+                description="Move canvas nodes to absolute coordinates (graph batch)",
+                args_schema=MoveNodesInput,
+            ),
+        ),
+        (
+            "apply_layout_ops",
+            StructuredTool.from_function(
+                coroutine=apply_layout_ops,
+                name="apply_layout_ops",
+                description=(
+                    "Apply ordered layout workflow ops (group/ungroup/grid/move) atomically"
+                ),
+                args_schema=ApplyLayoutOpsInput,
             ),
         ),
     ]

--- a/services/agent-runtime/app/tools/nest_client.py
+++ b/services/agent-runtime/app/tools/nest_client.py
@@ -550,6 +550,26 @@ class NestCanvasClient:
             body["gap"] = gap
         return await self._post("/agent/internal/arrange-nodes-grid", body)
 
+    async def move_nodes(self, *, items: list[dict[str, Any]]) -> dict[str, Any]:
+        return await self._post(
+            "/agent/internal/move-nodes",
+            {
+                "sessionId": self._session_id,
+                "userId": self._user_id,
+                "items": items,
+            },
+        )
+
+    async def apply_layout_ops(self, *, ops: list[dict[str, Any]]) -> dict[str, Any]:
+        return await self._post(
+            "/agent/internal/apply-layout-ops",
+            {
+                "sessionId": self._session_id,
+                "userId": self._user_id,
+                "ops": ops,
+            },
+        )
+
     async def get_image_edit_capabilities(self, *, node_id: str) -> dict[str, Any]:
         return await self._post(
             "/agent/internal/get-image-edit-capabilities",

--- a/services/agent-runtime/app/tools/tool_registry.py
+++ b/services/agent-runtime/app/tools/tool_registry.py
@@ -75,6 +75,8 @@ TOOL_TIERS: dict[str, ToolTier] = {
     "group_nodes": ToolTier.GRAPH_BATCH,
     "ungroup_node": ToolTier.GRAPH_BATCH,
     "arrange_nodes_grid": ToolTier.GRAPH_BATCH,
+    "move_nodes": ToolTier.GRAPH_BATCH,
+    "apply_layout_ops": ToolTier.GRAPH_BATCH,
     "run_icon_refine": ToolTier.GEN,
     "get_image_edit_capabilities": ToolTier.READ,
     "add_nodes_batch": ToolTier.GRAPH_BATCH,

--- a/services/agent-runtime/tests/test_explore_tools.py
+++ b/services/agent-runtime/tests/test_explore_tools.py
@@ -20,6 +20,8 @@ def test_explore_tools_exclude_generation():
     assert "run_image_generation" not in names
     assert "add_nodes_batch" not in names
     assert "group_nodes" not in names
+    assert "move_nodes" not in names
+    assert "apply_layout_ops" not in names
     assert names <= EXPLORE_TOOL_NAMES
 
 


### PR DESCRIPTION
## Summary
- **Previously partial**: individual `group_nodes` / `ungroup_node` / `arrange_nodes_grid` / `get_canvas_layout` existed but lacked a unified workflow surface and absolute positioning.
- **New Nest Harness APIs**:
  - `POST /agent/internal/move-nodes` — move nodes by absolute canvas coordinates
  - `POST /agent/internal/apply-layout-ops` — atomic batch: `group` | `ungroup` | `arrange_grid` | `move`
  - Enhanced `get-canvas-layout` with `absolutePosition` + `groups` summary
- **Runtime (graph-only)**: `move_nodes`, `apply_layout_ops` StructuredTools
- **Tests**: 19 util + 48 service layout/workflow cases

## Workflow op schema (SSOT)
```json
[
  { "op": "group", "nodeIds": ["a","b"], "title": "Block" },
  { "op": "arrange_grid", "nodeIds": ["a","b","c"], "gap": 40 },
  { "op": "move", "items": [{ "nodeId": "x", "x": 100, "y": 200 }] },
  { "op": "ungroup", "groupId": "group-..." }
]
```

## Test plan
- [x] `pnpm build`
- [x] `vitest` canvas-layout.util + agent-canvas-tools.service (67/67)
- [x] `pytest test_explore_tools.py`
- [ ] CI green


Made with [Cursor](https://cursor.com)