### PR TITLE
feat(agent-runtime): P2 GenerationRequest parity and IR slots (T22-T24)

### DIFF
--- a/docs/superpowers/specs/2026-08-09-sidebar-ref-image-routing-design.md
+++ b/docs/superpowers/specs/2026-08-09-sidebar-ref-image-routing-design.md
@@ -1,6 +1,6 @@
 # Agent 侧栏引用生图路由与澄清续接 — 设计规格
 
-> 状态：**待评审**（2026-08-09）  
+> 状态：**Implemented P0–P2**（2026-08-09）  
 > 范围：**Phase 0（P0 止血）** — 修复 `@T1 请按风格3出图` 类 utterance 的 L1 路由误判、route 澄清回复断裂、侧栏与 Dock 引用语义不对齐、执行过程 UX 误导  
 > **Phase 1（P1 架构收敛）** — 见本文 §9 [Route Unification ADR]；**禁止**在 P0 之后继续堆 hint 表，新 case 应推动 P1 落地  
 > 前置：[2026-08-09-atomic-intent-ir-design.md](./2026-08-09-atomic-intent-ir-design.md)、[2026-08-07-agent-sidebar-m3-explicit-refs-design.md](./2026-08-07-agent-sidebar-m3-explicit-refs-design.md)、[2026-08-07-platform-route-skill-boundary-design.md](./2026-08-07-platform-route-skill-boundary-design.md)  
@@ -666,3 +666,4 @@ skills/atomic-create/
 | v1.1 | 2026-08-09 | 追加 §9 Route Unification ADR；明确 P0/P1 边界 |
 | v1.2 | 2026-08-09 | §9.3–§9.11 目标架构 + 业界最佳实践；§2.4 预览 |
 | v1.3 | 2026-08-09 | 链全量实施计划 full.md |
+| v1.4 | 2026-08-09 | P2 GenerationRequest DTO + IR slots；状态 Implemented P0–P2 |

--- a/services/agent-runtime/app/graph/atomic_intent_ir.py
+++ b/services/agent-runtime/app/graph/atomic_intent_ir.py
@@ -62,6 +62,9 @@ _PROMPT_OBJECT_RE = re.compile(
 )
 
 
+_STYLE_SLOT_RE = re.compile(r"按?风格\s*(\d+)")
+
+
 @dataclass(frozen=True)
 class AtomicIntent:
     action: AtomicAction
@@ -69,6 +72,23 @@ class AtomicIntent:
     utterance: str
     source_markers: tuple[str, ...] = ()
     mentioned_keys: tuple[str, ...] = ()
+    slots: tuple[tuple[str, str], ...] = ()
+
+
+def intent_slots_dict(intent: AtomicIntent) -> dict[str, str]:
+    return dict(intent.slots)
+
+
+def _resolve_ir_slots(text: str, mentioned_keys: list[str] | None) -> tuple[tuple[str, str], ...]:
+    t = (text or "").strip()
+    items: dict[str, str] = {}
+    style_m = _STYLE_SLOT_RE.search(t)
+    if style_m:
+        items["style"] = style_m.group(1)
+    keys = [str(k) for k in (mentioned_keys or []) if str(k).strip()]
+    if keys:
+        items["ref"] = keys[0]
+    return tuple(sorted(items.items()))
 
 
 def _normalize(text: str) -> str:
@@ -262,6 +282,7 @@ def resolve_atomic_intent(
         utterance=t,
         source_markers=markers,
         mentioned_keys=keys,
+        slots=_resolve_ir_slots(t, list(keys)),
     )
 
 

