### PR TITLE
fix(agent-runtime): persist explore canvas_commands in graph state

### DIFF
--- a/services/agent-runtime/app/graph/explore_dispatch.py
+++ b/services/agent-runtime/app/graph/explore_dispatch.py
@@ -82,7 +82,7 @@ def classify_explore_intent(user_text: str, *, summary: dict | None = None) -> E
     if ("撤销" in u or "重做" in u) and ("画布" in u or "操作" in u or "撤销" in u):
         return "ui_command"
 
-    if "精修" in u and ("打开" in u or "编辑器" in u or "编辑" in u):
+    if "精修" in u and ("打开" in u or "编辑器" in u):
         return "ui_command"
 
     if ("定位" in u or "视口" in u) and ("节点" in u or "「" in u or has_canvas_node_id_reference(u)):

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -165,3 +165,7 @@ class AgentRuntimeState(TypedDict, total=False):
     gen_failed_keys: Annotated[list[str] | None, reset_or_union]
     gen_needs_user_keys: Annotated[list[str] | None, reset_or_union]
     gen_fail_details: Annotated[dict[str, dict] | None, reset_or_merge]
+
+    # explore_canvas path (Phase 2)
+    explore_summary: dict | None
+    canvas_commands: list[dict] | None

--- a/services/agent-runtime/tests/test_explore_dispatch.py
+++ b/services/agent-runtime/tests/test_explore_dispatch.py
@@ -16,6 +16,7 @@ CASES = [
     ("查询「换logo李宁」节点，把视口定位到它", "ui_command"),
     ("查询颜色变体1到4节点，把视口定位到它们", "ui_command"),
     ("查询「换logo李宁」图片节点并打开精修编辑器", "ui_command"),
+    ("查询「换logo李宁」这个图片节点支持哪些精修编辑模式？", "node_read"),
     ("查询「换logo李宁」节点并引入到 Agent 侧栏对话上下文", "ui_command"),
     ("取消 image-16 节点上正在进行的生成任务", "lifecycle"),
     ("查询「让模特穿上这双鞋子」节点，取消这次平台回退 fallback", "lifecycle"),


### PR DESCRIPTION
## Summary
- LangGraph dropped `canvas_commands` / `explore_summary` because they were missing from `AgentRuntimeState`
- UI mandatory dispatch tools ran but SSE never emitted `canvas_command` (Wave 2a prod demo: 7 weak UI cases)
- Tighten 精修 classifier so `get_image_edit_capabilities` queries stay `node_read`

## Test plan
- [x] pytest explore suite green
- [ ] Merge + deploy agent-runtime
- [ ] Re-run `prod-explore-28-tools-demo.py` — expect UI 6项 + introduce upgrade to tool


Made with [Cursor](https://cursor.com)