### PR TITLE
chore(deploy): align prod verify scripts with P1 routing

### DIFF
--- a/deploy/prod-atomic-intent-ir-verify.py
+++ b/deploy/prod-atomic-intent-ir-verify.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Production verify — source-backed video/image intent IR (B+C)."""
+"""Production verify — source-backed video/image intent IR (B+C).
+
+P1 note: ref-backed utterances (@T1 …) require sidebar mentionedKeys + text attachment
+to materialize image/video nodes (same as AC-01 / prod-route-unification-verify).
+"""
 
 from __future__ import annotations
 
@@ -9,7 +13,7 @@ import sys
 import time
 import uuid
 from http.client import IncompleteRead
-from typing import Any
+from typing import Any, TypedDict
 from urllib.request import Request, urlopen
 
 BASE = os.environ.get("BASE_URL", "http://119.29.173.89:8888").rstrip("/")
@@ -17,12 +21,39 @@ API = f"{BASE}/api"
 PHONE = os.environ.get("PHONE", "17279698608")
 CODE = os.environ.get("CODE", "123456")
 
-CASES = [
-    ("基于提示词生成视频", "video"),
-    ("@T1 请基于文案生成视频", "video"),
-    ("基于文本生成图片", "image"),
-    ("帮我生成一个蓝牙耳机的分镜提示词", "prompt"),
-    ("@T1 请按风格3出图", "image"),
+T1_TEXT_ATTACHMENT: dict[str, Any] = {
+    "id": "t1-text-ref",
+    "refKey": "T1",
+    "mediaType": "text",
+    "sourceKind": "asset",
+    "label": "T1文案",
+    "text": "蓝牙耳机详情页文案：轻量降噪，续航30小时。",
+}
+
+
+class IrCase(TypedDict, total=False):
+    utterance: str
+    expect: str
+    mentioned_keys: list[str]
+    attachments: list[dict[str, Any]]
+
+
+CASES: list[IrCase] = [
+    {"utterance": "基于提示词生成视频", "expect": "video"},
+    {
+        "utterance": "@T1 请基于文案生成视频",
+        "expect": "video",
+        "mentioned_keys": ["T1"],
+        "attachments": [dict(T1_TEXT_ATTACHMENT)],
+    },
+    {"utterance": "基于文本生成图片", "expect": "image"},
+    {"utterance": "帮我生成一个蓝牙耳机的分镜提示词", "expect": "prompt"},
+    {
+        "utterance": "@T1 请按风格3出图",
+        "expect": "image",
+        "mentioned_keys": ["T1"],
+        "attachments": [dict(T1_TEXT_ATTACHMENT)],
+    },
 ]
 
 PASS = FAIL = 0
@@ -51,8 +82,23 @@ def http(m: str, p: str, b: dict | None = None, t: str | None = None) -> Any:
         return json.loads(resp.read())
 
 
-def sse_collect(t: str, sid: str, msg: str, tid: str, *, timeout: float = 180) -> tuple[list[dict], list[dict]]:
+def sse_collect(
+    t: str,
+    sid: str,
+    msg: str,
+    tid: str,
+    *,
+    mentioned_keys: list[str] | None = None,
+    attachments: list[dict] | None = None,
+    timeout: float = 180,
+) -> tuple[list[dict], list[dict]]:
     body: dict[str, Any] = {"sessionId": sid, "message": msg, "threadId": tid}
+    if mentioned_keys:
+        body["mentionedKeys"] = mentioned_keys
+    if attachments:
+        body["attachments"] = attachments
+        if attachments and attachments[0].get("id"):
+            body["refOrder"] = [str(attachments[0]["id"])]
     h = {
         "Content-Type": "application/json",
         "Accept": "text/event-stream",
@@ -118,13 +164,22 @@ def main() -> int:
     tok = http("POST", "/auth/login", {"phone": PHONE, "code": CODE})["data"]["token"]
     record("Login", True)
 
-    sid = http("POST", "/sessions", {"title": f"ir-verify-{int(time.time())}"}, t=tok)["data"]["id"]
-
-    for utterance, expect_type in CASES:
+    for case in CASES:
+        utterance = case["utterance"]
+        expect_type = case["expect"]
+        sid = http("POST", "/sessions", {"title": f"ir-verify-{expect_type}-{int(time.time())}"}, t=tok)["data"]["id"]
         tid = f"{sid}:{uuid.uuid4().hex[:8]}"
-        actions, linked = sse_collect(tok, sid, utterance, tid, timeout=120)
+        actions, linked = sse_collect(
+            tok,
+            sid,
+            utterance,
+            tid,
+            mentioned_keys=case.get("mentioned_keys"),
+            attachments=case.get("attachments"),
+            timeout=120,
+        )
         node_type = first_node_type(actions)
-        lo_type = (linked[0].get("nodeType") if linked else None)
+        lo_type = linked[0].get("nodeType") if linked else None
         got = node_type or lo_type or "?"
         ok = got == expect_type
         record(f"{utterance} → {expect_type}", ok, f"got={got}, actions={len(actions)}")

--- a/deploy/prod-sidebar-attachments-verify.py
+++ b/deploy/prod-sidebar-attachments-verify.py
@@ -8,6 +8,7 @@ Sections:
      1. focusNodeId alone → no silent localRefs (M3 D-A/D-B)
      2. atomic_create + attachments + mentionedKeys → localRefs + node.data.mentionedKeys
      3. campaign plan → confirm split → seed image ref edges
+     4. P1: marketing without skillId → clarify_route (not silent campaign)
 
 Usage:
   python3 deploy/prod-sidebar-attachments-verify.py
@@ -87,6 +88,7 @@ def sse_collect(
     msg: str,
     tid: str,
     *,
+    skill_id: str | None = None,
     attachments: list[dict[str, Any]] | None = None,
     ref_order: list[str] | None = None,
     mentioned_keys: list[str] | None = None,
@@ -94,6 +96,8 @@ def sse_collect(
     timeout: float = 300,
 ) -> tuple[list[dict], str, set[str], str]:
     body: dict[str, Any] = {"sessionId": sid, "message": msg, "threadId": tid}
+    if skill_id:
+        body["skillId"] = skill_id
     if attachments:
         body["attachments"] = attachments
     if ref_order:
@@ -308,17 +312,54 @@ def _seed_image_with_media_edges(canvas: dict[str, Any]) -> tuple[dict[str, Any]
     return None, []
 
 
-def verify_campaign_attach_edges(tok: str) -> None:
-    sid = http("POST", "/sessions", {"title": f"sidebar-campaign-{int(time.time())}"}, t=tok)["data"]["id"]
+def verify_campaign_orch_clarify_without_skill(tok: str) -> None:
+    """P1 AC-04: orchestration utterance + attachment without Skill → clarify_route."""
+    sid = http("POST", "/sessions", {"title": f"sidebar-orch-clarify-{int(time.time())}"}, t=tok)["data"]["id"]
     tid = f"{sid}:{uuid.uuid4()}"
     attachments = [dict(MOCK_ATTACHMENT)]
     ref_order = [attachments[0]["id"]]
-
-    _, text1, types1, exit1 = sse_collect(
+    _, text, types, exit_reason = sse_collect(
         tok,
         sid,
         "天猫蓝牙耳机详情页营销方案，主图参考 @I1，品牌 lnkpi",
         tid,
+        attachments=attachments,
+        ref_order=ref_order,
+        mentioned_keys=["I1"],
+        timeout=SSE_TIMEOUT_SEC,
+    )
+    at_clarify = (
+        "1）" in text
+        or "Skill" in text
+        or "编排" in text
+        or "await_confirm" not in types
+    ) and "error" not in types
+    record(
+        "campaign orch without skill → clarify",
+        at_clarify and "拟定拆解约 14" not in text[:240],
+        text[:140],
+    )
+    record(
+        "campaign clarify shows ref acknowledgment",
+        "已看到引用" in text or "@I1" in text,
+        f"exit={exit_reason}",
+    )
+
+
+def verify_campaign_attach_edges(tok: str) -> None:
+    """Explicit skillId required for campaign path (P1 R-S1 / R-S2)."""
+    sid = http("POST", "/sessions", {"title": f"sidebar-campaign-{int(time.time())}"}, t=tok)["data"]["id"]
+    tid = f"{sid}:{uuid.uuid4()}"
+    attachments = [dict(MOCK_ATTACHMENT)]
+    ref_order = [attachments[0]["id"]]
+    campaign_msg = "天猫蓝牙耳机详情页营销方案，主图参考 @I1，品牌 lnkpi"
+
+    _, text1, types1, exit1 = sse_collect(
+        tok,
+        sid,
+        campaign_msg,
+        tid,
+        skill_id="canvas",
         attachments=attachments,
         ref_order=ref_order,
         mentioned_keys=["I1"],
@@ -330,10 +371,13 @@ def verify_campaign_attach_edges(tok: str) -> None:
         or "拟定拆解" in text1
         or ("拟定" in text1 and "请确认" in text1)
         or ("请确认" in text1 and ("拆解" in text1 or "模块" in text1))
+        or "确认方案" in text1
+        or "采纳推荐" in text1
     )
-    record("campaign plan with attachment", at_plan and "error" not in types1, text1[:140])
+    record("campaign plan with explicit skill", at_plan and "error" not in types1, text1[:140])
 
-    _, text2, types2, exit2 = sse_collect(tok, sid, "1", tid, timeout=SSE_TIMEOUT_SEC)
+    confirm_msg = "确认方案" if "确认方案" in text1 or "采纳推荐" in text1 else "确认出图"
+    _, text2, types2, exit2 = sse_collect(tok, sid, confirm_msg, tid, timeout=SSE_TIMEOUT_SEC)
     confirm_ok = "error" not in types2 and len(text2) > 0
     record("campaign confirm split", confirm_ok, f"exit={exit2} text={text2[:100]}")
 
@@ -374,6 +418,7 @@ def run_prod_smoke() -> None:
 
     verify_focus_only_no_silent_ref(tok)
     verify_atomic_local_refs(tok)
+    verify_campaign_orch_clarify_without_skill(tok)
     verify_campaign_attach_edges(tok)
 
 


### PR DESCRIPTION
## Summary

- **`prod-atomic-intent-ir-verify.py`**: ref-backed cases (`@T1` style3/video) now send `mentionedKeys` + text attachment; per-case sessions
- **`prod-sidebar-attachments-verify.py`**: split campaign checks — P1 clarify without skill (AC-04) vs explicit `skillId=canvas` campaign + attachment ref edges

## Test plan

- [x] `python3 deploy/prod-atomic-intent-ir-verify.py` — PASS=6 FAIL=0
- [x] `SKIP_UNIT=1 python3 deploy/prod-sidebar-attachments-verify.py` — PASS=14 FAIL=0


Made with [Cursor](https://cursor.com)