### PR TITLE
feat(web): P1/P2 homepage sessions, edge styles, and theme cleanup

### DIFF
--- a/apps/server/src/sessions/sessions.controller.ts
+++ b/apps/server/src/sessions/sessions.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Delete, Get, Inject, Param, Post, Put, Req, UseGuards } from '@nestjs/common'
-import { IsOptional, IsString } from 'class-validator'
+import { IsArray, IsOptional, IsString } from 'class-validator'
 import { AuthGuard } from '../auth/auth.guard'
 import { SessionsService } from './sessions.service'
 
@@ -22,6 +22,12 @@ class UpdateSessionDto {
   canvasData?: unknown
 }
 
+class BatchDeleteSessionsDto {
+  @IsArray()
+  @IsString({ each: true })
+  ids!: string[]
+}
+
 @Controller('sessions')
 export class SessionsController {
   constructor(@Inject(SessionsService) private readonly sessionsService: SessionsService) {}
@@ -37,6 +43,13 @@ export class SessionsController {
   @UseGuards(AuthGuard)
   async findAll(@Req() req: { user: { sub: string } }) {
     const data = await this.sessionsService.findAll(req.user.sub)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('batch-delete')
+  @UseGuards(AuthGuard)
+  async removeMany(@Req() req: { user: { sub: string } }, @Body() dto: BatchDeleteSessionsDto) {
+    const data = await this.sessionsService.removeMany(req.user.sub, dto.ids)
     return { code: 0, message: 'ok', data }
   }
 

--- a/apps/server/src/sessions/sessions.service.ts
+++ b/apps/server/src/sessions/sessions.service.ts
@@ -71,6 +71,15 @@ export class SessionsService {
     return { message: '已删除' }
   }
 
+  async removeMany(userId: string, ids: string[]) {
+    const uniqueIds = [...new Set(ids.filter(Boolean))]
+    if (!uniqueIds.length) return { deleted: 0 }
+    const result = await this.prisma.session.deleteMany({
+      where: { userId, id: { in: uniqueIds } },
+    })
+    return { deleted: result.count }
+  }
+
   async duplicate(userId: string, id: string) {
     const src = await this.prisma.session.findFirst({ where: { id, userId } })
     if (!src) throw new NotFoundException('会话不存在')

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -1674,8 +1674,9 @@ defineExpose({
 }
 
 .agent-head-btn.is-active {
-  background: var(--neo-accent-soft);
-  color: var(--neo-accent-text);
+  background: var(--neo-hi-bg);
+  color: var(--neo-hi-text);
+  box-shadow: var(--neo-hi-shadow);
 }
 
 .agent-readonly-btn {
@@ -1759,9 +1760,9 @@ defineExpose({
 }
 
 .agent-input-dock.is-drop-target {
-  border-color: var(--neo-accent-border);
-  background: var(--neo-accent-soft);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--neo-accent-border) 32%, transparent);
+  border-color: color-mix(in srgb, var(--neo-hi-text) 35%, var(--neo-border));
+  background: var(--neo-hover-bg);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--neo-hi-text) 18%, transparent);
 }
 
 .agent-prompt-field {
@@ -1818,7 +1819,7 @@ defineExpose({
 }
 
 .agent-skill-icon {
-  background: var(--neo-accent-soft);
-  color: var(--neo-accent-text);
+  background: var(--neo-hover-bg);
+  color: var(--neo-text-secondary);
 }
 </style>

--- a/apps/web/src/components/canvas/CanvasBottomLeftControls.vue
+++ b/apps/web/src/components/canvas/CanvasBottomLeftControls.vue
@@ -17,6 +17,7 @@ const emit = defineEmits<{
 
 const { viewport, zoomTo, fitView, nodes: flowNodes, setCenter } = useVueFlow()
 const showGridPanel = ref(false)
+const showEdgePanel = ref(false)
 const showListPanel = ref(false)
 const showMinimapPopover = ref(false)
 const minimapBodyRef = ref<HTMLElement | null>(null)
@@ -24,6 +25,7 @@ const rootRef = ref<HTMLElement | null>(null)
 
 useClickOutside(rootRef, () => {
   showGridPanel.value = false
+  showEdgePanel.value = false
   if (props.settings.minimapExpanded !== 0) {
     emit('update:settings', { minimapExpanded: 0 })
   }
@@ -293,7 +295,7 @@ watch(
             class="bar-btn"
             :class="showGridPanel ? 'is-accent' : ''"
             title="网格设置"
-            @click="showGridPanel = !showGridPanel"
+            @click="showGridPanel = !showGridPanel; showEdgePanel = false"
           >
             <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16M8 4v16M16 4v16" />
@@ -396,6 +398,74 @@ watch(
           </svg>
         </button>
 
+        <div class="relative">
+          <button
+            type="button"
+            class="bar-btn"
+            :class="showEdgePanel ? 'is-accent' : ''"
+            title="连线样式"
+            @click="showEdgePanel = !showEdgePanel; showGridPanel = false"
+          >
+            <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 12h16M4 6h10M4 18h14" />
+            </svg>
+          </button>
+          <div
+            v-if="showEdgePanel"
+            class="grid-settings-popover neo-popover pointer-events-auto absolute bottom-full left-0 z-10 mb-1.5 w-[210px] rounded-xl p-3"
+            @click.stop
+          >
+            <p class="panel-label mb-2 text-xs">连线样式</p>
+            <label class="panel-caption mb-2 block text-[10px]">
+              粗细 {{ settings.edgeWidth.toFixed(1) }}px
+              <input
+                type="range"
+                min="1"
+                max="4"
+                step="0.5"
+                class="mt-1 w-full accent-[var(--neo-slider-accent)]"
+                :value="settings.edgeWidth"
+                @input="patch({ edgeWidth: Number(($event.target as HTMLInputElement).value) })"
+              >
+            </label>
+            <label class="panel-caption mb-2 block text-[10px]">
+              颜色
+              <input
+                type="color"
+                class="mt-1 h-7 w-full cursor-pointer rounded border border-[var(--neo-border)] bg-transparent"
+                :value="settings.edgeColor || '#6b7280'"
+                @input="patch({ edgeColor: ($event.target as HTMLInputElement).value })"
+              >
+            </label>
+            <div class="mb-2 flex gap-1">
+              <button
+                type="button"
+                class="seg-btn flex-1 rounded-lg py-1 text-[10px]"
+                :class="settings.edgeDash === 'solid' ? 'is-on' : ''"
+                @click="patch({ edgeDash: 'solid' })"
+              >
+                实线
+              </button>
+              <button
+                type="button"
+                class="seg-btn flex-1 rounded-lg py-1 text-[10px]"
+                :class="settings.edgeDash === 'dashed' ? 'is-on' : ''"
+                @click="patch({ edgeDash: 'dashed' })"
+              >
+                虚线
+              </button>
+            </div>
+            <button
+              type="button"
+              class="seg-btn w-full rounded-lg py-1 text-[10px]"
+              :class="settings.edgeGlow ? 'is-on' : ''"
+              @click="patch({ edgeGlow: !settings.edgeGlow })"
+            >
+              {{ settings.edgeGlow ? '发光：开' : '发光：关' }}
+            </button>
+          </div>
+        </div>
+
         <button
           type="button"
           class="bar-btn"
@@ -473,8 +543,9 @@ watch(
 }
 
 .seg-btn.is-on {
-  background: var(--neo-accent-soft);
-  color: var(--neo-accent-text);
+  background: var(--neo-hi-bg);
+  color: var(--neo-hi-text);
+  box-shadow: var(--neo-hi-shadow);
 }
 
 .zoom-group {

--- a/apps/web/src/components/canvas/NodePanelDock.vue
+++ b/apps/web/src/components/canvas/NodePanelDock.vue
@@ -231,11 +231,12 @@ useClickOutside(rootRef, closePopovers)
 }
 .rail-btn:hover {
   background: var(--neo-hover-bg);
-  color: var(--neo-accent-text);
+  color: var(--neo-text-primary);
 }
 .rail-btn.is-active {
-  background: var(--neo-accent-soft);
-  color: var(--neo-accent-text);
+  background: var(--neo-hi-bg);
+  color: var(--neo-hi-text);
+  box-shadow: var(--neo-hi-shadow);
 }
 
 /* 统一大小的圆形图标底座 */
@@ -249,8 +250,8 @@ useClickOutside(rootRef, closePopovers)
   background: var(--neo-active-bg);
 }
 .rail-btn.is-active .rail-circle {
-  border-color: var(--neo-accent-border);
-  background: var(--neo-accent-soft);
+  border-color: color-mix(in srgb, var(--neo-hi-text) 30%, var(--neo-border));
+  background: var(--neo-active-bg);
 }
 
 /* 添加节点：白色高亮凸显（浅色主题下自动转深色高亮） */

--- a/apps/web/src/components/workflow/CreativeLauncher.vue
+++ b/apps/web/src/components/workflow/CreativeLauncher.vue
@@ -4,26 +4,26 @@ defineEmits<{ 'update:modelValue': [v: string]; create: []; guide: [] }>()
 </script>
 
 <template>
-  <div class="rounded-2xl border border-white/[0.08] bg-[#1a1a1a] p-2">
+  <div class="studio-launcher neo-glass-lite rounded-2xl p-2">
     <div class="flex flex-col gap-2 lg:flex-row lg:items-center">
       <input
         :value="modelValue"
-        class="flex-1 rounded-xl bg-transparent px-4 py-3 text-sm outline-none placeholder:text-white/40"
+        class="studio-launcher-input flex-1 rounded-xl bg-transparent px-4 py-3 text-sm outline-none"
         placeholder="说说你的创意，超创帮你在画布上实现 …"
         @input="$emit('update:modelValue', ($event.target as HTMLInputElement).value)"
         @keydown.enter="$emit('create')"
-      />
+      >
       <div class="flex shrink-0 gap-2">
         <button
           type="button"
-          class="rounded-xl border border-white/10 px-4 py-2.5 text-sm text-white/70 transition hover:bg-white/5"
+          class="studio-launcher-secondary rounded-xl border px-4 py-2.5 text-sm transition"
           @click="$emit('guide')"
         >
           告诉我你的想法
         </button>
         <button
           type="button"
-          class="rounded-xl bg-[#6366f1] px-5 py-2.5 text-sm font-medium transition hover:bg-[#818cf8]"
+          class="studio-launcher-primary rounded-xl px-5 py-2.5 text-sm font-medium transition"
           @click="$emit('create')"
         >
           创建画布
@@ -32,3 +32,38 @@ defineEmits<{ 'update:modelValue': [v: string]; create: []; guide: [] }>()
     </div>
   </div>
 </template>
+
+<style scoped>
+.studio-launcher {
+  border: 1px solid var(--neo-glass-border);
+  box-shadow: var(--neo-glass-shadow);
+}
+
+.studio-launcher-input {
+  color: var(--neo-text-primary);
+}
+
+.studio-launcher-input::placeholder {
+  color: var(--neo-text-muted);
+}
+
+.studio-launcher-secondary {
+  border-color: var(--neo-border);
+  color: var(--neo-text-secondary);
+}
+
+.studio-launcher-secondary:hover {
+  background: var(--neo-hover-bg);
+  color: var(--neo-text-primary);
+}
+
+.studio-launcher-primary {
+  background: var(--neo-hi-bg);
+  color: var(--neo-hi-text);
+  box-shadow: var(--neo-hi-shadow);
+}
+
+.studio-launcher-primary:hover {
+  filter: brightness(1.06);
+}
+</style>

--- a/apps/web/src/components/workflow/SessionCard.vue
+++ b/apps/web/src/components/workflow/SessionCard.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { Session } from '@lnkpi/shared'
+import { resolveMediaUrl } from '@/services/api-base'
+import { formatSessionTime } from '@/utils/formatSessionTime'
+import { extractSessionCover } from '@/utils/sessionCover'
+
+const props = defineProps<{
+  session: Session
+  manageMode?: boolean
+  selected?: boolean
+  menuOpen?: boolean
+}>()
+
+const emit = defineEmits<{
+  open: []
+  toggleMenu: []
+  rename: []
+  duplicate: []
+  delete: []
+  toggleSelect: []
+}>()
+
+const cover = computed(() => extractSessionCover(props.session))
+const coverUrl = computed(() => (cover.value ? resolveMediaUrl(cover.value.url) : ''))
+</script>
+
+<template>
+  <div
+    class="session-card group relative flex aspect-[4/3] flex-col overflow-hidden rounded-2xl border text-left transition"
+    :class="selected ? 'session-card-selected' : ''"
+  >
+    <label
+      v-if="manageMode"
+      class="absolute left-2 top-2 z-20 flex h-6 w-6 cursor-pointer items-center justify-center rounded-md border border-white/20 bg-black/50"
+      @click.stop
+    >
+      <input
+        type="checkbox"
+        class="h-3.5 w-3.5 accent-[var(--neo-accent)]"
+        :checked="selected"
+        @change="emit('toggleSelect')"
+      >
+    </label>
+
+    <div
+      class="session-card-menu-anchor absolute right-2 top-2 z-10"
+      @click.stop
+    >
+      <button
+        v-if="!manageMode"
+        type="button"
+        class="flex h-7 w-7 items-center justify-center rounded-lg bg-black/50 text-white/70 opacity-0 transition hover:bg-black/70 hover:text-white group-hover:opacity-100"
+        :class="{ 'opacity-100': menuOpen }"
+        title="更多操作"
+        @click="emit('toggleMenu')"
+      >
+        <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+          <circle cx="5" cy="12" r="2" />
+          <circle cx="12" cy="12" r="2" />
+          <circle cx="19" cy="12" r="2" />
+        </svg>
+      </button>
+      <div
+        v-if="menuOpen"
+        class="neo-popover absolute right-0 top-full mt-1 min-w-[120px] rounded-xl py-1"
+      >
+        <button type="button" class="neo-popover-item flex w-full px-3 py-2 text-left text-xs" @click="emit('rename')">
+          重命名
+        </button>
+        <button type="button" class="neo-popover-item flex w-full px-3 py-2 text-left text-xs" @click="emit('duplicate')">
+          复制副本
+        </button>
+        <button type="button" class="neo-popover-item flex w-full px-3 py-2 text-left text-xs text-red-400" @click="emit('delete')">
+          删除
+        </button>
+      </div>
+    </div>
+
+    <button type="button" class="flex h-full w-full flex-col" @click="manageMode ? emit('toggleSelect') : emit('open')">
+      <div class="relative min-h-0 flex-1 overflow-hidden bg-[var(--neo-hover-bg)]">
+        <img
+          v-if="cover?.kind === 'image' && coverUrl"
+          :src="coverUrl"
+          alt=""
+          loading="lazy"
+          class="h-full w-full object-cover transition duration-300 group-hover:scale-[1.03]"
+        >
+        <video
+          v-else-if="cover?.kind === 'video' && coverUrl"
+          :src="coverUrl"
+          muted
+          preload="metadata"
+          class="h-full w-full object-cover"
+        />
+        <div v-else class="flex h-full w-full items-center justify-center text-[var(--neo-text-muted)]">
+          <svg class="h-8 w-8 opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 5a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1V5zm10 0a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1V5zM4 15a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1v-4zm10 2h6m-3-3v6" />
+          </svg>
+        </div>
+        <div class="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t from-black/70 to-transparent" />
+      </div>
+      <div class="relative z-[1] -mt-6 px-3 pb-2.5 pt-0">
+        <p class="truncate text-[13px] font-medium text-white/90 group-hover:text-white">
+          {{ session.title || '未命名画布' }}
+        </p>
+        <p class="mt-0.5 text-[10px] text-white/45">{{ formatSessionTime(session.updatedAt) }}</p>
+      </div>
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.session-card {
+  border-color: var(--neo-border);
+  background: var(--neo-surface-card, #1a1a1a);
+}
+
+.session-card:hover {
+  border-color: color-mix(in srgb, var(--neo-hi-text) 28%, var(--neo-border));
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.22);
+}
+
+.session-card-selected {
+  border-color: var(--neo-hi-text);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--neo-hi-text) 40%, transparent);
+}
+</style>

--- a/apps/web/src/composables/useCanvasViewportSettings.ts
+++ b/apps/web/src/composables/useCanvasViewportSettings.ts
@@ -2,6 +2,7 @@ import { ref, watch } from 'vue'
 
 export type MinimapExpandedState = 0 | 1 | 2
 export type GridVariant = 'dots' | 'lines'
+export type EdgeDashStyle = 'solid' | 'dashed'
 
 export interface CanvasViewportSettings {
   gridVisible: boolean
@@ -12,6 +13,10 @@ export interface CanvasViewportSettings {
   minimapExpanded: MinimapExpandedState
   snapToGrid: boolean
   edgeAnimated: boolean
+  edgeWidth: number
+  edgeColor: string
+  edgeGlow: boolean
+  edgeDash: EdgeDashStyle
   viewLocked: boolean
   bottomToolbarScale: number
 }
@@ -27,6 +32,10 @@ const defaults: CanvasViewportSettings = {
   minimapExpanded: 0,
   snapToGrid: true,
   edgeAnimated: true,
+  edgeWidth: 1.5,
+  edgeColor: '',
+  edgeGlow: false,
+  edgeDash: 'solid',
   viewLocked: false,
   bottomToolbarScale: 1,
 }

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -427,6 +427,19 @@ watch(
 
 const canvasInteractionEnabled = computed(() => canvasMode.value === 'vueflow' && !viewportSettings.value.viewLocked)
 
+const canvasEdgeStyle = computed(() => {
+  const s = viewportSettings.value
+  const vars: Record<string, string> = {
+    '--canvas-edge-width': `${s.edgeWidth}px`,
+  }
+  if (s.edgeColor.trim()) vars['--canvas-edge-color'] = s.edgeColor.trim()
+  vars['--canvas-edge-glow'] = s.edgeGlow
+    ? 'drop-shadow(0 0 5px color-mix(in srgb, var(--canvas-edge-color, var(--neo-edge)) 55%, transparent))'
+    : 'none'
+  vars['--canvas-edge-dash'] = s.edgeDash === 'dashed' && !s.edgeAnimated ? '6 8' : 'none'
+  return vars
+})
+
 let onFallbackPendingFromPoll:
   | ((kind: 'studio' | 'material', id: string, nodeId: string, message?: string) => Promise<void>)
   | null = null
@@ -2691,6 +2704,7 @@ onMounted(() => {
           :delete-key-code="null"
           fit-view-on-init
           class="canvas-flow h-full"
+          :style="canvasEdgeStyle"
           @connect="onConnect"
           @connect-start="onConnectStart"
           @connect-end="onConnectEnd"

--- a/apps/web/src/pages/WorkflowPage.vue
+++ b/apps/web/src/pages/WorkflowPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, watch } from 'vue'
+import { ref, onMounted, onBeforeUnmount, watch, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import type { Work } from '@lnkpi/shared'
@@ -10,12 +10,12 @@ import { useAuthStore } from '@/stores/auth'
 import { useSessionRedirect } from '@/composables/useSessionRedirect'
 import WorkCard from '@/components/works/WorkCard.vue'
 import CreativeLauncher from '@/components/workflow/CreativeLauncher.vue'
+import SessionCard from '@/components/workflow/SessionCard.vue'
 import CarouselBanner from '@/components/workflow/CarouselBanner.vue'
 import CategoryTabs from '@/components/workflow/CategoryTabs.vue'
 import PublishNeoTVDialog from '@/components/works/PublishNeoTVDialog.vue'
 import BrandLogo from '@/components/brand/BrandLogo.vue'
 import type { Session } from '@lnkpi/shared'
-import { formatSessionTime } from '@/utils/formatSessionTime'
 
 const router = useRouter()
 const auth = useAuthStore()
@@ -29,7 +29,26 @@ const showPublish = ref(false)
 const userSessions = ref<Session[]>([])
 const mySessions = ref<Session[]>([])
 const openMenuId = ref<string | null>(null)
-const menuRefs = new Map<string, HTMLElement>()
+const sessionSearch = ref('')
+const showAllSessions = ref(false)
+const manageSessions = ref(false)
+const selectedSessionIds = ref<string[]>([])
+const DEFAULT_VISIBLE_SESSIONS = 5
+
+const filteredSessions = computed(() => {
+  const q = sessionSearch.value.trim().toLowerCase()
+  if (!q) return mySessions.value
+  return mySessions.value.filter((s) => (s.title || '未命名画布').toLowerCase().includes(q))
+})
+
+const visibleSessions = computed(() => {
+  if (showAllSessions.value || sessionSearch.value.trim()) return filteredSessions.value
+  return filteredSessions.value.slice(0, DEFAULT_VISIBLE_SESSIONS)
+})
+
+const hasMoreSessions = computed(
+  () => !sessionSearch.value.trim() && filteredSessions.value.length > DEFAULT_VISIBLE_SESSIONS,
+)
 const greeting = getGreeting()
 
 function handlePublishLocateNode(payload: { sessionId: string; nodeId: string }) {
@@ -102,11 +121,6 @@ async function fetchMySessions() {
   }
 }
 
-function setMenuRef(id: string, el: HTMLElement | null) {
-  if (el) menuRefs.set(id, el)
-  else menuRefs.delete(id)
-}
-
 function toggleMenu(sessionId: string) {
   openMenuId.value = openMenuId.value === sessionId ? null : sessionId
 }
@@ -115,10 +129,45 @@ function closeMenu() {
   openMenuId.value = null
 }
 
+function toggleManageSessions() {
+  manageSessions.value = !manageSessions.value
+  selectedSessionIds.value = []
+  closeMenu()
+}
+
+function toggleSessionSelect(sessionId: string) {
+  const set = new Set(selectedSessionIds.value)
+  if (set.has(sessionId)) set.delete(sessionId)
+  else set.add(sessionId)
+  selectedSessionIds.value = [...set]
+}
+
+async function batchDeleteSessions() {
+  if (!selectedSessionIds.value.length) return
+  try {
+    await ElMessageBox.confirm(
+      `确定删除选中的 ${selectedSessionIds.value.length} 个画布？此操作不可恢复。`,
+      '批量删除',
+      { confirmButtonText: '删除', cancelButtonText: '取消', type: 'warning' },
+    )
+  } catch {
+    return
+  }
+  try {
+    const { data } = await sessionsApi.removeMany(selectedSessionIds.value)
+    await fetchMySessions()
+    selectedSessionIds.value = []
+    manageSessions.value = false
+    ElMessage.success(`已删除 ${data.data.deleted} 个画布`)
+  } catch {
+    ElMessage.error('批量删除失败，请稍后重试')
+  }
+}
+
 function onDocumentPointerDown(event: PointerEvent) {
   if (!openMenuId.value) return
-  const el = menuRefs.get(openMenuId.value)
-  if (el && !el.contains(event.target as Node)) closeMenu()
+  const target = event.target as HTMLElement
+  if (!target.closest('.session-card-menu-anchor')) closeMenu()
 }
 
 async function renameSession(session: Session) {
@@ -287,14 +336,40 @@ watch(() => auth.isLoggedIn, () => {
 
     <!-- 我的画布：历史画布 + 新建入口 -->
     <section v-if="auth.isLoggedIn" class="mb-12">
-      <div class="mb-4 flex items-center justify-between">
-        <h2 class="text-lg font-semibold text-white/90">我的画布</h2>
-        <span v-if="mySessions.length" class="text-xs text-white/35">{{ mySessions.length }} 个画布</span>
+      <div class="mb-4 flex flex-wrap items-center gap-3">
+        <h2 class="text-lg font-semibold text-[var(--neo-text-primary)]">我的画布</h2>
+        <span v-if="mySessions.length" class="text-xs text-[var(--neo-text-muted)]">{{ filteredSessions.length }} 个</span>
+        <span class="flex-1" />
+        <input
+          v-if="mySessions.length"
+          v-model="sessionSearch"
+          type="search"
+          class="w-44 rounded-lg border border-[var(--neo-border)] bg-[var(--neo-hover-bg)] px-2.5 py-1.5 text-xs outline-none focus:border-[var(--neo-accent-border)]"
+          placeholder="搜索画布..."
+        >
+        <button
+          v-if="mySessions.length"
+          type="button"
+          class="rounded-lg px-2.5 py-1.5 text-xs transition"
+          :class="manageSessions ? 'bg-[var(--neo-hi-bg)] text-[var(--neo-hi-text)]' : 'text-[var(--neo-text-muted)] hover:bg-[var(--neo-hover-bg)]'"
+          @click="toggleManageSessions"
+        >
+          {{ manageSessions ? '完成' : '管理' }}
+        </button>
+        <button
+          v-if="manageSessions && selectedSessionIds.length"
+          type="button"
+          class="rounded-lg bg-red-500/15 px-2.5 py-1.5 text-xs text-red-400 transition hover:bg-red-500/25"
+          @click="batchDeleteSessions"
+        >
+          删除选中 ({{ selectedSessionIds.length }})
+        </button>
       </div>
       <div class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
         <button
+          v-if="!manageSessions"
           type="button"
-          class="flex aspect-[4/3] flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-white/15 bg-white/[0.02] text-white/50 transition hover:border-[#6366f1]/50 hover:bg-[#6366f1]/5 hover:text-[#818cf8]"
+          class="session-create-card flex aspect-[4/3] flex-col items-center justify-center gap-2 rounded-2xl border border-dashed transition"
           @click="createCanvas"
         >
           <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -302,75 +377,34 @@ watch(() => auth.isLoggedIn, () => {
           </svg>
           <span class="text-xs font-medium">新建画布</span>
         </button>
-        <div
-          v-for="session in mySessions.slice(0, 11)"
+        <SessionCard
+          v-for="session in visibleSessions"
           :key="session.id"
-          class="group relative flex aspect-[4/3] flex-col justify-between overflow-hidden rounded-2xl border border-white/[0.08] bg-[#1a1a1a] p-3 text-left transition hover:border-[#6366f1]/40 hover:bg-[#1f1f24]"
-        >
-          <div
-            :ref="(el) => setMenuRef(session.id, el as HTMLElement | null)"
-            class="absolute right-2 top-2 z-10"
-          >
-            <button
-              type="button"
-              class="flex h-7 w-7 items-center justify-center rounded-lg bg-black/50 text-white/70 opacity-0 transition hover:bg-black/70 hover:text-white group-hover:opacity-100"
-              :class="{ 'opacity-100': openMenuId === session.id }"
-              title="更多操作"
-              @click.stop="toggleMenu(session.id)"
-            >
-              <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
-                <circle cx="5" cy="12" r="2" />
-                <circle cx="12" cy="12" r="2" />
-                <circle cx="19" cy="12" r="2" />
-              </svg>
-            </button>
-            <div
-              v-if="openMenuId === session.id"
-              class="neo-popover absolute right-0 top-full mt-1 min-w-[120px] rounded-xl py-1"
-              @click.stop
-            >
-              <button
-                type="button"
-                class="neo-popover-item flex w-full px-3 py-2 text-left text-xs"
-                @click="renameSession(session)"
-              >
-                重命名
-              </button>
-              <button
-                type="button"
-                class="neo-popover-item flex w-full px-3 py-2 text-left text-xs"
-                @click="duplicateSession(session)"
-              >
-                复制副本
-              </button>
-              <button
-                type="button"
-                class="neo-popover-item flex w-full px-3 py-2 text-left text-xs text-red-400"
-                @click="deleteSession(session)"
-              >
-                删除
-              </button>
-            </div>
-          </div>
-          <button
-            type="button"
-            class="flex flex-1 flex-col justify-between text-left"
-            @click="openCanvas(session.id)"
-          >
-            <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-[#6366f1]/15 text-[#818cf8]">
-              <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.75" d="M4 5a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1V5zm10 0a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1V5zM4 15a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1v-4zm10 2h6m-3-3v6" />
-              </svg>
-            </div>
-            <div class="min-w-0">
-              <p class="truncate text-[13px] font-medium text-white/85 group-hover:text-white">
-                {{ session.title || '未命名画布' }}
-              </p>
-              <p class="mt-0.5 text-[10px] text-white/35">{{ formatSessionTime(session.updatedAt) }}</p>
-            </div>
-          </button>
-        </div>
+          :session="session"
+          :manage-mode="manageSessions"
+          :selected="selectedSessionIds.includes(session.id)"
+          :menu-open="openMenuId === session.id"
+          class="session-card-menu-anchor"
+          @open="openCanvas(session.id)"
+          @toggle-menu="toggleMenu(session.id)"
+          @rename="renameSession(session)"
+          @duplicate="duplicateSession(session)"
+          @delete="deleteSession(session)"
+          @toggle-select="toggleSessionSelect(session.id)"
+        />
       </div>
+      <div v-if="hasMoreSessions" class="mt-4 text-center">
+        <button
+          type="button"
+          class="rounded-lg px-4 py-2 text-xs text-[var(--neo-text-muted)] transition hover:bg-[var(--neo-hover-bg)] hover:text-[var(--neo-text-primary)]"
+          @click="showAllSessions = !showAllSessions"
+        >
+          {{ showAllSessions ? '收起' : `查看更多（${filteredSessions.length - DEFAULT_VISIBLE_SESSIONS}）` }}
+        </button>
+      </div>
+      <p v-if="sessionSearch && !filteredSessions.length" class="py-8 text-center text-sm text-[var(--neo-text-muted)]">
+        没有匹配的画布
+      </p>
     </section>
 
     <section class="mb-10">
@@ -414,3 +448,17 @@ watch(() => auth.isLoggedIn, () => {
     />
   </div>
 </template>
+
+<style scoped>
+.session-create-card {
+  border-color: var(--neo-border);
+  background: color-mix(in srgb, var(--neo-hover-bg) 40%, transparent);
+  color: var(--neo-text-muted);
+}
+
+.session-create-card:hover {
+  border-color: color-mix(in srgb, var(--neo-hi-text) 35%, var(--neo-border));
+  background: var(--neo-hover-bg);
+  color: var(--neo-hi-text);
+}
+</style>

--- a/apps/web/src/services/sessions-api.ts
+++ b/apps/web/src/services/sessions-api.ts
@@ -8,5 +8,7 @@ export const sessionsApi = {
   update: (id: string, data: { title?: string; canvasData?: unknown }) =>
     api.put<{ data: Session }>(`/sessions/${id}`, data),
   remove: (id: string) => api.delete(`/sessions/${id}`),
+  removeMany: (ids: string[]) =>
+    api.post<{ data: { deleted: number } }>('/sessions/batch-delete', { ids }),
   duplicate: (id: string) => api.post<{ data: Session }>(`/sessions/${id}/duplicate`),
 }

--- a/apps/web/src/styles/neo-node.css
+++ b/apps/web/src/styles/neo-node.css
@@ -1096,9 +1096,9 @@
 }
 
 .group-node-wrapper.is-active .group-node-container {
-  border-color: var(--neo-accent-border);
-  background: var(--neo-accent-soft);
-  box-shadow: 0 0 0 1px var(--neo-accent-border);
+  border-color: color-mix(in srgb, var(--neo-hi-text) 35%, var(--neo-border));
+  background: var(--neo-hover-bg);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--neo-hi-text) 25%, transparent);
 }
 
 /* ============================================================
@@ -1111,18 +1111,23 @@
      方向沿 dash 流动，帮助视觉回溯上游节点
    ============================================================ */
 .vue-flow__edge .vue-flow__edge-path {
-  stroke: var(--neo-edge) !important;
-  stroke-width: 1.5px;
+  stroke: var(--canvas-edge-color, var(--neo-edge)) !important;
+  stroke-width: var(--canvas-edge-width, 1.5px);
+  filter: var(--canvas-edge-glow, none);
   transition: stroke 0.2s ease, stroke-width 0.2s ease;
 }
 
+.vue-flow__edge:not(.animated):not(.neo-edge-upstream):not(.neo-edge-downstream) .vue-flow__edge-path {
+  stroke-dasharray: var(--canvas-edge-dash, none);
+}
+
 .vue-flow__edge:hover .vue-flow__edge-path {
-  stroke: var(--neo-edge-hover) !important;
+  stroke: var(--canvas-edge-color, var(--neo-edge-hover)) !important;
 }
 
 .vue-flow__edge.selected .vue-flow__edge-path {
-  stroke: var(--neo-edge-selected) !important;
-  stroke-width: 2px;
+  stroke: var(--canvas-edge-color, var(--neo-edge-selected)) !important;
+  stroke-width: calc(var(--canvas-edge-width, 1.5px) + 0.5px);
 }
 
 /* 连线过程中的预览线：电流青、发光、流动 */

--- a/apps/web/src/utils/sessionCover.test.ts
+++ b/apps/web/src/utils/sessionCover.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import type { Session } from '@lnkpi/shared'
+import { extractSessionCover } from './sessionCover'
+
+describe('extractSessionCover', () => {
+  it('returns first image node cover', () => {
+    const session = {
+      id: '1',
+      title: 't',
+      userId: 'u',
+      updatedAt: '',
+      createdAt: '',
+      canvasData: {
+        nodes: [
+          { id: 'a', type: 'text', data: { content: 'hello' } },
+          { id: 'b', type: 'image', data: { url: 'https://cdn/x.jpg' } },
+        ],
+        edges: [],
+      },
+    } satisfies Session
+    expect(extractSessionCover(session)).toEqual({ url: 'https://cdn/x.jpg', kind: 'image' })
+  })
+
+  it('prefers coverUrl over url', () => {
+    const session = {
+      id: '1',
+      title: 't',
+      userId: 'u',
+      updatedAt: '',
+      createdAt: '',
+      canvasData: {
+        nodes: [{ id: 'b', type: 'image', data: { url: 'a.jpg', coverUrl: 'cover.jpg' } }],
+        edges: [],
+      },
+    } satisfies Session
+    expect(extractSessionCover(session)?.url).toBe('cover.jpg')
+  })
+})

--- a/apps/web/src/utils/sessionCover.test.ts
+++ b/apps/web/src/utils/sessionCover.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import type { Session } from '@lnkpi/shared'
 import { extractSessionCover } from './sessionCover'
 
+const pos = { x: 0, y: 0 }
+
 describe('extractSessionCover', () => {
   it('returns first image node cover', () => {
     const session = {
@@ -12,8 +14,8 @@ describe('extractSessionCover', () => {
       createdAt: '',
       canvasData: {
         nodes: [
-          { id: 'a', type: 'text', data: { content: 'hello' } },
-          { id: 'b', type: 'image', data: { url: 'https://cdn/x.jpg' } },
+          { id: 'a', type: 'text', position: pos, data: { content: 'hello' } },
+          { id: 'b', type: 'image', position: pos, data: { url: 'https://cdn/x.jpg' } },
         ],
         edges: [],
       },
@@ -29,7 +31,7 @@ describe('extractSessionCover', () => {
       updatedAt: '',
       createdAt: '',
       canvasData: {
-        nodes: [{ id: 'b', type: 'image', data: { url: 'a.jpg', coverUrl: 'cover.jpg' } }],
+        nodes: [{ id: 'b', type: 'image', position: pos, data: { url: 'a.jpg', coverUrl: 'cover.jpg' } }],
         edges: [],
       },
     } satisfies Session

--- a/apps/web/src/utils/sessionCover.ts
+++ b/apps/web/src/utils/sessionCover.ts
@@ -1,0 +1,28 @@
+import type { Session } from '@lnkpi/shared'
+
+type CanvasNodeLike = {
+  type?: string
+  data?: { url?: string; coverUrl?: string }
+}
+
+const MEDIA_NODE_TYPES = new Set(['image', 'video', 'mediaInput', 'shot'])
+
+export function extractSessionCover(session: Session): { url: string; kind: 'image' | 'video' } | null {
+  const nodes = (session.canvasData?.nodes ?? []) as CanvasNodeLike[]
+  for (const node of nodes) {
+    const type = String(node.type ?? '')
+    const url = String(node.data?.coverUrl ?? node.data?.url ?? '').trim()
+    if (!url) continue
+    if (type === 'video' || /\.(mp4|webm|mov)(\?|$)/i.test(url)) {
+      return { url, kind: 'video' }
+    }
+    if (MEDIA_NODE_TYPES.has(type) || /\.(png|jpe?g|webp|gif|avif)(\?|$)/i.test(url)) {
+      return { url, kind: 'image' }
+    }
+  }
+  for (const node of nodes) {
+    const url = String(node.data?.coverUrl ?? node.data?.url ?? '').trim()
+    if (url) return { url, kind: 'image' }
+  }
+  return null
+}

--- a/docs/superpowers/specs/2026-08-10-ui-p1-p2-interactions-design.md
+++ b/docs/superpowers/specs/2026-08-10-ui-p1-p2-interactions-design.md
@@ -1,38 +1,32 @@
-# UI P1/P2 交互与视觉设计（待实现）
+# UI P1/P2 交互与视觉设计
 
-> P0 已在 `2026-08-10-ui-p0-interactions-design.md` 完成并合并。本文档跟踪剩余需求，建议拆成独立 PR。
+> P0 已在 `2026-08-10-ui-p0-interactions-design.md` 完成（PR #207）。
 
-## P1 — 主页画布列表
+## P1 — 主页画布列表 ✅
 
-- 默认只展示少量最近画布，其余「查看更多」
-- 每个画布卡片需有封面缩略图
-- 支持批量删除
-- 支持搜索 / 筛选画布
+- [x] 默认展示 5 个 +「查看更多」
+- [x] 封面缩略图（从 canvasData 首图/视频节点推导）
+- [x] 批量删除（`POST /sessions/batch-delete`）
+- [x] 搜索（客户端 title 过滤）
 
-## P2 — 视觉重做
+## P2 — 视觉重做（部分完成）
 
-### 主页 Studio 与 Agent 侧栏 Studio
+### 主页 Studio ✅
 
-- 重新设计输入区、模型选择与生成按钮布局
-- 与画布 dock-studio 视觉语言统一，降低信息密度
+- [x] `CreativeLauncher` 对齐 neo-glass / hi-bg 白钮
 
-### 画布主题与紫色背景
+### 画布主题与紫色背景（部分）
 
-- 去掉扎眼的紫色背景/高亮
-- 黑夜模式：画布 hover、工具栏、Agent 对话卡片改用白色/亮白 subtle 效果
-- 单击/双击反馈改为低对比度边框或 glow，而非大面积紫色填充
+- [x] Agent 顶栏 active、drop-target、skill icon
+- [x] 左侧 dock active 态
+- [x] 底栏 seg-btn、group 选中
+- [ ] 全站 token  sweep（main.css chips、selection rect 等）
 
-### 连线样式自定义
+### 连线样式自定义 ✅
 
-- 左下角工具栏「连线设置」支持：
-  - 线条粗细
-  - 线条颜色
-  - 发光效果开关
-  - 实线 / 虚线
+- [x] 粗细 / 颜色 / 发光 / 实虚线（localStorage + 底栏 popover）
 
-## 建议实现顺序
+### Agent 侧栏 Studio 布局
 
-1. P1 主页画布列表（独立 feature 分支）
-2. P2 画布主题 token 清理（fix/theme）
-3. P2 连线样式面板（feature/edge-style）
-4. P2 Studio 视觉重做（可与 theme 合并或分 PR）
+- [ ] 与 dock-studio 进一步统一（P0 已做 hover 参数条）
+


### PR DESCRIPTION
## Summary

**P1 — 主页画布列表**
- 新建 `SessionCard`：从 canvasData 提取封面缩略图
- 默认展示 5 个 +「查看更多」、标题搜索、管理模式下批量删除
- 后端 `POST /sessions/batch-delete`

**P2 — 视觉与连线**
- `CreativeLauncher` 对齐 neo-glass / 白色高亮主按钮
- 画布底栏新增「连线样式」：粗细、颜色、发光、实/虚线（localStorage）
- Agent 顶栏、dock active、底栏 seg-btn 等紫色填充改为 subtle 白高亮

P2 剩余项（全站 token sweep、Agent studio 布局深改）见 spec 待办。

## Test plan

- [x] `pnpm --filter @lnkpi/web test`（234 passed）
- [x] `pnpm build`
- [ ] 主页：封面卡片、搜索、查看更多、批量删
- [ ] 画布底栏：连线粗细/颜色/虚线/发光
- [ ] Agent / dock hover active 不再大面积紫色


Made with [Cursor](https://cursor.com)