--- a/services/agent-runtime/app/graph/generation_request.py
+++ b/services/agent-runtime/app/graph/generation_request.py
@@ -1,0 +1,141 @@
+"""P2: unified GenerationRequest DTO — sidebar atomic path ≡ Dock (RU-9, R-ALIGN-02)."""
+
+from __future__ import annotations
+
+from typing import Any, Literal, TypedDict
+
+from app.graph.atomic_intent_ir import AtomicIntent, derive_studio_prompt, intent_slots_dict, resolve_atomic_intent
+from app.graph.route_context import latest_user_text
+from app.graph.sidebar_attachments import assign_sidebar_ref_keys, resolve_sidebar_mentioned_keys
+
+GenerationModality = Literal["image", "video", "text", "prompt", "audio"]
+
+_DOCK_MODALITY = {
+    "image": "image",
+    "video": "video",
+    "text": "text",
+    "prompt": "prompt",
+    "audio": "audio",
+}
+
+
+class StudioRefPayload(TypedDict, total=False):
+    refKey: str
+    mediaType: str
+    label: str
+    text: str
+    url: str
+
+
+class GenerationRequest(TypedDict, total=False):
+    prompt: str
+    refs: list[StudioRefPayload]
+    mentioned_keys: list[str]
+    modality: GenerationModality
+    node_id: str | None
+    slots: dict[str, str]
+
+
+def _refs_from_sidebar(
+    attachments: list[dict] | None,
+    mentioned_keys: list[str] | None,
+) -> list[StudioRefPayload]:
+    raw = list(attachments or [])
+    keys = assign_sidebar_ref_keys(raw) or list(mentioned_keys or [])
+    refs: list[StudioRefPayload] = []
+    for idx, att in enumerate(raw):
+        if not isinstance(att, dict):
+            continue
+        ref_key = str(att.get("refKey") or att.get("ref_key") or (keys[idx] if idx < len(keys) else "")).strip()
+        media = str(att.get("mediaType") or att.get("media_type") or "text").strip().lower()
+        payload: StudioRefPayload = {"refKey": ref_key, "mediaType": media}
+        label = str(att.get("label") or "").strip()
+        if label:
+            payload["label"] = label
+        text = str(att.get("text") or att.get("content") or "").strip()
+        url = str(att.get("url") or "").strip()
+        if text:
+            payload["text"] = text
+        if url:
+            payload["url"] = url
+        refs.append(payload)
+    return refs
+
+
+def _intent_from_state(state: dict[str, Any], utterance: str, mentioned_keys: list[str]) -> AtomicIntent:
+    route_decision = state.get("route_decision")
+    if isinstance(route_decision, dict):
+        snapshot = route_decision.get("atomic_intent")
+        if isinstance(snapshot, dict) and snapshot.get("utterance"):
+            utterance = str(snapshot.get("utterance") or utterance)
+            mk = list(snapshot.get("mentioned_keys") or mentioned_keys)
+            return resolve_atomic_intent(utterance, mentioned_keys=mk or None)
+    return resolve_atomic_intent(utterance, mentioned_keys=mentioned_keys or None)
+
+
+def build_generation_request_from_atomic_state(state: dict[str, Any]) -> GenerationRequest:
+    """Sidebar atomic path: prompt + refs + mentioned_keys aligned with Dock."""
+    spec = state.get("atomic_spec") if isinstance(state.get("atomic_spec"), dict) else {}
+    utterance = latest_user_text(state.get("messages") or []) or str(spec.get("prompt") or "")
+    mentioned = resolve_sidebar_mentioned_keys(state)
+    intent = _intent_from_state(state, utterance, mentioned)
+    prompt = str(spec.get("prompt") or derive_studio_prompt(intent)).strip()
+    modality = str(spec.get("target_type") or intent.output_modality or "image")  # type: ignore[assignment]
+    node_id = str(state.get("atomic_node_id") or state.get("focus_node_id") or "").strip() or None
+    refs = _refs_from_sidebar(state.get("sidebar_attachments"), mentioned)
+    return GenerationRequest(
+        prompt=prompt,
+        refs=refs,
+        mentioned_keys=list(mentioned),
+        modality=modality,  # type: ignore[typeddict-item]
+        node_id=node_id,
+        slots=intent_slots_dict(intent),
+    )
+
+
+def build_generation_request_from_dock(
+    node: dict[str, Any],
+    *,
+    upstream: dict[str, Any] | None = None,
+    refs: list[StudioRefPayload] | None = None,
+    mentioned_keys: list[str] | None = None,
+) -> GenerationRequest:
+    """Dock path — field names aligned with web useNodeGeneration → studioApi.generateImage."""
+    del upstream  # reserved for referenceImageUrl merge parity
+    data = node.get("data") if isinstance(node.get("data"), dict) else {}
+    node_type = str(node.get("type") or "image")
+    prompt = str(data.get("prompt") or data.get("content") or "").strip()
+    keys = list(mentioned_keys or [])
+    intent = resolve_atomic_intent(prompt, mentioned_keys=keys or None)
+    modality = _DOCK_MODALITY.get(node_type, "image")
+    node_id = str(node.get("id") or "").strip() or None
+    return GenerationRequest(
+        prompt=prompt or derive_studio_prompt(intent),
+        refs=list(refs or []),
+        mentioned_keys=keys,
+        modality=modality,  # type: ignore[typeddict-item]
+        node_id=node_id,
+        slots=intent_slots_dict(intent),
+    )
+
+
+def generation_request_parity_keys(request: GenerationRequest) -> dict[str, Any]:
+    """Normalize for sidebar vs Dock parity assertions (AC-05)."""
+    refs = request.get("refs") or []
+    ref_sig = sorted(
+        (
+            str(r.get("refKey") or ""),
+            str(r.get("mediaType") or ""),
+            str(r.get("text") or ""),
+            str(r.get("url") or ""),
+        )
+        for r in refs
+        if isinstance(r, dict)
+    )
+    return {
+        "prompt": str(request.get("prompt") or ""),
+        "mentioned_keys": list(request.get("mentioned_keys") or []),
+        "modality": request.get("modality"),
+        "slots": dict(request.get("slots") or {}),
+        "refs": ref_sig,
+    }

