### PR TITLE
fix(web): scheme A UI polish — agent dock, toolbar, asset icons

### DIFF
--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -1446,12 +1446,13 @@ defineExpose({
 
               <div class="agent-dock-actions">
                 <div class="agent-dock-params">
-                  <UniversalModelSelector v-model="planningModel" type="text" />
+                  <UniversalModelSelector v-model="planningModel" type="text" ghost />
 
                   <div ref="attachMenuRef" class="relative">
                     <button
                       type="button"
-                      class="neo-ctl flex h-8 w-8 items-center justify-center rounded-lg"
+                      class="dock-ghost-ctl flex h-8 w-8 items-center justify-center rounded-lg"
+                      :class="{ 'is-open': attachMenuOpen }"
                       :disabled="readOnly || isUploading"
                       :title="readOnly ? '只读画布不能添加参考素材' : '添加引用素材'"
                       @click="toggleAttachMenu"
@@ -1481,7 +1482,8 @@ defineExpose({
                   <div ref="skillMenuRef" class="relative">
                   <button
                     type="button"
-                    class="neo-ctl flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-xs"
+                    class="dock-ghost-ctl flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-xs"
+                    :class="{ 'is-open': skillMenuOpen, 'has-value': activeSkillId !== null }"
                     title="技能"
                     @click="skillMenuOpen = !skillMenuOpen"
                   >
@@ -1787,8 +1789,7 @@ defineExpose({
   flex-wrap: wrap;
   align-items: center;
   gap: 6px;
-  padding-top: 8px;
-  border-top: 1px solid var(--neo-border);
+  padding-top: 6px;
 }
 
 .agent-dock-params {
@@ -1796,19 +1797,8 @@ defineExpose({
   flex: 1 1 auto;
   flex-wrap: wrap;
   align-items: center;
-  gap: 6px;
-  max-height: 0;
-  overflow: hidden;
-  opacity: 0;
-  pointer-events: none;
-  transition: max-height 0.2s ease, opacity 0.2s ease;
-}
-
-.agent-input-dock:hover .agent-dock-params,
-.agent-input-dock:focus-within .agent-dock-params {
-  max-height: 120px;
-  opacity: 1;
-  pointer-events: auto;
+  gap: 4px;
+  min-width: 0;
 }
 
 .agent-dock-primary {

--- a/apps/web/src/components/canvas/CanvasAssetPanel.vue
+++ b/apps/web/src/components/canvas/CanvasAssetPanel.vue
@@ -399,25 +399,33 @@ function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
               公共
             </span>
 
-            <!-- hover 操作层：加载到画布 / 删除 -->
+            <!-- hover 操作层 -->
             <div
-              class="absolute inset-x-0 bottom-0 flex items-center justify-center gap-1 bg-gradient-to-t from-black/85 to-transparent px-1 pb-1 pt-4 opacity-0 transition group-hover:opacity-100"
+              class="absolute inset-x-0 bottom-0 flex items-center justify-center gap-1.5 bg-gradient-to-t from-black/85 to-transparent px-1.5 pb-1.5 pt-5 opacity-0 transition group-hover:opacity-100"
             >
               <button
                 type="button"
-                class="rounded-md bg-white/90 px-1.5 py-0.5 text-[9px] font-medium text-black transition hover:bg-white"
+                class="asset-hover-btn"
                 title="加入 Agent 引用"
+                aria-label="加入 Agent 引用"
                 @click.stop="addToAgent(asset)"
               >
-                加入 Agent
+                <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M12 3l1.5 4.5L18 9l-4.5 1.5L12 15l-1.5-4.5L6 9l4.5-1.5L12 3z" />
+                  <path d="M5 19h14M12 15v4" stroke-linecap="round" />
+                </svg>
               </button>
               <button
                 type="button"
-                class="rounded-md bg-white/90 px-1.5 py-0.5 text-[9px] font-medium text-black transition hover:bg-white"
+                class="asset-hover-btn"
                 title="加载到当前画布"
+                aria-label="加载到当前画布"
                 @click.stop="apply(asset)"
               >
-                加载到画布
+                <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v12m0-12l-4 4m4-4l4 4" />
+                  <path stroke-linecap="round" d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2" />
+                </svg>
               </button>
               <button
                 v-if="asset.source === 'user'"
@@ -448,3 +456,23 @@ function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
     </div>
   </div>
 </template>
+
+<style scoped>
+.asset-hover-btn {
+  display: flex;
+  width: 26px;
+  height: 26px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.92);
+  color: #111;
+  transition: transform 0.15s ease, background 0.15s ease;
+}
+
+.asset-hover-btn:hover {
+  transform: scale(1.06);
+  background: #fff;
+}
+</style>

--- a/apps/web/src/components/canvas/CanvasBottomLeftControls.vue
+++ b/apps/web/src/components/canvas/CanvasBottomLeftControls.vue
@@ -16,7 +16,7 @@ const emit = defineEmits<{
 }>()
 
 const { viewport, zoomTo, fitView, nodes: flowNodes, setCenter } = useVueFlow()
-const showGridPanel = ref(false)
+const showCanvasSettings = ref(false)
 const showEdgePanel = ref(false)
 const showListPanel = ref(false)
 const showMinimapPopover = ref(false)
@@ -24,7 +24,7 @@ const minimapBodyRef = ref<HTMLElement | null>(null)
 const rootRef = ref<HTMLElement | null>(null)
 
 useClickOutside(rootRef, () => {
-  showGridPanel.value = false
+  showCanvasSettings.value = false
   showEdgePanel.value = false
   if (props.settings.minimapExpanded !== 0) {
     emit('update:settings', { minimapExpanded: 0 })
@@ -180,7 +180,20 @@ function onMapToggle() {
   emit('cycleMinimap')
 }
 
+function toggleEdgePanel() {
+  showEdgePanel.value = !showEdgePanel.value
+  if (showEdgePanel.value) showCanvasSettings.value = false
+}
+
+function toggleCanvasSettings() {
+  showCanvasSettings.value = !showCanvasSettings.value
+  if (showCanvasSettings.value) showEdgePanel.value = false
+}
+
 const mapActive = computed(() => props.settings.minimapExpanded > 0)
+const edgeActive = computed(
+  () => showEdgePanel.value || props.settings.edgeAnimated || props.settings.edgeGlow || props.settings.edgeDash === 'dashed',
+)
 
 watch(
   () => props.settings.minimapExpanded,
@@ -246,9 +259,8 @@ watch(
       </div>
     </div>
 
-    <!-- 单行底栏 -->
-    <div class="toolbar-row neo-glass-lite pointer-events-auto flex flex-nowrap items-center gap-1 rounded-xl px-1.5 py-1">
-      <!-- 小地图切换 -->
+    <!-- 单行底栏：小地图 | 缩放 | 适应 | 连线 | 画布设置 -->
+    <div class="toolbar-row neo-glass-lite pointer-events-auto flex flex-nowrap items-center gap-1 rounded-full px-1.5 py-1">
       <button
         type="button"
         class="bar-btn"
@@ -263,7 +275,6 @@ watch(
 
       <span class="toolbar-divider" />
 
-      <!-- 缩放组：固定宽度，避免挤压重叠 -->
       <div class="zoom-group flex shrink-0 items-center gap-1">
         <button type="button" class="bar-btn" title="缩小" @click="zoomBy(-10)">−</button>
         <input
@@ -281,203 +292,187 @@ watch(
 
       <span class="toolbar-divider" />
 
-      <!-- 工具组 -->
-      <div class="tool-group flex shrink-0 items-center gap-1">
-        <button type="button" class="bar-btn" title="适应画布" @click="resetView">
-          <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5v-4m0 4h-4m4 0l-5-5" />
-          </svg>
-        </button>
+      <button type="button" class="bar-btn" title="适应画布" @click="resetView">
+        <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5v-4m0 4h-4m4 0l-5-5" />
+        </svg>
+      </button>
 
-        <div class="relative">
-          <button
-            type="button"
-            class="bar-btn"
-            :class="showGridPanel ? 'is-accent' : ''"
-            title="网格设置"
-            @click="showGridPanel = !showGridPanel; showEdgePanel = false"
-          >
-            <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16M8 4v16M16 4v16" />
-            </svg>
-          </button>
-          <div
-            v-if="showGridPanel"
-            class="grid-settings-popover neo-popover pointer-events-auto absolute bottom-full left-0 z-10 mb-1.5 w-[200px] rounded-xl p-3"
-            @click.stop
-          >
-            <div class="mb-2 flex items-center justify-between">
-              <span class="panel-label text-xs">网格底纹</span>
-              <button
-                type="button"
-                class="seg-btn rounded-md px-2 py-0.5 text-[10px]"
-                :class="settings.gridVisible ? 'is-on' : ''"
-                @click="patch({ gridVisible: !settings.gridVisible })"
-              >
-                {{ settings.gridVisible ? '显示' : '隐藏' }}
-              </button>
-            </div>
-            <div class="mb-3 flex gap-1">
-              <button
-                type="button"
-                class="seg-btn flex-1 rounded-lg py-1 text-[10px]"
-                :class="settings.gridVariant === 'dots' ? 'is-on' : ''"
-                @click="patch({ gridVariant: 'dots' })"
-              >
-                点阵
-              </button>
-              <button
-                type="button"
-                class="seg-btn flex-1 rounded-lg py-1 text-[10px]"
-                :class="settings.gridVariant === 'lines' ? 'is-on' : ''"
-                @click="patch({ gridVariant: 'lines' })"
-              >
-                线格
-              </button>
-            </div>
-            <label class="panel-caption mb-2 block text-[10px]">
-              间距 {{ settings.gridGap }}px
-              <input
-                type="range"
-                min="8"
-                max="48"
-                step="2"
-                class="mt-1 w-full accent-[var(--neo-slider-accent)]"
-                :value="settings.gridGap"
-                @input="patch({ gridGap: Number(($event.target as HTMLInputElement).value) })"
-              >
-            </label>
-            <label class="panel-caption block text-[10px]">
-              点大小 {{ settings.gridDotSize.toFixed(1) }}
-              <input
-                type="range"
-                min="0.5"
-                max="4"
-                step="0.1"
-                class="mt-1 w-full accent-[var(--neo-slider-accent)]"
-                :value="settings.gridDotSize"
-                @input="patch({ gridDotSize: Number(($event.target as HTMLInputElement).value) })"
-              >
-            </label>
-            <label class="panel-caption mt-3 block text-[10px]">
-              Dock 缩放 {{ settings.bottomToolbarScale.toFixed(1) }}x
-              <input
-                type="range"
-                min="0.8"
-                max="2"
-                step="0.1"
-                class="mt-1 w-full accent-[var(--neo-slider-accent)]"
-                :value="settings.bottomToolbarScale"
-                @input="patch({ bottomToolbarScale: Number(($event.target as HTMLInputElement).value) })"
-              >
-            </label>
-          </div>
-        </div>
-
+      <div class="relative">
         <button
           type="button"
           class="bar-btn"
-          :class="settings.snapToGrid ? 'is-accent' : ''"
-          title="节点吸附网格"
-          @click="patch({ snapToGrid: !settings.snapToGrid })"
-        >
-          <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4h6v6H4V4zm10 0h6v6h-6V4zM4 14h6v6H4v-6zm10 0h6v6h-6v-6z" />
-          </svg>
-        </button>
-
-        <button
-          type="button"
-          class="bar-btn"
-          :class="settings.edgeAnimated ? 'is-accent' : ''"
-          title="连线动画"
-          @click="patch({ edgeAnimated: !settings.edgeAnimated })"
+          :class="edgeActive ? 'is-accent' : ''"
+          title="连线设置"
+          @click="toggleEdgePanel"
         >
           <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
           </svg>
         </button>
-
-        <div class="relative">
-          <button
-            type="button"
-            class="bar-btn"
-            :class="showEdgePanel ? 'is-accent' : ''"
-            title="连线样式"
-            @click="showEdgePanel = !showEdgePanel; showGridPanel = false"
-          >
-            <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 12h16M4 6h10M4 18h14" />
-            </svg>
-          </button>
-          <div
-            v-if="showEdgePanel"
-            class="grid-settings-popover neo-popover pointer-events-auto absolute bottom-full left-0 z-10 mb-1.5 w-[210px] rounded-xl p-3"
-            @click.stop
-          >
-            <p class="panel-label mb-2 text-xs">连线样式</p>
-            <label class="panel-caption mb-2 block text-[10px]">
-              粗细 {{ settings.edgeWidth.toFixed(1) }}px
-              <input
-                type="range"
-                min="1"
-                max="4"
-                step="0.5"
-                class="mt-1 w-full accent-[var(--neo-slider-accent)]"
-                :value="settings.edgeWidth"
-                @input="patch({ edgeWidth: Number(($event.target as HTMLInputElement).value) })"
-              >
-            </label>
-            <label class="panel-caption mb-2 block text-[10px]">
-              颜色
-              <input
-                type="color"
-                class="mt-1 h-7 w-full cursor-pointer rounded border border-[var(--neo-border)] bg-transparent"
-                :value="settings.edgeColor || '#6b7280'"
-                @input="patch({ edgeColor: ($event.target as HTMLInputElement).value })"
-              >
-            </label>
-            <div class="mb-2 flex gap-1">
-              <button
-                type="button"
-                class="seg-btn flex-1 rounded-lg py-1 text-[10px]"
-                :class="settings.edgeDash === 'solid' ? 'is-on' : ''"
-                @click="patch({ edgeDash: 'solid' })"
-              >
-                实线
-              </button>
-              <button
-                type="button"
-                class="seg-btn flex-1 rounded-lg py-1 text-[10px]"
-                :class="settings.edgeDash === 'dashed' ? 'is-on' : ''"
-                @click="patch({ edgeDash: 'dashed' })"
-              >
-                虚线
-              </button>
-            </div>
+        <div
+          v-if="showEdgePanel"
+          class="settings-popover neo-popover pointer-events-auto absolute bottom-full right-0 z-10 mb-1.5 w-[220px] rounded-xl p-3"
+          @click.stop
+        >
+          <p class="panel-label mb-2 text-xs">连线</p>
+          <div class="mb-3 flex items-center justify-between">
+            <span class="panel-caption text-[10px]">流动动画</span>
             <button
               type="button"
-              class="seg-btn w-full rounded-lg py-1 text-[10px]"
-              :class="settings.edgeGlow ? 'is-on' : ''"
-              @click="patch({ edgeGlow: !settings.edgeGlow })"
+              class="seg-btn rounded-md px-2 py-0.5 text-[10px]"
+              :class="settings.edgeAnimated ? 'is-on' : ''"
+              @click="patch({ edgeAnimated: !settings.edgeAnimated })"
             >
-              {{ settings.edgeGlow ? '发光：开' : '发光：关' }}
+              {{ settings.edgeAnimated ? '开' : '关' }}
             </button>
           </div>
+          <label class="panel-caption mb-2 block text-[10px]">
+            粗细 {{ settings.edgeWidth.toFixed(1) }}px
+            <input
+              type="range"
+              min="1"
+              max="4"
+              step="0.5"
+              class="mt-1 w-full accent-[var(--neo-slider-accent)]"
+              :value="settings.edgeWidth"
+              @input="patch({ edgeWidth: Number(($event.target as HTMLInputElement).value) })"
+            >
+          </label>
+          <label class="panel-caption mb-2 block text-[10px]">
+            颜色
+            <input
+              type="color"
+              class="mt-1 h-7 w-full cursor-pointer rounded border border-[var(--neo-border)] bg-transparent"
+              :value="settings.edgeColor || '#6b7280'"
+              @input="patch({ edgeColor: ($event.target as HTMLInputElement).value })"
+            >
+          </label>
+          <div class="mb-2 flex gap-1">
+            <button
+              type="button"
+              class="seg-btn flex-1 rounded-lg py-1 text-[10px]"
+              :class="settings.edgeDash === 'solid' ? 'is-on' : ''"
+              @click="patch({ edgeDash: 'solid' })"
+            >
+              实线
+            </button>
+            <button
+              type="button"
+              class="seg-btn flex-1 rounded-lg py-1 text-[10px]"
+              :class="settings.edgeDash === 'dashed' ? 'is-on' : ''"
+              @click="patch({ edgeDash: 'dashed' })"
+            >
+              虚线
+            </button>
+          </div>
+          <button
+            type="button"
+            class="seg-btn w-full rounded-lg py-1 text-[10px]"
+            :class="settings.edgeGlow ? 'is-on' : ''"
+            @click="patch({ edgeGlow: !settings.edgeGlow })"
+          >
+            {{ settings.edgeGlow ? '发光：开' : '发光：关' }}
+          </button>
         </div>
+      </div>
 
+      <div class="relative">
         <button
           type="button"
           class="bar-btn"
-          :class="settings.viewLocked ? 'bg-amber-500/20 text-amber-300' : ''"
-          title="锁定视图"
-          @click="patch({ viewLocked: !settings.viewLocked })"
+          :class="showCanvasSettings ? 'is-accent' : ''"
+          title="画布设置"
+          @click="toggleCanvasSettings"
         >
           <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path v-if="settings.viewLocked" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-            <path v-else stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 11V7a4 4 0 118 0m-4 8v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2z" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7z" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 8 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 8a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 8 4.6a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 8c.36 0 .7.07 1 .2H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
           </svg>
         </button>
+        <div
+          v-if="showCanvasSettings"
+          class="settings-popover neo-popover pointer-events-auto absolute bottom-full right-0 z-10 mb-1.5 w-[220px] rounded-xl p-3"
+          @click.stop
+        >
+          <p class="panel-label mb-2 text-xs">画布视图</p>
+          <div class="mb-2 flex items-center justify-between">
+            <span class="panel-caption text-[10px]">网格底纹</span>
+            <button
+              type="button"
+              class="seg-btn rounded-md px-2 py-0.5 text-[10px]"
+              :class="settings.gridVisible ? 'is-on' : ''"
+              @click="patch({ gridVisible: !settings.gridVisible })"
+            >
+              {{ settings.gridVisible ? '显示' : '隐藏' }}
+            </button>
+          </div>
+          <div class="mb-3 flex gap-1">
+            <button
+              type="button"
+              class="seg-btn flex-1 rounded-lg py-1 text-[10px]"
+              :class="settings.gridVariant === 'dots' ? 'is-on' : ''"
+              @click="patch({ gridVariant: 'dots' })"
+            >
+              点阵
+            </button>
+            <button
+              type="button"
+              class="seg-btn flex-1 rounded-lg py-1 text-[10px]"
+              :class="settings.gridVariant === 'lines' ? 'is-on' : ''"
+              @click="patch({ gridVariant: 'lines' })"
+            >
+              线格
+            </button>
+          </div>
+          <label class="panel-caption mb-2 block text-[10px]">
+            网格间距 {{ settings.gridGap }}px
+            <input
+              type="range"
+              min="8"
+              max="48"
+              step="2"
+              class="mt-1 w-full accent-[var(--neo-slider-accent)]"
+              :value="settings.gridGap"
+              @input="patch({ gridGap: Number(($event.target as HTMLInputElement).value) })"
+            >
+          </label>
+          <div class="mb-3 flex items-center justify-between">
+            <span class="panel-caption text-[10px]">节点吸附网格</span>
+            <button
+              type="button"
+              class="seg-btn rounded-md px-2 py-0.5 text-[10px]"
+              :class="settings.snapToGrid ? 'is-on' : ''"
+              title="拖动节点时对齐网格，便于整齐排版"
+              @click="patch({ snapToGrid: !settings.snapToGrid })"
+            >
+              {{ settings.snapToGrid ? '开' : '关' }}
+            </button>
+          </div>
+          <div class="mb-3 flex items-center justify-between">
+            <span class="panel-caption text-[10px]">锁定视图</span>
+            <button
+              type="button"
+              class="seg-btn rounded-md px-2 py-0.5 text-[10px]"
+              :class="settings.viewLocked ? 'is-on' : ''"
+              @click="patch({ viewLocked: !settings.viewLocked })"
+            >
+              {{ settings.viewLocked ? '已锁' : '未锁' }}
+            </button>
+          </div>
+          <label class="panel-caption block text-[10px]">
+            Dock 缩放 {{ settings.bottomToolbarScale.toFixed(1) }}x
+            <input
+              type="range"
+              min="0.8"
+              max="2"
+              step="0.1"
+              class="mt-1 w-full accent-[var(--neo-slider-accent)]"
+              :value="settings.bottomToolbarScale"
+              @input="patch({ bottomToolbarScale: Number(($event.target as HTMLInputElement).value) })"
+            >
+          </label>
+        </div>
       </div>
     </div>
   </div>
@@ -485,7 +480,7 @@ watch(
 
 <style scoped>
 .toolbar-row {
-  height: 36px;
+  height: 38px;
 }
 
 .toolbar-divider {
@@ -494,7 +489,7 @@ watch(
 }
 
 .bar-btn {
-  @apply flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-sm leading-none transition;
+  @apply flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm leading-none transition;
   color: var(--neo-text-muted);
 }
 

--- a/apps/web/src/components/canvas/NeoBaseNode.vue
+++ b/apps/web/src/components/canvas/NeoBaseNode.vue
@@ -136,6 +136,20 @@ function onAddToAgent(event: MouseEvent) {
       >
       <span v-else class="neo-node-title">{{ displayTitle }}</span>
       <span class="neo-node-status" :class="nodeStatus" />
+      <button
+        v-if="addToAgent && isHovered && !selected"
+        type="button"
+        class="neo-node-agent-add neo-node-agent-add--title"
+        title="加入 Agent 引用"
+        aria-label="加入 Agent 引用"
+        @click="onAddToAgent"
+        @mousedown.stop
+      >
+        <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M12 3l1.5 4.5L18 9l-4.5 1.5L12 15l-1.5-4.5L6 9l4.5-1.5L12 3z" />
+          <path d="M5 19h14M12 15v4" stroke-linecap="round" />
+        </svg>
+      </button>
     </div>
 
     <div
@@ -143,20 +157,6 @@ function onAddToAgent(event: MouseEvent) {
       :class="[meta.variant, { selected, 'neo-node-locate-flash': isLocateFlashing }]"
       :style="shellStyle"
     >
-      <button
-        v-if="addToAgent && isHovered && !selected"
-        type="button"
-        class="neo-node-agent-add"
-        title="加入 Agent 引用"
-        aria-label="加入 Agent 引用"
-        @click="onAddToAgent"
-        @mousedown.stop
-      >
-        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M12 3l1.5 4.5L18 9l-4.5 1.5L12 15l-1.5-4.5L6 9l4.5-1.5L12 3z" />
-          <path d="M5 19h14M12 15v4" stroke-linecap="round" />
-        </svg>
-      </button>
       <div class="neo-node-content">
         <slot />
       </div>

--- a/apps/web/src/components/canvas/UniversalModelSelector.vue
+++ b/apps/web/src/components/canvas/UniversalModelSelector.vue
@@ -15,12 +15,17 @@ export type SelectorModelOption = {
   disabled?: boolean
 }
 
-const props = defineProps<{
-  modelValue: string
-  type: GenerationType
-  /** Override catalog modality (e.g. audio when type is not in GenerationType) */
-  modality?: StudioModality
-}>()
+const props = withDefaults(
+  defineProps<{
+    modelValue: string
+    type: GenerationType
+    /** Override catalog modality (e.g. audio when type is not in GenerationType) */
+    modality?: StudioModality
+    /** ghost：无边框，hover 才高亮（Agent / 单层 dock） */
+    ghost?: boolean
+  }>(),
+  { ghost: false },
+)
 
 const emit = defineEmits<{
   'update:modelValue': [value: string]
@@ -111,7 +116,8 @@ function select(id: string) {
   <div ref="rootRef" class="relative">
     <button
       type="button"
-      class="neo-ctl flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-xs"
+      class="flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-xs"
+      :class="[ghost ? 'dock-ghost-ctl' : 'neo-ctl', open ? 'is-open' : '']"
       :title="typeTitle"
       @click="open = !open"
     >

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -1274,6 +1274,14 @@ function onNodeDragStop(event: NodeDragEvent) {
   if (node.parentNode) {
     nodes.value = resizeGroupToFitChildren(nodes.value as unknown as FlowNode[], node.parentNode) as EditableFlowNode[]
   }
+  if (viewportSettings.value.snapToGrid) {
+    locateFlashNodeIds.value = new Set([node.id])
+    window.setTimeout(() => {
+      if (locateFlashNodeIds.value.has(node.id)) {
+        locateFlashNodeIds.value = new Set()
+      }
+    }, 500)
+  }
   persistUserEdit()
 }
 

--- a/apps/web/src/styles/main.css
+++ b/apps/web/src/styles/main.css
@@ -138,6 +138,31 @@
     border-color: var(--neo-border-strong);
   }
 
+  /* dock / Agent 单层 ghost 控件：默认无边框，hover/focus 才显形 */
+  .dock-ghost-ctl {
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--neo-text-secondary);
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+  }
+
+  .dock-ghost-ctl:hover,
+  .dock-ghost-ctl:focus-visible {
+    border-color: var(--neo-border);
+    background: var(--neo-hover-bg);
+    color: var(--neo-text-primary);
+  }
+
+  .dock-ghost-ctl.is-open,
+  .dock-ghost-ctl.has-value {
+    color: var(--neo-text-primary);
+  }
+
+  .dock-ghost-ctl.is-open {
+    border-color: var(--neo-border);
+    background: var(--neo-hover-bg);
+  }
+
   /* 选项 chip：is-on 时品牌色高亮 */
   .neo-chip {
     background: var(--neo-hover-bg);

--- a/apps/web/src/styles/neo-node.css
+++ b/apps/web/src/styles/neo-node.css
@@ -9,6 +9,7 @@
   position: absolute;
   top: -32px;
   left: 0;
+  right: 0;
   z-index: 1;
   display: flex;
   align-items: center;
@@ -320,28 +321,34 @@
 }
 
 .neo-node-agent-add {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  z-index: 4;
   display: flex;
-  width: 28px;
-  height: 28px;
+  flex-shrink: 0;
   align-items: center;
   justify-content: center;
-  border: 1px solid var(--neo-accent-border);
-  border-radius: 8px;
-  background: var(--neo-surface-elevated, rgba(20, 20, 28, 0.92));
-  color: var(--neo-accent);
+  border: 1px solid transparent;
   cursor: pointer;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
-  transition: transform 0.15s ease, background 0.15s ease, color 0.15s ease;
+  background: transparent;
+  color: var(--neo-text-muted);
+  transition: transform 0.15s ease, background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
 }
 
-.neo-node-agent-add:hover {
-  transform: scale(1.06);
-  background: var(--neo-accent);
-  color: #fff;
+.neo-node-agent-add--title {
+  width: 24px;
+  height: 24px;
+  margin-left: auto;
+  border-radius: 999px;
+}
+
+.neo-node-external-title:hover .neo-node-agent-add--title,
+.neo-node-agent-add--title:hover {
+  border-color: var(--neo-border);
+  background: var(--neo-hover-bg);
+  color: var(--neo-hi-text);
+  box-shadow: var(--neo-hi-shadow);
+}
+
+.neo-node-agent-add--title:hover {
+  transform: scale(1.05);
 }
 
 .neo-node.selected {


### PR DESCRIPTION
## Summary

- **Agent 侧栏**：去掉整行折叠，模型/技能/+ 改用 `dock-ghost-ctl`（默认无边框，hover/focus 高亮），始终可操作
- **画布底栏（方案 A）**：常驻 5 项 — 小地图 | 缩放 | 适应 | 连线设置 | 画布设置；圆形按钮 + 胶囊容器
- **连线**：动画与样式合并进 ⚡ 单 popover，移除多余图标
- **画布设置**：网格、吸附、锁定、Dock 缩放收入 ⚙ 面板；吸附默认开，拖放结束轻闪反馈
- **资产库**：「加入 Agent」「加载到画布」改为圆形图标按钮
- **节点**：「加入 Agent」移至标题栏右侧，不再遮挡上传区

## Test plan

- [x] `pnpm --filter @lnkpi/web test`
- [x] `pnpm --filter @lnkpi/web build`
- [ ] Agent 底栏：模型/+/技能默认 ghost，hover 可点，+ 菜单三项可用
- [ ] 底栏：5 圆形按钮，连线/画布设置 popover
- [ ] 空图片节点 hover：上传与 Agent 按钮不重叠
- [ ] 资产库 hover：圆形 Agent / 加载图标


Made with [Cursor](https://cursor.com)