### PR TITLE
fix(agent-runtime): explore redo/export/save intent hotfix

### DIFF
--- a/deploy/prod-explore-28-tools-demo.py
+++ b/deploy/prod-explore-28-tools-demo.py
@@ -160,7 +160,7 @@ DEMOS: list[DemoCase] = [
     ),
     DemoCase(
         "cancel_generation",
-        "取消 image-16 节点上正在进行的生成任务",
+        "查询并取消 image-16 节点上正在进行的生成任务",
         ["取消", "cancel", "image-16", "没有", "未", "idle", "无"],
         allow_skip=True,
     ),

--- a/services/agent-runtime/app/graph/explore_dispatch.py
+++ b/services/agent-runtime/app/graph/explore_dispatch.py
@@ -34,7 +34,6 @@ _WRITE_VERBS = (
     "应用",
     "attach",
     "挂",
-    "导出",
 )
 _QUERY_VERBS = (
     "看看",
@@ -131,14 +130,20 @@ def classify_explore_intent(user_text: str, *, summary: dict | None = None) -> E
     if "确认" in u and any(x in u for x in ("回退", "fallback", "平台")):
         return "lifecycle"
 
-    if any(k in u for k in ("资产库", "素材库", "公共素材")):
-        if any(v in u for v in _QUERY_VERBS) and "保存" not in u:
-            return "asset_read"
-
     has_node = has_canvas_node_id_reference(u) or "「" in u or (
         isinstance(summary, dict)
         and resolve_node_ref(u, summary) is not None
     )
+
+    if any(k in u for k in ("资产库", "素材库", "公共素材")):
+        if any(v in u for v in _QUERY_VERBS) and "保存" not in u and not has_node:
+            return "asset_read"
+
+    if has_node and "保存" in u and "资产库" in u:
+        return "node_write"
+
+    if has_node and "导出" in u:
+        return "node_read"
 
     if has_node and any(v in u for v in _WRITE_VERBS):
         return "node_write"
@@ -279,18 +284,6 @@ async def _mandatory_ui(
 ) -> MandatoryExploreResult:
     u = user_text or ""
 
-    if "撤销" in u and ("画布" in u or "操作" in u):
-        await _invoke_tool(
-            tools_by_name, "undo", {}, canvas_commands=canvas_commands,
-            tool_results=tool_results, tools_called=tools_called,
-        )
-        return MandatoryExploreResult(
-            tool_results=tool_results,
-            canvas_commands=canvas_commands,
-            reply_text="已撤销上一步画布操作。",
-            tools_called=tools_called,
-        )
-
     if "重做" in u:
         await _invoke_tool(
             tools_by_name, "redo", {}, canvas_commands=canvas_commands,
@@ -300,6 +293,18 @@ async def _mandatory_ui(
             tool_results=tool_results,
             canvas_commands=canvas_commands,
             reply_text="已重做画布操作。",
+            tools_called=tools_called,
+        )
+
+    if "撤销" in u and ("画布" in u or "操作" in u):
+        await _invoke_tool(
+            tools_by_name, "undo", {}, canvas_commands=canvas_commands,
+            tool_results=tool_results, tools_called=tools_called,
+        )
+        return MandatoryExploreResult(
+            tool_results=tool_results,
+            canvas_commands=canvas_commands,
+            reply_text="已撤销上一步画布操作。",
             tools_called=tools_called,
         )
 

--- a/services/agent-runtime/tests/test_explore_dispatch.py
+++ b/services/agent-runtime/tests/test_explore_dispatch.py
@@ -27,6 +27,8 @@ CASES = [
     ("查询节点 image-16 的详细信息，包括 url 和 status", "node_read"),
     ("查询 image-16 这个节点当前的生成状态", "node_read"),
     ("查询画布上有哪些节点？列出每个节点的类型和状态", "open_query"),
+    ("查询并导出「换logo李宁」节点的图片下载链接", "node_read"),
+    ("查询「换logo李宁」节点并保存到我的资产库", "node_write"),
 ]
 
 

--- a/services/agent-runtime/tests/test_explore_mandatory.py
+++ b/services/agent-runtime/tests/test_explore_mandatory.py
@@ -107,6 +107,23 @@ async def test_mandatory_cancel_generation():
 
 
 @pytest.mark.asyncio
+async def test_mandatory_redo_before_undo_when_both_present():
+    tools = {
+        "redo": FakeTool("redo", {"ok": True, "canvasCommands": [{"type": "redo"}]}),
+        "undo": FakeTool("undo", {"ok": True, "canvasCommands": [{"type": "undo"}]}),
+    }
+    out = await run_mandatory_explore(
+        "ui_command",
+        "查询画布，重做刚才撤销的画布操作",
+        summary=SUMMARY,
+        tools_by_name=tools,
+    )
+    assert out.tools_called == ["redo"]
+    assert out.canvas_commands == [{"type": "redo"}]
+    assert tools["undo"].calls == []
+
+
+@pytest.mark.asyncio
 async def test_mandatory_list_user_assets():
     tools = {
         "list_user_assets": FakeTool(


### PR DESCRIPTION
## Summary
- **redo**: mandatory UI checks 重做 before 撤销 (fixes weak redo)
- **export**: 导出 + node ref → `node_read` (fixes export_media_package regression)
- **save**: 保存到资产库 + node ref → `node_write` (not asset_read)
- Demo script: `cancel_generation` adds 查询 prefix

## Test plan
- [x] pytest explore dispatch/mandatory/narrow_bind (13 passed)
- [ ] Merge + deploy agent-runtime
- [ ] prod 28-tool demo — target pass ≥26


Made with [Cursor](https://cursor.com)