### PR TITLE
feat(agent-runtime): explore mandatory dispatch for UI/lifecycle/asset (Phase 2a)

### DIFF
--- a/services/agent-runtime/app/graph/explore_dispatch.py
+++ b/services/agent-runtime/app/graph/explore_dispatch.py
@@ -1,0 +1,417 @@
+"""Explore intent classification and mandatory dispatch (Phase 2a)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from app.graph.canvas_commands import extract_canvas_commands
+from app.graph.explore_route import has_canvas_node_id_reference
+from app.graph.node_ref import resolve_node_ref, resolve_node_refs
+
+ExploreIntent = Literal[
+    "ui_command",
+    "lifecycle",
+    "asset_read",
+    "node_read",
+    "node_write",
+    "open_query",
+]
+
+MANDATORY_INTENTS = frozenset({"ui_command", "lifecycle", "asset_read"})
+
+_WRITE_VERBS = (
+    "更新",
+    "修改",
+    "设置",
+    "复制",
+    "上传",
+    "添加",
+    "保存",
+    "应用",
+    "attach",
+    "挂",
+    "导出",
+)
+_QUERY_VERBS = (
+    "看看",
+    "有哪些",
+    "列出",
+    "查询",
+    "检查",
+    "状态",
+    "什么情况",
+    "怎么样",
+)
+_MUTATE_VERBS = (
+    "更新",
+    "修改",
+    "设置",
+    "复制",
+    "上传",
+    "添加",
+    "保存",
+    "导出",
+    "引入",
+    "定位",
+    "撤销",
+    "重做",
+    "打开",
+    "挂",
+    "应用",
+    "attach",
+)
+_READ_VERBS = _QUERY_VERBS + ("诊断", "layout", "坐标", "位置", "详细信息")
+
+
+@dataclass
+class MandatoryExploreResult:
+    tool_results: list[Any] = field(default_factory=list)
+    canvas_commands: list[dict[str, Any]] = field(default_factory=list)
+    reply_text: str = ""
+    tools_called: list[str] = field(default_factory=list)
+
+
+def classify_explore_intent(user_text: str, *, summary: dict | None = None) -> ExploreIntent:
+    """Rule-based intent for explore dispatch (Phase 2a)."""
+    u = (user_text or "").strip()
+    if not u:
+        return "open_query"
+
+    if ("撤销" in u or "重做" in u) and ("画布" in u or "操作" in u or "撤销" in u):
+        return "ui_command"
+
+    if "精修" in u and ("打开" in u or "编辑器" in u or "编辑" in u):
+        return "ui_command"
+
+    if ("定位" in u or "视口" in u) and ("节点" in u or "「" in u or has_canvas_node_id_reference(u)):
+        return "ui_command"
+
+    if ("引入" in u or "侧栏" in u) and ("节点" in u or "「" in u or has_canvas_node_id_reference(u)):
+        return "ui_command"
+
+    if "取消" in u and any(x in u for x in ("生成", "任务", "回退", "fallback", "平台")):
+        return "lifecycle"
+
+    if "确认" in u and any(x in u for x in ("回退", "fallback", "平台")):
+        return "lifecycle"
+
+    if any(k in u for k in ("资产库", "素材库", "公共素材")):
+        if any(v in u for v in _QUERY_VERBS) and "保存" not in u:
+            return "asset_read"
+
+    has_node = has_canvas_node_id_reference(u) or "「" in u or (
+        isinstance(summary, dict)
+        and resolve_node_ref(u, summary) is not None
+    )
+
+    if has_node and any(v in u for v in _WRITE_VERBS):
+        return "node_write"
+
+    if has_node and any(v in u for v in _READ_VERBS):
+        return "node_read"
+
+    if any(v in u for v in _MUTATE_VERBS) and has_node:
+        return "node_write"
+
+    return "open_query"
+
+
+def _serialize_result(result: Any) -> str:
+    if isinstance(result, str):
+        return result
+    try:
+        return json.dumps(result, ensure_ascii=False, default=str)
+    except Exception:
+        return str(result)
+
+
+def _format_asset_reply(tool_name: str, result: Any) -> str:
+    if isinstance(result, dict) and result.get("error"):
+        return str(result.get("error"))
+    label = "公共素材库" if tool_name == "list_public_assets" else "我的资产库"
+    if isinstance(result, dict):
+        items = result.get("assets") or result.get("items") or []
+        if isinstance(items, list):
+            if not items:
+                return f"{label}暂无素材。"
+            names = []
+            for item in items[:8]:
+                if isinstance(item, dict):
+                    names.append(str(item.get("name") or item.get("label") or item.get("id") or ""))
+            preview = "、".join(n for n in names if n)
+            suffix = f"等共 {len(items)} 项" if len(items) > 8 else f"共 {len(items)} 项"
+            return f"{label}：{preview}（{suffix}）"
+    return f"已查询{label}。"
+
+
+def _lifecycle_user_message(result: Any) -> str | None:
+    if not isinstance(result, dict):
+        return None
+    err = str(result.get("error") or result.get("message") or "")
+    err_type = str(result.get("error_type") or "")
+    low = err.lower()
+    if "generationrecord" in low or "无进行" in err or "no generation" in low:
+        return "该节点无进行中的生成任务。"
+    if "fallback_pending" in low or "非 fallback" in err or "不在平台回退" in err:
+        return "该节点不在平台回退待确认状态。"
+    if err_type == "param_error" or "param" in err_type:
+        return "参数有误，请先查询该节点的生成状态后再重试。"
+    if result.get("ok"):
+        return None
+    return err or None
+
+
+async def _invoke_tool(
+    tools_by_name: dict[str, Any],
+    name: str,
+    args: dict[str, Any],
+    *,
+    canvas_commands: list[dict[str, Any]],
+    tool_results: list[Any],
+    tools_called: list[str],
+) -> Any:
+    tool = tools_by_name.get(name)
+    if tool is None:
+        result: Any = {"error": f"unknown tool: {name}"}
+    else:
+        result = await tool.ainvoke(args)
+    tools_called.append(name)
+    tool_results.append(result)
+    for cmd in extract_canvas_commands(result):
+        if cmd not in canvas_commands:
+            canvas_commands.append(cmd)
+    return result
+
+
+async def run_mandatory_explore(
+    intent: ExploreIntent,
+    user_text: str,
+    *,
+    summary: dict,
+    tools_by_name: dict[str, Any],
+) -> MandatoryExploreResult:
+    """Direct tool dispatch without LLM (UI / lifecycle / asset_read)."""
+    canvas_commands: list[dict[str, Any]] = []
+    tool_results: list[Any] = []
+    tools_called: list[str] = []
+
+    if intent == "ui_command":
+        return await _mandatory_ui(
+            user_text,
+            summary=summary,
+            tools_by_name=tools_by_name,
+            canvas_commands=canvas_commands,
+            tool_results=tool_results,
+            tools_called=tools_called,
+        )
+
+    if intent == "lifecycle":
+        return await _mandatory_lifecycle(
+            user_text,
+            summary=summary,
+            tools_by_name=tools_by_name,
+            canvas_commands=canvas_commands,
+            tool_results=tool_results,
+            tools_called=tools_called,
+        )
+
+    if intent == "asset_read":
+        return await _mandatory_asset(
+            user_text,
+            tools_by_name=tools_by_name,
+            canvas_commands=canvas_commands,
+            tool_results=tool_results,
+            tools_called=tools_called,
+        )
+
+    return MandatoryExploreResult(
+        reply_text="内部错误：非 mandatory intent",
+        canvas_commands=canvas_commands,
+        tool_results=tool_results,
+        tools_called=tools_called,
+    )
+
+
+async def _mandatory_ui(
+    user_text: str,
+    *,
+    summary: dict,
+    tools_by_name: dict[str, Any],
+    canvas_commands: list[dict[str, Any]],
+    tool_results: list[Any],
+    tools_called: list[str],
+) -> MandatoryExploreResult:
+    u = user_text or ""
+
+    if "撤销" in u and ("画布" in u or "操作" in u):
+        await _invoke_tool(
+            tools_by_name, "undo", {}, canvas_commands=canvas_commands,
+            tool_results=tool_results, tools_called=tools_called,
+        )
+        return MandatoryExploreResult(
+            tool_results=tool_results,
+            canvas_commands=canvas_commands,
+            reply_text="已撤销上一步画布操作。",
+            tools_called=tools_called,
+        )
+
+    if "重做" in u:
+        await _invoke_tool(
+            tools_by_name, "redo", {}, canvas_commands=canvas_commands,
+            tool_results=tool_results, tools_called=tools_called,
+        )
+        return MandatoryExploreResult(
+            tool_results=tool_results,
+            canvas_commands=canvas_commands,
+            reply_text="已重做画布操作。",
+            tools_called=tools_called,
+        )
+
+    if "精修" in u or ("打开" in u and "编辑器" in u):
+        node_id = resolve_node_ref(u, summary)
+        if not node_id:
+            return MandatoryExploreResult(
+                reply_text="请指定要精修的图片节点（如 image-16 或「节点标题」）。",
+            )
+        await _invoke_tool(
+            tools_by_name,
+            "open_image_editor",
+            {"node_id": node_id},
+            canvas_commands=canvas_commands,
+            tool_results=tool_results,
+            tools_called=tools_called,
+        )
+        return MandatoryExploreResult(
+            tool_results=tool_results,
+            canvas_commands=canvas_commands,
+            reply_text=f"已打开节点 {node_id} 的精修编辑器。",
+            tools_called=tools_called,
+        )
+
+    if "引入" in u or ("侧栏" in u and "节点" in u):
+        node_ids = resolve_node_refs(u, summary)
+        if not node_ids:
+            return MandatoryExploreResult(
+                reply_text="请指定要引入侧栏的节点（如 image-16 或「节点标题」）。",
+            )
+        await _invoke_tool(
+            tools_by_name,
+            "introduce_nodes_to_agent",
+            {"node_ids": node_ids},
+            canvas_commands=canvas_commands,
+            tool_results=tool_results,
+            tools_called=tools_called,
+        )
+        return MandatoryExploreResult(
+            tool_results=tool_results,
+            canvas_commands=canvas_commands,
+            reply_text=f"已将 {len(node_ids)} 个节点引入 Agent 侧栏上下文。",
+            tools_called=tools_called,
+        )
+
+    if "定位" in u or "视口" in u:
+        node_ids = resolve_node_refs(u, summary)
+        if not node_ids:
+            return MandatoryExploreResult(
+                reply_text="请指定要定位的节点（如 image-16 或「节点标题」）。",
+            )
+        if len(node_ids) == 1:
+            await _invoke_tool(
+                tools_by_name,
+                "focus_node",
+                {"node_id": node_ids[0]},
+                canvas_commands=canvas_commands,
+                tool_results=tool_results,
+                tools_called=tools_called,
+            )
+            reply = f"已将视口定位到节点 {node_ids[0]}。"
+        else:
+            await _invoke_tool(
+                tools_by_name,
+                "focus_nodes",
+                {"node_ids": node_ids},
+                canvas_commands=canvas_commands,
+                tool_results=tool_results,
+                tools_called=tools_called,
+            )
+            reply = f"已将视口定位到 {len(node_ids)} 个节点。"
+        return MandatoryExploreResult(
+            tool_results=tool_results,
+            canvas_commands=canvas_commands,
+            reply_text=reply,
+            tools_called=tools_called,
+        )
+
+    return MandatoryExploreResult(reply_text="未能识别 UI 操作，请说明定位、撤销、重做或精修等具体需求。")
+
+
+async def _mandatory_lifecycle(
+    user_text: str,
+    *,
+    summary: dict,
+    tools_by_name: dict[str, Any],
+    canvas_commands: list[dict[str, Any]],
+    tool_results: list[Any],
+    tools_called: list[str],
+) -> MandatoryExploreResult:
+    node_id = resolve_node_ref(user_text, summary)
+    if not node_id:
+        return MandatoryExploreResult(
+            reply_text="请指定节点 id（如 image-16），以便取消或确认生成任务。",
+        )
+
+    u = user_text or ""
+    if "确认" in u:
+        tool_name = "confirm_platform_fallback"
+        ok_msg = f"已确认节点 {node_id} 的平台回退继续。"
+    elif "取消" in u and any(x in u for x in ("回退", "fallback", "平台")):
+        tool_name = "cancel_platform_fallback"
+        ok_msg = f"已取消节点 {node_id} 的平台回退。"
+    else:
+        tool_name = "cancel_generation"
+        ok_msg = f"已取消节点 {node_id} 上的生成任务。"
+
+    result = await _invoke_tool(
+        tools_by_name,
+        tool_name,
+        {"node_id": node_id},
+        canvas_commands=canvas_commands,
+        tool_results=tool_results,
+        tools_called=tools_called,
+    )
+    err_msg = _lifecycle_user_message(result)
+    reply = err_msg if err_msg else ok_msg
+    return MandatoryExploreResult(
+        tool_results=tool_results,
+        canvas_commands=canvas_commands,
+        reply_text=reply,
+        tools_called=tools_called,
+    )
+
+
+async def _mandatory_asset(
+    user_text: str,
+    *,
+    tools_by_name: dict[str, Any],
+    canvas_commands: list[dict[str, Any]],
+    tool_results: list[Any],
+    tools_called: list[str],
+) -> MandatoryExploreResult:
+    u = user_text or ""
+    tool_name = "list_public_assets" if "公共" in u else "list_user_assets"
+    result = await _invoke_tool(
+        tools_by_name,
+        tool_name,
+        {},
+        canvas_commands=canvas_commands,
+        tool_results=tool_results,
+        tools_called=tools_called,
+    )
+    return MandatoryExploreResult(
+        tool_results=tool_results,
+        canvas_commands=canvas_commands,
+        reply_text=_format_asset_reply(tool_name, result),
+        tools_called=tools_called,
+    )

--- a/services/agent-runtime/app/graph/node_ref.py
+++ b/services/agent-runtime/app/graph/node_ref.py
@@ -18,6 +18,8 @@ _PREFIX_RANGE_PATTERN = re.compile(
     r"([\u4e00-\u9fff\w]+)(\d+)\s*(?:到|至|-)\s*(\d+)",
 )
 
+_QUERY_PREFIXES = ("查询", "看看", "列出", "检查", "定位")
+
 
 def extract_quoted_title(text: str) -> str | None:
     match = _QUOTED_TITLE_PATTERN.search(text or "")
@@ -65,6 +67,10 @@ def _resolve_prefix_range(text: str, summary: dict[str, Any] | None) -> list[str
     if not match:
         return []
     prefix, start_s, end_s = match.group(1), int(match.group(2)), int(match.group(3))
+    for qp in _QUERY_PREFIXES:
+        if prefix.startswith(qp):
+            prefix = prefix[len(qp) :]
+            break
     if end_s < start_s:
         start_s, end_s = end_s, start_s
     wanted_titles = {f"{prefix}{i}" for i in range(start_s, end_s + 1)}

--- a/services/agent-runtime/app/graph/node_ref.py
+++ b/services/agent-runtime/app/graph/node_ref.py
@@ -1,0 +1,134 @@
+"""Single source of truth for resolving canvas node references from user text."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from app.graph.explore_route import has_canvas_node_id_reference
+
+_NODE_ID_PATTERN = re.compile(
+    r"\b((?:prompt|image|text|video|audio|group)-[\w-]+)\b",
+    re.IGNORECASE,
+)
+
+_QUOTED_TITLE_PATTERN = re.compile(r"[「『\"]([^」』\"]+)[」』\"]")
+
+_PREFIX_RANGE_PATTERN = re.compile(
+    r"([\u4e00-\u9fff\w]+)(\d+)\s*(?:到|至|-)\s*(\d+)",
+)
+
+
+def extract_quoted_title(text: str) -> str | None:
+    match = _QUOTED_TITLE_PATTERN.search(text or "")
+    return match.group(1).strip() if match else None
+
+
+def _nodes_from_summary(summary: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(summary, dict):
+        return []
+    nodes = summary.get("nodes") or summary.get("nodeSummaries") or []
+    if not isinstance(nodes, list):
+        return []
+    return [n for n in nodes if isinstance(n, dict)]
+
+
+def _node_id_from_dict(node: dict[str, Any]) -> str | None:
+    nid = str(node.get("id") or node.get("nodeId") or "").strip()
+    return nid or None
+
+
+def _resolve_by_title_fragment(summary: dict[str, Any] | None, fragment: str) -> str | None:
+    frag = (fragment or "").strip()
+    if not frag:
+        return None
+    for node in _nodes_from_summary(summary):
+        node_title = str(node.get("title") or node.get("label") or "")
+        if frag in node_title or node_title in frag:
+            nid = _node_id_from_dict(node)
+            if nid:
+                return nid
+    return None
+
+
+def _first_explicit_node_id(text: str) -> str | None:
+    match = _NODE_ID_PATTERN.search(text or "")
+    return match.group(1) if match else None
+
+
+def _all_explicit_node_ids(text: str) -> list[str]:
+    return _NODE_ID_PATTERN.findall(text or "")
+
+
+def _resolve_prefix_range(text: str, summary: dict[str, Any] | None) -> list[str]:
+    match = _PREFIX_RANGE_PATTERN.search(text or "")
+    if not match:
+        return []
+    prefix, start_s, end_s = match.group(1), int(match.group(2)), int(match.group(3))
+    if end_s < start_s:
+        start_s, end_s = end_s, start_s
+    wanted_titles = {f"{prefix}{i}" for i in range(start_s, end_s + 1)}
+    out: list[str] = []
+    for node in _nodes_from_summary(summary):
+        title = str(node.get("title") or node.get("label") or "")
+        if title in wanted_titles:
+            nid = _node_id_from_dict(node)
+            if nid and nid not in out:
+                out.append(nid)
+    return out
+
+
+def resolve_node_ref(text: str, summary: dict[str, Any] | None) -> str | None:
+    """Resolve a single node id from user text and canvas summary."""
+    u = text or ""
+
+    explicit = _first_explicit_node_id(u)
+    if explicit:
+        return explicit
+
+    quoted = extract_quoted_title(u)
+    if quoted:
+        by_quote = _resolve_by_title_fragment(summary, quoted)
+        if by_quote:
+            return by_quote
+
+    for node in _nodes_from_summary(summary):
+        title = str(node.get("title") or node.get("label") or "")
+        if title and title in u:
+            nid = _node_id_from_dict(node)
+            if nid:
+                return nid
+
+    return None
+
+
+def resolve_node_refs(text: str, summary: dict[str, Any] | None) -> list[str]:
+    """Resolve zero or more node ids (explicit ids, prefix ranges, quoted titles)."""
+    u = text or ""
+    out: list[str] = []
+
+    for nid in _all_explicit_node_ids(u):
+        if nid not in out:
+            out.append(nid)
+    if out:
+        return out
+
+    for nid in _resolve_prefix_range(u, summary):
+        if nid not in out:
+            out.append(nid)
+    if out:
+        return out
+
+    quoted = extract_quoted_title(u)
+    if quoted:
+        single = _resolve_by_title_fragment(summary, quoted)
+        if single:
+            return [single]
+
+    single = resolve_node_ref(u, summary)
+    return [single] if single else []
+
+
+def text_has_node_reference(text: str) -> bool:
+    """True when text likely references an existing canvas node."""
+    return bool(has_canvas_node_id_reference(text) or extract_quoted_title(text))

--- a/services/agent-runtime/app/graph/nodes/explore.py
+++ b/services/agent-runtime/app/graph/nodes/explore.py
@@ -10,6 +10,11 @@ from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, Tool
 
 from app.errors import AgentToolError, from_exception
 from app.graph.canvas_commands import extract_canvas_commands
+from app.graph.explore_dispatch import (
+    MANDATORY_INTENTS,
+    classify_explore_intent,
+    run_mandatory_explore,
+)
 from app.tools.definitions import build_explore_tools
 
 MAX_EXPLORE_TOOL_ROUNDS = 4
@@ -197,6 +202,26 @@ def make_explore_node(*, llm: Any, nest: Any) -> Callable:
             summary = {"error": "无法拉取画布摘要"}
 
         user_text = _latest_user_text(state.get("messages") or []) or "看看画布状态"
+
+        intent = classify_explore_intent(user_text, summary=summary if isinstance(summary, dict) else None)
+        if intent in MANDATORY_INTENTS:
+            mandatory = await run_mandatory_explore(
+                intent,
+                user_text,
+                summary=summary if isinstance(summary, dict) else {},
+                tools_by_name=tools_by_name,
+            )
+            out: dict[str, Any] = {
+                "phase": "done",
+                "skill_id": None,
+                "user_decision": "none",
+                "messages": [AIMessage(content=mandatory.reply_text or "已完成操作。")],
+                "explore_summary": summary if isinstance(summary, dict) else None,
+            }
+            if mandatory.canvas_commands:
+                out["canvas_commands"] = mandatory.canvas_commands
+            return out
+
         convo: list[Any] = [
             SystemMessage(content=_EXPLORE_SYSTEM.format(summary=_serialize_tool_result(summary))),
             HumanMessage(content=user_text),

--- a/services/agent-runtime/tests/test_explore_dispatch.py
+++ b/services/agent-runtime/tests/test_explore_dispatch.py
@@ -1,0 +1,38 @@
+"""Tests for classify_explore_intent."""
+
+from app.graph.explore_dispatch import MANDATORY_INTENTS, classify_explore_intent
+
+SUMMARY = {
+    "nodes": [
+        {"id": "image-1786157513657-20", "title": "换logo李宁"},
+        {"id": "image-16", "title": "demo"},
+    ]
+}
+
+# Subset of deploy/prod-explore-28-tools-demo.py utterances
+CASES = [
+    ("查询画布，撤销上一步画布编辑操作", "ui_command"),
+    ("查询画布，重做刚才撤销的画布操作", "ui_command"),
+    ("查询「换logo李宁」节点，把视口定位到它", "ui_command"),
+    ("查询颜色变体1到4节点，把视口定位到它们", "ui_command"),
+    ("查询「换logo李宁」图片节点并打开精修编辑器", "ui_command"),
+    ("查询「换logo李宁」节点并引入到 Agent 侧栏对话上下文", "ui_command"),
+    ("取消 image-16 节点上正在进行的生成任务", "lifecycle"),
+    ("查询「让模特穿上这双鞋子」节点，取消这次平台回退 fallback", "lifecycle"),
+    ("查询「让模特穿上这双鞋子」节点，确认使用平台通道继续 fallback", "lifecycle"),
+    ("查询我的资产库有哪些素材，列出名称和类型", "asset_read"),
+    ("查询平台公共素材库有哪些内容", "asset_read"),
+    ("查询 prompt-1 节点，把它的 prompt 字段更新为 explore-set-prompt-测试文案", "node_write"),
+    ("查询节点 image-16 的详细信息，包括 url 和 status", "node_read"),
+    ("查询 image-16 这个节点当前的生成状态", "node_read"),
+    ("查询画布上有哪些节点？列出每个节点的类型和状态", "open_query"),
+]
+
+
+def test_mandatory_intents_set():
+    assert MANDATORY_INTENTS == frozenset({"ui_command", "lifecycle", "asset_read"})
+
+
+def test_classify_demo_utterances():
+    for text, expected in CASES:
+        assert classify_explore_intent(text, summary=SUMMARY) == expected, text

--- a/services/agent-runtime/tests/test_explore_mandatory.py
+++ b/services/agent-runtime/tests/test_explore_mandatory.py
@@ -1,0 +1,124 @@
+"""Integration tests for mandatory explore dispatch (no LLM)."""
+
+import pytest
+
+from app.graph.explore_dispatch import run_mandatory_explore
+
+SUMMARY = {
+    "nodes": [
+        {"id": "image-1786157513657-20", "title": "换logo李宁"},
+        {"id": "image-1786156321418-15", "title": "颜色变体1"},
+        {"id": "image-1786156321418-16", "title": "颜色变体2"},
+        {"id": "image-16", "title": "demo"},
+    ]
+}
+
+
+class FakeTool:
+    def __init__(self, name: str, result: dict) -> None:
+        self.name = name
+        self.result = result
+        self.calls: list[dict] = []
+
+    async def ainvoke(self, args: dict) -> dict:
+        self.calls.append(args)
+        return self.result
+
+
+
+@pytest.mark.asyncio
+async def test_mandatory_undo_emits_canvas_command():
+    tools = {
+        "undo": FakeTool("undo", {"ok": True, "canvasCommands": [{"type": "undo"}]}),
+    }
+    out = await run_mandatory_explore(
+        "ui_command",
+        "查询画布，撤销上一步画布编辑操作",
+        summary=SUMMARY,
+        tools_by_name=tools,
+    )
+    assert out.tools_called == ["undo"]
+    assert out.canvas_commands == [{"type": "undo"}]
+    assert tools["undo"].calls == [{}]
+
+
+@pytest.mark.asyncio
+async def test_mandatory_focus_node_by_title():
+    tools = {
+        "focus_node": FakeTool(
+            "focus_node",
+            {"ok": True, "canvasCommands": [{"type": "focus_node", "nodeId": "image-1786157513657-20"}]},
+        ),
+    }
+    out = await run_mandatory_explore(
+        "ui_command",
+        "查询「换logo李宁」节点，把视口定位到它",
+        summary=SUMMARY,
+        tools_by_name=tools,
+    )
+    assert out.tools_called == ["focus_node"]
+    assert tools["focus_node"].calls == [{"node_id": "image-1786157513657-20"}]
+    assert out.canvas_commands[0]["type"] == "focus_node"
+
+
+@pytest.mark.asyncio
+async def test_mandatory_focus_nodes_range():
+    tools = {
+        "focus_nodes": FakeTool(
+            "focus_nodes",
+            {"ok": True, "canvasCommands": [{"type": "focus_nodes", "nodeIds": ["a", "b"]}]},
+        ),
+    }
+    out = await run_mandatory_explore(
+        "ui_command",
+        "查询颜色变体1到4节点，把视口定位到它们",
+        summary=SUMMARY,
+        tools_by_name=tools,
+    )
+    assert out.tools_called == ["focus_nodes"]
+    assert len(tools["focus_nodes"].calls[0]["node_ids"]) >= 2
+
+
+@pytest.mark.asyncio
+async def test_mandatory_lifecycle_requires_node_id():
+    out = await run_mandatory_explore(
+        "lifecycle",
+        "取消正在进行的生成任务",
+        summary=SUMMARY,
+        tools_by_name={},
+    )
+    assert out.tools_called == []
+    assert "节点 id" in out.reply_text
+
+
+@pytest.mark.asyncio
+async def test_mandatory_cancel_generation():
+    tools = {
+        "cancel_generation": FakeTool("cancel_generation", {"ok": True}),
+    }
+    out = await run_mandatory_explore(
+        "lifecycle",
+        "取消 image-16 节点上正在进行的生成任务",
+        summary=SUMMARY,
+        tools_by_name=tools,
+    )
+    assert out.tools_called == ["cancel_generation"]
+    assert tools["cancel_generation"].calls == [{"node_id": "image-16"}]
+
+
+@pytest.mark.asyncio
+async def test_mandatory_list_user_assets():
+    tools = {
+        "list_user_assets": FakeTool(
+            "list_user_assets",
+            {"assets": [{"name": "logo.png"}, {"name": "bg.jpg"}]},
+        ),
+    }
+    out = await run_mandatory_explore(
+        "asset_read",
+        "查询我的资产库有哪些素材，列出名称和类型",
+        summary=SUMMARY,
+        tools_by_name=tools,
+    )
+    assert out.tools_called == ["list_user_assets"]
+    assert "logo.png" in out.reply_text

--- a/services/agent-runtime/tests/test_explore_mandatory_wiring.py
+++ b/services/agent-runtime/tests/test_explore_mandatory_wiring.py
@@ -1,0 +1,55 @@
+"""Tests for explore node mandatory dispatch wiring."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from app.graph.nodes.explore import make_explore_node
+
+
+@pytest.mark.asyncio
+async def test_explore_mandatory_skips_llm():
+    llm = MagicMock()
+    llm.bind_tools = MagicMock(return_value=llm)
+    llm.ainvoke = AsyncMock()
+
+    nest = MagicMock()
+    nest.get_canvas_summary = AsyncMock(
+        return_value={
+            "nodes": [{"id": "image-1786157513657-20", "title": "换logo李宁"}],
+        }
+    )
+
+    undo_tool = MagicMock()
+    undo_tool.ainvoke = AsyncMock(
+        return_value={"ok": True, "canvasCommands": [{"type": "undo"}]}
+    )
+
+    explore = make_explore_node(llm=llm, nest=nest)
+
+    # Patch build_explore_tools via explore module import path
+    import app.graph.nodes.explore as explore_mod
+
+    original_build = explore_mod.build_explore_tools
+    explore_mod.build_explore_tools = lambda _nest: [  # type: ignore[assignment]
+        MagicMock(name="undo", ainvoke=undo_tool.ainvoke),
+    ]
+    # StructuredTool needs .name
+    fake_undo = MagicMock()
+    fake_undo.name = "undo"
+    fake_undo.ainvoke = undo_tool.ainvoke
+    explore_mod.build_explore_tools = lambda _nest: [fake_undo]  # type: ignore[assignment]
+
+    try:
+        state = {
+            "messages": [HumanMessage(content="查询画布，撤销上一步画布编辑操作")],
+        }
+        result = await explore(state)
+    finally:
+        explore_mod.build_explore_tools = original_build
+
+    assert llm.ainvoke.await_count == 0
+    assert result.get("canvas_commands") == [{"type": "undo"}]
+    assert isinstance(result["messages"][0], AIMessage)
+    assert "撤销" in result["messages"][0].content

--- a/services/agent-runtime/tests/test_node_ref.py
+++ b/services/agent-runtime/tests/test_node_ref.py
@@ -1,0 +1,70 @@
+"""Tests for resolve_node_ref SSOT."""
+
+from app.graph.node_ref import (
+    extract_quoted_title,
+    resolve_node_ref,
+    resolve_node_refs,
+)
+
+SUMMARY = {
+    "nodes": [
+        {
+            "id": "image-1786157513657-20",
+            "title": "换logo李宁",
+            "type": "image",
+            "status": "completed",
+        },
+        {
+            "id": "image-1786156321418-15",
+            "title": "颜色变体1",
+            "type": "image",
+            "status": "completed",
+        },
+        {
+            "id": "image-1786156321418-16",
+            "title": "颜色变体2",
+            "type": "image",
+            "status": "completed",
+        },
+        {
+            "id": "prompt-1786156321418-99",
+            "title": "主文案",
+            "type": "prompt",
+            "status": "completed",
+        },
+    ]
+}
+
+
+def test_resolve_explicit_node_id():
+    assert resolve_node_ref("查询 image-16 状态", SUMMARY) == "image-16"
+    assert resolve_node_ref("更新 prompt-1786156321418-99 的 prompt", SUMMARY) == (
+        "prompt-1786156321418-99"
+    )
+
+
+def test_resolve_quoted_title():
+    assert extract_quoted_title("查询「换logo李宁」节点") == "换logo李宁"
+    assert extract_quoted_title('定位"主文案"') == "主文案"
+    assert resolve_node_ref("查询「换logo李宁」节点", SUMMARY) == "image-1786157513657-20"
+
+
+def test_resolve_title_substring_without_quotes():
+    assert resolve_node_ref("看看换logo李宁什么情况", SUMMARY) == "image-1786157513657-20"
+
+
+def test_resolve_node_refs_prefix_range():
+    ids = resolve_node_refs("颜色变体1到4", SUMMARY)
+    assert len(ids) >= 2
+    assert "image-1786156321418-15" in ids
+    assert "image-1786156321418-16" in ids
+
+
+def test_resolve_node_refs_comma_separated():
+    ids = resolve_node_refs("定位 image-1786156321418-15, image-1786156321418-16", SUMMARY)
+    assert ids == ["image-1786156321418-15", "image-1786156321418-16"]
+
+
+def test_resolve_no_match_returns_none():
+    assert resolve_node_ref("看看画布整体布局", SUMMARY) is None
+    assert resolve_node_refs("看看画布整体布局", SUMMARY) == []


### PR DESCRIPTION
## Summary
- Wave 2a: `node_ref.py` SSOT for node id/title/range resolution
- `explore_dispatch.py`: rule-based intent classification + mandatory tool dispatch (no LLM) for UI commands, lifecycle, and asset reads
- `explore.py`: mandatory path skips bind_tools loop; Phase 1 nudge/fallback retained for LLM branch (removed in 2d)

## Test plan
- [x] `cd services/agent-runtime && python3 -m pytest tests/test_explore*.py tests/test_node_ref.py tests/test_route_decide*.py -q` (36 passed)
- [x] `pnpm build`
- [ ] Merge + deploy agent-runtime
- [ ] `SESSION_ID=cmsjq3rpj005op801frieqj42 python3 deploy/prod-explore-28-tools-demo.py` — target pass ≥24/28


Made with [Cursor](https://cursor.com)