### PR TITLE
fix(agent-runtime): explore routing priority and tool-call reliability

### DIFF
--- a/deploy/prod-explore-28-tools-demo.py
+++ b/deploy/prod-explore-28-tools-demo.py
@@ -17,14 +17,20 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from typing import Any, Literal
+from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+BUSY_SNIPPETS = ("上一轮仍在处理中", "出图仍在进行中")
 BASE = os.environ.get("BASE_URL", "http://119.29.173.89:8888").rstrip("/")
 API = f"{BASE}/api"
 PHONE = os.environ.get("PHONE", "17279698608")
 CODE = os.environ.get("CODE", "123456")
 SESSION_ID = os.environ.get("SESSION_ID", "cmsjq3rpj005op801frieqj42").strip()
 SSE_TIMEOUT = float(os.environ.get("EXPLORE_DEMO_SSE_TIMEOUT", "120"))
+BUSY_RETRY_MAX = int(os.environ.get("EXPLORE_DEMO_BUSY_RETRIES", "8"))
+BUSY_RETRY_WAIT = float(os.environ.get("EXPLORE_DEMO_BUSY_WAIT", "15"))
+# 每工具独立 thread 可避免同 thread 锁冲突（默认开启，UI 仍可按 session 查看各 thread）
+PER_TOOL_THREAD = os.environ.get("EXPLORE_DEMO_PER_TOOL_THREAD", "1") != "0"
 
 ATOMIC_STEPS = frozenset({
     "parse_atomic_intent",
@@ -264,13 +270,17 @@ def sse_chat(
     canvas_cmds: list[str] = []
     parts: list[str] = []
     explore_payload: dict | None = None
+    saw_done = False
     end = time.time() + timeout
     with urlopen(r, timeout=timeout + 30) as resp:
         buf = ""
         while time.time() < end:
             chunk = resp.read(4096)
             if not chunk:
-                break
+                if saw_done:
+                    break
+                time.sleep(0.2)
+                continue
             buf += chunk.decode(errors="replace")
             while "\n\n" in buf:
                 block, buf = buf.split("\n\n", 1)
@@ -279,6 +289,7 @@ def sse_chat(
                         continue
                     pl = line[5:].strip()
                     if pl == "[DONE]":
+                        saw_done = True
                         break
                     try:
                         ev = json.loads(pl)
@@ -300,14 +311,21 @@ def sse_chat(
                     if et == "explore":
                         explore_payload = data if isinstance(data, dict) else None
                     if et == "done":
+                        saw_done = True
                         break
                     if et == "error":
                         err_msg = str((data or {}).get("message") or data)
                         parts.append(f"[ERROR: {err_msg}]")
+                        saw_done = True
                         break
+                if saw_done:
+                    break
+            if saw_done:
+                break
     text = parts[-1] if len(parts) == 1 and parts[0] else "".join(parts)
     explore_ran = "explore" in steps
     atomic_ran = any(s in ATOMIC_STEPS for s in steps)
+    busy = any(s in text for s in BUSY_SNIPPETS)
     return {
         "text": text,
         "types": sorted(types),
@@ -316,7 +334,34 @@ def sse_chat(
         "explore_ran": explore_ran,
         "atomic_ran": atomic_ran,
         "explore_payload": explore_payload,
+        "busy": busy,
+        "saw_done": saw_done,
     }
+
+
+def chat_with_retry(
+    tok: str,
+    sid: str,
+    msg: str,
+    tid: str,
+    *,
+    timeout: float,
+) -> dict[str, Any]:
+    last: dict[str, Any] = {}
+    for attempt in range(BUSY_RETRY_MAX + 1):
+        try:
+            last = sse_chat(tok, sid, msg, tid, timeout=timeout)
+        except (HTTPError, URLError, TimeoutError, ConnectionError) as exc:
+            if attempt >= BUSY_RETRY_MAX:
+                raise
+            time.sleep(BUSY_RETRY_WAIT)
+            continue
+        if not last.get("busy"):
+            return last
+        if attempt >= BUSY_RETRY_MAX:
+            return last
+        time.sleep(BUSY_RETRY_WAIT)
+    return last
 
 
 def _keyword_hit(text: str, keywords: list[str]) -> bool:
@@ -358,9 +403,11 @@ def verify_case(case: DemoCase, result: dict[str, Any]) -> tuple[Verdict, str]:
 
 
 def main() -> int:
-    tid = f"{SESSION_ID}:explore28-{uuid.uuid4().hex[:8]}"
+    run_id = uuid.uuid4().hex[:8]
+    base_tid = f"{SESSION_ID}:explore28-{run_id}"
     print("=== Explore 28 tools live demo (production user path) ===")
-    print(f"BASE={BASE} SESSION={SESSION_ID} THREAD={tid}\n")
+    print(f"BASE={BASE} SESSION={SESSION_ID} RUN={run_id}")
+    print(f"PER_TOOL_THREAD={PER_TOOL_THREAD} base_thread={base_tid}\n")
 
     try:
         http("POST", "/auth/send-code", {"phone": PHONE})
@@ -372,11 +419,15 @@ def main() -> int:
     record("Runtime health", "tool" if runtime_ok else "fail", str(rt.get("data")))
 
     results: list[dict[str, Any]] = []
+    threads: list[str] = []
     for i, case in enumerate(DEMOS, 1):
+        tid = f"{SESSION_ID}:demo-{case.tool}-{run_id}" if PER_TOOL_THREAD else base_tid
+        threads.append(tid)
         print(f"\n--- [{i}/28] {case.tool} ---")
+        print(f"THREAD: {tid}")
         print(f"USER: {case.message}")
         try:
-            result = sse_chat(tok, SESSION_ID, case.message, tid, timeout=SSE_TIMEOUT)
+            result = chat_with_retry(tok, SESSION_ID, case.message, tid, timeout=SSE_TIMEOUT)
             verdict, detail = verify_case(case, result)
             if verdict in ("fail", "wrong_route") and case.allow_skip:
                 record(case.tool, "skip", detail)
@@ -388,6 +439,7 @@ def main() -> int:
                     "tool": case.tool,
                     "verdict": verdict,
                     "detail": detail,
+                    "threadId": tid,
                     "message": case.message,
                     "steps": result.get("steps"),
                     "canvas_cmds": result.get("canvas_cmds"),
@@ -401,13 +453,18 @@ def main() -> int:
             else:
                 record(case.tool, "fail", str(exc))
                 verdict = "fail"
-            results.append({"tool": case.tool, "verdict": verdict, "detail": str(exc), "message": case.message})
-        time.sleep(1.5)
+            results.append(
+                {"tool": case.tool, "verdict": verdict, "detail": str(exc), "threadId": tid, "message": case.message}
+            )
+        time.sleep(2 if PER_TOOL_THREAD else 3)
 
     out_path = os.path.join(os.path.dirname(__file__), "prod-explore-28-tools-demo-results.json")
     summary = {
-        "threadId": tid,
+        "runId": run_id,
+        "baseThreadId": base_tid,
+        "threadIds": threads,
         "sessionId": SESSION_ID,
+        "perToolThread": PER_TOOL_THREAD,
         "pass_tool": PASS,
         "weak": WEAK,
         "fail": FAIL,
@@ -418,7 +475,8 @@ def main() -> int:
         json.dump(summary, f, ensure_ascii=False, indent=2)
 
     print(f"\n=== Summary: ✅ tool={PASS} ⚠️ weak={WEAK} ❌ fail={FAIL} ⏭️ skip={SKIP} ===")
-    print(f"UI replay: {BASE}/workflow/{SESSION_ID}  (thread: {tid})")
+    print(f"UI: {BASE}/workflow/{SESSION_ID}")
+    print(f"Sample threads: {threads[0]} … {threads[-1]}")
     print(f"Results JSON: {out_path}")
     return 0 if FAIL == 0 else 1
 

--- a/services/agent-runtime/app/graph/explore_route.py
+++ b/services/agent-runtime/app/graph/explore_route.py
@@ -1,0 +1,132 @@
+"""Explore canvas routing signals — existing-node ops vs atomic create."""
+
+from __future__ import annotations
+
+import re
+
+_NODE_ID_PATTERN = re.compile(
+    r"\b(?:prompt|image|text|video|audio|group)-[\w-]+\b",
+    re.IGNORECASE,
+)
+
+_EXPLORE_QUERY_VERBS = (
+    "看看",
+    "有哪些",
+    "列出",
+    "查询",
+    "检查",
+    "状态",
+    "什么情况",
+    "怎么样",
+)
+
+_EXPLORE_MUTATE_VERBS = (
+    "更新",
+    "修改",
+    "设置",
+    "复制",
+    "上传",
+    "添加",
+    "保存",
+    "导出",
+    "引入",
+    "定位",
+    "撤销",
+    "重做",
+    "打开",
+    "挂",
+    "应用",
+    "attach",
+)
+
+_EXPLORE_LIFECYCLE_MARKERS = (
+    "取消生成",
+    "平台回退",
+    "fallback",
+    "诊断",
+    "失败原因",
+)
+
+
+def has_canvas_node_id_reference(text: str) -> bool:
+    return bool(_NODE_ID_PATTERN.search(text or ""))
+
+
+def explore_explicit_intent(utterance: str) -> bool:
+    """True when utterance is an existing-node / canvas explore op (not new gen)."""
+    u = (utterance or "").strip()
+    if not u:
+        return False
+
+    if ("资产库" in u or "素材库" in u or "公共素材" in u) and any(
+        v in u for v in _EXPLORE_QUERY_VERBS
+    ):
+        return True
+
+    if has_canvas_node_id_reference(u) and any(
+        v in u for v in _EXPLORE_QUERY_VERBS + _EXPLORE_MUTATE_VERBS + ("取消", "确认")
+    ):
+        return True
+
+    if "节点" in u:
+        if any(v in u for v in _EXPLORE_MUTATE_VERBS):
+            if ("添加" in u or "上传" in u) and not any(
+                x in u for x in ("不要出图", "仅上传", "不要触发出图", "仅添加", "查询")
+            ):
+                pass
+            else:
+                return True
+        if any(v in u for v in _EXPLORE_QUERY_VERBS):
+            return True
+
+    if any(v in u for v in ("撤销", "重做")) and ("画布" in u or "操作" in u):
+        return True
+
+    if "精修" in u and ("打开" in u or "编辑器" in u or "编辑" in u):
+        return True
+
+    if "取消" in u and any(x in u for x in ("生成", "任务", "回退", "fallback")):
+        return True
+
+    if "确认" in u and any(x in u for x in ("回退", "fallback", "平台")):
+        return True
+
+    if any(k in u for k in _EXPLORE_LIFECYCLE_MARKERS):
+        return True
+
+    return False
+
+
+def explore_canvas_signal(
+    utterance: str,
+    *,
+    blocked_by_atomic: bool,
+) -> bool:
+    """Shared noun/verb table for explore_canvas routing."""
+    u = (utterance or "").strip()
+    if not u:
+        return False
+
+    if explore_explicit_intent(u):
+        return True
+
+    if blocked_by_atomic:
+        return False
+
+    nouns = (
+        "画布",
+        "节点",
+        "分镜",
+        "canvas",
+        "生成状态",
+        "生成任务",
+        "任务状态",
+        "资产库",
+        "素材库",
+        "素材",
+    )
+    verbs = _EXPLORE_QUERY_VERBS + _EXPLORE_MUTATE_VERBS
+    has_noun = any(n in u for n in nouns)
+    has_verb = any(v in u for v in verbs)
+    lifecycle = any(k in u for k in _EXPLORE_LIFECYCLE_MARKERS)
+    return lifecycle or (has_noun and has_verb)

--- a/services/agent-runtime/app/graph/nodes/explore.py
+++ b/services/agent-runtime/app/graph/nodes/explore.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import Any, Callable
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
@@ -11,13 +12,47 @@ from app.errors import AgentToolError, from_exception
 from app.graph.canvas_commands import extract_canvas_commands
 from app.tools.definitions import build_explore_tools
 
-MAX_EXPLORE_TOOL_ROUNDS = 3
+MAX_EXPLORE_TOOL_ROUNDS = 4
+
+_UI_COMMAND_TOOLS = frozenset({
+    "focus_node",
+    "focus_nodes",
+    "undo",
+    "redo",
+    "open_image_editor",
+    "introduce_nodes_to_agent",
+})
+
+_ASSET_READ_TOOLS = frozenset({"list_user_assets", "list_public_assets"})
+
+_LIFECYCLE_TOOLS = frozenset({
+    "cancel_generation",
+    "cancel_platform_fallback",
+    "confirm_platform_fallback",
+})
 
 _EXPLORE_SYSTEM = (
-    "你是 lnkpi 画布探索助手。用简洁中文回答。"
-    "可通过工具读取画布节点、查询生成状态、取消任务或处理平台回退。"
-    "不要调用 run_*_generation；用户要出图/生成视频时，提示其直接描述创作需求。"
-    "\n\n当前画布摘要：\n{summary}"
+    "你是 lnkpi 画布探索助手。用简洁中文回答。\n"
+    "规则：\n"
+    "1. 必须通过工具完成读写操作，禁止假装已执行。\n"
+    "2. UI 操作（focus_node/focus_nodes/undo/redo/open_image_editor/introduce_nodes_to_agent）"
+    "必须调用对应工具，不要仅用文字回复。\n"
+    "3. list_user_assets / list_public_assets 必须调用工具，不可拒答。\n"
+    "4. lifecycle 工具（cancel_* / confirm_platform_fallback）必须传 node_id"
+    "（从画布摘要解析节点 id，不要用标题字符串代替）。\n"
+    "5. 不要调用 run_*_generation；用户要出图/生成视频时，提示其直接描述创作需求。\n"
+    "\n当前画布摘要：\n{summary}"
+)
+
+_UI_NUDGE = (
+    "请调用对应的 explore 工具完成 UI/侧栏操作（focus_node、focus_nodes、undo、redo、"
+    "open_image_editor、introduce_nodes_to_agent），不要只用文字描述已执行。"
+)
+
+_ASSET_NUDGE = "请调用 list_user_assets 或 list_public_assets 查询资产库，不要拒答。"
+
+_CANCEL_NUDGE = (
+    "请调用 cancel_generation 或 cancel_platform_fallback，传入 node_id，不要让用户手动操作。"
 )
 
 
@@ -39,6 +74,117 @@ def _serialize_tool_result(result: Any) -> str:
         return str(result)
 
 
+def _needs_ui_nudge(user_text: str, called: set[str], canvas_commands: list[dict[str, Any]]) -> bool:
+    if canvas_commands:
+        return False
+    t = user_text
+    if any(k in t for k in ("定位", "视口", "撤销", "重做", "精修", "编辑器", "引入", "侧栏")):
+        return not called.intersection(_UI_COMMAND_TOOLS)
+    return False
+
+
+def _needs_asset_nudge(user_text: str, called: set[str]) -> bool:
+    if "资产" in user_text or "素材库" in user_text:
+        return not called.intersection(_ASSET_READ_TOOLS)
+    return False
+
+
+def _needs_cancel_nudge(user_text: str, called: set[str]) -> bool:
+    if "取消" in user_text and ("生成" in user_text or "任务" in user_text):
+        return "cancel_generation" not in called
+    return False
+
+
+def _pick_nudge(user_text: str, called: set[str], canvas_commands: list[dict[str, Any]]) -> str | None:
+    if _needs_ui_nudge(user_text, called, canvas_commands):
+        return _UI_NUDGE
+    if _needs_asset_nudge(user_text, called):
+        return _ASSET_NUDGE
+    if _needs_cancel_nudge(user_text, called):
+        return _CANCEL_NUDGE
+    return None
+
+
+async def _direct_undo_redo(
+    user_text: str,
+    tools_by_name: dict[str, Any],
+    called: set[str],
+    canvas_commands: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Deterministic fallback when LLM skips zero-arg UI tools."""
+    if canvas_commands:
+        return canvas_commands
+    out = list(canvas_commands)
+    if "撤销" in user_text and ("画布" in user_text or "操作" in user_text) and "undo" not in called:
+        result = await tools_by_name["undo"].ainvoke({})
+        called.add("undo")
+        for cmd in extract_canvas_commands(result):
+            if cmd not in out:
+                out.append(cmd)
+    elif "重做" in user_text and ("画布" in user_text or "撤销" in user_text) and "redo" not in called:
+        result = await tools_by_name["redo"].ainvoke({})
+        called.add("redo")
+        for cmd in extract_canvas_commands(result):
+            if cmd not in out:
+                out.append(cmd)
+    return out
+
+
+def _resolve_node_id_by_title(summary: Any, title_fragment: str) -> str | None:
+    if not isinstance(summary, dict):
+        return None
+    nodes = summary.get("nodes") or summary.get("nodeSummaries") or []
+    if not isinstance(nodes, list):
+        return None
+    frag = title_fragment.strip()
+    if not frag:
+        return None
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        node_title = str(node.get("title") or node.get("label") or "")
+        if frag in node_title or node_title in frag:
+            nid = str(node.get("id") or node.get("nodeId") or "")
+            if nid:
+                return nid
+    return None
+
+
+async def _direct_focus_or_editor(
+    user_text: str,
+    summary: Any,
+    tools_by_name: dict[str, Any],
+    called: set[str],
+    canvas_commands: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    if canvas_commands:
+        return canvas_commands
+    out = list(canvas_commands)
+    title_match = re.search(r"[「『\"]([^」』\"]+)[」』\"]", user_text)
+    title = title_match.group(1) if title_match else ""
+    node_id = _resolve_node_id_by_title(summary, title) if title else None
+
+    if node_id and "精修" in user_text and "open_image_editor" not in called:
+        result = await tools_by_name["open_image_editor"].ainvoke({"node_id": node_id})
+        called.add("open_image_editor")
+        for cmd in extract_canvas_commands(result):
+            if cmd not in out:
+                out.append(cmd)
+    elif node_id and ("定位" in user_text or "视口" in user_text) and "focus_node" not in called:
+        result = await tools_by_name["focus_node"].ainvoke({"node_id": node_id})
+        called.add("focus_node")
+        for cmd in extract_canvas_commands(result):
+            if cmd not in out:
+                out.append(cmd)
+    elif node_id and ("引入" in user_text or "侧栏" in user_text) and "introduce_nodes_to_agent" not in called:
+        result = await tools_by_name["introduce_nodes_to_agent"].ainvoke({"node_ids": [node_id]})
+        called.add("introduce_nodes_to_agent")
+        for cmd in extract_canvas_commands(result):
+            if cmd not in out:
+                out.append(cmd)
+    return out
+
+
 def make_explore_node(*, llm: Any, nest: Any) -> Callable:
     async def explore(state: dict) -> dict:
         tools = build_explore_tools(nest)
@@ -58,11 +204,20 @@ def make_explore_node(*, llm: Any, nest: Any) -> Callable:
 
         final_reply = ""
         canvas_commands: list[dict[str, Any]] = []
+        called_tools: set[str] = set()
+        nudged = False
+
         for _ in range(MAX_EXPLORE_TOOL_ROUNDS):
             ai = await llm_bound.ainvoke(convo)
             tool_calls = getattr(ai, "tool_calls", None) or []
             if not tool_calls:
                 final_reply = str(getattr(ai, "content", "") or "").strip()
+                nudge = _pick_nudge(user_text, called_tools, canvas_commands)
+                if nudge and not nudged:
+                    convo.append(ai)
+                    convo.append(HumanMessage(content=nudge))
+                    nudged = True
+                    continue
                 break
 
             convo.append(ai)
@@ -71,6 +226,7 @@ def make_explore_node(*, llm: Any, nest: Any) -> Callable:
                 args = tc.get("args") if isinstance(tc, dict) else getattr(tc, "args", {})
                 tool_call_id = tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", "")
                 tool = tools_by_name.get(name)
+                called_tools.add(str(name))
                 if tool is None:
                     result: Any = {"error": f"unknown tool: {name}"}
                 else:
@@ -101,6 +257,13 @@ def make_explore_node(*, llm: Any, nest: Any) -> Callable:
                 )
         else:
             final_reply = str(getattr(convo[-1], "content", "") or "").strip()
+
+        canvas_commands = await _direct_undo_redo(
+            user_text, tools_by_name, called_tools, canvas_commands
+        )
+        canvas_commands = await _direct_focus_or_editor(
+            user_text, summary, tools_by_name, called_tools, canvas_commands
+        )
 
         if not final_reply:
             final_reply = "已查询画布信息。如需继续操作，请说明具体节点或任务。"

--- a/services/agent-runtime/app/graph/route_decide.py
+++ b/services/agent-runtime/app/graph/route_decide.py
@@ -12,6 +12,7 @@ from app.graph.atomic_intent import (
     regenerate_phrase_intent,
     resolve_intake_route,
 )
+from app.graph.explore_route import explore_canvas_signal, explore_explicit_intent
 from app.graph.intent import marketing_intent, modify_intent, single_node_gen_intent
 from app.graph.l0_action import (
     TRANSFORM_VERBS,
@@ -70,21 +71,14 @@ def _explore_canvas_signal(ctx: RouteContext) -> bool:
     utterance = str(ctx.get("utterance") or "").strip()
     if not utterance:
         return False
-    if atomic_create_intent(utterance) or single_node_gen_intent(utterance):
-        return False
-    if regenerate_phrase_intent(utterance) or atomic_regenerate_intent(utterance):
-        return False
-    if marketing_intent(utterance):
-        return False
-    nouns = ("画布", "节点", "分镜", "canvas", "生成状态", "生成任务", "任务状态")
-    verbs = ("看看", "有哪些", "列出", "查询", "检查", "状态", "什么情况", "怎么样")
-    lifecycle = any(
-        k in utterance
-        for k in ("取消生成", "平台回退", "fallback", "诊断", "失败原因")
+    blocked = (
+        (atomic_create_intent(utterance) and not explore_explicit_intent(utterance))
+        or single_node_gen_intent(utterance)
+        or regenerate_phrase_intent(utterance)
+        or atomic_regenerate_intent(utterance)
+        or marketing_intent(utterance)
     )
-    has_noun = any(n in utterance for n in nouns)
-    has_verb = any(v in utterance for v in verbs)
-    return lifecycle or (has_noun and has_verb)
+    return explore_canvas_signal(utterance, blocked_by_atomic=blocked)
 
 
 def _sidebar_img2img_signal(ctx: RouteContext) -> bool:
@@ -204,6 +198,18 @@ def decide_route(ctx: RouteContext, *, valid_skill_ids: set[str] | None = None) 
             "is_modify": False,
         }
 
+    # Explore before atomic: existing-node read/write must not hijack atomic_create.
+    if _explore_canvas_signal(ctx):
+        return {
+            "flow_mode": "explore_canvas",
+            "l0_action": l0,
+            "confidence": 0.88,
+            "reason": "explore_canvas_intent",
+            "clarify_question": None,
+            "guard_veto": guard_veto,
+            "is_modify": False,
+        }
+
     if is_atomic or is_variant or (has_preserve_intent(utterance) and l0 in ("preserve", "generate", "unknown")):
         return {
             "flow_mode": "atomic_create",
@@ -234,17 +240,6 @@ def decide_route(ctx: RouteContext, *, valid_skill_ids: set[str] | None = None) 
             "reason": "empty_utterance",
             "clarify_question": None,
             "guard_veto": None,
-            "is_modify": False,
-        }
-
-    if _explore_canvas_signal(ctx):
-        return {
-            "flow_mode": "explore_canvas",
-            "l0_action": l0,
-            "confidence": 0.85,
-            "reason": "explore_canvas_intent",
-            "clarify_question": None,
-            "guard_veto": guard_veto,
             "is_modify": False,
         }
 

--- a/services/agent-runtime/app/tools/definitions.py
+++ b/services/agent-runtime/app/tools/definitions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from langchain_core.tools import StructuredTool
@@ -26,10 +27,14 @@ class NodeIdInput(BaseModel):
 
 class GenerationRecordInput(BaseModel):
     generation_record_id: str | None = Field(
-        default=None, description="Studio generation record id"
+        default=None, description="Studio generation record id (optional if node_id provided)"
     )
     node_id: str | None = Field(
-        default=None, description="Canvas node id (resolves generationRecordId from node data)"
+        default=None,
+        description=(
+            "Canvas node id such as image-16 — required for lifecycle tools when "
+            "generation_record_id is unknown; resolve from canvas summary, not title text"
+        ),
     )
 
 
@@ -297,6 +302,18 @@ def _all_tool_specs(client: NestCanvasClient) -> list[tuple[str, StructuredTool]
         ref_order: list[str] | None = None,
         mentioned_keys: list[str] | None = None,
     ) -> dict:
+        if isinstance(ref_order, str):
+            try:
+                parsed = json.loads(ref_order)
+                ref_order = parsed if isinstance(parsed, list) else None
+            except json.JSONDecodeError:
+                ref_order = None
+        if isinstance(mentioned_keys, str):
+            try:
+                parsed = json.loads(mentioned_keys)
+                mentioned_keys = parsed if isinstance(parsed, list) else None
+            except json.JSONDecodeError:
+                mentioned_keys = None
         return await client.apply_sidebar_attachments(
             node_ids=node_ids,
             attachments=attachments,

--- a/services/agent-runtime/tests/test_explore_node.py
+++ b/services/agent-runtime/tests/test_explore_node.py
@@ -1,0 +1,31 @@
+import pytest
+
+from app.graph.nodes.explore import _direct_undo_redo, _resolve_node_id_by_title
+
+
+class FakeTool:
+    def __init__(self, result: dict) -> None:
+        self.result = result
+        self.calls = 0
+
+    async def ainvoke(self, _args: dict) -> dict:
+        self.calls += 1
+        return self.result
+
+
+@pytest.mark.asyncio
+async def test_direct_undo_when_llm_skipped():
+    undo = FakeTool({"ok": True, "canvasCommands": [{"type": "undo"}]})
+    tools = {"undo": undo}
+    out = await _direct_undo_redo("查询画布，撤销上一步画布编辑操作", tools, set(), [])
+    assert out == [{"type": "undo"}]
+    assert undo.calls == 1
+
+
+def test_resolve_node_id_by_title():
+    summary = {
+        "nodes": [
+            {"id": "image-1786157513657-20", "title": "换logo李宁", "type": "image", "status": "completed"},
+        ],
+    }
+    assert _resolve_node_id_by_title(summary, "换logo李宁") == "image-1786157513657-20"

--- a/services/agent-runtime/tests/test_explore_route.py
+++ b/services/agent-runtime/tests/test_explore_route.py
@@ -1,0 +1,34 @@
+"""Tests for explore routing signals."""
+
+from app.graph.explore_route import explore_canvas_signal, explore_explicit_intent
+
+
+def test_explicit_node_id_update_routes_explore():
+    u = "查询 prompt-1 节点，把它的 prompt 字段更新为 explore-set-prompt-测试文案"
+    assert explore_explicit_intent(u) is True
+
+
+def test_asset_library_query():
+    u = "查询我的资产库有哪些素材，列出名称和类型"
+    assert explore_explicit_intent(u) is True
+
+
+def test_atomic_gen_still_blocked():
+    u = "帮我在画布上生成一张产品主图"
+    assert explore_explicit_intent(u) is False
+    assert explore_canvas_signal(u, blocked_by_atomic=True) is False
+
+
+def test_upsert_without_gen():
+    u = "查询画布空白区域，添加一个 prompt 节点 explore-upsert-demo（不要触发出图）"
+    assert explore_explicit_intent(u) is True
+
+
+def test_cancel_generation_lifecycle():
+    u = "取消 image-16 节点上正在进行的生成任务"
+    assert explore_explicit_intent(u) is True
+
+
+def test_upload_media_explore_only():
+    u = "查询画布，把图片 URL 上传到画布加一个 image 节点（仅上传，不要出图）"
+    assert explore_explicit_intent(u) is True

--- a/services/agent-runtime/tests/test_route_decide_explore.py
+++ b/services/agent-runtime/tests/test_route_decide_explore.py
@@ -25,3 +25,31 @@ def test_explore_lifecycle_diagnostic():
     })
     d = decide_route(ctx)
     assert d["flow_mode"] == "explore_canvas"
+
+
+def test_set_node_prompt_before_atomic():
+    ctx = assemble_route_context({
+        "messages": [{
+            "role": "user",
+            "content": "查询 prompt-1 节点，把它的 prompt 字段更新为 explore-set-prompt-测试文案",
+        }],
+    })
+    d = decide_route(ctx)
+    assert d["flow_mode"] == "explore_canvas"
+    assert d["flow_mode"] != "atomic_create"
+
+
+def test_list_user_assets_explore():
+    ctx = assemble_route_context({
+        "messages": [{"role": "user", "content": "查询我的资产库有哪些素材"}],
+    })
+    d = decide_route(ctx)
+    assert d["flow_mode"] == "explore_canvas"
+
+
+def test_cancel_generation_explore():
+    ctx = assemble_route_context({
+        "messages": [{"role": "user", "content": "取消 image-16 节点上正在进行的生成任务"}],
+    })
+    d = decide_route(ctx)
+    assert d["flow_mode"] == "explore_canvas"


### PR DESCRIPTION
## Summary

Fixes explore 28-tool demo failures across three layers:

- **Graph/Route**: `explore_route.py` + explore-before-atomic in `route_decide.py` — existing-node ops (set_node_*, asset query, lifecycle) no longer hijacked by atomic_create
- **Loop/Prompt**: explore system prompt mandates tool use; nudge retry when LLM skips; deterministic fallback for undo/redo/focus/open_image_editor/introduce
- **Harness**: `apply_sidebar_attachments` coerces JSON-string list params; lifecycle tool schema clarifies node_id requirement

Also hardens `deploy/prod-explore-28-tools-demo.py` (per-tool thread, busy retry, wait for SSE done).

## LLM「会调、调对」— 本 PR vs 终态架构

| 层 | 本 PR (Phase 1) | 终态建议 (Phase 2+) |
|----|-----------------|---------------------|
| Route | 规则词表 + explore 优先 | Mandatory-tool 子路径：UI command / lifecycle / asset read  bypass LLM 自由度 |
| Loop | nudge + 确定性兜底 | Tool-required graph node：无 tool_call 不结束 |
| Harness | schema coercion + Proxy | 集成测试 gate：28-tool CI + param contract tests |
| Observability | demo script verdict tiers | metrics: `tool_called`, `wrong_route`, `param_error` per tool |

**原则**：路由和 mandatory dispatch 是 SSOT；prompt/nudge 是过渡补丁，不应长期依赖。

## Test plan

- [x] `pytest services/agent-runtime/tests/test_explore_route.py`
- [x] `pytest services/agent-runtime/tests/test_route_decide_explore.py`
- [x] `pytest services/agent-runtime/tests/test_explore_node.py`
- [x] `pytest services/agent-runtime/tests/test_route_decide.py`
- [ ] CI green
- [ ] Post-merge: redeploy agent-runtime + rerun `prod-explore-28-tools-demo.py`


Made with [Cursor](https://cursor.com)