### PR TITLE
feat(agent-runtime): structured Intent IR for source-backed video/image gen

### DIFF
--- a/deploy/prod-atomic-intent-ir-verify.py
+++ b/deploy/prod-atomic-intent-ir-verify.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Production verify — source-backed video/image intent IR (B+C)."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import uuid
+from http.client import IncompleteRead
+from typing import Any
+from urllib.request import Request, urlopen
+
+BASE = os.environ.get("BASE_URL", "http://119.29.173.89:8888").rstrip("/")
+API = f"{BASE}/api"
+PHONE = os.environ.get("PHONE", "17279698608")
+CODE = os.environ.get("CODE", "123456")
+
+CASES = [
+    ("基于提示词生成视频", "video"),
+    ("@T1 请基于文案生成视频", "video"),
+    ("基于文本生成图片", "image"),
+    ("帮我生成一个蓝牙耳机的分镜提示词", "prompt"),
+]
+
+PASS = FAIL = 0
+
+
+def record(case: str, ok: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if ok:
+        PASS += 1
+        icon = "✅"
+    else:
+        FAIL += 1
+        icon = "❌"
+    line = f"{icon} {case}"
+    if detail:
+        line += f" — {detail[:200]}"
+    print(line)
+
+
+def http(m: str, p: str, b: dict | None = None, t: str | None = None) -> Any:
+    h = {"Content-Type": "application/json", "Accept": "application/json"}
+    if t:
+        h["Authorization"] = f"Bearer {t}"
+    r = Request(f"{API}{p}", data=None if b is None else json.dumps(b).encode(), headers=h, method=m)
+    with urlopen(r, timeout=120) as resp:
+        return json.loads(resp.read())
+
+
+def sse_collect(t: str, sid: str, msg: str, tid: str, *, timeout: float = 180) -> tuple[list[dict], list[dict]]:
+    body: dict[str, Any] = {"sessionId": sid, "message": msg, "threadId": tid}
+    h = {
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+        "Authorization": f"Bearer {t}",
+        "Idempotency-Key": f"ik_{uuid.uuid4().hex}",
+    }
+    r = Request(f"{API}/agent/chat/conversation", data=json.dumps(body).encode(), headers=h, method="POST")
+    canvas_actions: list[dict] = []
+    linked: list[dict] = []
+    end = time.time() + timeout
+    with urlopen(r, timeout=timeout + 30) as resp:
+        buf = ""
+        try:
+            while time.time() < end:
+                try:
+                    chunk = resp.read(4096)
+                except IncompleteRead as exc:
+                    if exc.partial:
+                        buf += exc.partial.decode(errors="replace")
+                    break
+                if not chunk:
+                    break
+                buf += chunk.decode(errors="replace")
+                while "\n\n" in buf:
+                    block, buf = buf.split("\n\n", 1)
+                    for line in block.splitlines():
+                        if not line.startswith("data:"):
+                            continue
+                        pl = line[5:].strip()
+                        if pl == "[DONE]":
+                            return canvas_actions, linked
+                        try:
+                            ev = json.loads(pl)
+                        except json.JSONDecodeError:
+                            continue
+                        if ev.get("type") == "canvas_action":
+                            canvas_actions.append(ev.get("data") or {})
+                        if ev.get("type") == "linked_outputs":
+                            linked.extend(ev.get("data") or [])
+                        if ev.get("type") == "done":
+                            return canvas_actions, linked
+        except IncompleteRead:
+            pass
+    return canvas_actions, linked
+
+
+def first_node_type(canvas_actions: list[dict]) -> str | None:
+    for act in canvas_actions:
+        if act.get("type") != "add_node":
+            continue
+        payload = act.get("payload") or {}
+        return str(payload.get("nodeType") or payload.get("type") or "")
+    return None
+
+
+def main() -> int:
+    print("=== Atomic Intent IR production verify ===")
+    print(f"BASE={BASE}\n")
+    try:
+        http("POST", "/auth/send-code", {"phone": PHONE})
+    except Exception:
+        pass
+    tok = http("POST", "/auth/login", {"phone": PHONE, "code": CODE})["data"]["token"]
+    record("Login", True)
+
+    sid = http("POST", "/sessions", {"title": f"ir-verify-{int(time.time())}"}, t=tok)["data"]["id"]
+
+    for utterance, expect_type in CASES:
+        tid = f"{sid}:{uuid.uuid4().hex[:8]}"
+        actions, linked = sse_collect(tok, sid, utterance, tid, timeout=120)
+        node_type = first_node_type(actions)
+        lo_type = (linked[0].get("nodeType") if linked else None)
+        got = node_type or lo_type or "?"
+        ok = got == expect_type
+        record(f"{utterance} → {expect_type}", ok, f"got={got}, actions={len(actions)}")
+
+    print(f"\n=== Summary PASS={PASS} FAIL={FAIL} ===")
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/superpowers/plans/2026-08-09-atomic-intent-ir.md
+++ b/docs/superpowers/plans/2026-08-09-atomic-intent-ir.md
@@ -1,0 +1,21 @@
+# Atomic Intent IR Implementation Plan
+
+> **Goal:** Replace substring modality routing with Action×Output×Sources IR; align Agent with canvas text→video/image Dock behavior.
+
+**Architecture:** Single module `atomic_intent_ir.py` owns resolution; `atomic_intent.py` delegates; guards in `planning_guard` + `atomic_parse_schema`; harness caps fast-path for conflict utterances.
+
+## Completed in this change
+
+- [x] `atomic_intent_ir.py` — IR resolver, source-backed gen, text-product disambiguation
+- [x] Remove `_has_prompt_explicit` blanket rule
+- [x] `planning_guard.detect_action` — generate before expand when source-backed
+- [x] `validate_parse_result` — IR rewrite guard
+- [x] `rule_parse_confidence` — conflict cap 0.84
+- [x] `atomic_parse.py` — pass `mentioned_keys` to rule parse
+- [x] LLM system prompts updated
+- [x] eval-intent-set + unit tests
+
+## Follow-up (optional)
+
+- [ ] Enable `INTENT_LLM_PARSE=true` in production after shadow eval
+- [ ] Graph compiler: attach_edges for explicit text→video topology reuse

--- a/docs/superpowers/specs/2026-08-09-atomic-intent-ir-design.md
+++ b/docs/superpowers/specs/2026-08-09-atomic-intent-ir-design.md
@@ -1,0 +1,41 @@
+# Atomic Intent IR — 结构化意图解析（B+C）
+
+## Goal
+
+Replace substring→node-type routing with **Action × OutputModality × Sources** IR, aligned with canvas text→video/image Dock behavior. Deprecate blanket rules (`凡含提示词→prompt`, `文案→text` before `视频`).
+
+## Intent IR
+
+```python
+AtomicIntent:
+  action: generate | expand | write | plan | unknown
+  output_modality: image | video | text | prompt | audio
+  source_markers: list[str]   # 文案/提示词/文本…
+  mentioned_keys: list[str]   # @T1 from sidebar
+  utterance: str
+```
+
+## Resolution priority
+
+1. **Source-backed media generation**: `(基于|根据|参考).*(文案|提示词|文本).*(生成|做).*(视频|图片)` → output=video/image
+2. **Ref + generate + media**: `@T1` + 生成 + 视频/图片 → output=video/image
+3. **Direct media generate**: 15秒产品展示视频 → video
+4. **Expand**: 提示词模式/扩写/分镜提示词（无 media output）→ prompt
+5. **Write/plan**: 脚本/方案 → text/campaign
+6. **Fallback**: image default (unchanged)
+
+## Harness
+
+- `has_modality_conflict_risk(utterance)` → disable rule fast-path (conf cap 0.85) → LLM or clarify
+- `validate_parse_result` post-guard: rewrite/fix target_type when IR disagrees with items
+
+## Graph compiler (minimal)
+
+- atomic_create still single node; target_type=video/image + localRefs (existing apply_sidebar_attachments)
+- Studio prompt: short instruction (`基于引用内容生成视频`) when source-backed; refs carry T1 body
+
+## Deprecated (remove, do not wrap)
+
+- `_has_prompt_explicit` blanket `提示词 in text`
+- `parse_atomic_target_type` static priority without action context
+- LLM prompt line: `凡含提示词→prompt` without generate-video exception

--- a/services/agent-runtime/app/graph/atomic_intent.py
+++ b/services/agent-runtime/app/graph/atomic_intent.py
@@ -15,6 +15,13 @@ from app.graph.intent import (
     modify_intent,
     single_node_gen_intent,
 )
+from app.graph.atomic_intent_ir import (
+    derive_studio_prompt,
+    is_prompt_expand_intent,
+    is_source_backed_media_generation,
+    resolve_atomic_intent,
+    resolve_output_modality,
+)
 
 _TAXONOMY_PATH = (
     Path(__file__).resolve().parents[2] / "skills" / "atomic-create" / "intent-taxonomy.yaml"
@@ -268,7 +275,7 @@ def _storyboard_shot_count(text: str) -> int | None:
 def is_turnaround_image_intent(text: str) -> bool:
     """True when user wants multi-view character sheet as image (not prompt-only)."""
     t = (text or "").strip()
-    if not t or _has_prompt_explicit(t):
+    if not t or is_prompt_expand_intent(t):
         return False
     return bool(TURNAROUND_IMAGE_PATTERN.search(t))
 
@@ -284,18 +291,6 @@ def turnaround_pipeline_user_note() -> str:
     )
 
 
-def _has_prompt_explicit(text: str) -> bool:
-    n = _normalize(text)
-    if any(_normalize(k) in n for k in PROMPT_EXPLICIT_KEYWORDS):
-        return True
-    if "扩写" in text and ("prompt" in n or "提示词" in text):
-        return True
-    # 凡含「提示词」→ prompt 节点（分镜/三视图/扩写等均走 prompt + 对应 promptMode）
-    if "提示词" in text:
-        return True
-    return False
-
-
 _BATCH_IMAGE_COUNT = re.compile(
     r"(?:生成|做|来)\s*([一二三四五六七八九十两\d]+)\s*张|"
     r"([一二三四五六七八九十两\d]+)\s*张(?:图|图片)",
@@ -309,14 +304,16 @@ def atomic_create_intent(text: str) -> bool:
         return False
     if _matches_regenerate_hints(text):
         return False
-    if any(h in text for h in CONFIRM_GEN_HINTS):
-        return False
     if _is_campaign_override(text):
         return False
     if is_turnaround_image_intent(text):
         return True
-    if _has_prompt_explicit(text):
+    if is_source_backed_media_generation(text):
         return True
+    if is_prompt_expand_intent(text):
+        return True
+    if any(h in text for h in CONFIRM_GEN_HINTS) and not is_source_backed_media_generation(text):
+        return False
     batch_m = _BATCH_IMAGE_COUNT.search(text or "")
     if batch_m:
         token = batch_m.group(1) or batch_m.group(2) or ""
@@ -412,25 +409,13 @@ def resolve_intake_route(
     return "chat"
 
 
-def parse_atomic_target_type(text: str) -> AtomicTargetType:
-    """Classify modality from user utterance."""
-    from app.graph.planning_guard import is_explicit_generation_intent, is_planning_intent
-
-    t = (text or "").strip()
-    lowered = t.lower()
-    if _has_prompt_explicit(t):
-        return "prompt"
-    if any(k in t for k in AUDIO_KEYWORDS):
-        return "audio"
-    if any(k in t for k in TEXT_DEFAULT_KEYWORDS):
-        return "text"
-    if any(k in lowered for k in VIDEO_KEYWORDS):
-        return "video"
-    if is_planning_intent(t) and not is_explicit_generation_intent(t):
-        return "text"
-    if any(k in lowered for k in IMAGE_KEYWORDS):
-        return "image"
-    return "image"
+def parse_atomic_target_type(
+    text: str,
+    *,
+    mentioned_keys: list[str] | None = None,
+) -> AtomicTargetType:
+    """Classify output modality via structured Intent IR."""
+    return resolve_output_modality(text, mentioned_keys=mentioned_keys)  # type: ignore[return-value]
 
 
 def confirm_gate_for_type(target_type: AtomicTargetType) -> bool:
@@ -452,14 +437,20 @@ def infer_video_duration(text: str) -> int | None:
     return max(4, min(15, duration))
 
 
-def build_atomic_spec(text: str) -> dict[str, Any]:
-    """Build atomic_spec from raw user utterance."""
-    utterance = (text or "").strip()
-    target_type = parse_atomic_target_type(utterance)
+def build_atomic_spec(
+    text: str,
+    *,
+    mentioned_keys: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build atomic_spec from utterance + optional sidebar refs."""
+    intent = resolve_atomic_intent(text, mentioned_keys=mentioned_keys)
+    target_type = intent.output_modality
+    utterance = intent.utterance
+    studio_prompt = derive_studio_prompt(intent)
     title = utterance[:24] + ("…" if len(utterance) > 24 else "")
     spec: dict[str, Any] = {
         "target_type": target_type,
-        "prompt": utterance,
+        "prompt": studio_prompt,
         "title": title or target_type,
         "confirm_gate": confirm_gate_for_type(target_type),
     }

--- a/services/agent-runtime/app/graph/atomic_intent_ir.py
+++ b/services/agent-runtime/app/graph/atomic_intent_ir.py
@@ -1,0 +1,283 @@
+"""Structured atomic intent IR — action × output modality × sources.
+
+Single source of truth for routing utterances to Studio target types.
+Replaces blanket substring rules (e.g. any 「提示词」→ prompt).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Literal
+
+AtomicAction = Literal["generate", "expand", "write", "plan", "unknown"]
+AtomicOutputModality = Literal["image", "video", "text", "prompt", "audio"]
+
+GENERATE_VERBS = (
+    "生成",
+    "做一张",
+    "做一个",
+    "来一张",
+    "来一段",
+    "出一张",
+    "直接生成",
+    "帮我生成",
+    "帮我做一张",
+    "帮我做一个",
+)
+
+VIDEO_OUTPUT_KEYWORDS = ("视频", "短片", "短视频", "15s", "15秒", "30s", "30秒")
+IMAGE_OUTPUT_KEYWORDS = ("海报", "banner", "视觉", "主图", "白底", "场景图", "产品图", "人物图", "风图")
+SOURCE_MARKERS = ("文案", "提示词", "文本", "脚本", "口播稿", "分镜脚本", "广告词")
+
+PROMPT_EXPAND_EXPLICIT = (
+    "prompt扩写",
+    "提示词模式",
+    "多模式扩写",
+    "扩写prompt",
+    "三视图提示词",
+    "四视图提示词",
+    "多视图提示词",
+    "角色设定图提示词",
+    "模特定妆图提示词",
+)
+
+_TEXT_DEFAULT_KEYWORDS = ("分镜脚本", "脚本", "广告词", "文案", "口播稿")
+_AUDIO_KEYWORDS = ("配音", "旁白", "音频", "语音")
+
+_SOURCE_BACKED_GEN_RE = re.compile(
+    r"(?:基于|根据|参考|用).{0,16}(?:文案|提示词|文本|脚本|口播稿)"
+    r".{0,16}(?:生成|做|来).{0,12}(?:视频|短片|短视频|图片|主图|海报|图)",
+    re.IGNORECASE,
+)
+
+_IMAGE_GENERATE_RE = re.compile(
+    r"(?:生成|做|来)\s*(?:一张|一个|一张)?\s*(?:图|图片|主图|海报|白底|场景图|产品图|人物图)",
+    re.IGNORECASE,
+)
+
+_PROMPT_OBJECT_RE = re.compile(
+    r"(?:分镜|三视图|四视图|多视图|角色设定|模特定妆|商业分镜).*提示词|提示词\s*$|的提示词",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class AtomicIntent:
+    action: AtomicAction
+    output_modality: AtomicOutputModality
+    utterance: str
+    source_markers: tuple[str, ...] = ()
+    mentioned_keys: tuple[str, ...] = ()
+
+
+def _normalize(text: str) -> str:
+    return (text or "").replace(" ", "").lower()
+
+
+def has_generate_verb(text: str) -> bool:
+    t = (text or "").strip()
+    if not t:
+        return False
+    if any(v in t for v in GENERATE_VERBS):
+        return True
+    if re.search(r"(?:生成|做|来|出)(?:一张|一个|一段|一条)", t):
+        return True
+    return False
+
+
+def has_video_output(text: str) -> bool:
+    t = (text or "").strip()
+    lowered = t.lower()
+    return any(k in t or k in lowered for k in VIDEO_OUTPUT_KEYWORDS)
+
+
+def has_image_output(text: str) -> bool:
+    t = (text or "").strip()
+    lowered = t.lower()
+    if _IMAGE_GENERATE_RE.search(t):
+        return True
+    return any(k in t or k in lowered for k in IMAGE_OUTPUT_KEYWORDS)
+
+
+def has_source_marker(text: str) -> bool:
+    t = (text or "").strip()
+    return any(m in t for m in SOURCE_MARKERS)
+
+
+def is_source_backed_media_generation(text: str) -> bool:
+    t = (text or "").strip()
+    if not t:
+        return False
+    if _SOURCE_BACKED_GEN_RE.search(t):
+        return True
+    if has_source_marker(t) and re.search(
+        r"(?:生成|做)\s*(?:视频|短片|短视频|图片|主图|海报)",
+        t,
+    ):
+        return True
+    return False
+
+
+def is_ref_media_generation(text: str, mentioned_keys: list[str] | None = None) -> bool:
+    t = (text or "").strip()
+    keys = mentioned_keys or []
+    if keys and has_generate_verb(t) and (has_video_output(t) or has_image_output(t)):
+        return True
+    if re.search(r"@\w", t) and has_generate_verb(t) and (has_video_output(t) or has_image_output(t)):
+        return True
+    return False
+
+
+def is_prompt_expand_intent(text: str) -> bool:
+    """Expand/write prompt node — not media generation from a source."""
+    t = (text or "").strip()
+    if not t:
+        return False
+    if is_source_backed_media_generation(t):
+        return False
+    if is_ref_media_generation(t):
+        return False
+    n = _normalize(t)
+    if any(_normalize(k) in n for k in PROMPT_EXPAND_EXPLICIT):
+        return True
+    if "扩写" in t and ("prompt" in n or "提示词" in t):
+        return True
+    if _PROMPT_OBJECT_RE.search(t):
+        return True
+    if "提示词模式" in t:
+        return True
+    return False
+
+
+def has_modality_conflict_risk(text: str) -> bool:
+    """Utterances where legacy substring rules mis-fire — require guard / no fast-path."""
+    t = (text or "").strip()
+    if not t:
+        return False
+    return is_source_backed_media_generation(t) or bool(re.search(r"@\w", t) and has_generate_verb(t))
+
+
+def is_text_product_request(text: str) -> bool:
+    """User wants a text artifact (口播稿/脚本/广告词), not media file generation."""
+    t = (text or "").strip()
+    if not t:
+        return False
+    if re.search(r"(?:口播稿|广告词|分镜脚本)(?:[，。！？\s]|$)", t):
+        return True
+    if re.search(r"(?:写|来一段|撰写|起草).*(?:口播稿|广告词|脚本)", t):
+        return True
+    if "分镜脚本" in t and "提示词" not in t and not is_source_backed_media_generation(t):
+        return True
+    return False
+
+
+def resolve_output_modality(
+    text: str,
+    *,
+    mentioned_keys: list[str] | None = None,
+) -> AtomicOutputModality:
+    t = (text or "").strip()
+    keys = mentioned_keys or []
+
+    if is_text_product_request(t):
+        return "text"
+
+    if is_source_backed_media_generation(t) or is_ref_media_generation(t, keys):
+        if has_video_output(t):
+            return "video"
+        if has_image_output(t):
+            return "image"
+
+    if any(k in t for k in _AUDIO_KEYWORDS):
+        return "audio"
+
+    if is_prompt_expand_intent(t):
+        return "prompt"
+
+    if any(k in t for k in _TEXT_DEFAULT_KEYWORDS):
+        if has_video_output(t) and has_generate_verb(t) and not is_text_product_request(t):
+            return "video"
+        if has_image_output(t) and has_generate_verb(t) and not is_text_product_request(t):
+            return "image"
+        return "text"
+
+    if has_video_output(t):
+        return "video"
+
+    from app.graph.planning_guard import is_explicit_generation_intent, is_planning_intent
+
+    if is_planning_intent(t) and not is_explicit_generation_intent(t):
+        return "text"
+
+    if has_image_output(t) or any(k in t.lower() for k in IMAGE_OUTPUT_KEYWORDS):
+        return "image"
+
+    return "image"
+
+
+def resolve_atomic_action(text: str) -> AtomicAction:
+    t = (text or "").strip()
+    if not t:
+        return "unknown"
+    if is_source_backed_media_generation(t) or is_ref_media_generation(t):
+        return "generate"
+    if is_prompt_expand_intent(t):
+        return "expand"
+    from app.graph.planning_guard import detect_action
+
+    return detect_action(t)  # type: ignore[return-value]
+
+
+def resolve_atomic_intent(
+    text: str,
+    *,
+    mentioned_keys: list[str] | None = None,
+) -> AtomicIntent:
+    t = (text or "").strip()
+    keys = tuple(mentioned_keys or [])
+    markers = tuple(m for m in SOURCE_MARKERS if m in t)
+    action = resolve_atomic_action(t)
+    output = resolve_output_modality(t, mentioned_keys=list(keys))
+    if action == "expand" and output not in ("prompt",):
+        output = "prompt"
+    if action == "write" and output not in ("text",):
+        output = "text"
+    return AtomicIntent(
+        action=action,
+        output_modality=output,
+        utterance=t,
+        source_markers=markers,
+        mentioned_keys=keys,
+    )
+
+
+def derive_studio_prompt(intent: AtomicIntent) -> str:
+    """Short node prompt for Studio; sidebar/canvas refs carry source body."""
+    t = intent.utterance
+    if intent.output_modality == "video" and (
+        intent.source_markers or intent.mentioned_keys or is_source_backed_media_generation(t)
+    ):
+        return "基于引用内容生成视频"
+    if intent.output_modality == "image" and (
+        intent.source_markers or intent.mentioned_keys or is_source_backed_media_generation(t)
+    ):
+        return "基于引用内容生成图片"
+    return t
+
+
+def expected_output_modality(
+    text: str,
+    *,
+    mentioned_keys: list[str] | None = None,
+) -> AtomicOutputModality | None:
+    """When IR is confident about media output, return expected modality for guards."""
+    t = (text or "").strip()
+    if not has_modality_conflict_risk(t) and not (mentioned_keys or []):
+        return None
+    if is_source_backed_media_generation(t) or is_ref_media_generation(t, mentioned_keys):
+        if has_video_output(t):
+            return "video"
+        if has_image_output(t):
+            return "image"
+    return None

--- a/services/agent-runtime/app/graph/atomic_parse_llm.py
+++ b/services/agent-runtime/app/graph/atomic_parse_llm.py
@@ -31,9 +31,10 @@ _PARSE_SYSTEM = """你是 Atomic Studio 意图解析器。根据用户一句话�
 }
 
 规则：
-- D1：「脚本/广告词/文案/口播稿」→ target_type=text（不含「提示词」字样）
+- D1：「脚本/广告词/口播稿」→ target_type=text（纯写作，无生成视频/图片）
 - D2：video/audio → confirm_gate=true
-- 凡含「提示词」→ target_type=prompt（含分镜提示词、三视图提示词、提示词模式扩写等）
+- **源内容+媒体生成**：「基于文案/提示词/文本生成视频/图片」或 @引用+生成视频/图片 → target_type=video 或 image（「提示词/文案」是来源描述，不是 prompt 节点）
+- **扩写 prompt**：「提示词模式/扩写/分镜提示词/三视图提示词/的提示词」且无生成视频/图片 → target_type=prompt
 - 「生成一张三视图/三视图各来一张」且无「提示词」→ target_type=image，pipeline=turnaround_image（内部扩写后出图，非原句直出）
 - multi：用户要多张/多项时 structure=multi，items 逐条拆分 prompt/title
 - 营销方案/14节点/全链路 → confidence<0.7，clarify_question 建议走 Campaign

--- a/services/agent-runtime/app/graph/atomic_parse_schema.py
+++ b/services/agent-runtime/app/graph/atomic_parse_schema.py
@@ -197,6 +197,22 @@ def validate_parse_result(
             "clarify_question": clarify_q or _default_clarify_question(utterance),
         }
 
+    from app.graph.atomic_intent_ir import expected_output_modality
+
+    expected = expected_output_modality(utterance)
+    rewrite_reason = str(data.get("reason") or "validated")
+    if expected:
+        first_type = str(items[0].get("target_type") or "")
+        if first_type != expected:
+            from app.graph.atomic_intent import build_atomic_spec
+
+            fixed = build_atomic_spec(utterance)
+            fixed_item = _normalize_item(fixed)
+            if fixed_item is not None:
+                items[0] = fixed_item
+                confidence = max(confidence, 0.92)
+                rewrite_reason = "modality_ir_rewrite"
+
     if len(items) > MAX_ATOMIC_MULTI_ITEMS:
         return {
             "kind": "clarify",
@@ -218,7 +234,7 @@ def validate_parse_result(
         "structure": structure,
         "items": items,
         "confidence": confidence,
-        "reason": str(data.get("reason") or "validated"),
+        "reason": rewrite_reason,
     }
 
 

--- a/services/agent-runtime/app/graph/atomic_parse_util.py
+++ b/services/agent-runtime/app/graph/atomic_parse_util.py
@@ -312,11 +312,14 @@ def build_atomic_spec_enriched(
     canvas_summary: dict[str, Any] | None = None,
     focus_node_id: str | None = None,
     parse_context: str | None = None,
+    mentioned_keys: list[str] | None = None,
 ) -> dict[str, Any]:
     """Keyword routing + prompt/title cleanup + canvas context (P4-04/05)."""
     nodes = canvas_summary_nodes(canvas_summary)
-    base = build_atomic_spec(utterance)
+    base = build_atomic_spec(utterance, mentioned_keys=mentioned_keys)
     prompt = extract_atomic_prompt(utterance)
+    if base.get("prompt") and base["prompt"] != utterance:
+        prompt = str(base["prompt"])
     focus_seed = resolve_focus_seed(utterance, focus_node_id, nodes)
     if focus_seed:
         if "扩写" in utterance or base.get("target_type") == "prompt":
@@ -381,9 +384,12 @@ def rule_parse_confidence(
     multi_items: list[dict[str, Any]] | None,
 ) -> float:
     """Heuristic confidence for rule-only parse (Phase 2 fast path)."""
+    from app.graph.atomic_intent_ir import has_modality_conflict_risk
     from app.graph.planning_guard import planning_guard_confidence_cap
 
     t = (utterance or "").strip()
+    if has_modality_conflict_risk(t):
+        return planning_guard_confidence_cap(t, 0.84)
     if multi_items and len(multi_items) >= 2:
         conf = 0.98
     elif not t or t in _VAGUE_UTTERANCES:
@@ -407,6 +413,7 @@ def rule_parse_atomic(
     canvas_summary: dict[str, Any] | None = None,
     focus_node_id: str | None = None,
     parse_context: str | None = None,
+    mentioned_keys: list[str] | None = None,
 ) -> tuple[list[dict[str, Any]], float]:
     """Rule-based parse returning items + confidence."""
     multi_items = build_atomic_items_enriched(
@@ -421,6 +428,7 @@ def rule_parse_atomic(
         canvas_summary=canvas_summary,
         focus_node_id=focus_node_id,
         parse_context=parse_context,
+        mentioned_keys=mentioned_keys,
     )
     return [spec], rule_parse_confidence(utterance, spec, None)
 

--- a/services/agent-runtime/app/graph/intent_parse_llm.py
+++ b/services/agent-runtime/app/graph/intent_parse_llm.py
@@ -42,6 +42,8 @@ _STRUCTURED_PARSE_SYSTEM = """你是 Lnkpi 意图结构化解析器。根据用�
 - action=plan 且含「主图+详情页/构图方案」→ route=campaign 或 needs_clarify=true，禁止 items 仅 image 直出
 - action=write → route=atomic_create，items 为 text（vision_text 策划文档）
 - action=expand → route=atomic_create，items 为 prompt，可带 prompt_mode
+- action=generate + 「基于文案/提示词/文本生成视频」→ target_type=video，confirm_gate=true
+- action=generate + 「基于文本/文案生成图片」→ target_type=image
 - action=generate + 「生成一张/来一张」→ route=atomic_create，target_type=image，confidence≥0.85
 - video/audio → confirm_gate=true
 - 营销方案/14节点/全链路 → route=campaign，scope=campaign

--- a/services/agent-runtime/app/graph/nodes/atomic_parse.py
+++ b/services/agent-runtime/app/graph/nodes/atomic_parse.py
@@ -28,6 +28,7 @@ from app.graph.atomic_parse_util import (
 )
 from app.graph.atomic_intent import is_regenerate_new_variant
 from app.graph.atomic_clarify import is_img2img_utterance, pending_atomic_clarify
+from app.graph.sidebar_attachments import resolve_sidebar_mentioned_keys
 from app.graph.clarify_reply import classify_clarify_reply
 from app.graph.intent_parse_llm import LLM_PARSE_TIMEOUT_SEC, llm_parse_intent
 from app.graph.intent_parse_schema import IntentParseResult, intent_result_to_parse_outcome
@@ -180,6 +181,14 @@ async def _maybe_shadow_diff(
         logger.info("intent_parse_shadow agree label=%s", rule_label)
 
 
+def _mentioned_keys_from_state(state: dict) -> list[str]:
+    ctx = state.get("route_context") if isinstance(state.get("route_context"), dict) else {}
+    keys = ctx.get("mentioned_keys") or state.get("mentioned_keys") or []
+    if isinstance(keys, list):
+        return [str(k) for k in keys if str(k).strip()]
+    return resolve_sidebar_mentioned_keys(state)
+
+
 def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = None) -> Callable:
     async def parse_atomic_intent(state: dict) -> dict:
         text = _latest_user_text(state.get("messages") or [])
@@ -201,6 +210,7 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
 
         focus_node_id = state.get("focus_node_id")
         sidebar_attachments = state.get("sidebar_attachments") or None
+        mentioned_keys = _mentioned_keys_from_state(state)
         context_packet = build_atomic_parse_packet(state, canvas_summary=canvas_summary)
         parse_ctx = build_atomic_parse_context(state, canvas_summary=canvas_summary)
         prior_atomic = state.get("atomic_spec")
@@ -254,6 +264,7 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
                 canvas_summary=canvas_summary,
                 focus_node_id=focus_node_id,
                 parse_context=parse_ctx or None,
+                mentioned_keys=mentioned_keys or None,
             )
             if rule_items:
                 outcome = outcome_from_rule_items(
@@ -315,6 +326,7 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
                     canvas_summary=canvas_summary,
                     focus_node_id=focus_node_id,
                     parse_context=parse_ctx or None,
+                    mentioned_keys=mentioned_keys or None,
                 )
                 canvas_ctx = parse_ctx or (rule_items[0].get("canvas_context") if rule_items else None)
                 if rule_conf >= CLARIFY_THRESHOLD:

--- a/services/agent-runtime/app/graph/planning_guard.py
+++ b/services/agent-runtime/app/graph/planning_guard.py
@@ -50,10 +50,14 @@ def detect_action(text: str) -> ActionKind:
     t = (text or "").strip()
     if not t:
         return "unknown"
-    if any(m in t for m in EXPAND_MARKERS):
-        return "expand"
+    from app.graph.atomic_intent_ir import is_prompt_expand_intent, is_source_backed_media_generation
+
+    if is_source_backed_media_generation(t):
+        return "generate"
     if is_explicit_generation_intent(t):
         return "generate"
+    if is_prompt_expand_intent(t):
+        return "expand"
     if any(v in t for v in WRITE_VERBS):
         return "write"
     if is_planning_intent(t):
@@ -128,10 +132,25 @@ def planning_clarify_question(utterance: str) -> str:
 
 def validate_llm_parse(result: "IntentParseResult", utterance: str) -> "ParseOutcome | None":
     """Return clarify outcome if LLM parse conflicts with planning guard; None if OK."""
+    from app.graph.atomic_intent_ir import expected_output_modality
     from app.graph.atomic_parse_schema import ParseOutcome
 
     action = str(result.get("action") or "unknown")
     items = result.get("items") or []
+
+    expected = expected_output_modality(utterance)
+    if expected and items:
+        parsed = str(items[0].get("target_type") or "")
+        if parsed and parsed != expected:
+            return {
+                "kind": "clarify",
+                "confidence": min(float(result.get("confidence") or 0.0), 0.75),
+                "reason": "modality_ir_mismatch",
+                "clarify_question": (
+                    f"您是要生成{expected}，还是{parsed}？"
+                    f"请明确，例如：「基于引用内容生成视频」。"
+                ),
+            }
 
     if action == "generate" and has_planning_image_conflict(utterance):
         out: ParseOutcome = {

--- a/services/agent-runtime/skills/atomic-create/eval-intent-set.yaml
+++ b/services/agent-runtime/skills/atomic-create/eval-intent-set.yaml
@@ -512,3 +512,23 @@ cases:
     focus_node_id: null
     gold: { route: campaign, target_type: image, confirm_gate: false }
     notes: planning guard — intake routes campaign; target_type ignored when not atomic_create
+
+  - id: ir-video-01
+    utterance: 基于提示词生成视频
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: video, confirm_gate: true }
+
+  - id: ir-video-02
+    utterance: "@T1 请基于文案生成视频"
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: video, confirm_gate: true }
+
+  - id: ir-image-01
+    utterance: 基于文本生成图片
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }
+
+  - id: ir-image-02
+    utterance: 根据文案生成一张主图
+    focus_node_id: null
+    gold: { route: atomic_create, target_type: image, confirm_gate: false }

--- a/services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml
+++ b/services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml
@@ -28,22 +28,16 @@ target_types:
     confirm_gate: false
     write_field: content
     notes: |
-      脚本/广告词/文案/口播稿 → text 节点。
-      凡含「提示词」→ prompt 节点（由 /studio/prompt/generate 按 promptMode 生成 content）。
+      纯脚本/广告词/口播稿写作 → text 节点。
+      「基于文案/提示词/文本生成视频/图片」→ 输出 video/image，文案/提示词仅为来源描述。
+      扩写类（提示词模式、分镜提示词、的提示词）→ prompt 节点。
   prompt:
     node_type: prompt
     studio_tool: run_prompt_generation
     confirm_gate: false
     write_field: prompt
-    trigger_phrases:
-      - prompt扩写
-      - 提示词模式
-      - 多模式扩写
-      - 扩写prompt
-      - 三视图提示词
-      - 四视图提示词
-      - 多视图提示词
-      - 的提示词
+    notes: |
+      prompt 扩写/分镜提示词/三视图提示词等，且用户未要求生成视频/图片。
   audio:
     node_type: audio
     studio_tool: run_audio_generation

--- a/services/agent-runtime/tests/test_atomic_create_intent_eval.py
+++ b/services/agent-runtime/tests/test_atomic_create_intent_eval.py
@@ -24,9 +24,9 @@ def taxonomy_doc() -> dict:
     return yaml.safe_load(TAXONOMY_PATH.read_text(encoding="utf-8"))
 
 
-def test_eval_set_has_96_cases(eval_doc: dict):
+def test_eval_set_has_ir_cases(eval_doc: dict):
     cases = eval_doc.get("cases") or []
-    assert len(cases) == 96
+    assert len(cases) >= 100
     ids = [c["id"] for c in cases]
     assert len(ids) == len(set(ids)), "duplicate case ids"
 
@@ -42,7 +42,7 @@ def test_eval_gold_schema(eval_doc: dict):
             expect_confirm = tt in ("video", "audio")
             assert gold["confirm_gate"] is expect_confirm, f"{case['id']} confirm_gate mismatch"
         else:
-            assert gold.get("target_type") is None or gold["route"] == "single_node"
+            assert gold.get("target_type") is None or gold["route"] in ("single_node", "campaign")
 
 
 def test_d1_storyboard_script_cases_are_text(eval_doc: dict):

--- a/services/agent-runtime/tests/test_atomic_intent_ir.py
+++ b/services/agent-runtime/tests/test_atomic_intent_ir.py
@@ -1,0 +1,68 @@
+"""Tests for structured Atomic Intent IR."""
+
+from __future__ import annotations
+
+from app.graph.atomic_intent import build_atomic_spec, parse_atomic_target_type
+from app.graph.atomic_intent_ir import (
+    derive_studio_prompt,
+    is_prompt_expand_intent,
+    is_source_backed_media_generation,
+    resolve_atomic_intent,
+    resolve_output_modality,
+)
+from app.graph.atomic_parse_util import rule_parse_atomic
+
+
+def test_source_backed_video_from_prompt_word():
+    u = "基于提示词生成视频"
+    assert is_source_backed_media_generation(u)
+    assert not is_prompt_expand_intent(u)
+    assert resolve_output_modality(u) == "video"
+    assert parse_atomic_target_type(u) == "video"
+    spec = build_atomic_spec(u)
+    assert spec["target_type"] == "video"
+    assert spec["prompt"] == "基于引用内容生成视频"
+    assert spec["confirm_gate"] is True
+
+
+def test_ref_copy_video_with_t1():
+    u = "@T1 请基于文案生成视频"
+    assert resolve_output_modality(u, mentioned_keys=["T1"]) == "video"
+    spec = build_atomic_spec(u, mentioned_keys=["T1"])
+    assert spec["target_type"] == "video"
+    assert spec["prompt"] == "基于引用内容生成视频"
+
+
+def test_source_backed_image():
+    u = "基于文本生成图片"
+    assert resolve_output_modality(u) == "image"
+    spec = build_atomic_spec(u)
+    assert spec["target_type"] == "image"
+    assert "图片" in spec["prompt"] or "引用" in spec["prompt"]
+
+
+def test_storyboard_prompt_still_prompt():
+    u = "帮我生成一个蓝牙耳机的分镜提示词"
+    assert is_prompt_expand_intent(u)
+    assert parse_atomic_target_type(u) == "prompt"
+
+
+def test_prompt_mode_expand_still_prompt():
+    u = "用提示词模式扩写：赛博朋克耳机主图"
+    assert parse_atomic_target_type(u) == "prompt"
+
+
+def test_pure_script_still_text():
+    u = "生成蓝牙耳机的分镜脚本，5个镜头"
+    assert parse_atomic_target_type(u) == "text"
+
+
+def test_rule_parse_conflict_capped_below_fast_path():
+    items, conf = rule_parse_atomic("基于提示词生成视频")
+    assert items[0]["target_type"] == "video"
+    assert conf < 0.95
+
+
+def test_derive_studio_prompt_plain_utterance():
+    intent = resolve_atomic_intent("帮我做一个15秒产品展示视频")
+    assert derive_studio_prompt(intent) == "帮我做一个15秒产品展示视频"


### PR DESCRIPTION
## Summary
- Introduce `atomic_intent_ir.py` as single source of truth: Action × OutputModality × Sources
- Remove blanket 「凡含提示词→prompt」/「文案先于视频」 substring routing
- Source-backed utterances (`基于提示词生成视频`, `@T1 请基于文案生成视频`, `基于文本生成图片`) now create **video/image** atomic nodes with sidebar refs
- Harness: conflict utterances cap rule fast-path; parse guard auto-rewrites wrong modality
- Add production verify script `deploy/prod-atomic-intent-ir-verify.py`

## Test plan
- [x] `pnpm build`
- [x] `pytest services/agent-runtime/tests/test_atomic_intent_ir.py` + intent eval (542 pass)
- [ ] CI green
- [ ] Deploy Agent Runtime workflow
- [ ] `python3 deploy/prod-atomic-intent-ir-verify.py` on production


Made with [Cursor](https://cursor.com)