### PR TITLE
feat(agent-runtime): remove implicit marketing route (P0 partial T1–T4)

### DIFF
--- a/docs/superpowers/plans/2026-08-09-sidebar-ref-image-routing-full.md
+++ b/docs/superpowers/plans/2026-08-09-sidebar-ref-image-routing-full.md
@@ -1,0 +1,500 @@
+# Agent 侧栏引用生图路由 — 全量实施计划（P0 + P1 + P2）
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 按 [design spec](../specs/2026-08-09-sidebar-ref-image-routing-design.md) 完成 P0 止血、P1 Route Unification 架构收敛、P2 执行层对齐；修复 `@T1 请按风格3出图` 及同类路由/clarify 断裂，建立 Cascade Router + precedence 表 + eval 契约，禁止再堆 hint 表。
+
+**Architecture:** P0 在现有 `decide_route` 上叠 IR 扩展、ref fast path、统一 `clarify_context`；P1 引入 `route_features` + `route_precedence` + `clarify_gate`，`decide_route` 瘦身为 orchestrator；P2 统一 `GenerationRequest` 与 IR slots。LLM 仅 L2 parse，L0 无 LLM。
+
+**Tech Stack:** Python 3.11+, LangGraph, pytest, YAML eval sets (`eval-route-set.yaml`, `eval-intent-set.yaml`), `deploy/prod-*-verify.py`
+
+**Spec:** [2026-08-09-sidebar-ref-image-routing-design.md](../specs/2026-08-09-sidebar-ref-image-routing-design.md)
+
+## Global Constraints
+
+- 满足 design §3 全部 `R-*`、§9 全部 `RU-*`、验收 AC-01–AC-07；不得回退 PR #197 video IR
+- P0 合并后 **禁止** 向 `MARKETING_HINTS` / `ATOMIC_CREATE_HINTS` 新增 permanent 条目（§9.17）
+- route 澄清 follow-up **禁止** default chat（R-CL-05）
+- atomic image：`prompt` + `localRefs` 分离（R-ALIGN-01）
+- P1 后 `decide_route` **零** substring hint 路由（§9.16）
+- 路由 PR 必须附带 `eval-route-set` case 或更新期望（RU-8）
+- 工作目录：`services/agent-runtime/`；`pytest tests/ -q` 全绿方可 claim 阶段完成
+- 每 Task 结束独立 commit；TDD 顺序：失败测试 → 实现 → 通过
+
+## 文件结构（终态，design §4 + §9.11）
+
+```text
+services/agent-runtime/app/graph/
+├── atomic_intent_ir.py       # L1 IR SoT
+├── route_context.py          # RouteContext 组装
+├── route_features.py         # [P1] extract_route_features
+├── route_precedence.py       # [P1] apply_route_precedence + RULES
+├── route_decide.py           # L0 orchestrator（P1 refactor）
+├── clarify_context.py        # [P0/P1] ClarifyContext + pending_clarify
+├── generation_request.py     # [P2] GenerationRequest DTO
+├── intent.py                 # MARKETING_HINTS（P1c 路由用途删除）
+├── atomic_intent.py          # P1c 路由 bool 删除
+├── atomic_clarify.py         # → clarify_context 迁移
+├── clarify_reply.py
+├── nodes/
+│   ├── intake.py
+│   ├── clarify_route.py      # P0 → P1 委托 clarify_gate
+│   ├── clarify_gate.py       # [P1] 统一 clarify
+│   ├── clarify_atomic_intent.py  # P1 合并进 clarify_gate
+│   └── atomic_parse.py
+└── builder.py                # clarify_gate 边
+
+skills/atomic-create/
+├── eval-route-set.yaml       # Harness CI
+└── eval-intent-set.yaml
+
+deploy/
+├── prod-atomic-intent-ir-verify.py
+└── prod-route-unification-verify.py  # [P1]
+```
+
+---
+
+## 需求覆盖索引
+
+| 规格 ID | Phase | Task |
+|---------|-------|------|
+| R-IR-01~05 | P0 | T1, T2 |
+| R-L1-01~04 | P0 | T3, T4 |
+| R-CL-01~05 | P0 | T5, T6, T7, T8 |
+| R-ALIGN-01~03 | P0/P2 | T2, T9, T22 |
+| R-PARSE-01~02 | P0 | T10 |
+| R-UX-01~04 | P0/P1 | T11, T18 |
+| RU-1~10 | P1 | T12–T21 |
+| AC-01~AC-07 | P0/P1 | T10, T11, T17, T21 |
+| Q1–Q5, E1–E10 | 全阶段 | 见上表 |
+
+---
+
+# Phase 0 — 止血（design §0–§8）
+
+> **退出标准：** AC-01–AC-07 全绿；`pytest tests/ -q`；prod style3 case
+
+---
+
+### T1: IR — `出图` / `按风格N`（R-IR-01~04）
+
+**Files:** `atomic_intent_ir.py`, `tests/test_atomic_intent_ir_ref_image.py`
+
+**Produces:** `is_ref_media_generation("@T1 请按风格3出图", ["T1"]) == True`
+
+- [ ] **Step 1:** 写失败测试（`test_has_generate_verb_chutu`, `test_ref_media_generation_t1_chutu`, `test_resolve_atomic_intent_style3`）
+- [ ] **Step 2:** `pytest tests/test_atomic_intent_ir_ref_image.py -v` → FAIL
+- [ ] **Step 3:** `GENERATE_VERBS` 增 `出图`/`出一张图`/`生成图`；`has_image_output` 增 `出图`/`按风格\d`；`is_ref_media_generation` 前置 T*+出图/风格N 分支
+- [ ] **Step 4:** pytest PASS
+- [ ] **Step 5:** `git commit -m "feat(agent-runtime): IR 出图/按风格N + T ref media gen"`
+
+---
+
+### T2: `derive_studio_prompt` 保留 utterance（R-IR-05, R-ALIGN-01）
+
+**Files:** `atomic_intent_ir.py`, `tests/test_atomic_intent_ir_ref_image.py`
+
+- [ ] **Step 1:** `test_derive_studio_prompt_keeps_style3_utterance` → FAIL
+- [ ] **Step 2:** `derive_studio_prompt`：有 `mentioned_keys` 且 utterance 非仅 `@\w+` → 返回原 utterance
+- [ ] **Step 3:** pytest PASS
+- [ ] **Step 4:** commit
+
+---
+
+### T3: `出图` demote + `atomic_create_intent` 同步（R-L1-01, R-ALIGN-03, E1）
+
+**Files:** `intent.py`, `atomic_intent.py`, `tests/test_marketing_intent_chutu.py`
+
+- [ ] **Step 1:**
+
+```python
+def test_chutu_alone_not_marketing():
+    assert not marketing_intent("@T1 请按风格3出图")
+
+def test_chutu_is_atomic_create():
+    assert atomic_create_intent("@T1 请按风格3出图")
+
+def test_detail_page_still_marketing():
+    assert marketing_intent("帮我做天猫详情页营销方案")
+```
+
+- [ ] **Step 2:** 从 `MARKETING_HINTS` 删除 `"出图"`；`atomic_create_intent` 增 `出图|出一张图|生成图` 分支（排除 CONFIRM_GEN）
+- [ ] **Step 3:** `pytest tests/test_marketing_intent_chutu.py tests/test_atomic_create_intent.py -q` PASS
+- [ ] **Step 4:** commit
+
+---
+
+### T4: L0 `_sidebar_ref_atomic_signal` fast path（R-L1-02~04, E3, E10）
+
+**Files:** `route_decide.py`, `tests/test_route_sidebar_ref_atomic.py`
+
+- [ ] **Step 1:**
+
+```python
+CTX = {
+    "utterance": "@T1 请按风格3出图",
+    "mentioned_keys": ["T1"],
+    "sidebar_attachments": [{"refKey": "T1", "mediaType": "text"}],
+    "checkpoint": {},
+}
+
+def test_style3_routes_atomic():
+    d = decide_route(CTX)
+    assert d["flow_mode"] == "atomic_create"
+    assert d["reason"] == "sidebar_ref_atomic"
+```
+
+- [ ] **Step 2:** 实现 `_text_mentioned_keys`、`_sidebar_ref_atomic_signal`；插入 `_sidebar_img2img_signal` 之后；orch 降级块跳过 ref atomic
+- [ ] **Step 3:** pytest PASS + `tests/test_route_decide.py`
+- [ ] **Step 4:** commit
+
+---
+
+### T5: `clarify_context` 模块 + `pending_clarify`（R-CL-01 基础, E4）
+
+**Files:** Create `clarify_context.py`；Modify `atomic_clarify.py`, `state.py`, `tests/test_pending_clarify.py`
+
+**Produces:** `pending_clarify(state)` 接受 `kind=route_orchestration|atomic_parse|img2img_confirm`
+
+- [ ] **Step 1:** 新建 `clarify_context.py`：
+
+```python
+ClarifyKind = Literal["route_orchestration", "atomic_parse", "img2img_confirm"]
+
+class ClarifyContext(TypedDict, total=False):
+    kind: ClarifyKind
+    original_utterance: str
+    clarify_question: str
+    mentioned_keys: list[str]
+    sidebar_attachment_ref_keys: list[str]
+    clarify_kind: str
+
+_VALID_KINDS = frozenset({"atomic_parse", "route_orchestration", "img2img_confirm"})
+
+def pending_clarify(state: dict) -> ClarifyContext | None: ...
+def pending_atomic_clarify(state: dict) -> ClarifyContext | None:
+    return pending_clarify(state)
+```
+
+- [ ] **Step 2:** `atomic_clarify.py` 委托 `clarify_context.pending_clarify`
+- [ ] **Step 3:** `state.py` 注释/字段 `clarify_context: dict | None`
+- [ ] **Step 4:** `test_pending_route_orchestration` + `test_pending_atomic_parse_still_works` PASS
+- [ ] **Step 5:** commit
+
+---
+
+### T6: `clarify_route` 写 checkpoint（R-CL-01, E8）
+
+**Files:** `nodes/clarify_route.py`, `tests/test_clarify_route_checkpoint.py`
+
+- [ ] **Step 1:** async test 期望 `clarify_context.kind==route_orchestration`, `phase==clarify`, `flow_mode!=chat`
+- [ ] **Step 2:** 实现：从 `route_context`/`sidebar_*` snapshot；`route_clarify=True`
+- [ ] **Step 3:** pytest PASS
+- [ ] **Step 4:** commit
+
+---
+
+### T7: `classify_clarify_reply` 继承 original（R-CL-03, E5, E9）
+
+**Files:** `clarify_reply.py`, `tests/test_clarify_reply.py`
+
+- [ ] **Step 1:** `test_clarify_reply_choice_1_inherits_original_style3` → prompt == `"@T1 请按风格3出图"`
+- [ ] **Step 2:** choice 1：`prompt = original_utterance.strip() or "生成一张主图"`
+- [ ] **Step 3:** pytest PASS
+- [ ] **Step 4:** commit
+
+---
+
+### T8: `intake` route clarify follow-up（R-CL-02, R-CL-05, E4, E9）
+
+**Files:** `nodes/intake.py`, `tests/test_route_clarify_followup.py`
+
+**Consumes:** `pending_clarify`, `classify_clarify_reply`  
+**Produces:** `pre_parsed_intent: IntentParseResult | None`（可选 shortcut）
+
+- [ ] **Step 1:**
+
+```python
+@pytest.mark.asyncio
+async def test_intake_reply_1_after_route_clarify():
+    out = await intake({
+        "messages": [HumanMessage(content="1")],
+        "clarify_context": {
+            "kind": "route_orchestration",
+            "original_utterance": "@T1 请按风格3出图",
+            "clarify_question": "回复 1/2/3",
+            "mentioned_keys": ["T1"],
+        },
+        "sidebar_mentioned_keys": ["T1"],
+    })
+    assert out["flow_mode"] == "atomic_create"
+    assert out.get("clarify_question") is None
+```
+
+- [ ] **Step 2:** `decide_route` **之前**处理 `pending_clarify` + `route_orchestration` + classify≠none
+- [ ] **Step 3:** choice 1 → `flow_mode=atomic_create`, `clarify_context=None`, 恢复 `sidebar_mentioned_keys`；可选 `pre_parsed_intent`
+- [ ] **Step 4:** choice 2 → campaign；choice 3 → atomic_create + vision_text item
+- [ ] **Step 5:** `atomic_parse.py` 开头：若 `state.get("pre_parsed_intent")` → shortcut parse_outcome
+- [ ] **Step 6:** pytest PASS + `tests/test_graph_routes.py`
+- [ ] **Step 7:** commit
+
+---
+
+### T9: Dock/侧栏 parity 文档 + atomic_create prompt 路径（R-ALIGN-01~02）
+
+**Files:** `nodes/atomic_parse.py`, `atomic_parse_schema.py`（确认 prompt 来自 derive_studio_prompt）
+
+- [ ] **Step 1:** 集成测试 `test_atomic_create_style3_prompt_and_refs`：mock nest，assert create 调用 prompt 含「按风格3」
+- [ ] **Step 2:** 确认 `parse_outcome_to_state` / create 节点使用 IR prompt
+- [ ] **Step 3:** commit
+
+---
+
+### T10: Eval cases + rule parse 风格 N（R-PARSE-01~02, AC-01~04）
+
+**Files:** `eval-route-set.yaml`, `eval-intent-set.yaml`, `atomic_parse_util.py`（若需）
+
+- [ ] **Step 1:** `eval-route-set.yaml` 增：
+
+```yaml
+- id: sidebar-t1-style3-atomic
+  messages: [{ role: user, content: "@T1 请按风格3出图" }]
+  sidebar: { mentioned_keys: ["T1"] }
+  expect: { flow_mode: atomic_create, reason: sidebar_ref_atomic }
+
+- id: tmall-detail-campaign-clarify
+  messages: [{ role: user, content: "帮我做天猫详情页营销方案出图" }]
+  expect: { flow_mode: clarify_route }
+```
+
+- [ ] **Step 2:** `eval-intent-set.yaml` 增 `sidebar-t1-style3-image`
+- [ ] **Step 3:** `rule_parse_atomic` 保留 utterance 中 `按风格(\d+)`
+- [ ] **Step 4:** 跑 eval harness / pytest schema tests
+- [ ] **Step 5:** commit
+
+---
+
+### T11: UX — clarify 文案 + thinking_summary + ref 确认（R-UX-01~04, R-CL-04, E6）
+
+**Files:** `route_decide.py`, `nodes/intake.py`, `nodes/clarify_route.py`, `nodes/atomic_parse.py`
+
+- [ ] **Step 1:** 更新 `ROUTE_CLARIFY_ORCHESTRATION`（选项 1 含「保留 @T*」）
+- [ ] **Step 2:** `needs_route_clarify` 时 `thinking_summary="待确认：单张出图还是完整编排"`
+- [ ] **Step 3:** clarify 消息 append「已看到引用 T1」（有 attachment 时）
+- [ ] **Step 4:** follow-up 失败路径：`intake` 返回明确错误 AIMessage，非 chat 节点
+- [ ] **Step 5:** atomic 成功 `thinking_summary="将创建 image 节点，引用 T1"`
+- [ ] **Step 6:** commit
+
+---
+
+### T12: P0 生产验证 + 全量回归
+
+**Files:** `deploy/prod-atomic-intent-ir-verify.py`
+
+- [ ] **Step 1:** 增 case `sidebar_t1_style3_image`
+- [ ] **Step 2:** `cd services/agent-runtime && pytest tests/ -q` 全绿
+- [ ] **Step 3:** 手动 AC-02：clarify → `1` → 非 chat
+- [ ] **Step 4:** commit；**打 tag / Issue 链 P1**
+
+---
+
+# Phase 1a — Route Features + Precedence（shadow）
+
+> **退出标准：** shadow 一致率 ≥99% on eval-route-set（design §9.12）
+
+---
+
+### T13: `route_features.py`（RU-3, RU-6）
+
+**Files:** Create `route_features.py`, `tests/test_route_features.py`
+
+**Produces:** `extract_route_features(ctx: RouteContext, intent: AtomicIntent) -> RouteFeatures`
+
+- [ ] **Step 1:** 失败测试覆盖 §9.8.2 全部字段（style3 ctx → `has_text_ref=True`, `orchestration_phrases=False`）
+- [ ] **Step 2:** 实现：从 `mentioned_keys`/`attachments`/`checkpoint`/`utterance` 提取；`orchestration_phrases` 用短语表（详情页/全链路/分镜），**不含**单字出图
+- [ ] **Step 3:** pytest PASS
+- [ ] **Step 4:** commit
+
+---
+
+### T14: `route_precedence.py` — 11 行策略表（RU-4, RU-5）
+
+**Files:** Create `route_precedence.py`, `tests/test_route_precedence.py`
+
+**Produces:** `apply_route_precedence(intent, features, ctx, *, pending_clarify_reply=None) -> RouteDecision`
+
+- [ ] **Step 1:** 每行 `rule_id` 一条单测（§9.9 表 1–11）
+- [ ] **Step 2:** 实现 `PRECEDENCE_RULES` 列表，首匹配返回；输出含 `precedence_rule_id`
+- [ ] **Step 3:** `ref_backed_generate` 测 style3；`orch_ambiguous` 测 AC-04
+- [ ] **Step 4:** commit
+
+---
+
+### T15: Shadow diff harness（RU-8, §9.14）
+
+**Files:** `route_decide.py`, `tests/test_route_shadow_diff.py`, `app/settings.py`
+
+- [ ] **Step 1:** `decide_route_legacy(ctx)` 重命名现有逻辑；新 `decide_route_unified(ctx)` 调 features+precedence
+- [ ] **Step 2:** `ROUTE_SHADOW_MODE` 时双跑，log diff（flow_mode, reason）
+- [ ] **Step 3:** 对 `eval-route-set.yaml` 全 case shadow；断言一致率 ≥99%
+- [ ] **Step 4:** commit
+
+---
+
+# Phase 1b — 切换 + clarify_gate
+
+> **退出标准：** §9.16 前 4 项；eval-route-set CI required
+
+---
+
+### T16: `decide_route` 切换到 unified（RU-1, RU-2）
+
+**Files:** `route_decide.py`, `tests/test_route_decide.py`
+
+- [ ] **Step 1:** `decide_route` 默认调 `decide_route_unified`；legacy 仅测试/fixture
+- [ ] **Step 2:** 删除 P0 临时 `_sidebar_ref_atomic_signal`（逻辑已在 precedence 4）
+- [ ] **Step 3:** 全量 pytest PASS
+- [ ] **Step 4:** commit
+
+---
+
+### T17: `clarify_gate` 统一子图（RU-7, §9.6）
+
+**Files:** Create `nodes/clarify_gate.py`, `builder.py`, `nodes/clarify_route.py`, `nodes/clarify_atomic_intent.py`
+
+- [ ] **Step 1:** `make_clarify_gate_node()`：写 `clarify_context`、phase=clarify、honest trace、**禁止** flow_mode=chat
+- [ ] **Step 2:** `builder.py`：`clarify_route` + `clarify_atomic_intent` → 均指向 `clarify_gate`（或 deprecate 旧节点为 thin wrapper）
+- [ ] **Step 3:** `tests/test_clarify_gate_unified.py`：route + atomic 两路径同结构 checkpoint
+- [ ] **Step 4:** commit
+
+---
+
+### T18: Execution trace 字段（§9.14, R-UX）
+
+**Files:** `nodes/intake.py`, `app/runs.py` 或 trace emitter
+
+- [ ] **Step 1:** `route_decision` 写入 `precedence_rule_id`, `route_features`, `atomic_intent` snapshot
+- [ ] **Step 2:** 集成测试 assert trace delta 含字段
+- [ ] **Step 3:** commit
+
+---
+
+### T19: eval-route-set CI 门禁（RU-8）
+
+**Files:** `.github/workflows/*` 或现有 CI, `tests/test_eval_route_set.py`
+
+- [ ] **Step 1:** 扩展 eval-route-set 至 ≥30 cases（img2img/video/explore/regression/clarify）
+- [ ] **Step 2:** CI job `pytest tests/test_eval_route_set.py` required
+- [ ] **Step 3:** commit
+
+---
+
+### T20: `prod-route-unification-verify.py`
+
+**Files:** `deploy/prod-route-unification-verify.py`
+
+- [ ] **Step 1:** 迁移 style3 + video + img2img cases
+- [ ] **Step 2:** 文档 README 一行用法
+- [ ] **Step 3:** commit
+
+---
+
+# Phase 1c — 废止 hint 路由
+
+> **退出标准：** §9.16 全部；§9.13 废止清单完成
+
+---
+
+### T21: 删除路由用 bool 分类器（RU-10, §9.13）
+
+**Files:** `intent.py`, `atomic_intent.py`, `route_decide.py`, 全测试
+
+- [ ] **Step 1:** grep 确认 `marketing_intent` 仅 orchestration feature / 非 L0 路由
+- [ ] **Step 2:** 删除 `decide_route` 内 `marketing_intent`/`atomic_create_intent`/`orchestration_complexity_intent` 调用
+- [ ] **Step 3:** `decide_route_legacy` 删除或移 test/fixtures
+- [ ] **Step 4:** `pytest tests/ -q` + eval-route-set
+- [ ] **Step 5:** 更新 [platform-route-skill-boundary](../specs/2026-08-07-platform-route-skill-boundary-design.md) 增 R-S9
+- [ ] **Step 6:** commit
+
+---
+
+# Phase 2 — GenerationRequest + Slots（design §9.12 P2）
+
+> **退出标准：** AC-05 字段级 parity；IR slots `style=3`
+
+---
+
+### T22: `generation_request.py` DTO（RU-9, R-ALIGN-02）
+
+**Files:** Create `generation_request.py`, `tests/test_generation_request.py`
+
+- [ ] **Step 1:**
+
+```python
+def build_generation_request_from_atomic_state(state: dict) -> GenerationRequest:
+    """侧栏 atomic 路径：prompt + refs + mentioned_keys."""
+    ...
+
+def build_generation_request_from_dock(node, upstream, refs, mentioned_keys) -> GenerationRequest:
+    """文档/测试用：与 web useNodeGeneration 字段对齐."""
+    ...
+```
+
+- [ ] **Step 2:** parity test：同语义 style3 侧栏 vs dock 构造 equal keys
+- [ ] **Step 3:** commit
+
+---
+
+### T23: IR slots `style` / `ref`（§9.8.3 P2, R-PARSE-01 增强）
+
+**Files:** `atomic_intent_ir.py`, `tests/test_atomic_intent_ir_ref_image.py`
+
+- [ ] **Step 1:** `resolve_atomic_intent` 解析 `按风格(\d+)` → `slots={"style": "3"}`
+- [ ] **Step 2:** pytest PASS
+- [ ] **Step 3:** commit
+
+---
+
+### T24: P2 eval + 文档收尾
+
+- [ ] **Step 1:** eval-intent-set 增 slots 期望
+- [ ] **Step 2:** design spec 状态改为 Implemented
+- [ ] **Step 3:** 最终 `pytest tests/ -q` + prod verify
+
+---
+
+## 阶段里程碑与合并策略
+
+| 里程碑 | Tasks | PR 建议 | 合并条件 |
+|--------|-------|---------|----------|
+| **M0 P0** | T1–T12 | `fix/sidebar-ref-image-routing-p0` | AC-01–07 + pytest |
+| **M1 P1a** | T13–T15 | `feat/route-unification-shadow` | shadow ≥99% |
+| **M2 P1b** | T16–T20 | `feat/route-unification-switch` | CI eval-route-set |
+| **M3 P1c** | T21 | `refactor/route-unification-cleanup` | §9.16 全绿 |
+| **M4 P2** | T22–T24 | `feat/generation-request-parity` | AC-05 parity |
+
+**依赖：** M1 依赖 M0；M2 依赖 M1；M3 依赖 M2；M4 可与 M3 并行（仅依赖 M0 prompt/refs 行为）。
+
+---
+
+## 计划自检（全部完成后勾选）
+
+- [ ] design §3 全部 R-* 有 Task
+- [ ] design §9 全部 RU-* 有 Task（T12–T21）
+- [ ] AC-01–AC-07 有明确验证 Task
+- [ ] Q1–Q5、E1–E10 覆盖索引已满足
+- [ ] 无 TBD / placeholder 步骤
+- [ ] P0 未新增 permanent hint 条目
+- [ ] P1c 后零 substring 路由
+
+---
+
+## 执行选项
+
+**Plan saved to:** `docs/superpowers/plans/2026-08-09-sidebar-ref-image-routing-full.md`
+
+**1. Subagent-Driven（推荐）** — 按 M0→M4 里程碑派生子 agent，里程碑间 review  
+**2. Inline Execution** — 本会话从 T1 顺序执行，每里程碑 checkpoint
+
+**Legacy P0-only plan（已 supersede）：** [2026-08-09-sidebar-ref-image-routing.md](./2026-08-09-sidebar-ref-image-routing.md)

