### PR TITLE
fix(agent): APIMart SSE 与文本视觉模型路由

### DIFF
--- a/apps/server/src/studio/studio.fallback.test.ts
+++ b/apps/server/src/studio/studio.fallback.test.ts
@@ -6,6 +6,7 @@ import {
   createImageProvider,
   createTextProvider,
   createVideoProvider,
+  generateTextForRefs,
   mergeRefsToPrompt,
 } from '@lnkpi/agent'
 import { BadRequestException } from '@nestjs/common'
@@ -33,7 +34,10 @@ vi.mock('@lnkpi/agent', async (importOriginal) => {
     createVideoProvider: vi.fn(() => ({ generate: videoGenerate })),
     createAudioProvider: vi.fn(() => ({ generate: audioGenerate })),
     createTextProvider: vi.fn(() => ({ generate: textGenerate })),
-    generateTextWithImages: vi.fn(),
+    generateTextForRefs: vi.fn(async (prompt: string, refs: string[], opts?: { model?: string; textOpts?: unknown }) => {
+      const result = await textGenerate(prompt, opts?.model, opts?.textOpts)
+      return { text: result.text, visionUsed: refs.length > 0 }
+    }),
   }
 })
 
@@ -137,10 +141,10 @@ describe('StudioService BYOK fallback_pending', () => {
       name: 'text',
       cost: 5,
       refundReason: '文本生成-BYOK失败退款',
-      failOnce: () => textGenerate.mockRejectedValueOnce(new Error('unauthorized api key')),
+      failOnce: () => vi.mocked(generateTextForRefs).mockRejectedValueOnce(new Error('unauthorized api key')),
       run: () => svc.generateText('u1', 'hello', 'ch_user::custom-model'),
-      createProvider: createTextProvider,
-      generate: textGenerate,
+      createProvider: generateTextForRefs,
+      generate: generateTextForRefs,
       platformModel: 'gemini-3.1-flash',
     },
     {
@@ -169,11 +173,22 @@ describe('StudioService BYOK fallback_pending', () => {
       expect(meta.refundReason).toBe('byok_failed')
       expect(pointsRefund).toHaveBeenCalledWith('u1', cost, refundReason)
       expect(createProvider).toHaveBeenCalledTimes(1)
-      expect(createProvider).toHaveBeenCalledWith({
-        apiKey: 'user-key',
-        baseUrl: 'https://user.example.com/v1',
-      })
-      expect(generate).toHaveBeenCalledTimes(1)
+      if (createProvider === generateTextForRefs) {
+        expect(generate).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.any(Array),
+          expect.objectContaining({
+            apiKey: 'user-key',
+            baseUrl: 'https://user.example.com/v1',
+          }),
+        )
+      } else {
+        expect(createProvider).toHaveBeenCalledWith({
+          apiKey: 'user-key',
+          baseUrl: 'https://user.example.com/v1',
+        })
+        expect(generate).toHaveBeenCalledTimes(1)
+      }
 
       resolveForGeneration.mockClear()
       vi.mocked(createProvider).mockClear()
@@ -221,7 +236,7 @@ describe('StudioService BYOK fallback_pending', () => {
       name: 'text',
       platformCost: 5,
       setupPending: async () => {
-        textGenerate.mockRejectedValueOnce(new Error('unauthorized'))
+        vi.mocked(generateTextForRefs).mockRejectedValueOnce(new Error('unauthorized'))
         await svc.generateText('u1', 'hello', 'ch_user::custom-model')
         textGenerate.mockResolvedValueOnce({ text: 'platform ok' })
       },
@@ -266,7 +281,7 @@ describe('StudioService BYOK fallback_pending', () => {
   })
 
   it('text confirm → platform uses catalog gateway model, not user custom', async () => {
-    textGenerate.mockRejectedValueOnce(new Error('unauthorized'))
+    vi.mocked(generateTextForRefs).mockRejectedValueOnce(new Error('unauthorized'))
     await svc.generateText('u1', 'hello', 'ch_user::custom-model')
     vi.clearAllMocks()
     textGenerate.mockResolvedValueOnce({ text: 'platform ok' })
@@ -355,7 +370,7 @@ describe('StudioService BYOK fallback_pending', () => {
 
   it('text: platform source failure → refund after consume', async () => {
     resolveForGeneration.mockResolvedValue(platformResolved)
-    textGenerate.mockRejectedValueOnce(new Error('platform upstream 502'))
+    vi.mocked(generateTextForRefs).mockRejectedValueOnce(new Error('platform upstream 502'))
     await expect(svc.generateText('u1', 'hello')).rejects.toThrow('platform upstream 502')
     expect(pointsConsume).toHaveBeenCalledWith('u1', 5, expect.any(String))
     expect(pointsRefund).toHaveBeenCalledWith('u1', 5, '文本生成-失败退款')
@@ -466,8 +481,8 @@ describe('StudioService BYOK fallback_pending', () => {
 
   it('text: client abort after generate → refund once and throw 已取消', async () => {
     resolveForGeneration.mockResolvedValue(platformResolved)
-    textGenerate.mockReset()
-    textGenerate.mockResolvedValue({ text: 'done' })
+    vi.mocked(generateTextForRefs).mockReset()
+    vi.mocked(generateTextForRefs).mockResolvedValue({ text: 'done', visionUsed: false })
     const listeners: Record<string, (() => void)[]> = {}
     const req = {
       aborted: false,

--- a/apps/server/src/studio/studio.integration.test.ts
+++ b/apps/server/src/studio/studio.integration.test.ts
@@ -6,7 +6,7 @@ import {
   createImageProvider,
   createTextProvider,
   createVideoProvider,
-  generateTextWithImages,
+  generateTextForRefs,
   mergeRefsToPrompt,
 } from '@lnkpi/agent'
 import { ProviderResolverService } from '../provider/provider-resolver.service'
@@ -22,7 +22,6 @@ const videoGenerate = vi.fn(async (_prompt: string, _opts?: Record<string, unkno
 }))
 const audioGenerate = vi.fn(async () => ({ url: 'https://example.com/a.mp3' }))
 const textGenerate = vi.fn(async (prompt: string) => ({ text: `ok:${prompt}` }))
-const visionGenerate = vi.fn(async (prompt: string) => ({ text: `vision:${prompt}` }))
 
 vi.mock('@lnkpi/agent', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@lnkpi/agent')>()
@@ -36,7 +35,12 @@ vi.mock('@lnkpi/agent', async (importOriginal) => {
     createVideoProvider: vi.fn(() => ({ generate: videoGenerate })),
     createAudioProvider: vi.fn(() => ({ generate: audioGenerate })),
     createTextProvider: vi.fn(() => ({ generate: textGenerate })),
-    generateTextWithImages: vi.fn(async (prompt: string) => visionGenerate(prompt)),
+    generateTextForRefs: vi.fn(async (prompt: string, refs: string[]) => {
+      if (refs.length > 0) {
+        return { text: `vision:${prompt}`, visionUsed: true }
+      }
+      return { text: `ok:${prompt}`, visionUsed: false }
+    }),
   }
 })
 
@@ -304,25 +308,30 @@ describe('StudioService integration (provider params)', () => {
   it('resolves text model via catalog gateway id when no image refs', async () => {
     await svc.generateText('u1', 'hello world', 'gemini-3.1-flash')
 
-    expect(createTextProvider).toHaveBeenCalled()
-    expect(textGenerate).toHaveBeenCalledWith('hello world', 'gemini-3.1-flash', {
-      thinking: false,
-      thinkingEffort: 'high',
-    })
-    expect(generateTextWithImages).not.toHaveBeenCalled()
+    expect(generateTextForRefs).toHaveBeenCalledWith(
+      'hello world',
+      [],
+      expect.objectContaining({
+        model: 'gemini-3.1-flash',
+        textOpts: { thinking: false, thinkingEffort: 'high' },
+      }),
+    )
   })
 
-  it('passes catalog gateway model to generateTextWithImages when image refs present', async () => {
+  it('passes catalog gateway model to generateTextForRefs when image refs present', async () => {
     const refUrl = 'https://example.com/dress.jpg'
     await svc.generateText('u1', 'describe dress', 'gemini-3.1-flash', [
       { refKey: 'i1', mediaType: 'image', url: refUrl },
     ])
 
-    expect(generateTextWithImages).toHaveBeenCalledWith('describe dress', [refUrl], {
-      model: 'gemini-3.1-flash',
-      apiKey: process.env.OPENAI_API_KEY,
-      baseUrl: process.env.OPENAI_BASE_URL,
-    })
-    expect(createTextProvider).not.toHaveBeenCalled()
+    expect(generateTextForRefs).toHaveBeenCalledWith(
+      'describe dress',
+      [refUrl],
+      expect.objectContaining({
+        model: 'gemini-3.1-flash',
+        apiKey: process.env.OPENAI_API_KEY,
+        baseUrl: process.env.OPENAI_BASE_URL,
+      }),
+    )
   })
 })

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -13,7 +13,7 @@ import {
   createTextProvider,
   createVideoProvider,
   generatePromptFromUserInput,
-  generateTextWithImages,
+  generateTextForRefs,
   imageRefDescriptorsFromRefs,
   mergeRefsToPrompt,
   Seedance1xUnsupportedError,
@@ -376,7 +376,7 @@ export class StudioService {
       channelId: resolved.channelId,
       skippedMerge,
       refsCount: refs?.length ?? 0,
-      visionUsed: referenceImages.length > 0,
+      visionUsed: false,
       referenceImages,
       thinking: textOpts.thinking,
       thinkingEffort: textOpts.thinking ? textOpts.thinkingEffort : undefined,
@@ -388,14 +388,12 @@ export class StudioService {
         throw new Error('missing api key')
       }
       const opts = providerOpts(resolved)
-      const { text } =
-        referenceImages.length > 0
-          ? await generateTextWithImages(mergedText, referenceImages, {
-              model: gatewayModelId,
-              apiKey: opts?.apiKey ?? process.env.OPENAI_API_KEY,
-              baseUrl: opts?.baseUrl ?? process.env.OPENAI_BASE_URL,
-            })
-          : await createTextProvider(opts).generate(mergedText, gatewayModelId, textOpts)
+      const { text, visionUsed } = await generateTextForRefs(mergedText, referenceImages, {
+        model: gatewayModelId,
+        apiKey: opts?.apiKey ?? process.env.OPENAI_API_KEY,
+        baseUrl: opts?.baseUrl ?? process.env.OPENAI_BASE_URL,
+        textOpts,
+      })
       if (cancel?.isCancelled()) {
         await this.points.refund(userId, cost, `${chargeReason}-取消退款`)
         throwCancelledException(cost)
@@ -408,7 +406,7 @@ export class StudioService {
           model: storeModel,
           url: null,
           status: 'completed',
-          metadata: JSON.stringify(applyChargeMeta({ ...baseMeta, text }, cost)),
+          metadata: JSON.stringify(applyChargeMeta({ ...baseMeta, text, visionUsed }, cost)),
           ...withCanvasScope(scope),
         },
       })
@@ -1291,7 +1289,7 @@ export class StudioService {
           text = content
           promptMeta = { mode, content }
         } else if (referenceImages.length > 0) {
-          const result = await generateTextWithImages(record.prompt, referenceImages, {
+          const result = await generateTextForRefs(record.prompt, referenceImages, {
             model: gatewayModelId,
             apiKey: process.env.OPENAI_API_KEY,
             baseUrl: process.env.OPENAI_BASE_URL,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -31,6 +31,12 @@ export type { MergeTextSource } from './refs/merge-refs'
 export { generateTextWithImages, ECOMMERCE_VISION_SYSTEM, DEFAULT_VISION_USER_PROMPT } from './refs/vision-text'
 export type { VisionTextOptions } from './refs/vision-text'
 export {
+  appendImageRefsForTextOnlyPrompt,
+  generateTextForRefs,
+  supportsVisionTextModel,
+} from './refs/text-generation'
+export type { TextGenerationWithRefsOptions } from './refs/text-generation'
+export {
   buildAudioRequest,
   buildImageProviderOptions,
   buildImageProviderGenerateOptions,

--- a/packages/agent/src/prompt-modes/classify.ts
+++ b/packages/agent/src/prompt-modes/classify.ts
@@ -35,6 +35,7 @@ export async function classifyPromptMode(
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
     body: JSON.stringify({
       model: opts?.model ?? process.env.OPENAI_CHAT_MODEL ?? 'gpt-4o',
+      stream: false,
       temperature: 0,
       messages: [
         {

--- a/packages/agent/src/prompt-modes/generate.ts
+++ b/packages/agent/src/prompt-modes/generate.ts
@@ -16,6 +16,7 @@ async function callChat(
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${opts.apiKey}` },
     body: JSON.stringify({
       model: opts.model,
+      stream: false,
       temperature: opts.temperature,
       messages,
     }),

--- a/packages/agent/src/refs/merge-refs.ts
+++ b/packages/agent/src/refs/merge-refs.ts
@@ -103,6 +103,7 @@ export async function mergeRefsToPrompt(input: {
   const model = input.model ?? process.env.OPENAI_CHAT_MODEL ?? 'gpt-4o'
   const body: Record<string, unknown> = {
     model,
+    stream: false,
     temperature: 0.3,
     messages: [
       {

--- a/packages/agent/src/refs/text-generation.test.ts
+++ b/packages/agent/src/refs/text-generation.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  appendImageRefsForTextOnlyPrompt,
+  generateTextForRefs,
+  supportsVisionTextModel,
+} from './text-generation'
+
+describe('supportsVisionTextModel', () => {
+  it('allows gemini and gpt-4o family', () => {
+    expect(supportsVisionTextModel('gemini-3.5-flash-lite')).toBe(true)
+    expect(supportsVisionTextModel('ch_x::gemini-3.1-flash')).toBe(true)
+    expect(supportsVisionTextModel('gpt-4o')).toBe(true)
+    expect(supportsVisionTextModel('agnes-2.0-flash')).toBe(true)
+  })
+
+  it('rejects deepseek and reasoning-only models', () => {
+    expect(supportsVisionTextModel('deepseek-v4-pro')).toBe(false)
+    expect(supportsVisionTextModel('ch_x::deepseek-v3.2')).toBe(false)
+    expect(supportsVisionTextModel('o3-mini')).toBe(false)
+  })
+})
+
+describe('appendImageRefsForTextOnlyPrompt', () => {
+  it('appends ref-image tags for text-only fallback', () => {
+    const out = appendImageRefsForTextOnlyPrompt('写方案', ['https://cdn.example/a.png'])
+    expect(out).toContain('写方案')
+    expect(out).toContain('[ref-image:https://cdn.example/a.png]')
+    expect(out).toContain('不支持直接识图')
+  })
+})
+
+describe('generateTextForRefs', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    delete process.env.OPENAI_API_KEY
+  })
+
+  it('uses vision chat for gemini when refs present', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'vision ok' } }] }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await generateTextForRefs('describe', ['https://cdn.example/a.png'], {
+      apiKey: 'k',
+      model: 'gemini-3.5-flash-lite',
+    })
+
+    expect(result).toEqual({ text: 'vision ok', visionUsed: true })
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1].body))
+    expect(body.stream).toBe(false)
+    expect(body.messages[1].content[1]).toEqual({
+      type: 'image_url',
+      image_url: { url: 'https://cdn.example/a.png' },
+    })
+  })
+
+  it('falls back to text-only provider for deepseek when refs present', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'text ok' } }] }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await generateTextForRefs('describe', ['https://cdn.example/a.png'], {
+      apiKey: 'k',
+      model: 'deepseek-v4-pro',
+    })
+
+    expect(result).toEqual({ text: 'text ok', visionUsed: false })
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1].body))
+    expect(body.stream).toBe(false)
+    expect(typeof body.messages[1].content).toBe('string')
+    expect(body.messages[1].content).toContain('[ref-image:https://cdn.example/a.png]')
+    expect(body.messages[1].content).not.toContain('image_url')
+  })
+
+  it('uses text provider without refs', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'plain' } }] }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await generateTextForRefs('hello', [], {
+      apiKey: 'k',
+      model: 'deepseek-v4-pro',
+    })
+
+    expect(result).toEqual({ text: 'plain', visionUsed: false })
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1].body))
+    expect(body.messages[1].content).toBe('hello')
+  })
+})

--- a/packages/agent/src/refs/text-generation.ts
+++ b/packages/agent/src/refs/text-generation.ts
@@ -1,0 +1,71 @@
+import { createTextProvider } from '../tools/text-provider'
+import type { TextGenerateOptions } from '../tools/text-provider'
+import { generateTextWithImages } from './vision-text'
+
+const VISION_MODEL_PATTERN =
+  /(?:^|[/:])(?:gemini|gpt-4o|gpt-4-turbo|gpt-4-vision|gpt-5|claude-(?:opus|sonnet|haiku|3)|agnes)(?:[-./]|$)/i
+
+const NON_VISION_MODEL_PATTERN =
+  /(?:^|[/:])(?:deepseek|o[134](?:-|$|-mini|-pro)|text-embedding|whisper|tts|dall-e|babbage|davinci|curie|ada|moderation|flowmusic|suno)(?:[-./]|$)/i
+
+/** Whether chat/completions accepts OpenAI-style image_url message parts for this model id. */
+export function supportsVisionTextModel(model?: string | null): boolean {
+  if (!model?.trim()) return false
+  const normalized = model.trim()
+  if (NON_VISION_MODEL_PATTERN.test(normalized)) return false
+  return VISION_MODEL_PATTERN.test(normalized)
+}
+
+export function appendImageRefsForTextOnlyPrompt(prompt: string, imageUrls: string[]): string {
+  const trimmed = prompt.trim()
+  const urls = imageUrls.map((url) => url.trim()).filter(Boolean)
+  if (urls.length === 0) return trimmed
+  const tags = urls.map((url) => `[ref-image:${url}]`).join('\n')
+  return `${trimmed}\n\n【参考图说明】当前文本模型不支持直接识图，以下为上游参考图 URL，请结合用户文字需求作答：\n${tags}`
+}
+
+export type TextGenerationWithRefsOptions = {
+  model?: string
+  apiKey?: string
+  baseUrl?: string
+  textOpts?: TextGenerateOptions
+}
+
+/** Route image-ref text generation to vision API or text-only fallback. */
+export async function generateTextForRefs(
+  prompt: string,
+  referenceImages: string[],
+  opts: TextGenerationWithRefsOptions = {},
+): Promise<{ text: string; visionUsed: boolean }> {
+  const refs = referenceImages.map((url) => url.trim()).filter(Boolean)
+  if (refs.length === 0) {
+    const provider = createTextProvider({
+      apiKey: opts.apiKey,
+      baseUrl: opts.baseUrl,
+      model: opts.model,
+    })
+    const { text } = await provider.generate(prompt, opts.model, opts.textOpts)
+    return { text, visionUsed: false }
+  }
+
+  if (supportsVisionTextModel(opts.model)) {
+    const { text } = await generateTextWithImages(prompt, refs, {
+      model: opts.model,
+      apiKey: opts.apiKey,
+      baseUrl: opts.baseUrl,
+    })
+    return { text, visionUsed: true }
+  }
+
+  const provider = createTextProvider({
+    apiKey: opts.apiKey,
+    baseUrl: opts.baseUrl,
+    model: opts.model,
+  })
+  const { text } = await provider.generate(
+    appendImageRefsForTextOnlyPrompt(prompt, refs),
+    opts.model,
+    opts.textOpts,
+  )
+  return { text, visionUsed: false }
+}

--- a/packages/agent/src/refs/vision-text.test.ts
+++ b/packages/agent/src/refs/vision-text.test.ts
@@ -45,8 +45,10 @@ describe('generateTextWithImages with key', () => {
     expect(fetchMock).toHaveBeenCalledOnce()
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     const body = JSON.parse(init.body as string) as {
+      stream?: boolean
       messages: Array<{ role: string; content: unknown }>
     }
+    expect(body.stream).toBe(false)
     expect(body.messages[0]).toEqual({ role: 'system', content: ECOMMERCE_VISION_SYSTEM })
     const userContent = body.messages[1].content as Array<{ type: string; text?: string; image_url?: { url: string } }>
     expect(userContent[0]).toEqual({ type: 'text', text: '衣服图' })

--- a/packages/agent/src/refs/vision-text.ts
+++ b/packages/agent/src/refs/vision-text.ts
@@ -66,6 +66,7 @@ export async function generateTextWithImages(
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
     body: JSON.stringify({
       model,
+      stream: false,
       temperature: 0.7,
       messages: [
         { role: 'system', content: ECOMMERCE_VISION_SYSTEM },

--- a/packages/agent/src/tools/text-provider.test.ts
+++ b/packages/agent/src/tools/text-provider.test.ts
@@ -91,6 +91,7 @@ describe('createTextProvider', () => {
     })
     await provider.generate('hello', 'deepseek-v4-pro')
     const body = JSON.parse(String((fetchMock.mock.calls[0] as [string, RequestInit])[1].body))
+    expect(body.stream).toBe(false)
     expect(body.thinking).toEqual({ type: 'disabled' })
     expect(body.reasoning_effort).toBeUndefined()
   })

--- a/packages/agent/src/tools/text-provider.ts
+++ b/packages/agent/src/tools/text-provider.ts
@@ -48,6 +48,7 @@ export class OpenAITextProvider implements TextProvider {
     const resolvedModel = model ?? this.model
     const body: Record<string, unknown> = {
       model: resolvedModel,
+      stream: false,
       messages: [
         { role: 'system', content: '你是专业 AI 创作助手，擅长脚本、旁白与分镜描述。用中文回复，结构清晰。' },
         { role: 'user', content: prompt },


### PR DESCRIPTION
## Summary
- 所有 `/chat/completions` 请求显式设置 `stream: false`，修复 APIMart 默认 SSE 响应导致 `res.json()` 解析失败（Gemini BYOK 看图写方案场景）。
- 新增 `generateTextForRefs`：有上游图片引用时，仅对支持 vision 的模型（Gemini/GPT-4o/Claude/Agnes 等）走 `image_url` 多模态；DeepSeek 等纯文本模型降级为文本 prompt + `[ref-image:url]`，避免 400 `unknown variant image_url`。
- Studio 文本生成与平台回退路径统一接入新 helper，metadata 中 `visionUsed` 反映实际调用路径。

## Test plan
- [x] `pnpm --filter @lnkpi/agent test`
- [x] `pnpm --filter @lnkpi/server exec vitest run src/studio/studio.integration.test.ts src/studio/studio.fallback.test.ts`
- [x] `pnpm build`
- [ ] 生产复验：APIMart BYOK + `gemini-3.5-flash-lite` + 上游图片 → 文本节点生成成功
- [ ] 生产复验：APIMart BYOK + `deepseek-v4-pro` + 上游图片 → 不再 400，可生成（文本降级，无法真正识图）


Made with [Cursor](https://cursor.com)