--- a/services/agent-runtime/app/graph/route_trace.py
+++ b/services/agent-runtime/app/graph/route_trace.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from app.graph.atomic_intent_ir import AtomicIntent
+from app.graph.atomic_intent_ir import AtomicIntent, intent_slots_dict
 from app.graph.route_decide import RouteDecision
 
 
@@ -17,6 +17,7 @@ def atomic_intent_snapshot(intent: AtomicIntent | None) -> dict[str, Any] | None
         "utterance": intent.utterance,
         "source_markers": list(intent.source_markers),
         "mentioned_keys": list(intent.mentioned_keys),
+        "slots": intent_slots_dict(intent),
     }
 
 

--- a/services/agent-runtime/skills/atomic-create/eval-intent-set.yaml
+++ b/services/agent-runtime/skills/atomic-create/eval-intent-set.yaml
@@ -40,6 +40,16 @@ cases:
     focus_node_id: null
     gold: { route: atomic_create, target_type: image, confirm_gate: false }
 
+  - id: img-style3-t1-ref
+    utterance: "@T1 请按风格3出图"
+    mentioned_keys: [T1]
+    focus_node_id: null
+    gold:
+      route: atomic_create
+      target_type: image
+      confirm_gate: false
+      slots: { style: "3", ref: T1 }
+
   # --- text / D1 脚本文案 (6) ---
   - id: txt-01
     utterance: 帮我生成一个蓝牙耳机的分镜提示词

--- a/services/agent-runtime/tests/test_atomic_create_intent.py
+++ b/services/agent-runtime/tests/test_atomic_create_intent.py
@@ -18,6 +18,7 @@ from app.graph.atomic_intent import (
     resolve_intake_route,
     turnaround_pipeline_user_note,
 )
+from app.graph.atomic_intent_ir import intent_slots_dict, resolve_atomic_intent
 from app.graph.nodes.intake import make_intake_node
 
 EVAL_PATH = Path(__file__).resolve().parents[1] / "skills" / "atomic-create" / "eval-intent-set.yaml"
@@ -35,12 +36,13 @@ def test_eval_routing_gold(eval_cases: list[dict]):
         utterance = case["utterance"]
         focus = case.get("focus_node_id")
         gold = case["gold"]
+        mentioned = list(case.get("mentioned_keys") or [])
         route = resolve_intake_route(utterance, focus_node_id=focus)
         if route != gold["route"]:
             mismatches.append(f"{case['id']}: route {route} != {gold['route']}")
             continue
         if gold["route"] == "atomic_create":
