### PR TITLE
feat(agent-runtime): P1a route unification shadow (T13-T15)

### DIFF
--- a/services/agent-runtime/app/config.py
+++ b/services/agent-runtime/app/config.py
@@ -37,6 +37,7 @@ class Settings(BaseSettings):
     intent_llm_parse: bool = Field(default=False, validation_alias="INTENT_LLM_PARSE")
     intent_llm_parse_shadow: bool = Field(default=False, validation_alias="INTENT_LLM_PARSE_SHADOW")
     agent_thinking_ui: bool = Field(default=False, validation_alias="AGENT_THINKING_UI")
+    route_shadow_mode: bool = Field(default=False, validation_alias="ROUTE_SHADOW_MODE")
 
     class Config:
         env_prefix = "LNKPI_"

--- a/services/agent-runtime/app/graph/route_decide.py
+++ b/services/agent-runtime/app/graph/route_decide.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from typing import Literal, TypedDict
 
+from app.config import settings
 from app.graph.atomic_intent import (
     atomic_create_intent,
     atomic_regenerate_intent,
@@ -13,7 +15,8 @@ from app.graph.atomic_intent import (
     regenerate_phrase_intent,
     resolve_intake_route,
 )
-from app.graph.atomic_intent_ir import is_ref_media_generation, resolve_output_modality
+from app.graph.atomic_intent_ir import AtomicIntent, is_ref_media_generation, resolve_atomic_intent, resolve_output_modality
+from app.graph.clarify_reply import ClarifyReplyResult
 from app.graph.explore_route import explore_canvas_signal, explore_explicit_intent
 from app.graph.intent import modify_intent, single_node_gen_intent
 from app.graph.l0_action import (
@@ -24,6 +27,10 @@ from app.graph.l0_action import (
 )
 from app.graph.planning_guard import ActionKind, has_planning_image_conflict
 from app.graph.route_context import RouteContext
+from app.graph.route_features import RouteFeatures, extract_route_features
+from app.graph.route_precedence import apply_route_precedence
+
+logger = logging.getLogger(__name__)
 
 CLARIFY_THRESHOLD = 0.70
 
@@ -54,6 +61,25 @@ class RouteDecision(TypedDict, total=False):
     clarify_question: str | None
     guard_veto: str | None
     is_modify: bool
+    precedence_rule_id: str
+    atomic_intent: AtomicIntent
+    route_features: RouteFeatures
+
+
+def _log_shadow_diff(ctx: RouteContext, legacy: RouteDecision, unified: RouteDecision) -> None:
+    if legacy.get("flow_mode") == unified.get("flow_mode") and legacy.get("reason") == unified.get(
+        "reason"
+    ):
+        return
+    logger.warning(
+        "route_shadow_diff utterance=%r legacy=%s/%s unified=%s/%s rule=%s",
+        ctx.get("utterance"),
+        legacy.get("flow_mode"),
+        legacy.get("reason"),
+        unified.get("flow_mode"),
+        unified.get("reason"),
+        unified.get("precedence_rule_id"),
+    )
 
 
 def _image_attachment_count(attachments: list[dict]) -> int:
@@ -129,7 +155,7 @@ def _sidebar_img2img_signal(ctx: RouteContext) -> bool:
     return len(keys) >= 2 or utterance_has_multi_image_refs(utterance)
 
 
-def decide_route(ctx: RouteContext, *, valid_skill_ids: set[str] | None = None) -> RouteDecision:
+def decide_route_legacy(ctx: RouteContext, *, valid_skill_ids: set[str] | None = None) -> RouteDecision:
     utterance = str(ctx.get("utterance") or "").strip()
     focus = ctx.get("focus_node_id")
     checkpoint = ctx.get("checkpoint") or {}
@@ -283,3 +309,42 @@ def decide_route(ctx: RouteContext, *, valid_skill_ids: set[str] | None = None) 
         "guard_veto": guard_veto,
         "is_modify": False,
     }
+
+
+def decide_route_unified(
+    ctx: RouteContext,
+    *,
+    valid_skill_ids: set[str] | None = None,
+    pending_clarify_reply: ClarifyReplyResult | None = None,
+) -> RouteDecision:
+    utterance = str(ctx.get("utterance") or "").strip()
+    keys = list(ctx.get("mentioned_keys") or [])
+    intent = resolve_atomic_intent(utterance, mentioned_keys=keys or None)
+    features = extract_route_features(ctx, intent)
+    raw = apply_route_precedence(
+        intent,
+        features,
+        ctx,
+        pending_clarify_reply=pending_clarify_reply,
+        valid_skill_ids=valid_skill_ids,
+    )
+    return RouteDecision(
+        flow_mode=raw["flow_mode"],  # type: ignore[typeddict-item]
+        l0_action=raw["l0_action"],
+        confidence=raw["confidence"],
+        reason=raw["reason"],
+        clarify_question=raw.get("clarify_question"),
+        guard_veto=raw.get("guard_veto"),
+        is_modify=raw.get("is_modify", False),
+        precedence_rule_id=raw.get("precedence_rule_id"),
+        atomic_intent=intent,
+        route_features=features,
+    )
+
+
+def decide_route(ctx: RouteContext, *, valid_skill_ids: set[str] | None = None) -> RouteDecision:
+    legacy = decide_route_legacy(ctx, valid_skill_ids=valid_skill_ids)
+    if settings.route_shadow_mode:
+        unified = decide_route_unified(ctx, valid_skill_ids=valid_skill_ids)
+        _log_shadow_diff(ctx, legacy, unified)
+    return legacy

--- a/services/agent-runtime/app/graph/route_features.py
+++ b/services/agent-runtime/app/graph/route_features.py
@@ -1,0 +1,114 @@
+"""P1: structured RouteFeatures from RouteContext + AtomicIntent (RU-3, RU-6)."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from app.graph.atomic_intent import atomic_create_intent, atomic_regenerate_intent, regenerate_phrase_intent
+from app.graph.atomic_intent_ir import AtomicIntent
+from app.graph.explore_route import explore_explicit_intent
+from app.graph.intent import single_node_gen_intent
+from app.graph.l0_action import has_preserve_intent, utterance_has_multi_image_refs
+from app.graph.planning_guard import has_planning_image_conflict
+from app.graph.route_context import RouteContext
+
+# Orchestration phrase table — no bare 「出图」 (RU-3 / design §9.8.2)
+_ORCHESTRATION_PHRASES = (
+    "详情页",
+    "全链路",
+    "营销方案",
+    "分镜脚本方案",
+    "详情页方案",
+    "详情页营销",
+    "详情页构图",
+    "详情页的构图",
+    "整套分镜",
+    "全套分镜",
+    "campaign",
+    "拆画布",
+    "14个节点",
+    "14节点",
+)
+
+
+class RouteFeatures(TypedDict, total=False):
+    has_text_ref: bool
+    has_image_ref: bool
+    has_multi_image_ref: bool
+    explicit_skill: bool
+    has_atomic_checkpoint: bool
+    preserve_composition: bool
+    orchestration_phrases: bool
+    modality_conflict_risk: bool
+    explore_blocked: bool
+
+
+def _text_keys(keys: list[str]) -> list[str]:
+    return [k for k in keys if str(k).upper().startswith("T")]
+
+
+def _image_keys(keys: list[str]) -> list[str]:
+    return [k for k in keys if str(k).upper().startswith("I")]
+
+
+def _has_orchestration_phrases(utterance: str) -> bool:
+    t = (utterance or "").strip()
+    if not t:
+        return False
+    if "出图" in t and not any(p in t for p in _ORCHESTRATION_PHRASES if p != "出图"):
+        # Single 「出图」/ ref-backed generate is not orchestration.
+        if not any(p in t for p in ("详情页", "全链路", "营销方案", "分镜", "campaign", "拆画布", "节点")):
+            return False
+    return any(p in t for p in _ORCHESTRATION_PHRASES)
+
+
+def _explore_blocked(utterance: str) -> bool:
+    if not utterance:
+        return False
+    blocked = (
+        (atomic_create_intent(utterance) and not explore_explicit_intent(utterance))
+        or single_node_gen_intent(utterance)
+        or regenerate_phrase_intent(utterance)
+        or atomic_regenerate_intent(utterance)
+    )
+    return blocked
+
+
+def extract_route_features(ctx: RouteContext, intent: AtomicIntent) -> RouteFeatures:
+    """Derive L0 routing features — no flow_mode decisions here."""
+    utterance = str(ctx.get("utterance") or intent.utterance or "").strip()
+    keys = list(ctx.get("mentioned_keys") or [])
+    attachments = ctx.get("sidebar_attachments") or []
+
+    text_keys = _text_keys(keys)
+    image_keys = _image_keys(keys)
+    has_text_attachment = any(
+        str(a.get("mediaType") or "").lower() == "text" for a in attachments
+    )
+    has_image_attachment = any(
+        str(a.get("mediaType") or "").lower() == "image" for a in attachments
+    )
+
+    checkpoint = ctx.get("checkpoint") or {}
+    atomic_node_id = str(checkpoint.get("atomic_node_id") or ctx.get("atomic_node_id") or "").strip()
+    atomic_spec = checkpoint.get("atomic_spec") or ctx.get("atomic_spec")
+    has_checkpoint = bool(atomic_node_id and isinstance(atomic_spec, dict))
+
+    multi_image = (
+        len(image_keys) >= 2
+        or utterance_has_multi_image_refs(utterance)
+        or sum(1 for a in attachments if str(a.get("mediaType") or "").lower() == "image") >= 2
+    )
+
+    return RouteFeatures(
+        has_text_ref=bool(text_keys or has_text_attachment),
+        has_image_ref=bool(image_keys or has_image_attachment),
+        has_multi_image_ref=multi_image,
+        explicit_skill=bool(str(ctx.get("requested_skill_id") or "").strip()),
+        has_atomic_checkpoint=has_checkpoint,
+        preserve_composition=has_preserve_intent(utterance),
+        orchestration_phrases=_has_orchestration_phrases(utterance),
+        modality_conflict_risk=has_planning_image_conflict(utterance)
+        and not has_preserve_intent(utterance),
+        explore_blocked=_explore_blocked(utterance),
+    )

--- a/services/agent-runtime/app/graph/route_precedence.py
+++ b/services/agent-runtime/app/graph/route_precedence.py
@@ -1,0 +1,411 @@
+"""P1: L0 precedence table — single conflict resolution protocol (RU-4, RU-5)."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Callable
+
+from app.graph.atomic_intent import (
+    atomic_create_intent,
+    atomic_regenerate_intent,
+    is_regenerate_new_variant,
+    orchestration_complexity_intent,
+    regenerate_phrase_intent,
+    resolve_intake_route,
+)
+from app.graph.atomic_intent_ir import AtomicIntent, is_ref_media_generation
+from app.graph.clarify_reply import ClarifyReplyResult, classify_clarify_reply
+from app.graph.explore_route import explore_canvas_signal
+from app.graph.intent import modify_intent, single_node_gen_intent
+from app.graph.l0_action import TRANSFORM_VERBS, detect_l0_action, has_preserve_intent
+from app.graph.route_context import RouteContext
+from app.graph.route_features import RouteFeatures
+
+ROUTE_CLARIFY_ORCHESTRATION = (
+    "听起来像多节点编排或 Skill 工作流需求。请确认：\n"
+    "1）按引用内容单张出图（保留 @T* / @I*）；\n"
+    "2）完整编排（请先在侧栏选用已安装的 Skill）；\n"
+    "3）其他说明。\n"
+    "回复 1 / 2 / 3。"
+)
+
+RuleFn = Callable[
+    [AtomicIntent, RouteFeatures, RouteContext, set[str] | None],
+    dict[str, Any] | None,
+]
+
+
+def _base_decision(
+    ctx: RouteContext,
+    *,
+    flow_mode: str,
+    reason: str,
+    confidence: float,
+    precedence_rule_id: str,
+    clarify_question: str | None = None,
+    guard_veto: str | None = None,
+    is_modify: bool = False,
+    intent: AtomicIntent | None = None,
+    features: RouteFeatures | None = None,
+) -> dict[str, Any]:
+    utterance = str(ctx.get("utterance") or "")
+    decision: dict[str, Any] = {
+        "flow_mode": flow_mode,  # type: ignore[typeddict-item]
+        "l0_action": detect_l0_action(utterance),
+        "confidence": confidence,
+        "reason": reason,
+        "clarify_question": clarify_question,
+        "guard_veto": guard_veto,
+        "is_modify": is_modify,
+        "precedence_rule_id": precedence_rule_id,
+    }
+    if intent is not None:
+        decision["atomic_intent"] = intent  # type: ignore[typeddict-unknown-key]
+    if features is not None:
+        decision["route_features"] = features  # type: ignore[typeddict-unknown-key]
+    return decision
+
+
+def _valid_skill_id(ctx: RouteContext, valid_skill_ids: set[str] | None) -> str | None:
+    requested = str(ctx.get("requested_skill_id") or "").strip()
+    if not requested:
+        return None
+    if valid_skill_ids and requested not in valid_skill_ids:
+        return None
+    return requested
+
+
+def _guard_veto(ctx: RouteContext) -> str | None:
+    utterance = str(ctx.get("utterance") or "")
+    if has_planning_image_conflict(utterance) and not has_preserve_intent(utterance):
+        return "planning_image_conflict"
+    return None
+
+
+def has_planning_image_conflict(utterance: str) -> bool:
+    from app.graph.planning_guard import has_planning_image_conflict as _conflict
+
+    return _conflict(utterance)
+
+
+def _sidebar_img2img_match(
+    intent: AtomicIntent, features: RouteFeatures, ctx: RouteContext
+) -> bool:
+    utterance = intent.utterance
+    if not features.get("has_multi_image_ref"):
+        return False
+    keys = list(ctx.get("mentioned_keys") or [])
+    image_keys = [k for k in keys if str(k).upper().startswith("I")]
+    has_transform = any(v in utterance for v in TRANSFORM_VERBS) or (
+        len(image_keys) >= 2 and ("让" in utterance or "请" in utterance)
+    )
+    return has_transform or bool(features.get("preserve_composition"))
+
+
+def _ref_backed_generate_match(intent: AtomicIntent, features: RouteFeatures) -> bool:
+    has_ref = bool(features.get("has_text_ref") or features.get("has_image_ref"))
+    if not has_ref:
+        return False
+    mk = list(intent.mentioned_keys) or None
+    if is_ref_media_generation(intent.utterance, mk):
+        return True
+    if intent.action == "generate" and intent.output_modality in ("image", "video"):
+        if "出图" in intent.utterance or "生成图" in intent.utterance or re.search(
+            r"按?风格\s*\d+", intent.utterance
+        ):
+            return True
+    return intent.action == "generate" and intent.output_modality in ("image", "video") and has_ref
+
+
+def _explore_match(intent: AtomicIntent, features: RouteFeatures) -> bool:
+    utterance = intent.utterance
+    if not utterance:
+        return False
+    blocked = bool(features.get("explore_blocked"))
+    return explore_canvas_signal(utterance, blocked_by_atomic=blocked)
+
+
+def _rule_modify_existing_plan(
+    intent: AtomicIntent, features: RouteFeatures, ctx: RouteContext, valid_skill_ids: set[str] | None
+) -> dict[str, Any] | None:
+    checkpoint = ctx.get("checkpoint") or {}
+    utterance = intent.utterance
+    if (
+        checkpoint.get("user_brief")
+        and checkpoint.get("plan_draft")
+        and modify_intent(utterance)
+        and not single_node_gen_intent(utterance)
+    ):
+        return _base_decision(
+            ctx,
+            flow_mode="campaign",
+            reason="modify_existing_plan",
+            confidence=0.92,
+            precedence_rule_id="modify_existing_plan",
+            guard_veto=_guard_veto(ctx),
+            is_modify=True,
+            intent=intent,
+            features=features,
+        )
+    return None
+
+
+def _rule_regen_no_checkpoint(
+    intent: AtomicIntent, features: RouteFeatures, ctx: RouteContext, valid_skill_ids: set[str] | None
+) -> dict[str, Any] | None:
+    if not features.get("has_atomic_checkpoint") and regenerate_phrase_intent(intent.utterance):
+        return _base_decision(
+            ctx,
+            flow_mode="clarify_route",
+            reason="regen_no_checkpoint",
+            confidence=0.95,
+            precedence_rule_id="regen_no_checkpoint",
+            guard_veto=_guard_veto(ctx),
+            intent=intent,
+            features=features,
+        )
+    return None
+
+
+def _rule_checkpoint_regen(
+    intent: AtomicIntent, features: RouteFeatures, ctx: RouteContext, valid_skill_ids: set[str] | None
+) -> dict[str, Any] | None:
+    if features.get("has_atomic_checkpoint") and atomic_regenerate_intent(intent.utterance):
+        return _base_decision(
+            ctx,
+            flow_mode="atomic_regenerate",
+            reason="atomic_regenerate_checkpoint",
+            confidence=0.96,
+            precedence_rule_id="checkpoint_regen",
+            guard_veto=_guard_veto(ctx),
+            intent=intent,
+            features=features,
+        )
+    return None
+
+
+def _rule_sidebar_img2img(
+    intent: AtomicIntent, features: RouteFeatures, ctx: RouteContext, valid_skill_ids: set[str] | None
+) -> dict[str, Any] | None:
+    if _sidebar_img2img_match(intent, features, ctx):
+        return _base_decision(
+            ctx,
+            flow_mode="atomic_create",
+            reason="sidebar_img2img_p1",
+            confidence=0.95,
+            precedence_rule_id="sidebar_img2img",
+            guard_veto=_guard_veto(ctx),
+            intent=intent,
+            features=features,
+        )
+    return None
+
+
+def _rule_ref_backed_generate(
+    intent: AtomicIntent, features: RouteFeatures, ctx: RouteContext, valid_skill_ids: set[str] | None
+) -> dict[str, Any] | None:
+    if _ref_backed_generate_match(intent, features):
+        return _base_decision(
+            ctx,
+            flow_mode="atomic_create",
+            reason="sidebar_ref_atomic",
+            confidence=0.92,
+            precedence_rule_id="ref_backed_generate",
+            guard_veto=_guard_veto(ctx),
+            intent=intent,
+            features=features,
+        )
+    return None
+
+
+def _rule_focus_gen(
+    intent: AtomicIntent, features: RouteFeatures, ctx: RouteContext, valid_skill_ids: set[str] | None
+) -> dict[str, Any] | None:
+    focus = ctx.get("focus_node_id")
+    utterance = intent.utterance
+    route = resolve_intake_route(utterance, focus_node_id=focus)
+    if (
+        focus
+        and route == "single_node"
+        and single_node_gen_intent(utterance)
+        and not modify_intent(utterance)
+    ):
+        return _base_decision(
+            ctx,
+            flow_mode="single_node",
+            reason="single_node_focus",
+            confidence=0.93,
+            precedence_rule_id="focus_gen",
+            guard_veto=_guard_veto(ctx),
+            intent=intent,
+            features=features,
+        )
+    return None
+
+
+def _rule_explicit_skill(
+    intent: AtomicIntent, features: RouteFeatures, ctx: RouteContext, valid_skill_ids: set[str] | None
+) -> dict[str, Any] | None:
+    if _valid_skill_id(ctx, valid_skill_ids):
+        return _base_decision(
+            ctx,
+            flow_mode="campaign",
+            reason="explicit_skill_orchestration",
+            confidence=0.90,
+            precedence_rule_id="explicit_skill_orch",
+            guard_veto=_guard_veto(ctx),
+            intent=intent,
+            features=features,
+        )
+    return None
+
+
+def _rule_orch_ambiguous(
+    intent: AtomicIntent, features: RouteFeatures, ctx: RouteContext, valid_skill_ids: set[str] | None
+) -> dict[str, Any] | None:
+    guard = _guard_veto(ctx)
+    orch = orchestration_complexity_intent(intent.utterance) == "campaign"
+    if guard or (orch and not _valid_skill_id(ctx, valid_skill_ids)):
+        return _base_decision(
+            ctx,
+            flow_mode="clarify_route",
+            reason="orchestration_without_skill",
+            confidence=0.75,
+            precedence_rule_id="orch_ambiguous",
+            clarify_question=ROUTE_CLARIFY_ORCHESTRATION,
+            guard_veto=guard,
+            intent=intent,
+            features=features,
+        )
+    return None
+
+
+def _rule_explore(
+    intent: AtomicIntent, features: RouteFeatures, ctx: RouteContext, valid_skill_ids: set[str] | None
+) -> dict[str, Any] | None:
+    if _explore_match(intent, features):
+        return _base_decision(
+            ctx,
+            flow_mode="explore_canvas",
+            reason="explore_canvas_intent",
+            confidence=0.88,
+            precedence_rule_id="explore",
+            guard_veto=_guard_veto(ctx),
+            intent=intent,
+            features=features,
+        )
+    return None
+
+
+def _rule_atomic_generate(
+    intent: AtomicIntent, features: RouteFeatures, ctx: RouteContext, valid_skill_ids: set[str] | None
+) -> dict[str, Any] | None:
+    utterance = intent.utterance
+    l0 = detect_l0_action(utterance)
+    route = resolve_intake_route(utterance, focus_node_id=ctx.get("focus_node_id"))
+    is_variant = bool(features.get("has_atomic_checkpoint")) and is_regenerate_new_variant(utterance)
+    is_atomic = route == "atomic_create" or atomic_create_intent(utterance)
+    if is_atomic or is_variant or (
+        has_preserve_intent(utterance) and l0 in ("preserve", "generate", "unknown")
+    ):
+        return _base_decision(
+            ctx,
+            flow_mode="atomic_create",
+            reason="atomic_create_intent",
+            confidence=0.88,
+            precedence_rule_id="atomic_generate",
+            guard_veto=_guard_veto(ctx),
+            intent=intent,
+            features=features,
+        )
+    return None
+
+
+def _rule_empty(
+    intent: AtomicIntent, features: RouteFeatures, ctx: RouteContext, valid_skill_ids: set[str] | None
+) -> dict[str, Any] | None:
+    if not intent.utterance.strip():
+        return _base_decision(
+            ctx,
+            flow_mode="chat",
+            reason="empty_utterance",
+            confidence=0.50,
+            precedence_rule_id="empty",
+            guard_veto=None,
+            intent=intent,
+            features=features,
+        )
+    return None
+
+
+def _rule_default_chat(
+    intent: AtomicIntent, features: RouteFeatures, ctx: RouteContext, valid_skill_ids: set[str] | None
+) -> dict[str, Any] | None:
+    return _base_decision(
+        ctx,
+        flow_mode="chat",
+        reason="default_chat",
+        confidence=0.80,
+        precedence_rule_id="default_chat",
+        guard_veto=_guard_veto(ctx),
+        intent=intent,
+        features=features,
+    )
+
+
+PRECEDENCE_RULES: list[tuple[str, RuleFn]] = [
+    ("modify_existing_plan", _rule_modify_existing_plan),
+    ("regen_no_checkpoint", _rule_regen_no_checkpoint),
+    ("checkpoint_regen", _rule_checkpoint_regen),
+    ("sidebar_img2img", _rule_sidebar_img2img),
+    ("ref_backed_generate", _rule_ref_backed_generate),
+    ("focus_gen", _rule_focus_gen),
+    ("explicit_skill_orch", _rule_explicit_skill),
+    ("orch_ambiguous", _rule_orch_ambiguous),
+    ("explore", _rule_explore),
+    ("atomic_generate", _rule_atomic_generate),
+    ("empty", _rule_empty),
+    ("default_chat", _rule_default_chat),
+]
+
+
+def apply_route_precedence(
+    intent: AtomicIntent,
+    features: RouteFeatures,
+    ctx: RouteContext,
+    *,
+    pending_clarify_reply: ClarifyReplyResult | None = None,
+    valid_skill_ids: set[str] | None = None,
+) -> dict[str, Any]:
+    """First matching precedence rule wins (design §9.9)."""
+    if pending_clarify_reply and pending_clarify_reply != "none":
+        route = str(pending_clarify_reply.get("route") or "atomic_create")
+        flow = "campaign" if route == "campaign" else "atomic_create"
+        return _base_decision(
+            ctx,
+            flow_mode=flow,
+            reason="clarify_resume",
+            confidence=0.91,
+            precedence_rule_id="clarify_resume",
+            intent=intent,
+            features=features,
+        )
+
+    for _rule_id, fn in PRECEDENCE_RULES:
+        decision = fn(intent, features, ctx, valid_skill_ids)
+        if decision is not None:
+            return decision
+
+    return _rule_default_chat(intent, features, ctx, valid_skill_ids)  # type: ignore[return-value]
+
+
+def classify_pending_clarify_reply(
+    original_utterance: str,
+    clarify_question: str,
+    user_reply: str,
+    *,
+    checkpoint: dict | None = None,
+) -> ClarifyReplyResult:
+    return classify_clarify_reply(
+        original_utterance, clarify_question, user_reply, checkpoint=checkpoint
+    )

--- a/services/agent-runtime/tests/test_route_features.py
+++ b/services/agent-runtime/tests/test_route_features.py
@@ -1,0 +1,101 @@
+"""T13: RouteFeatures extraction from RouteContext + AtomicIntent."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.graph.atomic_intent_ir import AtomicIntent, resolve_atomic_intent
+from app.graph.route_context import assemble_route_context
+from app.graph.route_features import extract_route_features
+
+STYLE3 = "@T1 请按风格3出图"
+
+
+def _intent(text: str, *, keys: list[str] | None = None) -> AtomicIntent:
+    return resolve_atomic_intent(text, mentioned_keys=keys)
+
+
+def test_style3_ctx_has_text_ref_not_orchestration_phrases():
+    ctx = assemble_route_context(
+        {
+            "messages": [{"role": "user", "content": STYLE3}],
+            "sidebar_mentioned_keys": ["T1"],
+            "sidebar_attachments": [{"refKey": "T1", "mediaType": "text"}],
+        }
+    )
+    intent = _intent(STYLE3, keys=["T1"])
+    features = extract_route_features(ctx, intent)
+    assert features["has_text_ref"] is True
+    assert features["orchestration_phrases"] is False
+    assert features["has_image_ref"] is False
+
+
+def test_img2img_multi_image_ref():
+    utterance = "@I1 模特 @I2 产品，让模特穿上"
+    ctx = assemble_route_context(
+        {
+            "messages": [{"role": "user", "content": utterance}],
+            "sidebar_mentioned_keys": ["I1", "I2"],
+        }
+    )
+    intent = _intent(utterance, keys=["I1", "I2"])
+    features = extract_route_features(ctx, intent)
+    assert features["has_multi_image_ref"] is True
+    assert features["has_image_ref"] is True
+
+
+def test_orchestration_phrases_without_single_chutu():
+    ctx = assemble_route_context(
+        {"messages": [{"role": "user", "content": "帮我做天猫详情页营销方案"}]}
+    )
+    intent = _intent("帮我做天猫详情页营销方案")
+    features = extract_route_features(ctx, intent)
+    assert features["orchestration_phrases"] is True
+
+
+def test_chutu_alone_not_orchestration_phrase():
+    ctx = assemble_route_context({"messages": [{"role": "user", "content": STYLE3}]})
+    intent = _intent(STYLE3, keys=["T1"])
+    features = extract_route_features(ctx, intent)
+    assert features["orchestration_phrases"] is False
+
+
+def test_explicit_skill_feature():
+    ctx = assemble_route_context(
+        {
+            "messages": [{"role": "user", "content": "详情页方案"}],
+            "requested_skill_id": "enterprise-marketing-campaign",
+        }
+    )
+    intent = _intent("详情页方案")
+    features = extract_route_features(ctx, intent)
+    assert features["explicit_skill"] is True
+
+
+def test_atomic_checkpoint_feature():
+    ctx = assemble_route_context(
+        {
+            "messages": [{"role": "user", "content": "重新生成一张"}],
+            "atomic_node_id": "node-1",
+            "atomic_spec": {"target_type": "image", "prompt": "x", "title": "x"},
+        }
+    )
+    intent = _intent("重新生成一张")
+    features = extract_route_features(ctx, intent)
+    assert features["has_atomic_checkpoint"] is True
+
+
+def test_modality_conflict_risk_planning_detail_page():
+    utterance = "请你帮我设计蓝牙耳机主图，详情页的构图方案"
+    ctx = assemble_route_context({"messages": [{"role": "user", "content": utterance}]})
+    intent = _intent(utterance)
+    features = extract_route_features(ctx, intent)
+    assert features["modality_conflict_risk"] is True
+
+
+def test_preserve_composition_feature():
+    utterance = "保持主图风格、背景、构图不变，生成换装图"
+    ctx = assemble_route_context({"messages": [{"role": "user", "content": utterance}]})
+    intent = _intent(utterance)
+    features = extract_route_features(ctx, intent)
+    assert features["preserve_composition"] is True

--- a/services/agent-runtime/tests/test_route_precedence.py
+++ b/services/agent-runtime/tests/test_route_precedence.py
@@ -1,0 +1,165 @@
+"""T14: apply_route_precedence — one test per precedence rule (design §9.9)."""
+
+from __future__ import annotations
+
+from app.graph.atomic_intent_ir import resolve_atomic_intent
+from app.graph.clarify_reply import classify_clarify_reply
+from app.graph.route_context import assemble_route_context
+from app.graph.route_features import extract_route_features
+from app.graph.route_precedence import (
+    ROUTE_CLARIFY_ORCHESTRATION,
+    apply_route_precedence,
+)
+
+STYLE3 = "@T1 请按风格3出图"
+IMG2IMG = "@I1 模特 @I2 产品，让模特穿上，保持构图不变"
+
+
+def _decide(state: dict, *, valid_skill_ids: set[str] | None = None, pending=None):
+    ctx = assemble_route_context(state)
+    intent = resolve_atomic_intent(
+        ctx["utterance"],
+        mentioned_keys=list(ctx.get("mentioned_keys") or []),
+    )
+    features = extract_route_features(ctx, intent)
+    return apply_route_precedence(
+        intent,
+        features,
+        ctx,
+        pending_clarify_reply=pending,
+        valid_skill_ids=valid_skill_ids,
+    )
+
+
+def test_precedence_modify_existing_plan():
+    d = _decide(
+        {
+            "messages": [{"role": "user", "content": "把模特定妆改为双人模特"}],
+            "user_brief": "洁具方案",
+            "plan_draft": "# plan",
+        }
+    )
+    assert d["flow_mode"] == "campaign"
+    assert d["precedence_rule_id"] == "modify_existing_plan"
+    assert d["is_modify"] is True
+
+
+def test_precedence_regen_no_checkpoint():
+    d = _decide({"messages": [{"role": "user", "content": "重新生成一张"}]})
+    assert d["flow_mode"] == "clarify_route"
+    assert d["precedence_rule_id"] == "regen_no_checkpoint"
+
+
+def test_precedence_checkpoint_regen():
+    d = _decide(
+        {
+            "messages": [{"role": "user", "content": "重新生成一张"}],
+            "atomic_node_id": "node-1",
+            "atomic_spec": {"target_type": "image", "prompt": "x", "title": "x"},
+        }
+    )
+    assert d["flow_mode"] == "atomic_regenerate"
+    assert d["precedence_rule_id"] == "checkpoint_regen"
+
+
+def test_precedence_sidebar_img2img():
+    d = _decide(
+        {
+            "messages": [{"role": "user", "content": IMG2IMG}],
+            "sidebar_mentioned_keys": ["I1", "I2"],
+            "sidebar_attachments": [
+                {"mediaType": "image", "url": "https://a/1.jpg"},
+                {"mediaType": "image", "url": "https://a/2.jpg"},
+            ],
+        }
+    )
+    assert d["flow_mode"] == "atomic_create"
+    assert d["precedence_rule_id"] == "sidebar_img2img"
+    assert d["reason"] == "sidebar_img2img_p1"
+
+
+def test_precedence_ref_backed_generate_style3():
+    d = _decide(
+        {
+            "messages": [{"role": "user", "content": STYLE3}],
+            "sidebar_mentioned_keys": ["T1"],
+            "sidebar_attachments": [{"refKey": "T1", "mediaType": "text"}],
+        }
+    )
+    assert d["flow_mode"] == "atomic_create"
+    assert d["precedence_rule_id"] == "ref_backed_generate"
+    assert d["reason"] == "sidebar_ref_atomic"
+
+
+def test_precedence_focus_gen():
+    d = _decide(
+        {
+            "messages": [{"role": "user", "content": "快速生成"}],
+            "focus_node_id": "image-1",
+        }
+    )
+    assert d["flow_mode"] == "single_node"
+    assert d["precedence_rule_id"] == "focus_gen"
+
+
+def test_precedence_explicit_skill_orch():
+    d = _decide(
+        {
+            "messages": [{"role": "user", "content": "详情页构图方案"}],
+            "requested_skill_id": "enterprise-marketing-campaign",
+        },
+        valid_skill_ids={"enterprise-marketing-campaign"},
+    )
+    assert d["flow_mode"] == "campaign"
+    assert d["precedence_rule_id"] == "explicit_skill_orch"
+
+
+def test_precedence_orch_ambiguous_ac04():
+    """AC-04: orchestration utterance without Skill → clarify_route."""
+    d = _decide({"messages": [{"role": "user", "content": "天猫蓝牙耳机详情页营销方案"}]})
+    assert d["flow_mode"] == "clarify_route"
+    assert d["precedence_rule_id"] == "orch_ambiguous"
+    assert d["clarify_question"] == ROUTE_CLARIFY_ORCHESTRATION
+
+
+def test_precedence_explore():
+    d = _decide(
+        {"messages": [{"role": "user", "content": "看看画布上有哪些节点，状态怎么样？"}]}
+    )
+    assert d["flow_mode"] == "explore_canvas"
+    assert d["precedence_rule_id"] == "explore"
+
+
+def test_precedence_atomic_generate():
+    d = _decide({"messages": [{"role": "user", "content": "帮我生成一张蓝牙耳机主图"}]})
+    assert d["flow_mode"] == "atomic_create"
+    assert d["precedence_rule_id"] == "atomic_generate"
+
+
+def test_precedence_empty():
+    d = _decide({"messages": [{"role": "user", "content": "   "}]})
+    assert d["flow_mode"] == "chat"
+    assert d["precedence_rule_id"] == "empty"
+
+
+def test_precedence_default_chat():
+    d = _decide({"messages": [{"role": "user", "content": "你好"}]})
+    assert d["flow_mode"] == "chat"
+    assert d["precedence_rule_id"] == "default_chat"
+
+
+def test_precedence_clarify_resume():
+    pending = classify_clarify_reply(
+        STYLE3,
+        ROUTE_CLARIFY_ORCHESTRATION,
+        "1",
+    )
+    d = _decide(
+        {
+            "messages": [{"role": "user", "content": "1"}],
+            "sidebar_mentioned_keys": ["T1"],
+        },
+        pending=pending,
+    )
+    assert d["flow_mode"] == "atomic_create"
+    assert d["precedence_rule_id"] == "clarify_resume"

--- a/services/agent-runtime/tests/test_route_shadow_diff.py
+++ b/services/agent-runtime/tests/test_route_shadow_diff.py
@@ -1,0 +1,61 @@
+"""T15: legacy vs unified route shadow diff on eval-route-set (≥99% parity)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from langchain_core.messages import HumanMessage
+
+from app.graph.route_context import assemble_route_context
+from app.graph.route_decide import decide_route_legacy, decide_route_unified
+
+EVAL_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "atomic-create"
+    / "eval-route-set.yaml"
+)
+VALID_SKILLS = {"enterprise-marketing-campaign"}
+MIN_AGREEMENT = 0.99
+
+
+@pytest.fixture(scope="module")
+def route_cases() -> list[dict]:
+    doc = yaml.safe_load(EVAL_PATH.read_text(encoding="utf-8"))
+    return doc["cases"]
+
+
+def _state_from_fixture(raw: dict) -> dict:
+    state = dict(raw)
+    msgs = state.pop("messages", [])
+    parsed = []
+    for m in msgs:
+        if isinstance(m, dict) and m.get("role") in ("user", "human"):
+            parsed.append(HumanMessage(content=str(m.get("content") or "")))
+        elif isinstance(m, HumanMessage):
+            parsed.append(m)
+    state["messages"] = parsed
+    return state
+
+
+def test_route_shadow_eval_route_set(route_cases: list[dict]):
+    total = len(route_cases)
+    mismatches: list[str] = []
+    for case in route_cases:
+        case_id = case["id"]
+        state = _state_from_fixture(case.get("state") or {})
+        ctx = assemble_route_context(state)
+        legacy = decide_route_legacy(ctx, valid_skill_ids=VALID_SKILLS)
+        unified = decide_route_unified(ctx, valid_skill_ids=VALID_SKILLS)
+        if legacy.get("flow_mode") != unified.get("flow_mode") or legacy.get("reason") != unified.get(
+            "reason"
+        ):
+            mismatches.append(
+                f"{case_id}: legacy={legacy.get('flow_mode')}/{legacy.get('reason')} "
+                f"unified={unified.get('flow_mode')}/{unified.get('reason')} "
+                f"rule={unified.get('precedence_rule_id')}"
+            )
+    agreement = (total - len(mismatches)) / total if total else 1.0
+    assert agreement >= MIN_AGREEMENT, "\n".join(mismatches)


### PR DESCRIPTION
## Summary

- **T13** — `route_features.py`: structured L0 features from `RouteContext` + `AtomicIntent` (`orchestration_phrases` excludes bare「出图」)
- **T14** — `route_precedence.py`: 12-rule precedence table (`apply_route_precedence`) with `precedence_rule_id`; covers style3 `ref_backed_generate` and AC-04 `orch_ambiguous`
- **T15** — Split `decide_route_legacy` / `decide_route_unified`; optional `LNKPI_ROUTE_SHADOW_MODE` dual-run logging; `test_route_shadow_diff.py` asserts eval-route-set parity ≥99% (currently 100%)

Production path unchanged: `decide_route()` still returns legacy until T16 switch.

## Test plan

- [x] `pytest services/agent-runtime/tests/test_route_features.py`
- [x] `pytest services/agent-runtime/tests/test_route_precedence.py`
- [x] `pytest services/agent-runtime/tests/test_route_shadow_diff.py`
- [x] `pytest services/agent-runtime/tests/test_route_decide.py tests/test_eval_route_set.py`
- [ ] CI green


Made with [Cursor](https://cursor.com)