--- a/docs/superpowers/plans/2026-08-09-sidebar-ref-image-routing.md
+++ b/docs/superpowers/plans/2026-08-09-sidebar-ref-image-routing.md
@@ -1,0 +1,720 @@
+# Agent 侧栏引用生图路由与澄清续接 — 实现计划（P0 only）
+
+> **Superseded by:** [2026-08-09-sidebar-ref-image-routing-full.md](./2026-08-09-sidebar-ref-image-routing-full.md)（含 P0+P1+P2 全量 24 Tasks）  
+> 本文档保留作 P0 Task 1–10 详细代码参考；新执行请用 full plan。
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 修复 `@T1 请按风格3出图` 的 L1 路由误判与 route 澄清回复断裂，使侧栏「引用 + 指令」与 Dock 语义对齐，并覆盖诊断清单 Q1–Q5 及 E1–E10 全部项。
+
+**Architecture:** 在 Intent IR 上增量扩展词表与 `is_ref_media_generation`；`decide_route` 新增 `_sidebar_ref_atomic_signal` 优先于 `marketing_intent`；统一 `clarify_context` checkpoint 使 route/atomic 澄清 follow-up 经 `classify_clarify_reply` 恢复 original + refs；eval + 生产脚本回归 AC-01–AC-07。
+
+**Tech Stack:** Python 3.11+, LangGraph agent-runtime, pytest, YAML eval sets, `deploy/prod-atomic-intent-ir-verify.py`
+
+**Spec:** [2026-08-09-sidebar-ref-image-routing-design.md](../specs/2026-08-09-sidebar-ref-image-routing-design.md)
+
+## Global Constraints
+
+- 规格需求 R-L1-01–R-UX-04、验收 AC-01–AC-07 均须满足；不得回退 PR #197 video IR 行为
+- `出图` 不得单独触发 `marketing_intent`（R-L1-01）
+- route 澄清 follow-up 禁止落入 default chat（R-CL-05）
+- atomic image：`prompt` + `localRefs` 分离，与 Dock 一致（R-ALIGN-01）
+- 每个 Task 独立可测；Task 内 TDD；每 Task 结束 commit
+- 测试命令根目录：`services/agent-runtime/`；`pytest tests/ -q` 全绿方可 claim 完成
+
+---
+
+## 问题覆盖索引（实施时勾选）
+
+| ID | Task | 覆盖 |
+|----|------|------|
+| Q1, E1, E2, E10 | Task 1–3 | IR + marketing hint |
+| Q1, E3, E10 | Task 4 | L1 ref atomic signal |
+| Q2, E3 | Task 5, 9 | Dock 对齐 eval |
+| Q3, E4, E8, E9 | Task 6–8 | clarify checkpoint |
+| Q4 全项 | Task 1–10 | 分散见各 Task |
+| Q5, E5, E6 | Task 8, 10 | UX copy + trace |
+| E7 | Task 2, 5 | 风格 N + prompt 保留 |
+| AC-01–AC-07 | Task 9–10 | eval + prod verify |
+
+---
+
+### Task 1: IR — `出图` / `按风格N` 词表扩展
+
+**覆盖:** Q1, E2, R-IR-01, R-IR-02, R-IR-03
+
+**Files:**
+- Create: `services/agent-runtime/tests/test_atomic_intent_ir_ref_image.py`
+- Modify: `services/agent-runtime/app/graph/atomic_intent_ir.py`
+
+**Interfaces:**
+- Produces: `has_generate_verb("请按风格3出图") -> True`; `is_ref_media_generation(u, ["T1"]) -> True`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# tests/test_atomic_intent_ir_ref_image.py
+from app.graph.atomic_intent_ir import (
+    has_generate_verb,
+    has_image_output,
+    is_ref_media_generation,
+    resolve_atomic_intent,
+)
+
+STYLE3 = "@T1 请按风格3出图"
+
+
+def test_has_generate_verb_chutu():
+    assert has_generate_verb("按风格3出图")
+    assert has_generate_verb("请出图")
+
+
+def test_has_image_output_style_n():
+    assert has_image_output("按风格3出图")
+
+
+def test_ref_media_generation_t1_chutu():
+    assert is_ref_media_generation(STYLE3, ["T1"])
+
+
+def test_resolve_atomic_intent_style3():
+    ir = resolve_atomic_intent(STYLE3, mentioned_keys=["T1"])
+    assert ir.action == "generate"
+    assert ir.output_modality == "image"
+    assert ir.mentioned_keys == ("T1",)
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+Run: `cd services/agent-runtime && pytest tests/test_atomic_intent_ir_ref_image.py -v`  
+Expected: FAIL on `has_generate_verb` / `is_ref_media_generation`
+
+- [ ] **Step 3: Implement minimal IR changes**
+
+在 `atomic_intent_ir.py`:
+
+1. `GENERATE_VERBS` 元组追加：`"出图"`, `"出一张图"`, `"生成图"`
+2. `has_generate_verb` 内 regex 追加：`r"(?:出图|出一张图|生成图)"`
+3. `has_image_output`：`"出图" in t` 或 `re.search(r"按风格\s*\d+", t)` 或 `re.search(r"风格\s*\d+", t)`
+4. `is_ref_media_generation` 在现有逻辑前追加：
+
+```python
+_STYLE_N_RE = re.compile(r"(?:按)?风格\s*(\d+)", re.IGNORECASE)
+
+def is_ref_media_generation(text: str, mentioned_keys: list[str] | None = None) -> bool:
+    t = (text or "").strip()
+    keys = mentioned_keys or []
+    text_keys = [k for k in keys if k.upper().startswith("T")]
+    if text_keys and (_STYLE_N_RE.search(t) or "出图" in t or "生成图" in t):
+        return True
+    # ... existing logic unchanged ...
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `cd services/agent-runtime && pytest tests/test_atomic_intent_ir_ref_image.py -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/agent-runtime/app/graph/atomic_intent_ir.py \
+  services/agent-runtime/tests/test_atomic_intent_ir_ref_image.py
+git commit -m "feat(agent-runtime): IR recognizes 出图 and 按风格N with T refs"
+```
+
+---
+
+### Task 2: IR — `derive_studio_prompt` 保留用户 utterance
+
+**覆盖:** Q2, E7, R-IR-05, R-ALIGN-01, R-PARSE-01
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/atomic_intent_ir.py`
+- Modify: `services/agent-runtime/tests/test_atomic_intent_ir_ref_image.py`
+
+- [ ] **Step 1: Add failing test**
+
+```python
+from app.graph.atomic_intent_ir import derive_studio_prompt, resolve_atomic_intent
+
+def test_derive_studio_prompt_keeps_style3_utterance():
+    ir = resolve_atomic_intent("@T1 请按风格3出图", mentioned_keys=["T1"])
+    assert derive_studio_prompt(ir) == "@T1 请按风格3出图"
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `pytest tests/test_atomic_intent_ir_ref_image.py::test_derive_studio_prompt_keeps_style3_utterance -v`
+
+- [ ] **Step 3: Update `derive_studio_prompt`**
+
+```python
+def derive_studio_prompt(intent: AtomicIntent) -> str:
+    t = intent.utterance.strip()
+    if intent.mentioned_keys and t and not re.fullmatch(r"@\w+\s*", t):
+        return t
+    if intent.output_modality == "video" and (...):
+        return "基于引用内容生成视频"
+    if intent.output_modality == "image" and (...):
+        return "基于引用内容生成图片"
+    return t
+```
+
+- [ ] **Step 4: Run tests — PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "feat(agent-runtime): keep user utterance in derive_studio_prompt when refs present"
+```
+
+---
+
+### Task 3: 移除 `出图` 的 blanket marketing 信号
+
+**覆盖:** Q1, E1, R-L1-01, R-ALIGN-03
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/intent.py`
+- Modify: `services/agent-runtime/app/graph/atomic_intent.py`（`atomic_create_intent` 同步 IR）
+- Create: `services/agent-runtime/tests/test_marketing_intent_chutu.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# tests/test_marketing_intent_chutu.py
+from app.graph.intent import marketing_intent
+from app.graph.atomic_intent import atomic_create_intent
+
+def test_chutu_alone_not_marketing():
+    assert not marketing_intent("@T1 请按风格3出图")
+
+def test_chutu_is_atomic_create():
+    assert atomic_create_intent("@T1 请按风格3出图")
+
+def test_detail_page_campaign_still_marketing():
+    assert marketing_intent("帮我做天猫详情页营销方案")
+```
+
+- [ ] **Step 2: Run — expect FAIL**（当前 marketing True）
+
+- [ ] **Step 3: Remove `"出图"` from `MARKETING_HINTS`**
+
+在 `intent.py` 的 `MARKETING_HINTS` 删除 `"出图"` 行。
+
+在 `atomic_intent.py` 的 `atomic_create_intent` 中，于 early return 之后追加：
+
+```python
+if re.search(r"(?:出图|出一张图|生成图)", text or ""):
+    if not any(h in text for h in CONFIRM_GEN_HINTS):
+        return True
+```
+
+- [ ] **Step 4: Run tests — PASS**
+
+Run: `pytest tests/test_marketing_intent_chutu.py tests/test_atomic_create_intent.py -q`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "fix(agent-runtime): 出图 triggers atomic not marketing"
+```
+
+---
+
+### Task 4: L1 — `_sidebar_ref_atomic_signal` fast path
+
+**覆盖:** Q1, Q2, E3, E10, R-L1-02, R-L1-03, R-L1-04
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/route_decide.py`
+- Create: `services/agent-runtime/tests/test_route_sidebar_ref_atomic.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# tests/test_route_sidebar_ref_atomic.py
+from app.graph.route_decide import decide_route
+
+CTX = {
+    "utterance": "@T1 请按风格3出图",
+    "mentioned_keys": ["T1"],
+    "sidebar_attachments": [{"refKey": "T1", "mediaType": "text"}],
+    "checkpoint": {},
+}
+
+def test_style3_routes_atomic_create():
+    d = decide_route(CTX)
+    assert d["flow_mode"] == "atomic_create"
+    assert d["reason"] == "sidebar_ref_atomic"
+
+def test_style3_not_clarify_route():
+    d = decide_route(CTX)
+    assert d["flow_mode"] != "clarify_route"
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Implement in `route_decide.py`**
+
+```python
+def _text_mentioned_keys(keys: list[str]) -> list[str]:
+    return [k for k in keys if k.upper().startswith("T")]
+
+def _sidebar_ref_atomic_signal(ctx: RouteContext) -> bool:
+    utterance = str(ctx.get("utterance") or "").strip()
+    if not utterance:
+        return False
+    keys = _text_mentioned_keys(ctx.get("mentioned_keys") or [])
+    attachments = ctx.get("sidebar_attachments") or []
+    has_ref = bool(keys) or any(
+        str(a.get("mediaType") or "").lower() == "text" for a in attachments
+    )
+    if not has_ref:
+        return False
+    from app.graph.atomic_intent_ir import (
+        is_ref_media_generation,
+        resolve_output_modality,
+        has_generate_verb,
+    )
+    mk = keys or None
+    if is_ref_media_generation(utterance, mk):
+        return True
+    if resolve_output_modality(utterance, mentioned_keys=mk) in ("image", "video"):
+        if has_generate_verb(utterance) or "出图" in utterance:
+            return True
+    return False
+```
+
+在 `decide_route` 中，`_sidebar_img2img_signal` 块之后、 `resolve_intake_route` 之前插入：
+
+```python
+if _sidebar_ref_atomic_signal(ctx):
+    return {
+        "flow_mode": "atomic_create",
+        "l0_action": l0,
+        "confidence": 0.92,
+        "reason": "sidebar_ref_atomic",
+        ...
+    }
+```
+
+修改 orch 降级块（约 L170–177）：若 `_sidebar_ref_atomic_signal(ctx)` 为真，跳过 `is_atomic = False` 降级。
+
+- [ ] **Step 4: Run — PASS**
+
+Run: `pytest tests/test_route_sidebar_ref_atomic.py tests/test_route_decide.py -q`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "feat(agent-runtime): sidebar T-ref + 出图 fast path to atomic_create"
+```
+
+---
+
+### Task 5: 统一 `clarify_context` 结构与 `pending_clarify`
+
+**覆盖:** Q3, E4, E8, R-CL-01
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/atomic_clarify.py`
+- Modify: `services/agent-runtime/app/graph/state.py`（文档注释或 TypedDict 字段）
+- Create: `services/agent-runtime/tests/test_pending_clarify.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# tests/test_pending_clarify.py
+from app.graph.atomic_clarify import pending_clarify
+
+def test_pending_route_orchestration():
+    state = {
+        "clarify_context": {
+            "kind": "route_orchestration",
+            "original_utterance": "@T1 请按风格3出图",
+            "clarify_question": "回复 1/2/3",
+            "mentioned_keys": ["T1"],
+        }
+    }
+    assert pending_clarify(state) is not None
+
+def test_pending_atomic_parse_still_works():
+    state = {
+        "clarify_context": {
+            "kind": "atomic_parse",
+            "original_utterance": "帮我生成",
+            "clarify_question": "q",
+        }
+    }
+    assert pending_clarify(state) is not None
+```
+
+- [ ] **Step 2: Run — expect FAIL**（仅 atomic_parse 有 original 时返回）
+
+- [ ] **Step 3: Implement `pending_clarify`**
+
+```python
+_CLARIFY_KINDS = frozenset({"atomic_parse", "route_orchestration", "img2img_confirm"})
+
+def pending_clarify(state: dict[str, Any]) -> dict[str, Any] | None:
+    ctx = state.get("clarify_context")
+    if not isinstance(ctx, dict):
+        return None
+    if not str(ctx.get("original_utterance") or "").strip():
+        return None
+    kind = str(ctx.get("kind") or "atomic_parse")
+    if kind not in _CLARIFY_KINDS:
+        return None
+    return ctx
+
+def pending_atomic_clarify(state: dict[str, Any]) -> dict[str, Any] | None:
+    return pending_clarify(state)
+```
+
+- [ ] **Step 4: Run — PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "refactor(agent-runtime): unified pending_clarify for route and atomic"
+```
+
+---
+
+### Task 6: `clarify_route` 写入 checkpoint
+
+**覆盖:** Q3, E8, R-CL-01
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/nodes/clarify_route.py`
+- Modify: `services/agent-runtime/app/graph/route_context.py`（如需 snapshot helper）
+- Create: `services/agent-runtime/tests/test_clarify_route_checkpoint.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+import pytest
+from app.graph.nodes.clarify_route import make_clarify_route_node
+
+@pytest.mark.asyncio
+async def test_clarify_route_writes_context():
+    node = make_clarify_route_node()
+    out = await node({
+        "clarify_question": "回复 1/2/3",
+        "route_context": {
+            "utterance": "@T1 请按风格3出图",
+            "mentioned_keys": ["T1"],
+        },
+        "sidebar_attachments": [{"refKey": "T1"}],
+        "sidebar_mentioned_keys": ["T1"],
+    })
+    ctx = out.get("clarify_context")
+    assert ctx["kind"] == "route_orchestration"
+    assert ctx["original_utterance"] == "@T1 请按风格3出图"
+    assert ctx["mentioned_keys"] == ["T1"]
+    assert out["phase"] == "clarify"
+    assert out.get("flow_mode") != "chat"
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Update `clarify_route.py`**
+
+```python
+async def clarify_route(state: dict) -> dict:
+    question = str(state.get("clarify_question") or "").strip() or (...)
+    route_ctx = state.get("route_context") or {}
+    original = str(route_ctx.get("utterance") or "").strip()
+    mentioned = list(state.get("sidebar_mentioned_keys") or route_ctx.get("mentioned_keys") or [])
+    attachments = list(state.get("sidebar_attachments") or [])
+    return {
+        "phase": "clarify",
+        "flow_mode": "clarify_route",
+        "route_clarify": True,
+        "clarify_question": question,
+        "clarify_context": {
+            "kind": "route_orchestration",
+            "original_utterance": original,
+            "clarify_question": question,
+            "mentioned_keys": mentioned,
+            "sidebar_attachment_ref_keys": [
+                str(a.get("refKey") or "") for a in attachments if a.get("refKey")
+            ],
+        },
+        "messages": [AIMessage(content=question)],
+    }
+```
+
+- [ ] **Step 4: Run — PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "fix(agent-runtime): clarify_route persists clarify_context checkpoint"
+```
+
+---
+
+### Task 7: `classify_clarify_reply` 继承 original utterance
+
+**覆盖:** Q3, E5, E9, R-CL-03
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/clarify_reply.py`
+- Modify: `services/agent-runtime/tests/test_clarify_reply.py`
+
+- [ ] **Step 1: Add failing test**
+
+```python
+def test_clarify_reply_choice_1_inherits_original_style3():
+    original = "@T1 请按风格3出图"
+    result = classify_clarify_reply(original, "q", "1")
+    assert result["items"][0]["prompt"] == original
+    assert result["items"][0]["target_type"] == "image"
+```
+
+- [ ] **Step 2: Run — expect FAIL**（硬编码蓝牙耳机）
+
+- [ ] **Step 3: Update choice 1 branch**
+
+```python
+if lowered in _CHOICE_ONE or any(k in raw for k in ("单张主图", "直接出图", "只要主图")):
+    prompt = original_utterance.strip()
+    if not prompt:
+        prompt = "生成一张主图"
+    elif "主图" in original_utterance and "蓝牙耳机" in original_utterance:
+        prompt = "生成一张蓝牙耳机主图"
+    return {
+        ...
+        "items": [{"target_type": "image", "title": prompt[:24], "prompt": prompt, ...}],
+        ...
+    }
+```
+
+- [ ] **Step 4: Run — PASS**
+
+Run: `pytest tests/test_clarify_reply.py -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "fix(agent-runtime): clarify choice 1 inherits original utterance"
+```
+
+---
+
+### Task 8: `intake` route clarify follow-up 路由
+
+**覆盖:** Q3, E4, E9, R-CL-02, R-CL-05, R-UX-03
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/nodes/intake.py`
+- Modify: `services/agent-runtime/app/graph/builder.py`（若需新 route 边）
+- Create: `services/agent-runtime/tests/test_route_clarify_followup.py`
+
+- [ ] **Step 1: Write failing integration test**
+
+```python
+# tests/test_route_clarify_followup.py
+import pytest
+from langchain_core.messages import HumanMessage
+from app.graph.nodes.intake import make_intake_node
+from pathlib import Path
+
+SKILLS = Path(__file__).resolve().parents[1] / "skills"
+
+@pytest.mark.asyncio
+async def test_intake_reply_1_after_route_clarify():
+    intake = make_intake_node(SKILLS)
+    state = {
+        "messages": [HumanMessage(content="1")],
+        "clarify_context": {
+            "kind": "route_orchestration",
+            "original_utterance": "@T1 请按风格3出图",
+            "clarify_question": "回复 1/2/3",
+            "mentioned_keys": ["T1"],
+        },
+        "sidebar_mentioned_keys": ["T1"],
+    }
+    out = await intake(state)
+    assert out["flow_mode"] == "atomic_create"
+    assert out.get("clarify_question") is None
+    assert out.get("route_clarify") is False
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Update `intake.py`**
+
+在 `text = ...` 之后、`decide_route` 之前插入 clarify follow-up 处理：
+
+```python
+from app.graph.atomic_clarify import pending_clarify
+from app.graph.clarify_reply import classify_clarify_reply
+
+pending = pending_clarify(state)
+if pending and str(pending.get("kind") or "") == "route_orchestration":
+    original = str(pending.get("original_utterance") or "")
+    question = str(pending.get("clarify_question") or state.get("clarify_question") or "")
+    classified = classify_clarify_reply(original, question, text)
+    if classified != "none":
+        route = classified.get("route")
+        if route == "atomic_create":
+            return {
+                "phase": "intake",
+                "flow_mode": "atomic_create",
+                "skill_id": None,
+                "mode": "create",
+                "clarify_question": None,
+                "clarify_context": None,
+                "route_clarify": False,
+                "sidebar_mentioned_keys": pending.get("mentioned_keys") or state.get("sidebar_mentioned_keys"),
+                # 可选：写入 pre_parsed_atomic 供 atomic_parse 短路
+                "pre_parsed_intent": classified,
+                ...
+            }
+        if route == "campaign":
+            ...
+```
+
+若采用 `pre_parsed_intent`，在 `atomic_parse.py` 开头检测并短路（可选子步骤）。
+
+将现有 `pending_clarify and is_affirmative_clarify_reply` 块改为使用 `pending_clarify` 而非仅 `pending_atomic_clarify`。
+
+- [ ] **Step 4: Run — PASS**
+
+Run: `pytest tests/test_route_clarify_followup.py -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "fix(agent-runtime): route clarify 1/2/3 follow-up routes to atomic/campaign"
+```
+
+---
+
+### Task 9: Eval cases + route 文案 + thinking_summary
+
+**覆盖:** Q5, E5, E6, R-CL-04, R-UX-01, R-UX-02, R-PARSE-02, AC-01–AC-07
+
+**Files:**
+- Modify: `services/agent-runtime/skills/atomic-create/eval-intent-set.yaml`
+- Modify: `services/agent-runtime/skills/atomic-create/eval-route-set.yaml`
+- Modify: `services/agent-runtime/app/graph/route_decide.py`（`ROUTE_CLARIFY_ORCHESTRATION` 文案）
+- Modify: `services/agent-runtime/app/graph/nodes/intake.py` 或 `atomic_parse.py`（clarify thinking_summary）
+
+- [ ] **Step 1: Add eval YAML entries**
+
+`eval-route-set.yaml`:
+
+```yaml
+- id: sidebar-t1-style3-atomic
+  messages:
+    - role: user
+      content: "@T1 请按风格3出图"
+  sidebar:
+    mentioned_keys: ["T1"]
+  expect:
+    flow_mode: atomic_create
+    reason: sidebar_ref_atomic
+```
+
+`eval-intent-set.yaml`:
+
+```yaml
+- id: sidebar-t1-style3-image
+  utterance: "@T1 请按风格3出图"
+  mentioned_keys: ["T1"]
+  expect:
+    target_type: image
+    action: generate
+```
+
+- [ ] **Step 2: Update clarify copy**
+
+```python
+ROUTE_CLARIFY_ORCHESTRATION = (
+    "听起来像多节点编排或营销方案需求。请确认：\n"
+    "1）按引用内容单张出图（保留 @T* / @I*）；\n"
+    "2）完整编排（请在侧栏选用已安装的 Skill）；\n"
+    "3）其他说明。\n"
+    "回复 1 / 2 / 3。"
+)
+```
+
+- [ ] **Step 3: Clarify thinking_summary**
+
+intake 在 `needs_route_clarify` 时设置：
+
+```python
+out["thinking_summary"] = "待确认：单张出图还是完整编排"
+```
+
+- [ ] **Step 4: Run eval harness**
+
+Run: `cd services/agent-runtime && pytest tests/test_intent_parse_schema.py tests/test_route_decide.py -q`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "test(agent-runtime): eval cases for @T1 style3 + clarify UX copy"
+```
+
+---
+
+### Task 10: 生产验证脚本 + 全量回归
+
+**覆盖:** AC-01, AC-02, AC-05, R-ALIGN-02
+
+**Files:**
+- Modify: `deploy/prod-atomic-intent-ir-verify.py`
+
+- [ ] **Step 1: Add prod case**
+
+```python
+CASES.append({
+    "name": "sidebar_t1_style3_image",
+    "utterance": "@T1 请按风格3出图",
+    "mentioned_keys": ["T1"],
+    "expect_node_type": "image",
+})
+```
+
+- [ ] **Step 2: Run full agent-runtime tests**
+
+Run: `cd services/agent-runtime && pytest tests/ -q`  
+Expected: all pass
+
+- [ ] **Step 3: Document Dock parity note**
+
+在 spec 或 plan 末尾确认：Dock 路径 `prompt=按风格3出图` + edge T1 refs 与 agent atomic 一致（人工 AC-05 checklist）。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add deploy/prod-atomic-intent-ir-verify.py
+git commit -m "chore(deploy): prod verify case for @T1 style3 image routing"
+```
+
+---
+
+## 计划自检（实施完成后勾选）
+
+- [ ] Q1–Q5：每条均有 Task 覆盖（见索引表）
+- [ ] E1–E10：每条均有 Task 覆盖
+- [ ] R-L1-01–R-UX-04：均可指向 Task 1–10
+- [ ] AC-01–AC-07：Task 9–10 + 集成测试
+- [ ] 无 TBD / placeholder 步骤
+- [ ] PR #197 video cases 回归通过
+
+---
+
+## 执行选项
+
+**Plan saved to:** `docs/superpowers/plans/2026-08-09-sidebar-ref-image-routing.md`
+
+**1. Subagent-Driven（推荐）** — 每 Task 派生子 agent，Task 间 review  
+**2. Inline Execution** — 本会话按 Task 1→10 顺序执行，checkpoint Review
+
+请选择执行方式；规格评审通过后开始 Task 1。

--- a/docs/superpowers/specs/2026-08-09-sidebar-ref-image-routing-design.md
+++ b/docs/superpowers/specs/2026-08-09-sidebar-ref-image-routing-design.md
@@ -1,0 +1,668 @@
+# Agent 侧栏引用生图路由与澄清续接 — 设计规格
+
+> 状态：**待评审**（2026-08-09）  
+> 范围：**Phase 0（P0 止血）** — 修复 `@T1 请按风格3出图` 类 utterance 的 L1 路由误判、route 澄清回复断裂、侧栏与 Dock 引用语义不对齐、执行过程 UX 误导  
+> **Phase 1（P1 架构收敛）** — 见本文 §9 [Route Unification ADR]；**禁止**在 P0 之后继续堆 hint 表，新 case 应推动 P1 落地  
+> 前置：[2026-08-09-atomic-intent-ir-design.md](./2026-08-09-atomic-intent-ir-design.md)、[2026-08-07-agent-sidebar-m3-explicit-refs-design.md](./2026-08-07-agent-sidebar-m3-explicit-refs-design.md)、[2026-08-07-platform-route-skill-boundary-design.md](./2026-08-07-platform-route-skill-boundary-design.md)  
+> 生产 case：`@T1 请按风格3出图` → 编排澄清 → 用户回 `1` → 落入 chat（未建 image 节点、未触发生成）
+
+---
+
+## 0. 决策摘要
+
+| # | 决策 | 说明 |
+|---|------|------|
+| **D-A** | **`@T* / @I* + 出图/生成图` 走 atomic fast path** | L1 `decide_route` 在 `marketing_intent` 之前判定；有 sidebar ref + image 信号 → `atomic_create` |
+| **D-B** | **`出图` 从 blanket `MARKETING_HINTS` 移除** | 营销编排改由「详情页/全链路/分镜/campaign 短语 + skill」触发；单张「出图」不再单独触发 campaign |
+| **D-C** | **统一 `clarify_context` checkpoint** | route 澄清与 atomic 澄清共用同一结构；follow-up 继承 `original_utterance + mentioned_keys + sidebar_attachments` |
+| **D-D** | **route 澄清回复 `1/2/3` 走 `classify_clarify_reply`** | intake 检测 pending route clarify → 恢复上下文 → `atomic_parse` 或 campaign |
+| **D-E** | **IR 扩展：`出图`、`按风格N`** | `has_generate_verb` / `is_ref_media_generation` 识别短指令；prompt 保留用户 utterance（含风格 N） |
+| **D-F** | **侧栏 atomic 与 Dock 对齐：prompt + refs 分离** | node.prompt = 用户指令；T1 正文经 localRefs；禁止澄清后硬编码「蓝牙耳机主图」 |
+| **D-G** | **澄清/失败时 execution trace 与文案 honest** | clarify 步骤显示「待确认意图」；确认后将创建 image + 引用 T1 |
+
+**推荐方案（相对 B/C 备选）：** 在现有 Intent IR 上增量修补（D-A–G），不引入新 LLM 路由层。理由：根因是规则冲突与状态丢失，非 parse 能力不足；改动面可控、可 eval 回归。
+
+> **P0 边界声明：** D-A–G 及 §3 全部 `R-*` 需求属于 **止血层**——允许新增 `_sidebar_ref_atomic_signal` 等 **feature 级 fast path**，但 **禁止** 再向 `MARKETING_HINTS` / `ATOMIC_CREATE_HINTS` 等 hint 表追加同义词条。P0 合并后须启动 §9 Route Unification（P1），否则技术债按 case 线性增长。
+
+| 备选 | 优点 | 缺点 | 结论 |
+|------|------|------|------|
+| **A. IR + L1 规则修补（推荐）** | 与 PR #197 一致、可单测 | 需仔细梳理 hint 表 | ✅ 采用 |
+| **B. 侧栏 utterance 跳过 L1，直连 atomic_parse** | 与 Dock 行为最接近 | campaign 边界模糊 | 部分吸收（ref+出图 fast path） |
+| **C. 澄清全 LLM 分类** | 自然语言 follow-up 强 | 延迟、不可回归 | 仅作 `classify_clarify_reply` 未来 fallback |
+
+---
+
+## 1. 问题溯源矩阵（用户 Q1–Q5 + 诊断清单）
+
+| ID | 来源 | 现象 / 根因 | 规格需求 ID |
+|----|------|-------------|-------------|
+| **Q1** | 用户问题 1 | `@T1 请按风格3出图` 未识别为 atomic image；`出图`∈`MARKETING_HINTS` + IR 无 `出图` verb | R-L1-01, R-IR-01, R-IR-02 |
+| **Q2** | 用户问题 2 | 侧栏 utterance 路由 vs Dock 拓扑 refs 两套入口；`mentioned_keys` 未参与 L1（除 img2img） | R-ALIGN-01, R-ALIGN-02, R-L1-02 |
+| **Q3** | 用户问题 3 | route 澄清后回 `1` 进 chat；无 `clarify_context`；`classify_clarify_reply` 未接入 | R-CL-01, R-CL-02, R-CL-03 |
+| **Q4** | 用户问题 4 | 见 §1.1 扩展问题 E1–E10 | 各 R-* 映射 |
+| **Q5** | 用户问题 5 | 澄清文案错位、执行步骤误导、无引用确认 | R-UX-01–R-UX-04 |
+| **E1** | 诊断 | `出图` 与 atomic 生图语义冲突 | R-L1-01 |
+| **E2** | 诊断 | IR 词表缺 `出图` / `按风格N` | R-IR-01, R-IR-03 |
+| **E3** | 诊断 | `route_decide` 不消费 T 引用 | R-L1-02 |
+| **E4** | 诊断 | route / atomic 两套 clarify 无统一 checkpoint | R-CL-01 |
+| **E5** | 诊断 | 澄清选项与用户「按风格3出图」不对齐 | R-UX-02, R-CL-04 |
+| **E6** | 诊断 | 执行过程显示「拟定方案」但未进 atomic/campaign | R-UX-01 |
+| **E7** | 诊断 | 「风格3」未从 T1 正文解析 | R-IR-03, R-PARSE-01 |
+| **E8** | 诊断 | `clarify_route` 设 `flow_mode=chat` 丢状态 | R-CL-01 |
+| **E9** | 诊断 | chat 系统提示与澄清选项 1 矛盾 | R-CL-03, R-UX-03 |
+| **E10** | 诊断 | Intent IR 与 L1 路由脱节 | R-L1-02, R-IR-02 |
+
+### 1.1 验收用例（必须全部通过）
+
+| Case ID | 输入 | 期望 |
+|---------|------|------|
+| **AC-01** | `@T1 请按风格3出图` + sidebar T1 attachment | `flow_mode=atomic_create` → image 节点 + localRefs 含 T1 + prompt 含「按风格3出图」 |
+| **AC-02** | 同上 → 若仍 clarify → 用户 `1` | 恢复 AC-01 行为，**不得**进 chat |
+| **AC-03** | `@T1 请基于文案生成视频` | video（Intent IR 已有，回归） |
+| **AC-04** | `帮我做天猫详情页营销方案出图` + 无 @ref | 仍可走 campaign / clarify_route（营销短语保留） |
+| **AC-05** | Dock：image 节点连 T1 + dock 输入「按风格3出图」 | 与 AC-01 Studio 调用等价（prompt + refs） |
+| **AC-06** | route clarify → `2` | campaign 路径（skill 提示） |
+| **AC-07** | route clarify → `3` | text vision_text 或 write，保留 original utterance |
+
+---
+
+## 2. 架构
+
+### 2.1 数据流（修复后）
+
+```text
+用户: @T1 请按风格3出图
+  │
+  ├─ sidebar_attachments / mentioned_keys ──► RouteContext
+  │
+  ▼
+decide_route
+  ├─ [NEW] sidebar_ref_atomic_signal(ctx)?  ──► atomic_create (bypass marketing)
+  ├─ resolve_atomic_intent(utterance, mentioned_keys)
+  └─ marketing_intent (出图 已移除 blanket)
+  │
+  ▼
+atomic_parse → image item + derive_studio_prompt(保留 utterance)
+  │
+  ▼
+create_atomic_node → apply_sidebar_attachments(localRefs, mentionedKeys)
+  │
+  ▼
+Studio: prompt + refs(T1 body)
+```
+
+### 2.2 澄清续接（修复后）
+
+```text
+decide_route → clarify_route
+  │
+  ├─ [NEW] 写入 clarify_context:
+  │     kind=route_orchestration
+  │     original_utterance, clarify_question
+  │     mentioned_keys, sidebar_attachments (snapshot)
+  │
+  ▼
+用户: 1
+  │
+  ▼
+intake: pending_clarify(ctx) → classify_clarify_reply(original, q, "1")
+  │
+  ├─ choice 1 → atomic_create + 继承 original + refs
+  ├─ choice 2 → campaign
+  └─ choice 3 → vision_text / write
+```
+
+### 2.3 `clarify_context` 结构（统一）
+
+```python
+ClarifyContext = TypedDict:
+  kind: Literal["route_orchestration", "atomic_parse", "img2img_confirm"]
+  original_utterance: str
+  clarify_question: str
+  mentioned_keys: list[str]          # snapshot
+  sidebar_attachment_ids: list[str]  # 或 ref keys，与 state 对齐
+  clarify_kind: str                  # reason / legacy
+```
+
+`pending_atomic_clarify` 重命名为 **`pending_clarify`**（alias 保留兼容），接受 `kind in ("atomic_parse", "route_orchestration", ...)`。
+
+### 2.4 P1 目标架构（预览）
+
+P0（§2.1–§2.3）为过渡态。P1 终态架构见 **§9.3–§9.11**：Cascade Router（L0–L3）、Intent IR 为 SoT、precedence 策略表、统一 `clarify_gate`、`GenerationRequest` 侧栏/Dock 对齐。业界最佳实践映射见 §9.3。
+
+---
+
+## 3. 功能需求
+
+### 3.1 L1 路由（R-L1-*）
+
+| ID | 需求 |
+|----|------|
+| **R-L1-01** | 从 `MARKETING_HINTS` 移除 `"出图"`；保留「详情页」「全链路」「分镜」等编排信号 |
+| **R-L1-02** | 新增 `_sidebar_ref_atomic_signal(ctx)`：`mentioned_keys` 非空 +（`resolve_output_modality` 为 image/video **或** utterance 含 `出图`/`按风格`/`生成图`）→ `atomic_create`，confidence≥0.92，reason=`sidebar_ref_atomic` |
+| **R-L1-03** | `_sidebar_ref_atomic_signal` 在 `marketing_intent` / orchestration campaign 分支**之前**评估 |
+| **R-L1-04** | `orch==campaign && is_atomic` 降级逻辑：若 `_sidebar_ref_atomic_signal` 为真，**不**降级为 campaign |
+
+### 3.2 Intent IR（R-IR-*）
+
+| ID | 需求 |
+|----|------|
+| **R-IR-01** | `has_generate_verb` 增加：`出图`、`出一张图`、`生成图` |
+| **R-IR-02** | `has_image_output` 增加：`出图`；`按风格` + 数字可选 |
+| **R-IR-03** | `is_ref_media_generation`：当 `mentioned_keys` 含 T* 且 utterance 含 `出图` 或 `按风格\d` → True（无需完整 generate 短语） |
+| **R-IR-04** | `resolve_atomic_action`：上述 ref+出图 → `generate` |
+| **R-IR-05** | `derive_studio_prompt`：有 mentioned_keys + 用户 utterance 非空 → **保留 utterance**（不替换为泛化句），除非 utterance 仅 `@T1` |
+
+### 3.3 澄清续接（R-CL-*）
+
+| ID | 需求 |
+|----|------|
+| **R-CL-01** | `clarify_route` 节点写入 `clarify_context`（kind=`route_orchestration`），phase=`clarify`（非 done），保留 attachments snapshot |
+| **R-CL-02** | `intake`：若 `pending_clarify` 且 reply 为 `1/2/3` 或 `classify_clarify_reply`≠none → 设置 `flow_mode` 并 **恢复** snapshot 到 state |
+| **R-CL-03** | choice `1`：`classify_clarify_reply` prompt **优先** `original_utterance`；仅当 original 为空时用模板 |
+| **R-CL-04** | `ROUTE_CLARIFY_ORCHESTRATION` 文案更新：选项 1 明确「按引用内容单张出图（保留 @T*）」 |
+| **R-CL-05** | route clarify follow-up 走 `parse_atomic_intent` 或 shortcut 到已有 `IntentParseResult`，**禁止** default chat |
+
+### 3.4 侧栏 ↔ Dock 对齐（R-ALIGN-*）
+
+| ID | 需求 |
+|----|------|
+| **R-ALIGN-01** | atomic image 创建：`node.prompt` = 用户 utterance（或 derive_studio_prompt 结果）；T* 正文仅经 `localRefs` |
+| **R-ALIGN-02** | 文档 + eval：同一语义 AC-01 与 AC-05 Studio 请求字段一致（prompt、refs、mentionedKeys） |
+| **R-ALIGN-03** | `atomic_create_intent`：`出图` + 非 confirm 短语 → True（与 IR 一致） |
+
+### 3.5 解析增强（R-PARSE-*）
+
+| ID | 需求 |
+|----|------|
+| **R-PARSE-01** | `rule_parse_atomic` / LLM prompt：识别 `按风格(\d+)` / `风格(\d+)`，写入 item.prompt（不尝试从 T1 正文切片，MVP 仅保留指令；P2 可选正文解析） |
+| **R-PARSE-02** | eval case 写入 `eval-intent-set.yaml` + `eval-route-set.yaml` |
+
+### 3.6 UX（R-UX-*）
+
+| ID | 需求 |
+|----|------|
+| **R-UX-01** | clarify 阶段 `thinking_summary` / execution trace：`待确认：单张出图还是完整编排`（禁止「拟定方案」） |
+| **R-UX-02** | 澄清消息展示：`已看到引用 T1`（若有 attachment） |
+| **R-UX-03** | 澄清 follow-up 失败时：明确错误 + 建议重发完整指令，**禁止** generic chat「有什么可以帮你」 |
+| **R-UX-04** | atomic 成功路径：trace 显示 `将创建 image 节点，引用 T1` |
+
+---
+
+## 4. 文件级变更清单
+
+| 文件 | 变更 |
+|------|------|
+| `services/agent-runtime/app/graph/intent.py` | 调整 `MARKETING_HINTS` |
+| `services/agent-runtime/app/graph/route_decide.py` | `_sidebar_ref_atomic_signal`、优先级 |
+| `services/agent-runtime/app/graph/atomic_intent_ir.py` | 词表 + ref+出图 |
+| `services/agent-runtime/app/graph/atomic_intent.py` | `atomic_create_intent` 同步 |
+| `services/agent-runtime/app/graph/nodes/clarify_route.py` | 写 `clarify_context` |
+| `services/agent-runtime/app/graph/nodes/intake.py` | route clarify follow-up |
+| `services/agent-runtime/app/graph/atomic_clarify.py` | `pending_clarify` 泛化 |
+| `services/agent-runtime/app/graph/clarify_reply.py` | 继承 original utterance |
+| `services/agent-runtime/app/graph/state.py` | `clarify_context` TypedDict（可选） |
+| `services/agent-runtime/app/graph/nodes/atomic_parse.py` | thinking_summary clarify 文案 |
+| `services/agent-runtime/skills/atomic-create/eval-*.yaml` | AC-01/02 cases |
+| `deploy/prod-atomic-intent-ir-verify.py` | 新增 style3 case |
+
+---
+
+## 5. 测试策略
+
+| 层级 | 内容 |
+|------|------|
+| **单元** | IR verb/output、`_sidebar_ref_atomic_signal`、`classify_clarify_reply` 继承 original |
+| **集成** | intake → clarify_route → intake(`1`) → atomic_create graph route |
+| **回归** | 现有 video IR cases、img2img、campaign 无 skill clarify |
+| **生产脚本** | `@T1 请按风格3出图` → image 节点 |
+
+---
+
+## 6. 非范围
+
+- V*/A* 引用生图（仍 P1）
+- 从 T1 正文自动抽取「风格3」段落（P2；MVP 仅保留 utterance 指令）
+- 前端 MentionInput / 芯片 UI 改造（已有 M3）
+- 新 LLM 路由层替代 `decide_route`
+
+---
+
+## 7. 风险与缓解
+
+| 风险 | 缓解 |
+|------|------|
+| 移除 `出图` 降低 campaign 召回 | 保留「详情页+方案」「全链路」等短语；eval AC-04 |
+| route clarify snapshot 与 attachments 不一致 | snapshot ref keys + attachment ids；intake 恢复时校验 |
+| 「风格3」语义依赖 T1 内容 | UX 提示 + prompt 保留用户原文；P2 正文解析 |
+
+---
+
+## 8. 规格自检
+
+- [x] 无 TBD / 占位符
+- [x] Q1–Q5 均有 R-* 映射
+- [x] E1–E10 均有 R-* 映射
+- [x] 验收 AC-01–AC-07 可执行
+- [x] 与 Intent IR PR #197 兼容（增量非重写）
+
+**请评审本规格（P0）。全量实施计划（P0+P1+P2）：** [`2026-08-09-sidebar-ref-image-routing-full.md`](../plans/2026-08-09-sidebar-ref-image-routing-full.md)  
+**P0 精简计划（已 supersede）：** `docs/superpowers/plans/2026-08-09-sidebar-ref-image-routing.md`  
+**P1 架构收敛：** 见 §9；全量计划 Task T13–T21
+
+---
+
+## 9. Phase 2: Route Unification ADR
+
+> **文档性质：** Architecture Decision Record（ADR），记录 P1 架构收敛方向  
+> **状态：** Proposed（P0 合并后进入设计评审）  
+> **动机：** P0 通过 fast path + hint 微调止血，但 `decide_route` 仍并行调用 `marketing_intent` / `atomic_create_intent` / `orchestration_complexity_intent` / Intent IR 四套结论；**每来一个生产 case 就加一条 hint 或 fast path 不可持续**  
+> **目标：** 单一 Intent SoT + 显式 precedence 策略表 + RouteContext 全量参与；hint 表 **只读 deprecated**，新语义进 IR feature / eval 契约  
+> **前置：** 本文 P0（§0–§8）、[2026-08-09-atomic-intent-ir-design.md](./2026-08-09-atomic-intent-ir-design.md)、[2026-08-07-platform-route-skill-boundary-design.md](./2026-08-07-platform-route-skill-boundary-design.md)
+
+### 9.1 问题陈述：为何不能继续堆 hint 表
+
+| 症状 | 机制 | P0 做法 | P1 收敛 |
+|------|------|---------|---------|
+| 同词多路由 | `出图` 同时命中 marketing 与 atomic | 从 MARKETING_HINTS 移除 | 废弃 label 式 hint；改 **feature** |
+| IR 与 L1 结论打架 | IR→image，L1→clarify_route | fast path 绕过 | L0 **只读** IR + ctx |
+| 上下文参与不一致 | img2img 看 I*，T* 不看 | `_sidebar_ref_atomic_signal` | `extract_route_features(ctx)` 统一 |
+| 澄清链断裂 | route / atomic 两套 checkpoint | 统一 `clarify_context`（P0） | 单一 clarify 子图（P1） |
+| 不可回归 | 改 hint 顺序即改产品行为 | eval case 补 AC-01 | **eval-route-set CI 门禁** |
+
+**ADR 结论：** P0 是 **有时间盒的例外**；合并 PR 必须附带 Issue/Plan 链到 P1，且 **6 个月内** 不得新增 permanent hint 条目（仅允许 IR feature flag + eval）。
+
+### 9.2 决策摘要（P1）
+
+| # | 决策 | 说明 |
+|---|------|------|
+| **RU-1** | **Intent IR 为唯一语义 SoT** | `resolve_atomic_intent(utterance, route_context)` 产出 `AtomicIntent`；下游禁止再独立扫 substring |
+| **RU-2** | **`decide_route` 瘦身为 precedence 执行器** | 输入 `(AtomicIntent, RouteFeatures, RouteContext)`；输出 `RouteDecision`；**删除**并行 bool 分类器 |
+| **RU-3** | **Feature 化，非 Label 化** | 路由信号为结构化 feature（见 §9.3），不是 `keyword in text → flow_mode` |
+| **RU-4** | **显式 Precedence 策略表** | 优先级写死在 `route_precedence.yaml`（或 Python 常量表 + 单测），顺序变更须 eval 全绿 |
+| **RU-5** | **L0 只判 graph region** | `atomic_create \| orchestration \| explore \| single_node \| chat \| clarify`；节点类型/prompt 交给 L2 parse |
+| **RU-6** | **RouteContext 硬信号优先于 utterance** | UI/skill/checkpoint/refs 可 **override** 低置信文本推断 |
+| **RU-7** | **Clarify 为 Loop 一等节点** | 单一 `clarify_gate` 子图；所有低置信走同一 checkpoint；禁止 clarify→chat 无声断裂 |
+| **RU-8** | **Harness 契约** | `eval-route-set.yaml` 为路由 CI 门禁；无 eval 的 routing PR 禁止合并 |
+| **RU-9** | **侧栏 ≡ Dock 请求模型** | 共用 `GenerationRequest { prompt, refs, mentionedKeys }`；路由成功后构造同一结构 |
+| **RU-10** | **废止模块（deprecated，P1 完成后删除）** | `marketing_intent()`、`atomic_create_intent()` 作为路由输入、`orchestration_complexity_intent()` 独立 veto |
+
+### 9.3 业界最佳实践借鉴
+
+lnkpi 意图路由的 P1 终态对齐以下业界共识（非「全 LLM」亦非「全关键词」）：
+
+| 模式 | 来源 | 核心思想 | lnkpi 落地 |
+|------|------|----------|------------|
+| **Cascade Router（分层路由）** | Dialogflow CX、Semantic Kernel Planners | 粗路由 → 细解析 → 执行；越往上分支越少 | L0 `flow_mode`（≤7 分支）→ L2 `atomic_parse` → Studio |
+| **Structured Intent / Slot Filling** | Rasa CALM、Dialogflow ES | 意图 = 结构化对象 + 槽位，非 bool 标签 | `AtomicIntent { action, modality, keys, slots }` |
+| **Context-First Routing** | OpenAI Agents、Anthropic Tool Use | UI 动作与结构化上下文优先于裸文本 | `RouteContext` 硬信号 override utterance |
+| **LLM as Parser, Not Router** | OpenAI Structured Outputs、LangGraph tutorials | LLM 输出 constrained JSON；路由动作空间小 | LLM 仅在 L2 parse；L0 不用自由文本选路 |
+| **Ambiguity → Clarify（非 silent default）** | Rasa disambiguation、Alexa NLU | 低置信必澄清；checkpoint 可续接 | 单一 `clarify_gate` + `clarify_context` |
+| **Eval as Contract（Harness）** | Google ML Test Score、Rasa test stories | 路由变更 = 契约变更；CI 门禁 | `eval-route-set.yaml` required check |
+| **Small Action Space** | Anthropic Building Effective Agents | Router 分支 5–8 个；复杂度下沉 parse | `atomic_create \| orchestration \| explore \| …` |
+| **Trajectory over Response** | Loop Engineering（IBM/Alphamatch） | 价值在轨迹（澄清→恢复→执行），非单轮回复 | clarify 是 Loop 节点，非 chat 前置 |
+
+**反模式（当前须消除）：**
+
+| 反模式 | 现状 | P1 禁止 |
+|--------|------|---------|
+| Parallel bool classifiers | 5+ 函数各扫 substring | 单一 IR SoT |
+| Keyword → flow_mode | `出图` → marketing | Feature + precedence 行 |
+| Route before context | T* ref 不参与 L1 | `extract_route_features(ctx)` |
+| Clarify dead-end | route clarify → chat | clarify_gate → resume |
+| Untestable routing | if/else 顺序即政策 | precedence 表 + eval |
+
+---
+
+### 9.4 目标架构总览（P1 终态）
+
+P0（§2）为 **过渡态**：在旧 `decide_route` 上叠 fast path。P1 **终态**如下——**一条管线、一个 SoT、一张 precedence 表**：
+
+```mermaid
+flowchart TB
+  subgraph inputs [Inputs — Context-First]
+    U[utterance]
+    RC[RouteContext]
+  end
+
+  subgraph l0 [L0 Platform Router — small action space]
+    EF[extract_route_features]
+    IR[resolve_atomic_intent — SoT]
+    PR[apply_route_precedence]
+    EF --> PR
+    IR --> PR
+    RC --> EF
+    U --> IR
+    RC --> IR
+  end
+
+  subgraph branches [Graph Regions]
+    AT[atomic_create_gate]
+    OR[orchestration_gate]
+    CG[clarify_gate]
+    EX[explore]
+    SN[single_node]
+    CH[chat]
+  end
+
+  subgraph l2 [L2 Task Parse — LLM allowed]
+    AP[atomic_parse]
+    PG[planning_guard — parse only]
+  end
+
+  subgraph exec [Execution — unified model]
+    GR[GenerationRequest]
+    ST[Studio / Campaign]
+  end
+
+  PR -->|atomic_create| AT
+  PR -->|orchestration| OR
+  PR -->|clarify| CG
+  PR -->|explore| EX
+  PR -->|single_node| SN
+  PR -->|chat| CH
+
+  CG -->|follow-up| PR
+  AT --> AP
+  AP --> PG
+  AP --> GR
+  SN --> GR
+  GR --> ST
+```
+
+**设计铁律（对应 RU-1 ~ RU-10）：**
+
+1. **One Intent, Many Consumers** — 仅 `resolve_atomic_intent()` 解读 utterance 语义；`decide_route` 只读 IR + features。  
+2. **Rules = Features, Not Labels** — 禁止 `keyword in text → flow_mode`；改为 `RouteFeatures` 布尔/分值字段。  
+3. **Route Minimization** — L0 只选 graph region；`target_type` / `prompt` / `slots` 属 L2。  
+4. **Context Overrides Text** — 有 `@T1` attachment 时，低置信文本推断不得否决 ref-backed generate。  
+5. **Clarify is Loop, Not Fallback** — 澄清后必回 L0 或 L2，禁止无声落 chat。
+
+---
+
+### 9.5 六层工程栈映射
+
+对照 [graph-engineering-design §1.1](./2026-07-26-graph-engineering-design.md) 六层模型，Route Unification 各层职责：
+
+| 层 | P1 职责 | 关键产物 | 本 ADR 决策 |
+|----|---------|----------|-------------|
+| **Graph Engineering** | L0 路由节点、clarify_gate 子图、checkpoint channel | `route_decide` 瘦身、`clarify_gate` 统一 | RU-2, RU-7 |
+| **Loop Engineering** | 澄清→恢复→执行轨迹；低置信不终止 | clarify follow-up 回 `apply_route_precedence` | RU-7 |
+| **Context Engineering** | `RouteContext` 全量组装；refs/focus/checkpoint 进 features | `assemble_route_context` 扩展 | RU-6 |
+| **Prompt Engineering** | L2 parse / classify 模板；**不参与 L0** | `atomic_parse_llm` system prompt | LLM 仅 L2 |
+| **Harness Engineering** | eval-route-set CI、shadow diff、prod verify | `eval-route-set.yaml` 门禁 | RU-8 |
+| **Observability** | trace 写入 features / precedence_rule_id | execution trace 字段 | §9.14 |
+
+**设计顺序（自顶向下，业界推荐）：** Graph（L0 分支）→ Loop（clarify 续接）→ Context（RouteContext）→ Harness（eval）→ Prompt（L2 优化）。**禁止**仅用 Prompt 修补 L0 误判。
+
+---
+
+### 9.6 LangGraph 目标拓扑
+
+P1 终态 Graph 与当前 P0 差异：**单一 clarify 子图**、**intake 不再并行 bool 扫描**。
+
+```text
+START
+  │
+  ▼
+intake ── assemble RouteContext + pending_clarify?
+  │
+  ├─ pending_clarify + valid reply ──► restore ctx ──► (shortcut L2 or re-enter L0)
+  │
+  ▼
+route_decide ── extract_features + resolve_ir + apply_precedence
+  │
+  ├── atomic_create ──► parse_atomic_intent (L2)
+  │                         │
+  │                         ├─ success ──► create_atomic_node ──► apply_sidebar_refs ──► done
+  │                         └─ needs_clarify ──► clarify_gate ──► END (checkpoint)
+  │
+  ├── orchestration ──► skill_gate (explicit skill only) ──► …
+  │
+  ├── clarify ──► clarify_gate ──► END (checkpoint; phase=clarify, NOT flow_mode=chat)
+  │
+  ├── explore / single_node / chat ──► …
+  │
+  └── (removed: parallel marketing_intent branch in intake)
+```
+
+**clarify_gate（统一子图，P1 新增）：**
+
+| 步骤 | 行为 |
+|------|------|
+| 写入 | `clarify_context`（kind、original、snapshot） |
+| 输出 | 用户可见 clarify 文案 + honest `thinking_summary` |
+| phase | `clarify`（保持会话可续接） |
+| 禁止 | `flow_mode=chat` + 无 checkpoint |
+
+---
+
+### 9.7 分层路由管线（L0–L3 Cascade）
+
+| 层级 | 名称 | 输入 | 输出 | 机制 | LLM |
+|------|------|------|------|------|-----|
+| **L0** | Platform Router | RouteContext | `flow_mode` + `reason` + `confidence` | features + precedence | ❌ |
+| **L1** | Intent IR | utterance + ctx | `AtomicIntent` | 规则 + IR resolver | ❌ |
+| **L2** | Task Parse | AtomicIntent + canvas | `IntentParseResult` / items | rule fast-path + LLM schema | ✅（低置信/复杂） |
+| **L3** | Execute | GenerationRequest | Studio record / nodes | Nest API | ❌ |
+
+**信号优先级（Context-First，L0 内建）：**
+
+| 优先级 | 信号 | 示例 |
+|--------|------|------|
+| 1 | 用户显式 UI | 选 Skill、Dock 生成、focus 节点 |
+| 2 | 结构化上下文 | `@T1` attachment、checkpoint、canvas focus |
+| 3 | IR 高置信 | ref + generate + modality |
+| 4 | LLM structured parse | L2 confidence ≥ threshold |
+| 5 | Clarify | 多意图 / 低置信 |
+| 6 | Safe default | chat + 明确下一步提示 |
+
+---
+
+### 9.8 核心数据模型
+
+#### 9.8.1 `RouteContext`（Context Engineering — 已有，P1 全量消费）
+
+```python
+RouteContext = TypedDict:
+    utterance: str
+    mentioned_keys: list[str]
+    sidebar_attachments: list[dict]
+    focus_node_id: str | None
+    requested_skill_id: str | None
+    checkpoint: RouteCheckpoint
+```
+
+#### 9.8.2 `RouteFeatures`（P1 新增 — Feature 化，非 Label）
+
+```python
+RouteFeatures = TypedDict:
+    has_text_ref: bool           # T* in keys or attachments
+    has_image_ref: bool          # I* ≥ 1
+    has_multi_image_ref: bool    # img2img
+    explicit_skill: bool         # requested_skill_id valid
+    has_atomic_checkpoint: bool
+    preserve_composition: bool   # L0 preserve verbs
+    orchestration_phrases: bool  # 详情页/全链路/分镜套系（不含单字「出图」）
+    modality_conflict_risk: bool # IR guard
+    explore_blocked: bool        # atomic/explicit gen blocks explore
+```
+
+#### 9.8.3 `AtomicIntent`（IR SoT — 扩展 slots，P2）
+
+```python
+AtomicIntent = dataclass:
+    action: generate | expand | write | plan | unknown
+    output_modality: image | video | text | prompt | audio
+    utterance: str
+    source_markers: tuple[str, ...]
+    mentioned_keys: tuple[str, ...]
+    slots: dict[str, str]        # P2: style="3", ref="T1"
+    confidence: float              # P1: rule-derived; L2 may override parse
+```
+
+#### 9.8.4 `RouteDecision`（L0 输出）
+
+```python
+RouteDecision = TypedDict:
+    flow_mode: atomic_create | orchestration | clarify | explore_canvas | single_node | chat
+    precedence_rule_id: str      # 可追溯：命中 precedence 表第 N 行
+    l0_action: ActionKind
+    confidence: float
+    reason: str
+    clarify_question: str | None
+    atomic_intent: AtomicIntent  # snapshot for trace
+    route_features: RouteFeatures
+```
+
+#### 9.8.5 `GenerationRequest`（侧栏 ≡ Dock，P1/P2）
+
+```python
+GenerationRequest = TypedDict:
+    prompt: str                    # 用户指令（含「按风格3出图」）
+    refs: list[StudioRefPayload]   # T1 正文 / I1 URL via localRefs
+    mentioned_keys: list[str]      # @T1 分工语义
+    modality: image | video | ...
+    node_id: str | None            # canvas scope
+```
+
+#### 9.8.6 `ClarifyContext`（Loop checkpoint — P0 引入，P1 统一）
+
+见 §2.3；P1 所有 clarify 路径（route / atomic / img2img）**必须**写入同一结构。
+
+---
+
+### 9.9 信号优先级与 Precedence 策略表
+
+**Precedence 表 = 唯一冲突消解协议**（借鉴 Rasa policy precedence + Dialogflow route groups）：
+
+| 序 | rule_id | 条件 | flow_mode | reason |
+|----|---------|------|-----------|--------|
+| 1 | `clarify_resume` | `pending_clarify` + 有效 follow-up | 由 classify 决定 | clarify_resume |
+| 2 | `checkpoint_regen` | `has_atomic_checkpoint` + regenerate | atomic_regenerate | checkpoint_regen |
+| 3 | `sidebar_img2img` | `has_multi_image_ref` + transform/preserve | atomic_create | sidebar_img2img |
+| 4 | `ref_backed_generate` | `intent.action==generate` + ref + modality∈{image,video} | atomic_create | ref_backed_generate |
+| 5 | `focus_gen` | `focus_node_id` + single_node_gen | single_node | focus_gen |
+| 6 | `explicit_skill_orch` | `explicit_skill` + orchestration_phrases | orchestration | explicit_skill_orch |
+| 7 | `atomic_generate` | `intent.action==generate` + 高置信 modality | atomic_create | atomic_generate |
+| 8 | `orch_ambiguous` | orchestration_phrases + 无 ref + 无 skill | clarify | orch_ambiguous |
+| 9 | `explore` | explore 信号 + 未被 atomic 阻断 | explore_canvas | explore |
+| 10 | `empty` | 空 utterance | chat | empty |
+| 11 | `default_chat` | default | chat | default_chat |
+
+**冲突消解规则：** 只此一张表；`decide_route.py` 内 **禁止** 新增 `if marketing_intent` 分支。新 case → 新 `RouteFeatures` 字段或调整 precedence 行 + `eval-route-set` case。
+
+**实现位置（P1）：** `services/agent-runtime/app/graph/route_precedence.py`（新模块，单测 + YAML 可选同步）。
+
+---
+
+### 9.10 侧栏 / Dock 统一执行模型
+
+**最佳实践：** 路由层与执行层解耦——L0/L2 只产出 `GenerationRequest`，Studio 不关心入口是侧栏还是 Dock。
+
+```text
+                    ┌─────────────────┐
+  Agent 侧栏 ──────►│                 │
+  utterance+refs    │ GenerationRequest│──────► studioApi.generateImage(...)
+                    │  prompt          │        canvasApi.generateImage(...)
+  Dock 生成 ──────►│  refs            │        (同一 Nest 后端)
+  localPrompt+edges │  mentionedKeys   │
+                    └─────────────────┘
+```
+
+| 字段 | 侧栏来源 | Dock 来源 |
+|------|----------|-----------|
+| `prompt` | utterance / derive_studio_prompt | `node.data.prompt`（Dock 输入） |
+| `refs` | sidebar_attachments → localRefs | edges + localRefs（resolveNodeRefs） |
+| `mentionedKeys` | parseRefMentions + sidebar_mentioned_keys | parseRefMentions(prompt) |
+
+**parity 验收：** AC-01（侧栏）与 AC-05（Dock）构造的 `GenerationRequest` 字段级一致（R-ALIGN-02）。
+
+---
+
+### 9.11 目标模块结构（P1 文件布局）
+
+```text
+services/agent-runtime/app/graph/
+├── atomic_intent_ir.py      # L1 IR SoT（扩展 slots）
+├── route_context.py         # Context 组装（已有）
+├── route_features.py        # [NEW] extract_route_features()
+├── route_precedence.py      # [NEW] apply_route_precedence()
+├── route_decide.py          # [REFACTOR] 瘦身为 orchestrator
+├── clarify_context.py       # [NEW] ClarifyContext types + pending_clarify
+├── nodes/
+│   ├── intake.py
+│   ├── clarify_gate.py      # [NEW] 统一 clarify 子图入口
+│   └── atomic_parse.py      # L2 only
+└── generation_request.py    # [NEW] 侧栏/Dock 统一 DTO（可选 shared pkg）
+
+skills/atomic-create/
+├── eval-route-set.yaml      # Harness 契约（CI required）
+└── eval-intent-set.yaml     # L2 parse 契约
+```
+
+---
+
+### 9.12 P0 → P1 迁移计划
+
+| 阶段 | 内容 | 退出标准 |
+|------|------|----------|
+| **P0**（本文 §3） | fast path、clarify checkpoint、出图 demote、IR 词表 | AC-01–AC-07 全绿 |
+| **P1a** | 引入 `extract_route_features` + `apply_route_precedence`；旧逻辑 shadow diff | shadow 一致率 ≥99% on eval-route-set |
+| **P1b** | `decide_route` 切到新路径；旧 bool 分类器标记 `@deprecated` | CI eval-route-set 门禁 |
+| **P1c** | 删除 deprecated 分类器；文档更新 | 无 `MARKETING_HINTS` 路由引用 |
+| **P2** | `GenerationRequest` 统一；风格 N slot；T1 正文切片（可选） | Dock/侧栏 parity eval |
+
+### 9.13 废止与保留
+
+| 模块 | P1 后状态 |
+|------|-----------|
+| `atomic_intent_ir.py` | **保留并扩展** — 唯一 IR SoT |
+| `marketing_intent()` | **删除**（路由用途）；orchestration 改用 `orchestration_phrases` feature |
+| `atomic_create_intent()` | **删除**（路由用途）；保留为 IR 测试 helper 或内联到 feature |
+| `orchestration_complexity_intent()` | **删除**；合并到 precedence 第 8 行 |
+| `_sidebar_img2img_signal` / `_sidebar_ref_atomic_signal` | **合并**入 `RouteFeatures` + precedence 3–4 行 |
+| `planning_guard` | **保留** — L2 parse guard，**不参与** L0 route veto |
+| `classify_clarify_reply` | **保留** — clarify follow-up parser |
+
+### 9.14 Harness 与 Observability（P1 必交付）
+
+| 交付物 | 要求 |
+|--------|------|
+| `eval-route-set.yaml` | ≥30 cases：atomic / orch / clarify / explore / regression；CI required check |
+| Shadow route diff | 可选：`ROUTE_SHADOW_MODE=true` 时新旧 decide_route 双跑写 log |
+| Trace 字段 | `route_features`、`atomic_intent`、`precedence_rule_id`、`route_decision` 写入 execution trace |
+| 生产 verify | 扩展 `prod-atomic-intent-ir-verify.py` → `prod-route-unification-verify.py` |
+
+### 9.15 非范围（P1）
+
+- 用 LLM 替代整张 precedence 表（LLM 仍仅 L2 parse + 可选 clarify NLU fallback）
+- Skill 市场 / 用户安装 UI
+- 前端路由或 Dock 改造（除 GenerationRequest 类型对齐）
+- 多语言 utterance 路由
+
+### 9.16 P1 验收标准
+
+- [ ] `decide_route` 单文件内 **零** `MARKETING_HINTS` / `ATOMIC_CREATE_HINTS` substring 路由
+- [ ] 任意路由变更必须附带 `eval-route-set` case 或修改既有 case 期望
+- [ ] AC-01–AC-07 + platform-route img2img case + video IR case 全绿
+- [ ] clarify follow-up（route + atomic）100% 不落入 default chat（自动化测试）
+- [ ] 文档：[platform-route-skill-boundary](./2026-08-07-platform-route-skill-boundary-design.md) 追加 R-S9「Route Unification 完成」
+- [ ] execution trace 含 `precedence_rule_id`（§9.14）
+
+### 9.17 治理：禁止再次堆 hint 表
+
+1. **PR 审查清单：** 若 diff 新增 `*_HINTS` 条目或 `if any(h in text for h in ...)` 路由分支 → **拒绝**，要求改 feature + precedence + eval。
+2. **Issue 模板：** 路由 bug 必须标注「P0 hotfix 或 P1 precedence 行」二选一，禁止第三种「临时 hint」。
+3. **Deprecation 时钟：** P0 合并日 + 90 天触发 P1b 截止；逾期则 freeze 新 feature 直至 P1 完成。
+
+---
+
+## 10. 文档版本
+
+| 版本 | 日期 | 变更 |
+|------|------|------|
+| v1.0 | 2026-08-09 | P0 止血规格 §0–§8 |
+| v1.1 | 2026-08-09 | 追加 §9 Route Unification ADR；明确 P0/P1 边界 |
+| v1.2 | 2026-08-09 | §9.3–§9.11 目标架构 + 业界最佳实践；§2.4 预览 |
+| v1.3 | 2026-08-09 | 链全量实施计划 full.md |

--- a/services/agent-runtime/app/graph/atomic_intent.py
+++ b/services/agent-runtime/app/graph/atomic_intent.py
@@ -11,7 +11,6 @@ import yaml
 
 from app.graph.intent import (
     CONFIRM_GEN_HINTS,
-    marketing_intent,
     modify_intent,
     single_node_gen_intent,
 )
@@ -330,6 +329,8 @@ def atomic_create_intent(text: str) -> bool:
         return True
     if any(h in lowered for h in IMAGE_KEYWORDS):
         return True
+    if re.search(r"(?:出图|出一张图|生成图)", text or ""):
+        return True
     return False
 
 
@@ -377,8 +378,6 @@ def orchestration_complexity_intent(text: str) -> OrchestrationComplexity:
         return "atomic"
     if atomic_create_intent(t):
         return "atomic"
-    if marketing_intent(t):
-        return "campaign"
     return "clarify"
 
 
@@ -386,26 +385,20 @@ def resolve_intake_route(
     text: str,
     *,
     focus_node_id: str | None,
-) -> Literal["campaign", "single_node", "atomic_create", "chat"]:
-    """Intake routing per ADR-003 priority."""
+) -> Literal["single_node", "atomic_create", "chat"]:
+    """Intake routing — campaign/orchestration requires explicit skill in route_decide."""
     if (
         focus_node_id
         and single_node_gen_intent(text)
         and not modify_intent(text)
     ):
         return "single_node"
-    from app.graph.planning_guard import detect_action, has_planning_image_conflict, is_planning_intent
+    from app.graph.planning_guard import detect_action
 
-    if has_planning_image_conflict(text):
-        return "campaign"
-    if "详情页" in text and is_planning_intent(text) and detect_action(text) != "write":
-        return "campaign"
     if detect_action(text) == "write":
         return "atomic_create"
     if atomic_create_intent(text):
         return "atomic_create"
-    if marketing_intent(text):
-        return "campaign"
     return "chat"
 
 

--- a/services/agent-runtime/app/graph/atomic_intent_ir.py
+++ b/services/agent-runtime/app/graph/atomic_intent_ir.py
@@ -83,6 +83,8 @@ def has_generate_verb(text: str) -> bool:
         return True
     if re.search(r"(?:生成|做|来|出)(?:一张|一个|一段|一条)", t):
         return True
+    if re.search(r"(?:出图|出一张图|生成图)", t):
+        return True
     return False
 
 
@@ -96,6 +98,8 @@ def has_image_output(text: str) -> bool:
     t = (text or "").strip()
     lowered = t.lower()
     if _IMAGE_GENERATE_RE.search(t):
+        return True
+    if "出图" in t or "生成图" in t or re.search(r"按?风格\s*\d+", t):
         return True
     return any(k in t or k in lowered for k in IMAGE_OUTPUT_KEYWORDS)
 
@@ -122,6 +126,11 @@ def is_source_backed_media_generation(text: str) -> bool:
 def is_ref_media_generation(text: str, mentioned_keys: list[str] | None = None) -> bool:
     t = (text or "").strip()
     keys = mentioned_keys or []
+    text_keys = [k for k in keys if k.upper().startswith("T")]
+    if text_keys and (
+        re.search(r"按?风格\s*\d+", t) or "出图" in t or "生成图" in t
+    ):
+        return True
     if keys and has_generate_verb(t) and (has_video_output(t) or has_image_output(t)):
         return True
     if re.search(r"@\w", t) and has_generate_verb(t) and (has_video_output(t) or has_image_output(t)):
@@ -216,11 +225,15 @@ def resolve_output_modality(
     return "image"
 
 
-def resolve_atomic_action(text: str) -> AtomicAction:
+def resolve_atomic_action(
+    text: str,
+    *,
+    mentioned_keys: list[str] | None = None,
+) -> AtomicAction:
     t = (text or "").strip()
     if not t:
         return "unknown"
-    if is_source_backed_media_generation(t) or is_ref_media_generation(t):
+    if is_source_backed_media_generation(t) or is_ref_media_generation(t, mentioned_keys):
         return "generate"
     if is_prompt_expand_intent(t):
         return "expand"
@@ -237,7 +250,7 @@ def resolve_atomic_intent(
     t = (text or "").strip()
     keys = tuple(mentioned_keys or [])
     markers = tuple(m for m in SOURCE_MARKERS if m in t)
-    action = resolve_atomic_action(t)
+    action = resolve_atomic_action(t, mentioned_keys=list(keys))
     output = resolve_output_modality(t, mentioned_keys=list(keys))
     if action == "expand" and output not in ("prompt",):
         output = "prompt"
@@ -254,7 +267,10 @@ def resolve_atomic_intent(
 
 def derive_studio_prompt(intent: AtomicIntent) -> str:
     """Short node prompt for Studio; sidebar/canvas refs carry source body."""
-    t = intent.utterance
+    t = intent.utterance.strip()
+    if intent.mentioned_keys and t and not re.fullmatch(r"@\w+\s*", t):
+        if re.search(r"按?风格\s*\d+", t) or "出图" in t or "生成图" in t:
+            return t
     if intent.output_modality == "video" and (
         intent.source_markers or intent.mentioned_keys or is_source_backed_media_generation(t)
     ):

--- a/services/agent-runtime/app/graph/atomic_parse_schema.py
+++ b/services/agent-runtime/app/graph/atomic_parse_schema.py
@@ -9,7 +9,6 @@ from langchain_core.messages import AIMessage
 from app.graph.atomic_intent import confirm_gate_for_type, _is_campaign_override
 from app.graph.sidebar_attachments import assign_sidebar_ref_keys
 from app.graph.sidebar_copy import format_atomic_multi_ack, format_atomic_parse_ack
-from app.graph.intent import marketing_intent
 from app.graph.planning_guard import has_planning_image_conflict, planning_clarify_question
 
 CLARIFY_THRESHOLD = 0.70
@@ -142,9 +141,7 @@ def validate_parse_result(
             "clarify_question": planning_clarify_question(utterance),
         }
 
-    if _is_campaign_override(utterance) or (
-        marketing_intent(utterance) and "营销方案" in utterance
-    ):
+    if _is_campaign_override(utterance):
         return {
             "kind": "clarify",
             "confidence": 0.0,

--- a/services/agent-runtime/app/graph/copy_sot.py
+++ b/services/agent-runtime/app/graph/copy_sot.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from app.graph.intent import marketing_intent
-
 
 @dataclass(frozen=True)
 class CopySoT:
@@ -38,9 +36,6 @@ def brief_from_messages(messages: list[Any]) -> str:
         ):
             continue
         candidates.append(text)
-    for text in candidates:
-        if marketing_intent(text):
-            return text
     return candidates[0] if candidates else ""
 
 

--- a/services/agent-runtime/app/graph/intent.py
+++ b/services/agent-runtime/app/graph/intent.py
@@ -1,30 +1,17 @@
 """Unified intent classification constants and functions (W9).
 
 This module consolidates intent-related keywords that were previously scattered across:
-- intake.py: _MODIFY_HINTS, _MARKETING_HINTS
+- intake.py: _MODIFY_HINTS
 - await_topo.py: _NODE_REVISE_HINTS, _TOPO_REVISE_HINTS, _CONFIRM_GEN_HINTS
 - await_confirm.py: _CONFIRM_HINTS, _REVISE_HINTS
+
+Orchestration / Campaign routing no longer uses keyword-based marketing_intent.
+Use explicit requested_skill_id in route_decide (platform-route R-S1/R-S2).
 """
 
 from __future__ import annotations
 
 from typing import Literal
-
-# Intake node: marketing intent keywords
-MARKETING_HINTS = (
-    "营销",
-    "主图",
-    "详情页",
-    "banner",
-    "campaign",
-    "洁具",
-    "卫浴",
-    "电商",
-    "天猫",
-    "拆画布",
-    "出图",
-    "分镜",
-)
 
 # Intake node: modification intent keywords
 MODIFY_HINTS = (
@@ -145,14 +132,6 @@ CONFIRM_NEGATIONS = (
     "无需修改",
     "没有修改",
 )
-
-
-def marketing_intent(text: str) -> bool:
-    """Check if text indicates marketing/campaign canvas orchestration intent."""
-    lowered = (text or "").strip().lower()
-    if not lowered:
-        return False
-    return any(h in lowered for h in MARKETING_HINTS)
 
 
 def modify_intent(text: str) -> bool:

--- a/services/agent-runtime/app/graph/nodes/intake.py
+++ b/services/agent-runtime/app/graph/nodes/intake.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable
 
-from app.graph.intent import marketing_intent, modify_intent, single_node_gen_intent
+from app.graph.intent import modify_intent, single_node_gen_intent
 from app.graph.atomic_clarify import is_affirmative_clarify_reply, pending_atomic_clarify
 from app.graph.route_context import assemble_route_context, latest_user_text
 from app.graph.route_decide import ROUTE_CLARIFY_ORCHESTRATION, decide_route

--- a/services/agent-runtime/app/graph/route_decide.py
+++ b/services/agent-runtime/app/graph/route_decide.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Literal, TypedDict
 
 from app.graph.atomic_intent import (
@@ -12,8 +13,9 @@ from app.graph.atomic_intent import (
     regenerate_phrase_intent,
     resolve_intake_route,
 )
+from app.graph.atomic_intent_ir import is_ref_media_generation, resolve_output_modality
 from app.graph.explore_route import explore_canvas_signal, explore_explicit_intent
-from app.graph.intent import marketing_intent, modify_intent, single_node_gen_intent
+from app.graph.intent import modify_intent, single_node_gen_intent
 from app.graph.l0_action import (
     TRANSFORM_VERBS,
     detect_l0_action,
@@ -26,9 +28,9 @@ from app.graph.route_context import RouteContext
 CLARIFY_THRESHOLD = 0.70
 
 ROUTE_CLARIFY_ORCHESTRATION = (
-    "听起来像多节点编排或营销方案需求。请确认：\n"
-    "1）单张/图生图原子出图；\n"
-    "2）完整编排（请在侧栏选用已安装的 Skill）；\n"
+    "听起来像多节点编排或 Skill 工作流需求。请确认：\n"
+    "1）按引用内容单张出图（保留 @T* / @I*）；\n"
+    "2）完整编排（请先在侧栏选用已安装的 Skill）；\n"
     "3）其他说明。\n"
     "回复 1 / 2 / 3。"
 )
@@ -67,6 +69,34 @@ def _image_mentioned_keys(keys: list[str]) -> list[str]:
     return [k for k in keys if k.upper().startswith("I")]
 
 
+def _text_mentioned_keys(keys: list[str]) -> list[str]:
+    return [k for k in keys if k.upper().startswith("T")]
+
+
+def _sidebar_ref_atomic_signal(ctx: RouteContext) -> bool:
+    """T/I ref + image/video generate utterance → atomic (explicit-skill model)."""
+    utterance = str(ctx.get("utterance") or "").strip()
+    if not utterance:
+        return False
+    keys = list(ctx.get("mentioned_keys") or [])
+    text_keys = _text_mentioned_keys(keys)
+    attachments = ctx.get("sidebar_attachments") or []
+    has_ref = bool(text_keys or keys) or any(
+        str(a.get("mediaType") or "").lower() in ("text", "image") for a in attachments
+    )
+    if not has_ref:
+        return False
+    mk = keys or None
+    if is_ref_media_generation(utterance, mk):
+        return True
+    modality = resolve_output_modality(utterance, mentioned_keys=mk)
+    if modality in ("image", "video") and (
+        "出图" in utterance or "生成图" in utterance or re.search(r"按?风格\s*\d+", utterance)
+    ):
+        return True
+    return False
+
+
 def _explore_canvas_signal(ctx: RouteContext) -> bool:
     utterance = str(ctx.get("utterance") or "").strip()
     if not utterance:
@@ -76,7 +106,6 @@ def _explore_canvas_signal(ctx: RouteContext) -> bool:
         or single_node_gen_intent(utterance)
         or regenerate_phrase_intent(utterance)
         or atomic_regenerate_intent(utterance)
-        or marketing_intent(utterance)
     )
     return explore_canvas_signal(utterance, blocked_by_atomic=blocked)
 
@@ -162,19 +191,21 @@ def decide_route(ctx: RouteContext, *, valid_skill_ids: set[str] | None = None) 
             "is_modify": False,
         }
 
+    if _sidebar_ref_atomic_signal(ctx):
+        return {
+            "flow_mode": "atomic_create",
+            "l0_action": l0,
+            "confidence": 0.92,
+            "reason": "sidebar_ref_atomic",
+            "clarify_question": None,
+            "guard_veto": guard_veto,
+            "is_modify": False,
+        }
+
     route = resolve_intake_route(utterance, focus_node_id=focus)
     orch = orchestration_complexity_intent(utterance)
     is_atomic = route == "atomic_create" or atomic_create_intent(utterance)
     is_variant = has_checkpoint and is_regenerate_new_variant(utterance)
-
-    if orch == "campaign" and (is_atomic or is_variant):
-        preserve_or_img2img = has_preserve_intent(utterance) or (
-            utterance_has_multi_image_refs(utterance) and any(v in utterance for v in TRANSFORM_VERBS)
-        )
-        if not preserve_or_img2img:
-            is_atomic = False
-            is_variant = False
-            route = "campaign"
 
     if focus and route == "single_node" and single_node_gen_intent(utterance) and not modify_intent(utterance):
         return {
@@ -187,13 +218,24 @@ def decide_route(ctx: RouteContext, *, valid_skill_ids: set[str] | None = None) 
             "is_modify": False,
         }
 
-    if skill_id and (marketing_intent(utterance) or route == "campaign" or orch == "campaign"):
+    if skill_id:
         return {
             "flow_mode": "campaign",
             "l0_action": l0,
             "confidence": 0.90,
             "reason": "explicit_skill_orchestration",
             "clarify_question": None,
+            "guard_veto": guard_veto,
+            "is_modify": False,
+        }
+
+    if guard_veto or (orch == "campaign" and not skill_id):
+        return {
+            "flow_mode": "clarify_route",
+            "l0_action": l0,
+            "confidence": 0.75,
+            "reason": "orchestration_without_skill",
+            "clarify_question": ROUTE_CLARIFY_ORCHESTRATION,
             "guard_veto": guard_veto,
             "is_modify": False,
         }
@@ -217,17 +259,6 @@ def decide_route(ctx: RouteContext, *, valid_skill_ids: set[str] | None = None) 
             "confidence": 0.88,
             "reason": "atomic_create_intent",
             "clarify_question": None,
-            "guard_veto": guard_veto,
-            "is_modify": False,
-        }
-
-    if marketing_intent(utterance) or (orch == "campaign" and route == "campaign") or guard_veto:
-        return {
-            "flow_mode": "clarify_route",
-            "l0_action": l0,
-            "confidence": 0.75,
-            "reason": "orchestration_without_skill",
-            "clarify_question": ROUTE_CLARIFY_ORCHESTRATION,
             "guard_veto": guard_veto,
             "is_modify": False,
         }

--- a/services/agent-runtime/skills/atomic-create/eval-intent-set.yaml
+++ b/services/agent-runtime/skills/atomic-create/eval-intent-set.yaml
@@ -155,12 +155,12 @@ cases:
   - id: neg-camp-01
     utterance: 帮我做一套天猫蓝牙耳机详情页营销方案
     focus_node_id: null
-    gold: { route: campaign, target_type: null, confirm_gate: false }
+    gold: { route: chat, target_type: null, confirm_gate: false }
 
   - id: neg-camp-02
     utterance: 天猫详情页，拆14个画布节点，品牌lnkpi
     focus_node_id: null
-    gold: { route: campaign, target_type: null, confirm_gate: false }
+    gold: { route: chat, target_type: null, confirm_gate: false }
 
   # --- negative: chat (1) ---
   - id: neg-chat-01
@@ -221,7 +221,7 @@ cases:
   - id: trap-confirm-02
     utterance: 开始出图
     focus_node_id: null
-    gold: { route: campaign, target_type: null, confirm_gate: false }
+    gold: { route: chat, target_type: null, confirm_gate: false }
     notes: campaign confirm reply, not atomic_create
 
   - id: trap-confirm-03
@@ -259,12 +259,12 @@ cases:
   - id: neg-camp-03
     utterance: 帮我策划一套全链路营销方案，要拆画布
     focus_node_id: null
-    gold: { route: campaign, target_type: null, confirm_gate: false }
+    gold: { route: chat, target_type: null, confirm_gate: false }
 
   - id: neg-camp-04
     utterance: 做一套详情页 campaign，14个节点
     focus_node_id: null
-    gold: { route: campaign, target_type: null, confirm_gate: false }
+    gold: { route: chat, target_type: null, confirm_gate: false }
 
   - id: neg-chat-02
     utterance: 谢谢
@@ -360,12 +360,12 @@ cases:
   - id: p2-camp-01
     utterance: 帮我策划天猫详情页全链路
     focus_node_id: null
-    gold: { route: campaign, target_type: null, confirm_gate: false }
+    gold: { route: chat, target_type: null, confirm_gate: false }
 
   - id: p2-camp-02
     utterance: 做一套蓝牙耳机营销方案，要拆画布
     focus_node_id: null
-    gold: { route: campaign, target_type: null, confirm_gate: false }
+    gold: { route: chat, target_type: null, confirm_gate: false }
 
   - id: p2-chat-01
     utterance: 你好
@@ -510,7 +510,7 @@ cases:
   - id: plan-01
     utterance: 请你帮我设计一个蓝牙耳机主图，详情页的构图方案
     focus_node_id: null
-    gold: { route: campaign, target_type: image, confirm_gate: false }
+    gold: { route: atomic_create, target_type: text, confirm_gate: false }
     notes: planning guard — intake routes campaign; target_type ignored when not atomic_create
 
   - id: ir-video-01

--- a/services/agent-runtime/skills/atomic-create/eval-orchestration-set.yaml
+++ b/services/agent-runtime/skills/atomic-create/eval-orchestration-set.yaml
@@ -7,19 +7,19 @@ meta:
 cases:
   - id: orch-01
     utterance: 帮我生成12个分镜镜头
-    gold: { complexity: campaign, route: campaign }
+    gold: { complexity: campaign, platform_flow: clarify_route }
 
   - id: orch-02
     utterance: 做一套天猫蓝牙耳机详情页营销方案
-    gold: { complexity: campaign, route: campaign }
+    gold: { complexity: campaign, platform_flow: clarify_route }
 
   - id: orch-03
     utterance: 帮我做全链路营销方案
-    gold: { complexity: campaign, route: campaign }
+    gold: { complexity: campaign, platform_flow: clarify_route }
 
   - id: orch-04
     utterance: 生成6个分镜脚本
-    gold: { complexity: campaign, route: campaign }
+    gold: { complexity: campaign, platform_flow: clarify_route }
 
   - id: orch-05
     utterance: 帮我生成三张图，分别是蓝牙耳机主图、白底图、三视图。
@@ -39,7 +39,7 @@ cases:
 
   - id: orch-09
     utterance: 14节点详情页方案
-    gold: { complexity: campaign, route: campaign }
+    gold: { complexity: campaign, platform_flow: clarify_route }
 
   - id: orch-10
     utterance: 帮我生成
@@ -47,7 +47,7 @@ cases:
 
   - id: orch-11
     utterance: 生成4张分镜图
-    gold: { complexity: campaign, route: campaign }
+    gold: { complexity: campaign, platform_flow: clarify_route }
 
   - id: orch-12
     utterance: 来一张风图，户外跑步场景
@@ -55,7 +55,7 @@ cases:
 
   - id: orch-13
     utterance: 帮我做一套campaign全链路
-    gold: { complexity: campaign, route: campaign }
+    gold: { complexity: campaign, platform_flow: clarify_route }
 
   - id: orch-14
     utterance: 生成2张图片，分别是白底图、场景图。
@@ -63,7 +63,7 @@ cases:
 
   - id: orch-15
     utterance: 整套分镜脚本方案
-    gold: { complexity: campaign, route: campaign }
+    gold: { complexity: campaign, platform_flow: clarify_route }
 
   - id: orch-16
     utterance: 15秒产品展示视频
@@ -71,7 +71,7 @@ cases:
 
   - id: orch-17
     utterance: 详情页方案拆画布
-    gold: { complexity: campaign, route: campaign }
+    gold: { complexity: campaign, platform_flow: clarify_route }
 
   - id: orch-18
     utterance: 帮我生成一个蓝牙耳机的分镜提示词
@@ -79,11 +79,11 @@ cases:
 
   - id: orch-19
     utterance: 生成十个镜头分镜
-    gold: { complexity: campaign, route: campaign }
+    gold: { complexity: campaign, platform_flow: clarify_route }
 
   - id: orch-21
     utterance: 请你帮我设计一个蓝牙耳机主图，详情页的构图方案
-    gold: { complexity: campaign, route: campaign }
+    gold: { complexity: campaign, platform_flow: clarify_route }
 
   - id: orch-20
     utterance: 做一个Banner图

--- a/services/agent-runtime/skills/atomic-create/eval-planning-guard-set.yaml
+++ b/services/agent-runtime/skills/atomic-create/eval-planning-guard-set.yaml
@@ -8,43 +8,43 @@ cases:
   # --- plan-campaign (10) ---
   - id: pg-01
     utterance: 请你帮我设计一个蓝牙耳机主图，详情页的构图方案
-    gold: { route: campaign, complexity: campaign, forbid_target: image, allow_clarify: true }
+    gold: { platform_flow: clarify_route, complexity: campaign, forbid_target: image, allow_clarify: true }
 
   - id: pg-02
     utterance: 帮我规划天猫蓝牙耳机详情页的视觉结构和模块顺序
-    gold: { route: campaign, complexity: campaign, forbid_target: image }
+    gold: { platform_flow: clarify_route, complexity: campaign, forbid_target: image }
 
   - id: pg-03
     utterance: 蓝牙耳机详情页构图方案
-    gold: { route: campaign, complexity: campaign, forbid_target: image }
+    gold: { platform_flow: clarify_route, complexity: campaign, forbid_target: image }
 
   - id: pg-04
     utterance: 设计一套详情页视觉方案，含主图和白底
-    gold: { route: campaign, complexity: campaign, forbid_target: image }
+    gold: { platform_flow: clarify_route, complexity: campaign, forbid_target: image }
 
   - id: pg-05
     utterance: 详情页营销视觉策划，运动耳机
-    gold: { route: campaign, complexity: campaign, forbid_target: image }
+    gold: { platform_flow: clarify_route, complexity: campaign, forbid_target: image }
 
   - id: pg-06
     utterance: 帮我做详情页方案，主图场景图布局
-    gold: { route: campaign, complexity: campaign, forbid_target: image }
+    gold: { platform_flow: clarify_route, complexity: campaign, forbid_target: image }
 
   - id: pg-07
     utterance: 电商详情页整体框架设计，蓝牙耳机
-    gold: { route: campaign, complexity: campaign, forbid_target: image }
+    gold: { platform_flow: clarify_route, complexity: campaign, forbid_target: image }
 
   - id: pg-08
     utterance: 主图加详情页模块的完整视觉方案
-    gold: { route: campaign, complexity: campaign, forbid_target: image }
+    gold: { platform_flow: clarify_route, complexity: campaign, forbid_target: image }
 
   - id: pg-09
     utterance: 详情页结构布局方案，3C数码耳机
-    gold: { route: campaign, complexity: campaign, forbid_target: image }
+    gold: { platform_flow: clarify_route, complexity: campaign, forbid_target: image }
 
   - id: pg-10
     utterance: 帮我设计详情页Banner和主图的整体思路
-    gold: { route: campaign, complexity: campaign, forbid_target: image }
+    gold: { platform_flow: clarify_route, complexity: campaign, forbid_target: image }
 
   # --- plan-clarify via validate (5) ---
   - id: pg-cl-01

--- a/services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml
+++ b/services/agent-runtime/skills/atomic-create/intent-taxonomy.yaml
@@ -50,9 +50,10 @@ target_types:
     write_field: prompt
 
 intake_priority:
-  - id: campaign_override
-    when: marketing_intent and not atomic_create_intent
+  - id: explicit_skill
+    when: requested_skill_id is set
     route: campaign
+    notes: Orchestration only via user-selected Skill (platform-route R-S1)
   - id: single_node
     when: focus_node_id and single_node_gen_intent and not modify_intent
     route: single_node
@@ -61,12 +62,12 @@ intake_priority:
     route: atomic_regenerate
     notes: Same-node retry only (no variant/adjust tail). Variant phrases route to atomic_create.
   - id: atomic_create
-    when: atomic_create_intent and not marketing_intent
+    when: atomic_create_intent
     route: atomic_create
-  - id: orchestration_campaign
-    when: orchestration_complexity_intent == campaign
-    route: campaign
-    notes: Overrides atomic_create for high-complexity storyboard / full-funnel requests
+  - id: orchestration_clarify
+    when: orchestration_complexity_intent == campaign and not requested_skill_id
+    route: clarify_route
+    notes: High-complexity utterance without Skill → clarify, not silent campaign
   - id: fallback
     when: default
     route: chat

--- a/services/agent-runtime/tests/test_atomic_create_intent.py
+++ b/services/agent-runtime/tests/test_atomic_create_intent.py
@@ -76,9 +76,10 @@ def test_parse_atomic_target_type_planning_detail_page_is_text():
     assert parse_atomic_target_type(u) == "text"
 
 
-def test_resolve_intake_route_planning_goes_campaign():
+def test_resolve_intake_route_planning_may_atomic_without_skill():
+    """resolve_intake_route is atomic-first; orchestration clarify is in decide_route."""
     u = "请你帮我设计一个蓝牙耳机主图，详情页的构图方案"
-    assert resolve_intake_route(u, focus_node_id=None) == "campaign"
+    assert resolve_intake_route(u, focus_node_id=None) == "atomic_create"
 
 
 def test_turnaround_pipeline_spec_for_direct_image_request():

--- a/services/agent-runtime/tests/test_atomic_intent_ir_ref_image.py
+++ b/services/agent-runtime/tests/test_atomic_intent_ir_ref_image.py
@@ -1,0 +1,34 @@
+from app.graph.atomic_intent_ir import (
+    derive_studio_prompt,
+    has_generate_verb,
+    has_image_output,
+    is_ref_media_generation,
+    resolve_atomic_intent,
+)
+
+STYLE3 = "@T1 请按风格3出图"
+
+
+def test_has_generate_verb_chutu():
+    assert has_generate_verb("按风格3出图")
+    assert has_generate_verb("请出图")
+
+
+def test_has_image_output_style_n():
+    assert has_image_output("按风格3出图")
+
+
+def test_ref_media_generation_t1_chutu():
+    assert is_ref_media_generation(STYLE3, ["T1"])
+
+
+def test_resolve_atomic_intent_style3():
+    ir = resolve_atomic_intent(STYLE3, mentioned_keys=["T1"])
+    assert ir.action == "generate"
+    assert ir.output_modality == "image"
+    assert ir.mentioned_keys == ("T1",)
+
+
+def test_derive_studio_prompt_keeps_style3_utterance():
+    ir = resolve_atomic_intent(STYLE3, mentioned_keys=["T1"])
+    assert derive_studio_prompt(ir) == STYLE3

--- a/services/agent-runtime/tests/test_intake_gate.py
+++ b/services/agent-runtime/tests/test_intake_gate.py
@@ -7,18 +7,9 @@ from pathlib import Path
 import pytest
 from langchain_core.messages import HumanMessage
 
-from app.graph.nodes.intake import make_intake_node, marketing_intent, modify_intent
+from app.graph.nodes.intake import make_intake_node, modify_intent
 
 SKILLS_DIR = Path(__file__).resolve().parents[1] / "skills"
-
-
-def test_marketing_intent_true_for_campaign_brief():
-    assert marketing_intent("帮我做一套蓝牙音箱天猫详情页营销方案并出图")
-
-
-def test_marketing_intent_false_for_hello():
-    assert not marketing_intent("你好")
-    assert not marketing_intent("这个音箱怎么样")
 
 
 @pytest.mark.asyncio

--- a/services/agent-runtime/tests/test_intent_llm_parse_eval.py
+++ b/services/agent-runtime/tests/test_intent_llm_parse_eval.py
@@ -11,6 +11,8 @@ import yaml
 from app.graph.atomic_intent import parse_atomic_target_type, resolve_intake_route
 from app.graph.intent_parse_schema import intent_result_to_parse_outcome
 from app.graph.planning_guard import validate_llm_parse
+from app.graph.route_context import assemble_route_context
+from app.graph.route_decide import decide_route
 
 EVAL_PATH = (
     Path(__file__).resolve().parents[1]
@@ -91,10 +93,12 @@ def test_eval_fixture_rule_route_agreement(llm_cases: list[dict]):
     for case in routable:
         utterance = case["utterance"]
         gold_route = case["gold"]["route"]
-        pred = resolve_intake_route(utterance, focus_node_id=None)
         if gold_route == "campaign":
-            ok = pred == "campaign"
+            ctx = assemble_route_context({"messages": [{"role": "user", "content": utterance}]})
+            pred = decide_route(ctx)["flow_mode"]
+            ok = pred == "clarify_route"
         else:
+            pred = resolve_intake_route(utterance, focus_node_id=None)
             ok = pred == "atomic_create"
             if not ok and parse_atomic_target_type(utterance):
                 ok = pred == "atomic_create"

--- a/services/agent-runtime/tests/test_planning_guard_eval.py
+++ b/services/agent-runtime/tests/test_planning_guard_eval.py
@@ -16,6 +16,8 @@ from app.graph.atomic_intent import (
 from app.graph.atomic_parse_schema import validate_parse_result
 from app.graph.atomic_parse_util import rule_parse_confidence
 from app.graph.planning_guard import has_planning_image_conflict
+from app.graph.route_context import assemble_route_context
+from app.graph.route_decide import decide_route
 
 EVAL_PATH = (
     Path(__file__).resolve().parents[1]
@@ -37,6 +39,12 @@ def test_eval_planning_guard_gold(planning_cases: list[dict]):
         utterance = case["utterance"]
         gold = case["gold"]
         case_id = case["id"]
+
+        if "platform_flow" in gold:
+            ctx = assemble_route_context({"messages": [{"role": "user", "content": utterance}]})
+            flow = decide_route(ctx)["flow_mode"]
+            if flow != gold["platform_flow"]:
+                mismatches.append(f"{case_id}: platform_flow {flow} != {gold['platform_flow']}")
 
         if "route" in gold:
             route = resolve_intake_route(utterance, focus_node_id=None)

--- a/services/agent-runtime/tests/test_route_decide.py
+++ b/services/agent-runtime/tests/test_route_decide.py
@@ -56,3 +56,14 @@ def test_prod_utterance_atomic_without_attachments():
     ctx = assemble_route_context({"messages": [{"role": "user", "content": PROD}]})
     d = decide_route(ctx)
     assert d["flow_mode"] == "atomic_create"
+
+
+def test_sidebar_t1_style3_atomic():
+    ctx = assemble_route_context({
+        "messages": [{"role": "user", "content": "@T1 请按风格3出图"}],
+        "sidebar_mentioned_keys": ["T1"],
+        "sidebar_attachments": [{"refKey": "T1", "mediaType": "text"}],
+    })
+    d = decide_route(ctx)
+    assert d["flow_mode"] == "atomic_create"
+    assert d["reason"] == "sidebar_ref_atomic"

--- a/services/agent-runtime/tests/test_runs_stream.py
+++ b/services/agent-runtime/tests/test_runs_stream.py
@@ -145,14 +145,9 @@ def test_runs_stream_ndjson_smoke():
         events = [json.loads(line) for line in response.iter_lines() if line]
 
     types = [e["type"] for e in events]
-    # plan 确认前不写画布，首轮只有文本门
+    # 无显式 Skill 时不 silent 进入 campaign；应 route clarify 而非 plan interrupt
     assert "text_replace" in types or "text_delta" in types
-    assert "interrupt" in types
-    interrupt_ev = next(e for e in events if e["type"] == "interrupt")
-    assert interrupt_ev["data"]["interrupted"] is True
-    assert interrupt_ev["data"]["node"] == "await_confirm"
-    assert interrupt_ev["data"]["phase"] == "await_confirm"
-    assert types.index("interrupt") < types.index("done")
+    assert "interrupt" not in types
     assert "done" in types
     assert "error" not in types
     assert "upsert_prompt_node" not in nest.calls
@@ -162,4 +157,4 @@ def test_runs_stream_ndjson_smoke():
         e["data"]["text"] for e in events if e["type"] in ("text_delta", "text_replace")
     ]
     text = text_parts[-1] if text_parts else ""
-    assert "1 / A" in text or "确认方案" in text or "方案" in text
+    assert "Skill" in text or "1）" in text or "编排" in text

--- a/services/agent-runtime/tests/test_single_node_intent.py
+++ b/services/agent-runtime/tests/test_single_node_intent.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from app.graph.intent import marketing_intent, single_node_gen_intent
+from app.graph.intent import single_node_gen_intent
 
 
 def test_single_node_gen_intent_keywords():
@@ -13,7 +13,6 @@ def test_single_node_gen_intent_keywords():
 
 def test_single_node_gen_intent_does_not_match_full_campaign():
     text = "帮我做一套蓝牙音箱天猫详情页营销方案并出图"
-    assert marketing_intent(text)
     assert not single_node_gen_intent(text)
 
 


### PR DESCRIPTION
## Summary

- **废止隐式 marketing 路由**：删除 `MARKETING_HINTS` / `marketing_intent()`；Campaign 仅由 `requested_skill_id` 触发；无 Skill 的高复杂度 utterance → `clarify_route`
- **P0 止血（T1–T4 部分）**：Intent IR 支持 `出图`/`按风格N`；`@T* + 出图` → `sidebar_ref_atomic` → `atomic_create`；`derive_studio_prompt` 保留原 utterance
- **Eval + 文档**：更新 eval gold 期望；新增 design spec + 全量实施计划（P0+P1+P2）

## 范围说明

本 PR 为 P0 **前半段**（T1–T4 + marketing 路由清理）。**未包含** T5–T12（`clarify_context` checkpoint、route clarify follow-up `1/2/3`、UX/thinking_summary、prod verify），将在后续 PR 继续。

## Test plan

- [x] `cd services/agent-runtime && python3 -m pytest tests/ -q` — 551 passed
- [ ] CI green
- [ ] 合并后开 `feature/sidebar-ref-image-routing-p0` 继续 T5–T12


Made with [Cursor](https://cursor.com)