-            spec = build_atomic_spec(utterance)
+            spec = build_atomic_spec(utterance, mentioned_keys=mentioned or None)
             if spec["target_type"] != gold["target_type"]:
                 mismatches.append(
                     f"{case['id']}: target {spec['target_type']} != {gold['target_type']}"
@@ -49,6 +51,14 @@ def test_eval_routing_gold(eval_cases: list[dict]):
                 mismatches.append(
                     f"{case['id']}: confirm_gate {spec['confirm_gate']} != {gold['confirm_gate']}"
                 )
+            expected_slots = gold.get("slots")
+            if expected_slots is not None:
+                ir = resolve_atomic_intent(utterance, mentioned_keys=mentioned or None)
+                got_slots = intent_slots_dict(ir)
+                if got_slots != dict(expected_slots):
+                    mismatches.append(
+                        f"{case['id']}: slots {got_slots} != {expected_slots}"
+                    )
     assert not mismatches, "\n".join(mismatches)
 
 

--- a/services/agent-runtime/tests/test_atomic_intent_ir_ref_image.py
+++ b/services/agent-runtime/tests/test_atomic_intent_ir_ref_image.py
@@ -27,6 +27,12 @@ def test_resolve_atomic_intent_style3():
     assert ir.action == "generate"
     assert ir.output_modality == "image"
     assert ir.mentioned_keys == ("T1",)
+    assert dict(ir.slots) == {"ref": "T1", "style": "3"}
+
+
+def test_resolve_atomic_intent_style_only_without_ref_key():
+    ir = resolve_atomic_intent("请按风格2出图", mentioned_keys=None)
+    assert dict(ir.slots) == {"style": "2"}
 
 
 def test_derive_studio_prompt_keeps_style3_utterance():

--- a/services/agent-runtime/tests/test_generation_request.py
+++ b/services/agent-runtime/tests/test_generation_request.py
@@ -1,0 +1,59 @@
+"""T22: GenerationRequest DTO — sidebar vs Dock parity."""
+
+from __future__ import annotations
+
+from langchain_core.messages import HumanMessage
+
+from app.graph.generation_request import (
+    build_generation_request_from_atomic_state,
+    build_generation_request_from_dock,
+    generation_request_parity_keys,
+)
+
+STYLE3 = "@T1 请按风格3出图"
+T1_REF = {"refKey": "T1", "mediaType": "text", "text": "风格3说明正文"}
+
+
+def test_style3_sidebar_dock_parity():
+    sidebar_state = {
+        "messages": [HumanMessage(content=STYLE3)],
+        "sidebar_mentioned_keys": ["T1"],
+        "sidebar_attachments": [dict(T1_REF)],
+        "atomic_spec": {
+            "target_type": "image",
+            "prompt": STYLE3,
+            "title": STYLE3[:24],
+            "confirm_gate": False,
+        },
+        "atomic_node_id": "image-style3",
+    }
+    dock_node = {
+        "id": "image-style3",
+        "type": "image",
+        "data": {"prompt": STYLE3},
+    }
+    sidebar_req = build_generation_request_from_atomic_state(sidebar_state)
+    dock_req = build_generation_request_from_dock(
+        dock_node,
+        refs=[T1_REF],
+        mentioned_keys=["T1"],
+    )
+    assert generation_request_parity_keys(sidebar_req) == generation_request_parity_keys(dock_req)
+    assert sidebar_req["slots"] == {"ref": "T1", "style": "3"}
+    assert sidebar_req["modality"] == "image"
+    assert sidebar_req["prompt"] == STYLE3
+
+
+def test_atomic_state_uses_spec_prompt():
+    state = {
+        "messages": [HumanMessage(content="帮我生成一张蓝牙耳机主图")],
+        "atomic_spec": {
+            "target_type": "image",
+            "prompt": "帮我生成一张蓝牙耳机主图",
+            "title": "蓝牙耳机主图",
+        },
+    }
+    req = build_generation_request_from_atomic_state(state)
+    assert req["prompt"] == "帮我生成一张蓝牙耳机主图"
+    assert req["modality"] == "image"
+    assert req["mentioned_keys"] == []


### PR DESCRIPTION
## Summary

- **T22** — `generation_request.py`: `build_generation_request_from_atomic_state` / `build_generation_request_from_dock` with AC-05 parity helper; style3 sidebar ≡ Dock test
- **T23** — `AtomicIntent.slots`: `按风格N` → `{style: "N", ref: "T*"}`, included in route trace snapshots
- **T24** — `eval-intent-set` adds `img-style3-t1-ref` slots gold; design spec marked **Implemented P0–P2**

Builds on merged P1 route unification (#202, #203).

## Test plan

- [x] `pytest services/agent-runtime` — 596 passed
- [x] `pytest tests/test_generation_request.py tests/test_atomic_intent_ir_ref_image.py`
- [x] `pytest tests/test_atomic_create_intent.py` (eval-intent-set slots case)
- [ ] CI green


Made with [Cursor](https://cursor.com)