### PR TITLE
feat(agent-runtime): explore narrow bind and write loop gate (Phase 2b)

### DIFF
--- a/services/agent-runtime/app/graph/explore_dispatch.py
+++ b/services/agent-runtime/app/graph/explore_dispatch.py
@@ -9,6 +9,8 @@ from typing import Any, Literal
 from app.graph.canvas_commands import extract_canvas_commands
 from app.graph.explore_route import has_canvas_node_id_reference
 from app.graph.node_ref import resolve_node_ref, resolve_node_refs
+from app.tools.definitions import DEFAULT_WRITE_BIND, EXPLORE_READ_TOOLS, EXPLORE_WRITE_TOOLS
+from app.tools.tool_registry import EXPLORE_TOOL_NAMES
 
 ExploreIntent = Literal[
     "ui_command",
@@ -71,6 +73,38 @@ class MandatoryExploreResult:
     canvas_commands: list[dict[str, Any]] = field(default_factory=list)
     reply_text: str = ""
     tools_called: list[str] = field(default_factory=list)
+
+
+def select_narrow_write_tools(user_text: str) -> frozenset[str]:
+    """Pick ≤5 write tools from user_text keywords (Phase 2b narrow bind)."""
+    u = user_text or ""
+    low = u.lower()
+    if "prompt" in low or "prompt-" in low:
+        return frozenset({"set_node_prompt", "upsert_prompt_node"})
+    if "复制" in u:
+        return frozenset({"duplicate_node"})
+    if any(k in low for k in ("上传", "url", "picsum", "http")):
+        return frozenset({"upload_media_to_canvas"})
+    if any(k in low for k in ("attach", "参考", "侧栏", "localrefs")):
+        return frozenset({"attach_refs", "apply_sidebar_attachments"})
+    if "保存" in u and "资产" in u:
+        return frozenset({"save_node_to_asset_library"})
+    if "应用" in u and "资产" in u:
+        return frozenset({"apply_asset_to_node"})
+    if "text-" in low or "文案" in u:
+        return frozenset({"set_node_content", "set_node_prompt"})
+    return DEFAULT_WRITE_BIND
+
+
+def select_explore_tool_names(intent: ExploreIntent, user_text: str) -> frozenset[str]:
+    """Tool names to bind for LLM explore branch."""
+    if intent == "node_read":
+        return EXPLORE_READ_TOOLS
+    if intent == "node_write":
+        names = select_narrow_write_tools(user_text)
+        assert len(names) <= 5
+        return names
+    return EXPLORE_TOOL_NAMES
 
 
 def classify_explore_intent(user_text: str, *, summary: dict | None = None) -> ExploreIntent:

--- a/services/agent-runtime/app/graph/explore_dispatch.py
+++ b/services/agent-runtime/app/graph/explore_dispatch.py
@@ -116,7 +116,7 @@ def classify_explore_intent(user_text: str, *, summary: dict | None = None) -> E
     if ("撤销" in u or "重做" in u) and ("画布" in u or "操作" in u or "撤销" in u):
         return "ui_command"
 
-    if "精修" in u and ("打开" in u or "编辑器" in u or "编辑" in u):
+    if "精修" in u and ("打开" in u or "编辑器" in u):
         return "ui_command"
 
     if ("定位" in u or "视口" in u) and ("节点" in u or "「" in u or has_canvas_node_id_reference(u)):

--- a/services/agent-runtime/app/graph/nodes/explore.py
+++ b/services/agent-runtime/app/graph/nodes/explore.py
@@ -14,8 +14,9 @@ from app.graph.explore_dispatch import (
     MANDATORY_INTENTS,
     classify_explore_intent,
     run_mandatory_explore,
+    select_explore_tool_names,
 )
-from app.tools.definitions import build_explore_tools
+from app.tools.definitions import EXPLORE_WRITE_TOOLS, build_explore_tools
 
 MAX_EXPLORE_TOOL_ROUNDS = 4
 
@@ -59,6 +60,8 @@ _ASSET_NUDGE = "请调用 list_user_assets 或 list_public_assets 查询资产�
 _CANCEL_NUDGE = (
     "请调用 cancel_generation 或 cancel_platform_fallback，传入 node_id，不要让用户手动操作。"
 )
+
+_NODE_WRITE_CLARIFY = "未能更新节点，请提供节点 id（如 prompt-1）。"
 
 
 def _latest_user_text(messages: list[Any]) -> str:
@@ -192,9 +195,8 @@ async def _direct_focus_or_editor(
 
 def make_explore_node(*, llm: Any, nest: Any) -> Callable:
     async def explore(state: dict) -> dict:
-        tools = build_explore_tools(nest)
-        tools_by_name = {t.name: t for t in tools}
-        llm_bound = llm.bind_tools(tools)
+        all_tools = build_explore_tools(nest)
+        tools_by_name = {t.name: t for t in all_tools}
 
         try:
             summary = await nest.get_canvas_summary()
@@ -222,8 +224,17 @@ def make_explore_node(*, llm: Any, nest: Any) -> Callable:
                 out["canvas_commands"] = mandatory.canvas_commands
             return out
 
+        tool_names = select_explore_tool_names(intent, user_text)
+        bound_tools = [tools_by_name[n] for n in sorted(tool_names) if n in tools_by_name]
+        llm_bound = llm.bind_tools(bound_tools)
+
+        system_content = _EXPLORE_SYSTEM.format(summary=_serialize_tool_result(summary))
+        if intent == "node_write":
+            allowed = ", ".join(sorted(tool_names))
+            system_content += f"\n6. 本轮只允许调用下列工具之一：{allowed}。"
+
         convo: list[Any] = [
-            SystemMessage(content=_EXPLORE_SYSTEM.format(summary=_serialize_tool_result(summary))),
+            SystemMessage(content=system_content),
             HumanMessage(content=user_text),
         ]
 
@@ -231,12 +242,30 @@ def make_explore_node(*, llm: Any, nest: Any) -> Callable:
         canvas_commands: list[dict[str, Any]] = []
         called_tools: set[str] = set()
         nudged = False
+        write_retry_done = False
 
         for _ in range(MAX_EXPLORE_TOOL_ROUNDS):
             ai = await llm_bound.ainvoke(convo)
             tool_calls = getattr(ai, "tool_calls", None) or []
             if not tool_calls:
                 final_reply = str(getattr(ai, "content", "") or "").strip()
+                if (
+                    intent == "node_write"
+                    and not called_tools.intersection(EXPLORE_WRITE_TOOLS)
+                    and not write_retry_done
+                ):
+                    write_retry_done = True
+                    tool_names = select_explore_tool_names("node_write", user_text)
+                    bound_tools = [tools_by_name[n] for n in sorted(tool_names) if n in tools_by_name]
+                    llm_bound = llm.bind_tools(bound_tools)
+                    allowed = ", ".join(sorted(tool_names))
+                    convo.append(ai)
+                    convo.append(
+                        SystemMessage(
+                            content=f"必须调用下列写入工具之一完成操作：{allowed}。"
+                        )
+                    )
+                    continue
                 nudge = _pick_nudge(user_text, called_tools, canvas_commands)
                 if nudge and not nudged:
                     convo.append(ai)
@@ -289,6 +318,9 @@ def make_explore_node(*, llm: Any, nest: Any) -> Callable:
         canvas_commands = await _direct_focus_or_editor(
             user_text, summary, tools_by_name, called_tools, canvas_commands
         )
+
+        if intent == "node_write" and not called_tools.intersection(EXPLORE_WRITE_TOOLS):
+            final_reply = _NODE_WRITE_CLARIFY
 
         if not final_reply:
             final_reply = "已查询画布信息。如需继续操作，请说明具体节点或任务。"

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -165,3 +165,7 @@ class AgentRuntimeState(TypedDict, total=False):
     gen_failed_keys: Annotated[list[str] | None, reset_or_union]
     gen_needs_user_keys: Annotated[list[str] | None, reset_or_union]
     gen_fail_details: Annotated[dict[str, dict] | None, reset_or_merge]
+
+    # explore_canvas path (Phase 2)
+    explore_summary: dict | None
+    canvas_commands: list[dict] | None

--- a/services/agent-runtime/app/tools/definitions.py
+++ b/services/agent-runtime/app/tools/definitions.py
@@ -14,6 +14,37 @@ from app.tools.prompt_templates import (
 )
 from app.tools.tool_registry import EXPLORE_TOOL_NAMES, is_explore_tool
 
+EXPLORE_READ_TOOLS = frozenset({
+    "get_canvas_summary",
+    "get_node",
+    "get_canvas_layout",
+    "get_generation_status",
+    "get_generation_diagnostic",
+    "list_generation_tasks",
+    "get_image_edit_capabilities",
+    "export_media_package",
+})
+
+EXPLORE_WRITE_TOOLS = frozenset({
+    "set_node_prompt",
+    "set_node_content",
+    "attach_refs",
+    "upsert_prompt_node",
+    "duplicate_node",
+    "upload_media_to_canvas",
+    "apply_sidebar_attachments",
+    "save_node_to_asset_library",
+    "apply_asset_to_node",
+})
+
+DEFAULT_WRITE_BIND = frozenset({
+    "set_node_prompt",
+    "set_node_content",
+    "attach_refs",
+    "duplicate_node",
+    "upsert_prompt_node",
+})
+
 
 class UpsertPromptNodeInput(BaseModel):
     prompt: str = Field(description=UPSERT_PROMPT_NODE_PROMPT_FIELD)
@@ -651,6 +682,16 @@ def _all_tool_specs(client: NestCanvasClient) -> list[tuple[str, StructuredTool]
 def build_explore_tools(client: NestCanvasClient) -> list[StructuredTool]:
     """Tools bindable in explore sub-graph (read + light write + lifecycle)."""
     return [tool for name, tool in _all_tool_specs(client) if name in EXPLORE_TOOL_NAMES]
+
+
+def build_explore_tools_subset(
+    client: NestCanvasClient,
+    names: frozenset[str],
+) -> list[StructuredTool]:
+    """Build a filtered explore tool list (narrow bind)."""
+    allowed = names & EXPLORE_TOOL_NAMES
+    by_name = {name: tool for name, tool in _all_tool_specs(client) if name in allowed}
+    return [by_name[n] for n in sorted(by_name)]
 
 
 def build_canvas_tools(client: NestCanvasClient) -> list[StructuredTool]:

--- a/services/agent-runtime/tests/test_explore_dispatch.py
+++ b/services/agent-runtime/tests/test_explore_dispatch.py
@@ -16,6 +16,7 @@ CASES = [
     ("查询「换logo李宁」节点，把视口定位到它", "ui_command"),
     ("查询颜色变体1到4节点，把视口定位到它们", "ui_command"),
     ("查询「换logo李宁」图片节点并打开精修编辑器", "ui_command"),
+    ("查询「换logo李宁」这个图片节点支持哪些精修编辑模式？", "node_read"),
     ("查询「换logo李宁」节点并引入到 Agent 侧栏对话上下文", "ui_command"),
     ("取消 image-16 节点上正在进行的生成任务", "lifecycle"),
     ("查询「让模特穿上这双鞋子」节点，取消这次平台回退 fallback", "lifecycle"),

--- a/services/agent-runtime/tests/test_explore_narrow_bind.py
+++ b/services/agent-runtime/tests/test_explore_narrow_bind.py
@@ -1,0 +1,27 @@
+"""Tests for narrow bind tool selection (Phase 2b)."""
+
+from app.graph.explore_dispatch import select_explore_tool_names, select_narrow_write_tools
+from app.tools.definitions import EXPLORE_READ_TOOLS
+from app.tools.tool_registry import EXPLORE_TOOL_NAMES
+
+
+def test_node_read_binds_read_subset():
+    names = select_explore_tool_names("node_read", "查询 image-16 状态")
+    assert names == EXPLORE_READ_TOOLS
+    assert len(names) <= 10
+
+
+def test_node_write_narrow_by_prompt_keyword():
+    names = select_narrow_write_tools("查询 prompt-1 节点，更新 prompt 字段")
+    assert names == frozenset({"set_node_prompt", "upsert_prompt_node"})
+    assert len(names) <= 5
+
+
+def test_node_write_narrow_by_upload_keyword():
+    names = select_narrow_write_tools("上传 https://picsum.photos/512 到画布")
+    assert names == frozenset({"upload_media_to_canvas"})
+
+
+def test_open_query_binds_full_whitelist():
+    names = select_explore_tool_names("open_query", "查询画布上有哪些节点")
+    assert names == EXPLORE_TOOL_NAMES

--- a/services/agent-runtime/tests/test_explore_tools_subset.py
+++ b/services/agent-runtime/tests/test_explore_tools_subset.py
@@ -1,0 +1,30 @@
+"""Tests for explore tool subset builder (Phase 2b)."""
+
+from unittest.mock import MagicMock
+
+from app.tools.definitions import (
+    EXPLORE_READ_TOOLS,
+    EXPLORE_WRITE_TOOLS,
+    build_explore_tools_subset,
+)
+from app.tools.tool_registry import EXPLORE_TOOL_NAMES
+
+
+def test_read_subset_within_explore_whitelist():
+    tools = build_explore_tools_subset(MagicMock(), EXPLORE_READ_TOOLS)
+    names = {t.name for t in tools}
+    assert names == EXPLORE_READ_TOOLS
+    assert names <= EXPLORE_TOOL_NAMES
+
+
+def test_write_default_subset_at_most_five():
+    subset = frozenset({
+        "set_node_prompt",
+        "set_node_content",
+        "attach_refs",
+        "duplicate_node",
+        "upsert_prompt_node",
+    })
+    tools = build_explore_tools_subset(MagicMock(), subset)
+    assert len(tools) <= 5
+    assert {t.name for t in tools} <= EXPLORE_WRITE_TOOLS

--- a/services/agent-runtime/tests/test_explore_write_gate.py
+++ b/services/agent-runtime/tests/test_explore_write_gate.py
@@ -1,0 +1,48 @@
+"""Tests for node_write loop gate (Phase 2b)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from app.graph.nodes.explore import make_explore_node
+
+
+@pytest.mark.asyncio
+async def test_node_write_loop_gate_clarifies_after_empty_tool_calls():
+    llm = MagicMock()
+    llm.bind_tools = MagicMock(side_effect=lambda tools: llm)
+    llm.ainvoke = AsyncMock(
+        side_effect=[
+            AIMessage(content="好的，已更新。"),
+            AIMessage(content="仍然无法调用。"),
+        ]
+    )
+
+    nest = MagicMock()
+    nest.get_canvas_summary = AsyncMock(return_value={"nodes": []})
+
+    fake_tool = MagicMock()
+    fake_tool.name = "set_node_prompt"
+    fake_tool.ainvoke = AsyncMock(return_value={"ok": True})
+
+    import app.graph.nodes.explore as explore_mod
+
+    original = explore_mod.build_explore_tools
+    explore_mod.build_explore_tools = lambda _nest: [fake_tool]
+    try:
+        explore = make_explore_node(llm=llm, nest=nest)
+        result = await explore(
+            {
+                "messages": [
+                    HumanMessage(
+                        content="查询 prompt-1 节点，把 prompt 更新为 explore-set-prompt-测试"
+                    )
+                ],
+            }
+        )
+    finally:
+        explore_mod.build_explore_tools = original
+
+    assert llm.bind_tools.call_count >= 2
+    assert "未能更新节点" in result["messages"][0].content


### PR DESCRIPTION
## Summary
- `build_explore_tools_subset` + READ/WRITE tool constants
- `select_explore_tool_names` / `select_narrow_write_tools` for ≤5 write bind
- `node_write` loop gate: one narrow re-bind retry, then clarify message

## Test plan
- [x] `pytest tests/test_explore*.py tests/test_node_ref.py tests/test_route_decide*.py -q` (43 passed)
- [ ] Merge after 2a prod demo baseline
- [ ] Deploy + prod 28-tool demo (target pass ≥26)


Made with [Cursor](https://cursor.com)