### PR TITLE
feat(web): canvas ref pick, icon system, and P2 theme sweep

### DIFF
--- a/apps/web/src/components/agent/AgentCanvasOutputs.vue
+++ b/apps/web/src/components/agent/AgentCanvasOutputs.vue
@@ -3,6 +3,7 @@ import { computed, ref, watch } from 'vue'
 import type { LinkedCanvasOutput } from '@lnkpi/shared'
 import { ElMessage } from 'element-plus'
 import DockTypeIcon from '@/components/canvas/dock-studio/shared/DockTypeIcon.vue'
+import CanvasLocateButton from '@/components/shared/CanvasLocateButton.vue'
 import {
   locatableNodeIds,
   shouldCollapseOutputs,
@@ -79,7 +80,7 @@ function statusIcon(status: LinkedCanvasOutput['status']): string {
 function maybeShowLocateHint() {
   if (localStorage.getItem(LOCATE_HINT_KEY)) return
   localStorage.setItem(LOCATE_HINT_KEY, '1')
-  ElMessage.info('点击定位可在画布中找到对应节点')
+  ElMessage.info('点击图钉可在画布中找到对应节点')
 }
 
 function onLocate(nodeId: string) {
@@ -102,15 +103,13 @@ function isPulsing(nodeId: string): boolean {
   <div v-if="outputs.length" class="agent-canvas-outputs mt-1.5 border-t border-white/10 pt-1.5">
     <div class="mb-1 flex items-center justify-between gap-2 text-[11px] text-[var(--neo-text-muted)]">
       <span>画布产出 · {{ outputs.length }}</span>
-      <button
+      <CanvasLocateButton
         v-if="showFocusAll"
-        type="button"
-        class="agent-locate-btn neo-ctl rounded-md px-2 py-0.5 text-[10px]"
+        :size="12"
+        label="全部"
         title="在画布中定位全部"
         @click="onFocusAll"
-      >
-        全部定位
-      </button>
+      />
     </div>
     <ul class="space-y-1">
       <li
@@ -127,15 +126,12 @@ function isPulsing(nodeId: string): boolean {
           class="min-w-0 flex-1 truncate"
           :class="item.status === 'failed' ? 'text-red-400/90' : 'text-[var(--neo-fg)]'"
         >{{ item.title }}</span>
-        <button
+        <CanvasLocateButton
           v-if="item.status === 'done' || item.status === 'failed'"
-          type="button"
-          :class="['agent-locate-btn neo-ctl shrink-0 rounded-md px-2 py-0.5 text-[10px]', { 'agent-locate-btn--pulse': isPulsing(item.nodeId) }]"
+          :pulse="isPulsing(item.nodeId)"
           title="在画布中定位"
-          @click="onLocate(item.nodeId)"
-        >
-          定位
-        </button>
+          @click="() => onLocate(item.nodeId)"
+        />
         <span
           v-else-if="item.status === 'running'"
           class="shrink-0 text-[10px] text-[var(--neo-text-muted)] animate-pulse"
@@ -152,33 +148,3 @@ function isPulsing(nodeId: string): boolean {
     </button>
   </div>
 </template>
-
-<style scoped>
-.agent-locate-btn {
-  color: var(--neo-text-muted);
-  background: transparent;
-  border: 1px solid transparent;
-}
-
-.agent-locate-btn:hover {
-  color: var(--neo-accent-text);
-  background: var(--neo-hover);
-  border-color: var(--neo-border);
-}
-
-.agent-locate-btn--pulse {
-  animation: agent-locate-pulse 2s ease-out 1;
-}
-
-@keyframes agent-locate-pulse {
-  0% {
-    box-shadow: 0 0 0 0 color-mix(in srgb, var(--neo-accent-border) 55%, transparent);
-  }
-  40% {
-    box-shadow: 0 0 0 4px color-mix(in srgb, var(--neo-accent-border) 25%, transparent);
-  }
-  100% {
-    box-shadow: 0 0 0 0 transparent;
-  }
-}
-</style>

--- a/apps/web/src/components/agent/AgentExecutionTrace.vue
+++ b/apps/web/src/components/agent/AgentExecutionTrace.vue
@@ -2,6 +2,7 @@
 import { computed, ref, watch } from 'vue'
 import type { ExecutionTraceState, ExecutionStep } from '@/components/agent/executionTraceReducer'
 import { formatDuration } from '@/components/agent/executionStepLabels'
+import CanvasLocatePinIcon from '@/components/shared/CanvasLocatePinIcon.vue'
 
 const props = defineProps<{
   trace: ExecutionTraceState
@@ -84,7 +85,7 @@ function onStepClick(step: ExecutionStep) {
       <li
         v-for="step in trace.steps"
         :key="step.id"
-        class="text-[10px] leading-snug"
+        class="flex items-start gap-1.5 text-[10px] leading-snug"
         :class="[
           step.meta?.nodeId ? 'cursor-pointer hover:text-[var(--neo-accent-text)]' : '',
           step.status === 'failed' ? 'text-red-400/90' : 'text-[var(--neo-text-muted)]',
@@ -94,8 +95,11 @@ function onStepClick(step: ExecutionStep) {
         ]"
         @click="onStepClick(step)"
       >
-        <span>{{ statusIcon(step) }} {{ step.label }}{{ stepDuration(step) }}</span>
-        <p v-if="step.detail" class="mt-0.5 pl-3 opacity-75">{{ step.detail }}</p>
+        <span class="min-w-0 flex-1">
+          <span>{{ statusIcon(step) }} {{ step.label }}{{ stepDuration(step) }}</span>
+          <p v-if="step.detail" class="mt-0.5 pl-3 opacity-75">{{ step.detail }}</p>
+        </span>
+        <CanvasLocatePinIcon v-if="step.meta?.nodeId" :size="11" class="mt-0.5 shrink-0 opacity-60" />
       </li>
     </ul>
   </div>

--- a/apps/web/src/components/agent/AgentRefStrip.vue
+++ b/apps/web/src/components/agent/AgentRefStrip.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { SidebarAttachment } from '@lnkpi/shared'
 import AgentSidebarRefChip from '@/components/agent/AgentSidebarRefChip.vue'
+import CanvasRefTargetIcon from '@/components/shared/CanvasRefTargetIcon.vue'
 import { computed, ref } from 'vue'
 import type { NodeRef } from '@/composables/useNodeRefs'
 
@@ -9,12 +10,16 @@ const props = defineProps<{
   removable?: boolean
   /** History messages: click re-adds attachment to composer */
   historyInteractive?: boolean
+  /** 无 chip 时展示「从画布选节点」入口 */
+  showEmptyPickCta?: boolean
+  pickModeActive?: boolean
 }>()
 const emit = defineEmits<{
   remove: [id: string]
   mention: [refKey: string]
   reattach: [attachment: SidebarAttachment]
   reorder: [ids: string[]]
+  startCanvasPick: []
 }>()
 
 const dragRefId = ref<string | null>(null)
@@ -113,6 +118,16 @@ function onChipMention(refKey: string) {
       />
     </div>
   </div>
+  <button
+    v-else-if="showEmptyPickCta"
+    type="button"
+    class="agent-ref-strip-empty"
+    :class="{ 'is-active': pickModeActive }"
+    @click="emit('startCanvasPick')"
+  >
+    <CanvasRefTargetIcon :size="14" :filled="pickModeActive" />
+    <span>从画布选节点</span>
+  </button>
 </template>
 
 <style scoped>
@@ -145,5 +160,28 @@ function onChipMention(refKey: string) {
 
 .agent-ref-strip__chip--readonly :deep(.dock-ref-chip__remove) {
   display: none;
+}
+
+.agent-ref-strip-empty {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 36px;
+  margin-bottom: 4px;
+  border: 1px dashed var(--neo-border);
+  border-radius: 12px;
+  background: transparent;
+  font-size: 11px;
+  color: var(--neo-text-muted);
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.agent-ref-strip-empty:hover,
+.agent-ref-strip-empty.is-active {
+  border-color: color-mix(in srgb, var(--neo-hi-text) 20%, var(--neo-border));
+  background: var(--neo-hover-bg);
+  color: var(--neo-text-primary);
 }
 </style>

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -50,7 +50,7 @@ import ForceChoiceDialog, { type ForceChoiceKind } from '@/components/agent/Forc
 import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGenerateButton.vue'
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
-import { useSidebarAttachments, assignRefKeysFor, type FocusNodeLike } from '@/composables/useSidebarAttachments'
+import { useSidebarAttachments, assignRefKeysFor, type FocusNodeLike, type CanvasRefAddResult } from '@/composables/useSidebarAttachments'
 import { parseRefMentions } from '@/composables/useRefMentions'
 import MentionInput, { type MentionOption } from '@/components/canvas/MentionInput.vue'
 import { useClickOutside } from '@/composables/useClickOutside'
@@ -61,6 +61,8 @@ import {
   getAgentSkill,
 } from '@/constants/agentSkillMap'
 import UniversalModelSelector from '@/components/canvas/UniversalModelSelector.vue'
+import CanvasRefTargetIcon from '@/components/shared/CanvasRefTargetIcon.vue'
+import { useCanvasRefPickMode } from '@/composables/useCanvasRefPickMode'
 import { formatDuration as formatTraceDuration } from '@/components/agent/executionStepLabels'
 import { formatSessionTime, lastThreadStorageKey } from '@/utils/formatSessionTime'
 import { randomId } from '@/utils/randomId'
@@ -93,9 +95,11 @@ const emit = defineEmits<{
   redo: []
   openImageEditor: [nodeId: string]
   expandedChange: [expanded: boolean]
-  /** 从「添加引用 → 画布节点」触发，由画布页注入当前选中节点 */
-  requestCanvasRefs: []
+  /** 切换画布引用 Pick 模式（由 CanvasPage 处理选中 seed） */
+  canvasRefPickToggle: []
 }>()
+
+const pickMode = useCanvasRefPickMode()
 
 const agent = useAgentStore()
 const auth = useAuthStore()
@@ -287,14 +291,23 @@ function pickLocalUpload() {
   openFilePicker()
 }
 
-function pickCanvasNodes() {
-  attachMenuOpen.value = false
-  emit('requestCanvasRefs')
-}
-
 function pickAssetLibrary() {
   attachMenuOpen.value = false
   assetPickerOpen.value = true
+}
+
+function onCanvasRefPickToggle() {
+  emit('canvasRefPickToggle')
+}
+
+function onStartCanvasPick() {
+  if (!pickMode.active.value) emit('canvasRefPickToggle')
+}
+
+function onInputDockPointerDown(event: PointerEvent) {
+  if (!pickMode.active.value) return
+  if ((event.target as Element).closest('.canvas-ref-pick-btn')) return
+  pickMode.deactivate()
 }
 
 async function addFiles(files: FileList | File[]) {
@@ -1098,10 +1111,15 @@ defineExpose({
   setComposerInput,
   addAttachment,
   reconcileFromNodes,
-  addFromCanvasNodes: (nodes: FocusNodeLike[]) => {
-    const n = sidebar.addFromCanvasNodes(nodes)
-    if (n < nodes.length) ElMessage.warning(`最多添加 ${SIDEBAR_ATTACHMENT_MAX} 个参考素材`)
-    return n
+  addFromCanvasNodes: (nodes: FocusNodeLike[]): CanvasRefAddResult => {
+    const result = sidebar.addFromCanvasNodesDetailed(nodes)
+    if (result.added < nodes.length && nodes.length === 1) {
+      if (result.empty) ElMessage.warning('该节点暂无可用内容')
+      else if (result.duplicate) ElMessage.info('该节点已在引用中')
+    } else if (result.added < nodes.length && sidebar.pendingAttachments.value.length >= SIDEBAR_ATTACHMENT_MAX) {
+      ElMessage.warning(`最多 ${SIDEBAR_ATTACHMENT_MAX} 个参考素材`)
+    }
+    return result
   },
 })
 </script>
@@ -1418,14 +1436,17 @@ defineExpose({
               @dragover.prevent="onDragOver"
               @dragleave.prevent="onDragLeave"
               @drop.prevent="onDrop"
+              @pointerdown="onInputDockPointerDown"
             >
               <AgentRefStrip
-                v-if="pendingAttachmentItems.length"
                 :items="pendingAttachmentItems"
                 :removable="true"
+                :show-empty-pick-cta="!readOnly"
+                :pick-mode-active="pickMode.active.value"
                 @remove="sidebar.remove"
                 @mention="insertRefMention"
                 @reorder="sidebar.reorder"
+                @start-canvas-pick="onStartCanvasPick"
               />
               <input
                 ref="fileInputRef"
@@ -1448,6 +1469,17 @@ defineExpose({
                 <div class="agent-dock-params">
                   <UniversalModelSelector v-model="planningModel" type="text" ghost />
 
+                  <button
+                    type="button"
+                    class="canvas-ref-pick-btn dock-ghost-ctl flex h-8 w-8 items-center justify-center rounded-lg"
+                    :class="{ 'is-active': pickMode.active.value, 'is-open': pickMode.active.value }"
+                    :disabled="readOnly || isUploading"
+                    title="从画布选节点作引用"
+                    @click.stop="onCanvasRefPickToggle"
+                  >
+                    <CanvasRefTargetIcon :size="16" :filled="pickMode.active.value" />
+                  </button>
+
                   <div ref="attachMenuRef" class="relative">
                     <button
                       type="button"
@@ -1468,9 +1500,6 @@ defineExpose({
                     >
                       <button type="button" class="neo-popover-item block w-full px-3 py-2 text-left text-xs" @click="pickLocalUpload">
                         本地上传
-                      </button>
-                      <button type="button" class="neo-popover-item block w-full px-3 py-2 text-left text-xs" @click="pickCanvasNodes">
-                        画布节点
                       </button>
                       <button type="button" class="neo-popover-item block w-full px-3 py-2 text-left text-xs" @click="pickAssetLibrary">
                         我的资产库
@@ -1713,15 +1742,20 @@ defineExpose({
 }
 
 .agent-bubble-user {
-  background: var(--neo-brand-gradient);
-  color: #fff;
-  box-shadow: 0 4px 14px rgba(109, 93, 252, 0.25);
+  background: var(--neo-hi-bg);
+  color: var(--neo-hi-text);
+  box-shadow: var(--neo-hi-shadow);
 }
 
 .agent-bubble-assistant {
   background: var(--neo-surface-elevated);
   border: 1px solid var(--neo-border);
   color: var(--neo-text-primary);
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.agent-bubble-assistant:hover {
+  border-color: color-mix(in srgb, var(--neo-hi-text) 18%, var(--neo-border));
 }
 
 .agent-tools {

--- a/apps/web/src/components/agent/AgentSidebarRefChip.vue
+++ b/apps/web/src/components/agent/AgentSidebarRefChip.vue
@@ -187,8 +187,8 @@ function onClick() {
 }
 
 .dock-ref-chip.is-drag-over {
-  border-color: var(--neo-accent-border);
-  background: var(--neo-accent-soft);
+  border-color: color-mix(in srgb, var(--neo-hi-text) 35%, var(--neo-border));
+  background: var(--neo-hover-bg);
 }
 
 .dock-ref-chip:active[draggable='true'] {

--- a/apps/web/src/components/agent/AgentTaskProgressCard.vue
+++ b/apps/web/src/components/agent/AgentTaskProgressCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { AgentTaskProgressState } from './agentTaskProgress'
+import CanvasLocatePinIcon from '@/components/shared/CanvasLocatePinIcon.vue'
 
 defineProps<{
   progress: AgentTaskProgressState
@@ -29,7 +30,7 @@ const statusLabel: Record<string, string> = {
       <li
         v-for="item in progress.items"
         :key="item.id"
-        class="flex cursor-pointer items-start gap-2 rounded-lg px-1.5 py-1 hover:bg-[var(--neo-hover)]"
+        class="group flex cursor-pointer items-start gap-2 rounded-lg px-1.5 py-1 hover:bg-[var(--neo-hover)]"
         @click="item.nodeId && emit('focusNode', item.nodeId)"
       >
         <span class="mt-0.5 w-14 shrink-0 opacity-70">{{ statusLabel[item.status] || item.status }}</span>
@@ -40,6 +41,9 @@ const statusLabel: Record<string, string> = {
           </span>
           <div v-if="item.errorHint" class="mt-0.5 opacity-60">{{ item.errorHint }}</div>
           <div v-if="item.errorCode && !item.errorHint" class="mt-0.5 opacity-50">{{ item.errorCode }}</div>
+        </span>
+        <span v-if="item.nodeId" class="mt-0.5 shrink-0 opacity-0 transition group-hover:opacity-70">
+          <CanvasLocatePinIcon :size="12" />
         </span>
       </li>
     </ul>

--- a/apps/web/src/components/canvas/CanvasAssetPanel.vue
+++ b/apps/web/src/components/canvas/CanvasAssetPanel.vue
@@ -6,6 +6,7 @@ import { assetLibraryVersion, bumpAssetLibrary, saveAssetToLibrary } from '@/com
 import { fileToPersistedPayload } from '@/composables/useMediaUpload'
 import { resolveMediaUrl } from '@/services/api-base'
 import { useCanvasEditorStore } from '@/stores/canvasEditor'
+import CanvasRefTargetIcon from '@/components/shared/CanvasRefTargetIcon.vue'
 
 export interface CanvasAssetItem {
   id: string
@@ -274,8 +275,8 @@ function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
     <div class="flex items-center gap-1 border-b border-[var(--neo-border)] px-3 pt-2.5 pb-2">
       <button
         type="button"
-        class="rounded-lg px-2.5 py-1 text-[11px] font-medium transition"
-        :class="tab === 'user' ? 'bg-[var(--neo-accent-soft)] text-[var(--neo-accent-text)]' : 'text-[var(--neo-text-muted)] hover:bg-[var(--neo-hover-bg)] hover:text-[var(--neo-text-secondary)]'"
+        class="neo-dock-panel-tab"
+        :class="tab === 'user' ? 'is-active' : ''"
         @click="switchTab('user')"
       >
         我的资产
@@ -283,8 +284,8 @@ function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
       </button>
       <button
         type="button"
-        class="rounded-lg px-2.5 py-1 text-[11px] font-medium transition"
-        :class="tab === 'public' ? 'bg-[var(--neo-accent-soft)] text-[var(--neo-accent-text)]' : 'text-[var(--neo-text-muted)] hover:bg-[var(--neo-hover-bg)] hover:text-[var(--neo-text-secondary)]'"
+        class="neo-dock-panel-tab"
+        :class="tab === 'public' ? 'is-active' : ''"
         @click="switchTab('public')"
       >
         公共资产
@@ -293,7 +294,7 @@ function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
       <button
         v-if="tab === 'user'"
         type="button"
-        class="flex items-center gap-1 rounded-lg px-2 py-1 text-[10px] text-[var(--neo-accent-text)] hover:bg-[var(--neo-hover-bg)]"
+        class="flex items-center gap-1 rounded-lg px-2 py-1 text-[10px] text-[var(--neo-text-secondary)] transition hover:bg-[var(--neo-hover-bg)] hover:text-[var(--neo-text-primary)]"
         :disabled="uploading"
         title="上传素材到资产库"
         @click="openUploadPicker"
@@ -330,7 +331,7 @@ function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
     <div class="px-3 pt-2">
       <input
         v-model="search"
-        class="w-full rounded-lg border border-[var(--neo-border)] bg-[var(--neo-hover-bg)] px-2 py-1.5 text-[11px] outline-none focus:border-[var(--neo-accent-border)]"
+        class="w-full rounded-lg border border-[var(--neo-border)] bg-[var(--neo-hover-bg)] px-2 py-1.5 text-[11px] outline-none focus:border-[var(--neo-border-strong)]"
         placeholder="搜索资产..."
       >
     </div>
@@ -349,7 +350,7 @@ function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
 
       <div v-for="group in timeline" :key="group.label" class="mb-3 last:mb-1">
         <p class="mb-1.5 flex items-center gap-1.5 text-[10px] text-[var(--neo-text-muted)]">
-          <span class="h-1 w-1 rounded-full bg-[var(--neo-accent)]" />
+          <span class="h-1 w-1 rounded-full bg-[var(--neo-text-muted)]" />
           {{ group.label }}
         </p>
         <div class="grid grid-cols-3 gap-1.5">
@@ -359,7 +360,7 @@ function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
             role="button"
             tabindex="0"
             draggable="true"
-            class="group relative aspect-square cursor-zoom-in overflow-hidden rounded-lg border border-[var(--neo-border)] bg-[var(--neo-hover-bg)] transition hover:border-[var(--neo-accent-border)]"
+            class="group relative aspect-square cursor-zoom-in overflow-hidden rounded-lg border border-[var(--neo-border)] bg-[var(--neo-hover-bg)] transition hover:border-[var(--neo-border-strong)]"
             :title="`${asset.label}（点击预览 · 可拖到画布新建节点 / 拖到底部工具条作引用）`"
             @dragstart="onDragStart($event, asset)"
             @click="preview(asset)"
@@ -394,7 +395,7 @@ function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
             </span>
             <span
               v-if="asset.source === 'public'"
-              class="absolute right-1 top-1 rounded bg-[var(--neo-accent)] px-1 py-px text-[8px] text-white"
+              class="absolute right-1 top-1 rounded bg-[var(--neo-hi-bg)] px-1 py-px text-[8px] text-[var(--neo-hi-text)]"
             >
               公共
             </span>
@@ -410,10 +411,7 @@ function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
                 aria-label="加入 Agent 引用"
                 @click.stop="addToAgent(asset)"
               >
-                <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2">
-                  <path d="M12 3l1.5 4.5L18 9l-4.5 1.5L12 15l-1.5-4.5L6 9l4.5-1.5L12 3z" />
-                  <path d="M5 19h14M12 15v4" stroke-linecap="round" />
-                </svg>
+                <CanvasRefTargetIcon :size="12" />
               </button>
               <button
                 type="button"

--- a/apps/web/src/components/canvas/CanvasBottomLeftControls.vue
+++ b/apps/web/src/components/canvas/CanvasBottomLeftControls.vue
@@ -4,6 +4,7 @@ import { MiniMap } from '@vue-flow/minimap'
 import { useVueFlow } from '@vue-flow/core'
 import { useClickOutside } from '@/composables/useClickOutside'
 import type { CanvasViewportSettings } from '@/composables/useCanvasViewportSettings'
+import CanvasLocatePinIcon from '@/components/shared/CanvasLocatePinIcon.vue'
 
 const props = defineProps<{
   settings: CanvasViewportSettings
@@ -250,10 +251,11 @@ watch(
             v-for="node in items"
             :key="node.id"
             type="button"
-            class="neo-popover-item mb-0.5 flex w-full rounded-lg px-2 py-1 text-left text-[11px]"
+            class="neo-popover-item mb-0.5 flex w-full items-center gap-1.5 rounded-lg px-2 py-1 text-left text-[11px]"
             @click="focusNode(node.id)"
           >
-            {{ nodeLabel(node) }}
+            <CanvasLocatePinIcon :size="12" class="shrink-0 opacity-70" />
+            <span class="min-w-0 truncate">{{ nodeLabel(node) }}</span>
           </button>
         </div>
       </div>
@@ -491,11 +493,16 @@ watch(
 .bar-btn {
   @apply flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm leading-none transition;
   color: var(--neo-text-muted);
+  transition: background 0.15s ease, color 0.15s ease, transform 0.1s ease, box-shadow 0.15s ease;
 }
 
 .bar-btn:hover {
   background: var(--neo-hover-bg);
   color: var(--neo-text-primary);
+}
+
+.bar-btn:active {
+  transform: scale(0.94);
 }
 
 .bar-btn.is-accent {

--- a/apps/web/src/components/canvas/CanvasRefPickOverlay.vue
+++ b/apps/web/src/components/canvas/CanvasRefPickOverlay.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+defineProps<{
+  pickedCount: number
+}>()
+
+const emit = defineEmits<{
+  done: []
+}>()
+</script>
+
+<template>
+  <div class="canvas-ref-pick-overlay" aria-live="polite">
+    <div class="canvas-ref-pick-vignette" />
+    <div class="canvas-ref-pick-bar neo-glass-lite pointer-events-auto">
+      <span class="canvas-ref-pick-bar__hint">
+        点选节点加入引用
+        <span v-if="pickedCount > 0" class="canvas-ref-pick-bar__count">· 已选 {{ pickedCount }}</span>
+      </span>
+      <button type="button" class="canvas-ref-pick-bar__done neo-ctl rounded-lg px-2.5 py-1 text-[11px] font-medium" @click="emit('done')">
+        完成
+      </button>
+      <span class="canvas-ref-pick-bar__esc text-[10px] text-[var(--neo-text-muted)]">Esc</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.canvas-ref-pick-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 45;
+  pointer-events: none;
+}
+
+.canvas-ref-pick-vignette {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.22);
+  pointer-events: none;
+}
+
+.canvas-ref-pick-bar {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  max-width: min(420px, calc(100% - 24px));
+  padding: 8px 12px;
+  border-radius: 999px;
+  transform: translateX(-50%);
+}
+
+.canvas-ref-pick-bar__hint {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--neo-text-primary);
+  white-space: nowrap;
+}
+
+.canvas-ref-pick-bar__count {
+  color: var(--neo-hi-text);
+}
+
+.canvas-ref-pick-bar__done {
+  flex-shrink: 0;
+  background: var(--neo-hi-bg);
+  color: var(--neo-hi-text);
+  box-shadow: var(--neo-hi-shadow);
+}
+
+.canvas-ref-pick-bar__esc {
+  flex-shrink: 0;
+}
+</style>

--- a/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
+++ b/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
@@ -6,6 +6,8 @@ import { modelOptionName } from '@lnkpi/shared'
 import { studioApi, type GenerationRecord } from '@/services/studio-api'
 import DockTypeIcon from '@/components/canvas/dock-studio/shared/DockTypeIcon.vue'
 import NodeDiagnosticPopover from '@/components/canvas/NodeDiagnosticPopover.vue'
+import CanvasLocateButton from '@/components/shared/CanvasLocateButton.vue'
+import CanvasLocatePinIcon from '@/components/shared/CanvasLocatePinIcon.vue'
 import { useCanvasEditorStore } from '@/stores/canvasEditor'
 import { useProviderBootstrap } from '@/composables/useProviderBootstrap'
 import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
@@ -99,8 +101,8 @@ const TYPE_LABELS: Record<string, string> = {
 
 const STATUS_META: Record<string, { label: string; cls: string }> = {
   completed: { label: '成功', cls: 'bg-emerald-500/15 text-emerald-300' },
-  generating: { label: '生成中', cls: 'bg-indigo-500/15 text-indigo-300 animate-pulse' },
-  pending: { label: '排队中', cls: 'bg-indigo-500/15 text-indigo-300 animate-pulse' },
+  generating: { label: '生成中', cls: 'bg-sky-500/15 text-sky-300 animate-pulse' },
+  pending: { label: '排队中', cls: 'bg-[var(--neo-active-bg)] text-[var(--neo-text-secondary)] animate-pulse' },
   fallback_pending: { label: '待确认', cls: 'bg-amber-500/15 text-amber-300' },
   failed: { label: '失败', cls: 'bg-red-500/15 text-red-300' },
   error: { label: '失败', cls: 'bg-red-500/15 text-red-300' },
@@ -673,10 +675,7 @@ onUnmounted(stopPolling)
           class="mt-3 flex w-full items-center justify-center gap-1.5 rounded-xl bg-[var(--neo-hi-bg)] py-2 text-[11px] font-medium text-[var(--neo-hi-text)] transition hover:brightness-105"
           @click="emitLocate(detailGroup.latest)"
         >
-          <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-            <circle cx="12" cy="12" r="3" />
-            <path stroke-linecap="round" d="M12 2v4m0 12v4M2 12h4m12 0h4" />
-          </svg>
+          <CanvasLocatePinIcon :size="14" />
           定位到画布节点
         </button>
       </div>
@@ -706,14 +705,14 @@ onUnmounted(stopPolling)
           v-for="tab in LIFECYCLE_TABS"
           :key="tab.key"
           type="button"
-          class="flex flex-1 items-center justify-center gap-1 rounded-lg px-2 py-1.5 text-[11px] transition"
-          :class="lifecycle === tab.key ? 'bg-[var(--neo-accent-soft)] text-[var(--neo-accent-text)]' : 'text-[var(--neo-text-muted)] hover:bg-[var(--neo-hover-bg)] hover:text-[var(--neo-text-secondary)]'"
+          class="neo-dock-panel-tab flex flex-1 items-center justify-center gap-1 px-2 py-1.5"
+          :class="lifecycle === tab.key ? 'is-active' : ''"
           @click="lifecycle = tab.key"
         >
           <span>{{ tab.label }}</span>
           <span
             class="min-w-[1.1rem] rounded-md px-1 text-center text-[9px] tabular-nums"
-            :class="lifecycle === tab.key ? 'bg-[var(--neo-accent-border)]/30' : 'bg-[var(--neo-active-bg)]'"
+            :class="lifecycle === tab.key ? 'bg-[var(--neo-active-bg)] text-[var(--neo-hi-text)]' : 'bg-[var(--neo-active-bg)]'"
           >
             {{ lifecycleCounts[tab.key] }}
           </span>
@@ -725,8 +724,8 @@ onUnmounted(stopPolling)
           v-for="f in FILTERS"
           :key="f.key"
           type="button"
-          class="rounded-full px-2.5 py-1 text-[10px] transition"
-          :class="filter === f.key ? 'bg-[var(--neo-accent-soft)] text-[var(--neo-accent-text)]' : 'bg-[var(--neo-hover-bg)] text-[var(--neo-text-muted)] hover:bg-[var(--neo-active-bg)] hover:text-[var(--neo-text-secondary)]'"
+          class="neo-dock-panel-chip"
+          :class="filter === f.key ? 'is-active' : ''"
           @click="filter = f.key"
         >
           {{ f.label }}
@@ -743,7 +742,7 @@ onUnmounted(stopPolling)
             :key="groupKey(group)"
             role="button"
             tabindex="0"
-            class="group flex cursor-pointer items-center gap-2 rounded-xl border border-[var(--neo-border)] bg-[var(--neo-hover-bg)] px-2.5 py-2 transition hover:border-[var(--neo-accent-border)]"
+            class="group flex cursor-pointer items-center gap-2 rounded-xl border border-[var(--neo-border)] bg-[var(--neo-hover-bg)] px-2.5 py-2 transition hover:border-[var(--neo-border-strong)] hover:bg-[var(--neo-active-bg)]/35"
             title="点击查看详情"
             @click="openGroupDetail(group)"
             @keydown.enter="openGroupDetail(group)"
@@ -788,17 +787,11 @@ onUnmounted(stopPolling)
             >
               重试
             </button>
-            <button
-              type="button"
-              class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg text-[var(--neo-text-muted)] opacity-0 transition hover:bg-[var(--neo-active-bg)] hover:text-[var(--neo-text-primary)] group-hover:opacity-100"
+            <CanvasLocateButton
+              class="opacity-0 transition group-hover:opacity-100"
               title="定位到画布节点"
-              @click.stop="emitLocate(group.latest)"
-            >
-              <svg class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                <circle cx="12" cy="12" r="3" />
-                <path stroke-linecap="round" d="M12 2v4m0 12v4M2 12h4m12 0h4" />
-              </svg>
-            </button>
+              @click="(e) => { e.stopPropagation(); emitLocate(group.latest) }"
+            />
           </div>
         </div>
       </div>

--- a/apps/web/src/components/canvas/ClickRippleLayer.vue
+++ b/apps/web/src/components/canvas/ClickRippleLayer.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { onUnmounted, ref, watch } from 'vue'
+import { computed, onUnmounted, ref, watch } from 'vue'
+import type { CanvasTheme } from '@/composables/useCanvasTheme'
 
-/** 逆向 NeoWOW MouseTrailEffect：SVG 单圈 + rAF，600ms / r 6→28 */
+/** 画布空白处单击/双击涟漪：暗色主题用亮白圈，亮色主题用淡灰圈 */
 interface RippleCircle {
   id: number
   x: number
@@ -19,19 +20,21 @@ interface RippleCircle {
 const props = withDefaults(
   defineProps<{
     container?: HTMLElement | null
-    color?: string
+    theme?: CanvasTheme
   }>(),
-  { color: '#a78bfa' },
+  { theme: 'dark' },
 )
 
-const RIPPLE_DURATION = 600
-const MIN_RADIUS = 6
-const MAX_RADIUS = 28
+const RIPPLE_DURATION = 520
 const BASE_STROKE = 1.5
 
 const circles = ref<RippleCircle[]>([])
 let circleId = 0
 let boundEl: HTMLElement | null = null
+
+const clickColor = computed(() =>
+  props.theme === 'light' ? 'rgba(23, 25, 35, 0.5)' : 'rgba(255, 255, 255, 0.78)',
+)
 
 const SKIP_SELECTOR = [
   'button',
@@ -86,8 +89,8 @@ function animateCircle(seed: RippleCircle) {
     circles.value[idx] = {
       ...circles.value[idx],
       radius: seed.minRadius + (seed.maxRadius - seed.minRadius) * progress,
-      opacity: 1 - progress,
-      strokeWidth: seed.baseStrokeWidth * (1 - progress * 0.5),
+      opacity: (1 - progress) * 0.95,
+      strokeWidth: seed.baseStrokeWidth * (1 - progress * 0.45),
     }
     requestAnimationFrame(tick)
   }
@@ -95,18 +98,24 @@ function animateCircle(seed: RippleCircle) {
   requestAnimationFrame(tick)
 }
 
-function spawnCircle(clientX: number, clientY: number) {
+function spawnCircle(
+  clientX: number,
+  clientY: number,
+  opts?: { minRadius?: number; maxRadius?: number; stroke?: number },
+) {
+  const minRadius = opts?.minRadius ?? 5
+  const maxRadius = opts?.maxRadius ?? 26
   const seed: RippleCircle = {
     id: circleId++,
     x: clientX,
     y: clientY,
-    radius: MIN_RADIUS,
-    opacity: 1,
-    color: props.color,
-    strokeWidth: BASE_STROKE,
-    baseStrokeWidth: BASE_STROKE,
-    maxRadius: MAX_RADIUS,
-    minRadius: MIN_RADIUS,
+    radius: minRadius,
+    opacity: 0.95,
+    color: clickColor.value,
+    strokeWidth: opts?.stroke ?? BASE_STROKE,
+    baseStrokeWidth: opts?.stroke ?? BASE_STROKE,
+    maxRadius,
+    minRadius,
     startTime: performance.now(),
   }
   circles.value.push(seed)
@@ -119,14 +128,22 @@ function onClick(event: MouseEvent) {
   spawnCircle(event.clientX, event.clientY)
 }
 
+function onDblClick(event: MouseEvent) {
+  if (event.button !== 0) return
+  if (shouldSkip(event.target)) return
+  spawnCircle(event.clientX, event.clientY, { minRadius: 8, maxRadius: 42, stroke: 2 })
+}
+
 function bindTarget(el: HTMLElement | null | undefined) {
   if (boundEl) {
     boundEl.removeEventListener('click', onClick, { capture: true })
+    boundEl.removeEventListener('dblclick', onDblClick, { capture: true })
     boundEl = null
   }
   if (!el) return
   boundEl = el
   boundEl.addEventListener('click', onClick, { capture: true })
+  boundEl.addEventListener('dblclick', onDblClick, { capture: true })
 }
 
 watch(
@@ -144,7 +161,7 @@ onUnmounted(() => bindTarget(null))
       <svg class="trail-svg" xmlns="http://www.w3.org/2000/svg">
         <defs>
           <filter id="neo-click-ripple-glow">
-            <feGaussianBlur stdDeviation="1" result="coloredBlur" />
+            <feGaussianBlur stdDeviation="0.8" result="coloredBlur" />
             <feMerge>
               <feMergeNode in="coloredBlur" />
               <feMergeNode in="SourceGraphic" />

--- a/apps/web/src/components/canvas/ConnectNodePicker.vue
+++ b/apps/web/src/components/canvas/ConnectNodePicker.vue
@@ -57,7 +57,7 @@ onUnmounted(() => document.removeEventListener('keydown', onDocumentKeydown))
           v-for="item in items"
           :key="item.type"
           type="button"
-          class="neo-popover-item flex w-full items-start gap-3 rounded-xl px-3 py-2.5 text-left"
+          class="neo-popover-item neo-popover-card-item flex w-full items-start gap-3 rounded-xl px-3 py-2.5 text-left"
           @click="emit('select', item.type)"
         >
           <span
@@ -69,7 +69,7 @@ onUnmounted(() => document.removeEventListener('keydown', onDocumentKeydown))
           <div class="min-w-0 flex-1">
             <div class="flex items-center gap-2">
               <span class="text-[13px] text-[var(--neo-text-primary)]">{{ item.label }}</span>
-              <span v-if="item.badge" class="rounded bg-[var(--neo-accent-soft)] px-1.5 py-0.5 text-[9px] text-[var(--neo-accent-text)]">
+              <span v-if="item.badge" class="rounded bg-[var(--neo-active-bg)] px-1.5 py-0.5 text-[9px] text-[var(--neo-text-muted)]">
                 {{ item.badge }}
               </span>
             </div>

--- a/apps/web/src/components/canvas/MentionInput.vue
+++ b/apps/web/src/components/canvas/MentionInput.vue
@@ -170,7 +170,7 @@ function onKeydown(e: KeyboardEvent) {
         v-for="(item, idx) in filteredMentions"
         :key="item.id"
         class="neo-popover-item cursor-pointer px-3 py-2 text-sm"
-        :class="idx === selectedIndex ? '!bg-[var(--neo-accent-soft)] !text-[var(--neo-accent-text)]' : ''"
+        :class="idx === selectedIndex ? '!bg-[var(--neo-hi-bg)] !text-[var(--neo-hi-text)]' : ''"
         @mousedown.prevent="insertMention(item)"
       >
         <span class="opacity-50">@</span>{{ item.label }}

--- a/apps/web/src/components/canvas/NeoBaseNode.vue
+++ b/apps/web/src/components/canvas/NeoBaseNode.vue
@@ -7,7 +7,8 @@ import {
   resolveNeoNodeTitle,
   type NeoNodeStatus,
 } from '@/components/canvas/neoNodeMeta'
-import { CANVAS_NODE_ADD_AGENT_KEY, CANVAS_NODE_LOCATE_FLASH_KEY, CANVAS_NODE_RENAME_KEY } from '@/composables/canvasNodeActions'
+import { CANVAS_NODE_ADD_AGENT_KEY, CANVAS_NODE_LOCATE_FLASH_KEY, CANVAS_NODE_RENAME_KEY, CANVAS_REF_PICK_ACTIVE_KEY, CANVAS_REF_PICK_NODE_IDS_KEY, CANVAS_REF_PICK_REJECT_KEY } from '@/composables/canvasNodeActions'
+import CanvasRefTargetIcon from '@/components/shared/CanvasRefTargetIcon.vue'
 
 const props = withDefaults(
   defineProps<{
@@ -51,9 +52,30 @@ const shellStyle = computed(() => {
 const { id: nodeId } = useNode()
 const renameNode = inject(CANVAS_NODE_RENAME_KEY, null)
 const addToAgent = inject(CANVAS_NODE_ADD_AGENT_KEY, null)
+const pickActive = inject(CANVAS_REF_PICK_ACTIVE_KEY, ref(false))
+const pickedNodeIds = inject(CANVAS_REF_PICK_NODE_IDS_KEY, ref(new Set<string>()))
+const pickRejectNodeId = inject(CANVAS_REF_PICK_REJECT_KEY, ref<string | null>(null))
+const isPickMarked = computed(() => pickedNodeIds.value.has(nodeId))
+const isPickReject = computed(() => pickRejectNodeId.value === nodeId)
 const locateFlashNodeIds = inject(CANVAS_NODE_LOCATE_FLASH_KEY, ref(new Set<string>()))
 const isLocateFlashing = computed(() => locateFlashNodeIds.value.has(nodeId))
 const isHovered = ref(false)
+let hoverLeaveTimer: ReturnType<typeof setTimeout> | null = null
+
+function setHovered(next: boolean) {
+  if (hoverLeaveTimer) {
+    clearTimeout(hoverLeaveTimer)
+    hoverLeaveTimer = null
+  }
+  if (next) {
+    isHovered.value = true
+    return
+  }
+  hoverLeaveTimer = setTimeout(() => {
+    isHovered.value = false
+    hoverLeaveTimer = null
+  }, 80)
+}
 
 const showHandles = computed(() => props.selected || isHovered.value)
 const isRenaming = ref(false)
@@ -87,11 +109,23 @@ function onAddToAgent(event: MouseEvent) {
 <template>
   <div
     class="neo-node-wrapper"
-    :class="{ 'is-active': selected, 'show-handles': showHandles }"
-    @mouseenter="isHovered = true"
-    @mouseleave="isHovered = false"
+    :class="{
+      'is-active': selected,
+      'show-handles': showHandles,
+      'is-hovered': isHovered,
+      'is-ref-pick-active': pickActive,
+      'is-ref-pick-marked': isPickMarked,
+      'is-ref-pick-reject': isPickReject,
+    }"
+    @mouseenter="setHovered(true)"
+    @mouseleave="setHovered(false)"
   >
-    <div class="neo-node-external-title" @dblclick.stop="startRename">
+    <div
+      class="neo-node-external-title"
+      @dblclick.stop="startRename"
+      @mouseenter="setHovered(true)"
+      @mouseleave="setHovered(false)"
+    >
       <div class="neo-node-icon" :class="meta.variant">
         <svg v-if="meta.icon === 'prompt'" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
           <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
@@ -134,21 +168,18 @@ function onAddToAgent(event: MouseEvent) {
         @click.stop
         @mousedown.stop
       >
-      <span v-else class="neo-node-title">{{ displayTitle }}</span>
-      <span class="neo-node-status" :class="nodeStatus" />
+      <span v-else class="neo-node-title min-w-0 flex-1 truncate">{{ displayTitle }}</span>
+      <span class="neo-node-status shrink-0" :class="nodeStatus" />
       <button
-        v-if="addToAgent && isHovered && !selected"
+        v-if="addToAgent"
         type="button"
-        class="neo-node-agent-add neo-node-agent-add--title"
+        class="neo-node-agent-add neo-node-agent-add--title shrink-0"
         title="加入 Agent 引用"
         aria-label="加入 Agent 引用"
         @click="onAddToAgent"
         @mousedown.stop
       >
-        <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M12 3l1.5 4.5L18 9l-4.5 1.5L12 15l-1.5-4.5L6 9l4.5-1.5L12 3z" />
-          <path d="M5 19h14M12 15v4" stroke-linecap="round" />
-        </svg>
+        <CanvasRefTargetIcon :size="13" />
       </button>
     </div>
 

--- a/apps/web/src/components/canvas/NodePanelDock.vue
+++ b/apps/web/src/components/canvas/NodePanelDock.vue
@@ -173,7 +173,7 @@ useClickOutside(rootRef, closePopovers)
             v-for="item in menuItems"
             :key="item.type"
             type="button"
-            class="neo-popover-item flex w-full items-start gap-3 rounded-xl px-3 py-2.5 text-left"
+            class="neo-popover-item neo-popover-card-item flex w-full items-start gap-3 rounded-xl px-3 py-2.5 text-left"
             @click="add(item.type)"
           >
             <span
@@ -185,7 +185,7 @@ useClickOutside(rootRef, closePopovers)
             <div class="min-w-0 flex-1">
               <div class="flex items-center gap-2">
                 <span class="popover-item-title text-[13px]">{{ item.label }}</span>
-                <span v-if="item.badge" class="rounded bg-[var(--neo-accent-soft)] px-1.5 py-0.5 text-[9px] text-[var(--neo-accent-text)]">
+                <span v-if="item.badge" class="rounded bg-[var(--neo-active-bg)] px-1.5 py-0.5 text-[9px] text-[var(--neo-text-muted)]">
                   {{ item.badge }}
                 </span>
               </div>

--- a/apps/web/src/components/canvas/dock-studio/panels/SceneComposerDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/SceneComposerDockPanel.vue
@@ -171,7 +171,7 @@ const canBatchGenerate = computed(() =>
           <span class="text-[10px] uppercase tracking-wide text-white/40">场景</span>
           <button
             type="button"
-            class="text-[10px] text-[#818cf8] hover:text-[#a5b4fc]"
+            class="text-[10px] text-[var(--neo-hi-text)] hover:opacity-80"
             :disabled="locked"
             @click="addScene"
           >
@@ -245,8 +245,8 @@ const canBatchGenerate = computed(() =>
                     v-for="opt in ([['image', '图'], ['video', '视'], ['none', '无']] as const)"
                     :key="opt[0]"
                     type="button"
-                    class="rounded px-1.5 py-0.5 text-[10px]"
-                    :class="shot.mediaType === opt[0] ? 'bg-[#6366f1]/30 text-[#818cf8]' : 'text-white/45'"
+                    class="dock-seg-btn rounded px-1.5 py-0.5"
+                    :class="{ 'is-on': shot.mediaType === opt[0] }"
                     :disabled="locked"
                     @click="setShotMediaType(activeScene.id, shot.id, opt[0])"
                   >

--- a/apps/web/src/components/canvas/dock-studio/panels/ShotDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ShotDockPanel.vue
@@ -120,8 +120,8 @@ function toggleVoice() {
           v-for="opt in SHOT_GENERATE_MODE_OPTIONS"
           :key="opt.value"
           type="button"
-          class="rounded-md px-2 py-1 text-[10px] transition"
-          :class="shotGenerateMode === opt.value ? 'bg-[#6366f1]/30 text-[#818cf8]' : 'text-white/50'"
+          class="dock-seg-btn rounded-md px-2 py-1"
+          :class="{ 'is-on': shotGenerateMode === opt.value }"
           :disabled="readonly"
           @click="setMode(opt.value)"
         >

--- a/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
@@ -177,8 +177,8 @@ function onRefMention(refKey: string) {
       >
         <button
           type="button"
-          class="text-[10px] transition"
-          :class="textThinking ? 'text-[#818cf8]' : 'text-white/50 hover:text-white/70'"
+          class="dock-seg-btn rounded-md px-1.5 py-1"
+          :class="{ 'is-on': textThinking }"
           :disabled="readonly"
           title="深度思考（DeepSeek V4）"
           @click="setThinking(!textThinking)"
@@ -188,8 +188,8 @@ function onRefMention(refKey: string) {
         <template v-if="textThinking">
           <button
             type="button"
-            class="rounded px-1.5 py-0.5 text-[10px] transition"
-            :class="textThinkingEffort === 'high' ? 'bg-[#6366f1]/30 text-[#818cf8]' : 'text-white/45 hover:bg-white/10'"
+            class="dock-seg-btn"
+            :class="{ 'is-on': textThinkingEffort === 'high' }"
             :disabled="readonly"
             @click="setThinkingEffort('high')"
           >
@@ -197,8 +197,8 @@ function onRefMention(refKey: string) {
           </button>
           <button
             type="button"
-            class="rounded px-1.5 py-0.5 text-[10px] transition"
-            :class="textThinkingEffort === 'max' ? 'bg-[#6366f1]/30 text-[#818cf8]' : 'text-white/45 hover:bg-white/10'"
+            class="dock-seg-btn"
+            :class="{ 'is-on': textThinkingEffort === 'max' }"
             :disabled="readonly"
             @click="setThinkingEffort('max')"
           >

--- a/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
@@ -236,8 +236,8 @@ function onRefMention(refKey: string) {
       <div class="flex items-center gap-0.5 rounded-lg border border-white/10 bg-white/5 p-0.5">
         <button
           type="button"
-          class="rounded-md px-1.5 py-1 transition"
-          :class="videoMode === 'text_to_video' ? 'bg-[#6366f1]/30 text-[#818cf8]' : 'text-white/45'"
+          class="dock-seg-btn rounded-md px-1.5 py-1"
+          :class="{ 'is-on': videoMode === 'text_to_video' }"
           :disabled="readonly"
           title="文生视频"
           @click="setVideoMode('text_to_video')"
@@ -246,8 +246,8 @@ function onRefMention(refKey: string) {
         </button>
         <button
           type="button"
-          class="rounded-md px-1.5 py-1 transition"
-          :class="videoMode === 'image_to_video' ? 'bg-[#6366f1]/30 text-[#818cf8]' : 'text-white/45'"
+          class="dock-seg-btn rounded-md px-1.5 py-1"
+          :class="{ 'is-on': videoMode === 'image_to_video' }"
           :disabled="readonly"
           title="图生视频"
           @click="setVideoMode('image_to_video')"
@@ -257,8 +257,8 @@ function onRefMention(refKey: string) {
         <button
           v-if="canUseFirstLastFrame"
           type="button"
-          class="rounded-md px-1.5 py-1 text-[10px] transition"
-          :class="videoMode === 'first_last_frame' ? 'bg-[#6366f1]/30 text-[#818cf8]' : 'text-white/45'"
+          class="dock-seg-btn rounded-md px-1.5 py-1 text-[10px]"
+          :class="{ 'is-on': videoMode === 'first_last_frame' }"
           :disabled="readonly"
           title="首尾帧"
           @click="setVideoMode('first_last_frame')"

--- a/apps/web/src/components/canvas/dock-studio/shared/DockRefChip.vue
+++ b/apps/web/src/components/canvas/dock-studio/shared/DockRefChip.vue
@@ -189,8 +189,8 @@ function onClick() {
 }
 
 .dock-ref-chip.is-drag-over {
-  border-color: var(--neo-accent-border);
-  background: var(--neo-accent-soft);
+  border-color: color-mix(in srgb, var(--neo-hi-text) 35%, var(--neo-border));
+  background: var(--neo-hover-bg);
 }
 
 .dock-ref-chip.is-stale {

--- a/apps/web/src/components/shared/CanvasLocateButton.vue
+++ b/apps/web/src/components/shared/CanvasLocateButton.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import CanvasLocatePinIcon from '@/components/shared/CanvasLocatePinIcon.vue'
+
+withDefaults(
+  defineProps<{
+    size?: number
+    title?: string
+    label?: string
+    pulse?: boolean
+  }>(),
+  { size: 12, title: '在画布中定位' },
+)
+
+const emit = defineEmits<{
+  click: [event: MouseEvent]
+}>()
+</script>
+
+<template>
+  <button
+    type="button"
+    class="neo-locate-btn"
+    :class="{ 'neo-locate-btn--pulse': pulse, 'neo-locate-btn--with-label': Boolean(label) }"
+    :title="title"
+    :aria-label="title"
+    @click="emit('click', $event)"
+  >
+    <CanvasLocatePinIcon :size="size" />
+    <span v-if="label" class="neo-locate-btn__label">{{ label }}</span>
+  </button>
+</template>
+
+<style scoped>
+.neo-locate-btn {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--neo-text-muted);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.neo-locate-btn--with-label {
+  width: auto;
+  min-width: 24px;
+  padding: 0 8px;
+  border-radius: 8px;
+}
+
+.neo-locate-btn__label {
+  font-size: 10px;
+  line-height: 1;
+}
+
+.neo-locate-btn:hover {
+  color: var(--neo-hi-text);
+  background: var(--neo-hover-bg);
+  border-color: var(--neo-border);
+}
+
+.neo-locate-btn--pulse {
+  animation: neo-locate-pulse 2s ease-out 1;
+}
+
+@keyframes neo-locate-pulse {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--neo-hi-bg) 55%, transparent);
+  }
+  40% {
+    box-shadow: 0 0 0 4px color-mix(in srgb, var(--neo-hi-bg) 25%, transparent);
+  }
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
+</style>

--- a/apps/web/src/components/shared/CanvasLocatePinIcon.vue
+++ b/apps/web/src/components/shared/CanvasLocatePinIcon.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+/** 画布节点定位（跳转/聚焦）— 与引用到 Agent 的 CanvasRefTargetIcon 区分 */
+withDefaults(
+  defineProps<{
+    size?: number
+    /** 列表行内等小尺寸场景 */
+    filled?: boolean
+  }>(),
+  { size: 16, filled: false },
+)
+</script>
+
+<template>
+  <svg
+    :width="size"
+    :height="size"
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden="true"
+  >
+    <path
+      d="M12 21.5s-6.5-4.74-6.5-11.5a6.5 6.5 0 1 1 13 0c0 6.76-6.5 11.5-6.5 11.5z"
+      stroke="currentColor"
+      stroke-width="1.75"
+      stroke-linejoin="round"
+      :fill="filled ? 'currentColor' : 'none'"
+      :opacity="filled ? 0.18 : 1"
+    />
+    <circle
+      cx="12"
+      cy="10"
+      r="2.25"
+      :fill="filled ? 'currentColor' : 'currentColor'"
+      stroke="none"
+    />
+  </svg>
+</template>

--- a/apps/web/src/components/shared/CanvasRefTargetIcon.vue
+++ b/apps/web/src/components/shared/CanvasRefTargetIcon.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+/** 画布引用靶心箭 — Agent dock 🎯 与节点标题栏快捷入口共用 */
+withDefaults(
+  defineProps<{
+    size?: number
+    /** Pick 模式激活 / 按钮 is-active 时为 true */
+    filled?: boolean
+  }>(),
+  { size: 16, filled: false },
+)
+</script>
+
+<template>
+  <svg
+    :width="size"
+    :height="size"
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden="true"
+  >
+    <!-- 靶环 -->
+    <circle
+      cx="12"
+      cy="12"
+      r="8.5"
+      stroke="currentColor"
+      stroke-width="1.75"
+      :fill="filled ? 'currentColor' : 'none'"
+      :opacity="filled ? 0.12 : 1"
+    />
+    <circle
+      cx="12"
+      cy="12"
+      r="4.5"
+      stroke="currentColor"
+      stroke-width="1.75"
+      :fill="filled ? 'currentColor' : 'none'"
+      :opacity="filled ? 0.22 : 1"
+    />
+    <circle
+      cx="12"
+      cy="12"
+      r="1.5"
+      fill="currentColor"
+      stroke="none"
+    />
+    <!-- 箭矢（右上 → 靶心） -->
+    <path
+      d="M19.5 4.5 L12.8 11.2"
+      stroke="currentColor"
+      stroke-width="1.75"
+      stroke-linecap="round"
+    />
+    <path
+      d="M19.5 4.5 L19.5 7.8 L16.2 4.5 Z"
+      :fill="filled ? 'currentColor' : 'none'"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linejoin="round"
+    />
+    <!-- 箭羽 -->
+    <path
+      d="M19.5 4.5 L17.6 6.4 M19.5 4.5 L21.4 6.4"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+    />
+  </svg>
+</template>

--- a/apps/web/src/components/works/PublishNeoTVDialog.vue
+++ b/apps/web/src/components/works/PublishNeoTVDialog.vue
@@ -6,6 +6,7 @@ import { worksApi } from '@/services/works-api'
 import { resolveMediaUrl } from '@/services/api-base'
 import { useCanvasEditorStore } from '@/stores/canvasEditor'
 import MediaPreviewOverlay from '@/components/canvas/MediaPreviewOverlay.vue'
+import CanvasLocateButton from '@/components/shared/CanvasLocateButton.vue'
 
 const props = defineProps<{
   modelValue: boolean
@@ -214,14 +215,10 @@ async function handlePublish() {
                 >
                   预览
                 </button>
-                <button
-                  type="button"
-                  class="rounded-md px-2 py-1 text-[11px] text-white/55 transition hover:bg-white/10 hover:text-white"
+                <CanvasLocateButton
                   title="定位到画布"
-                  @click="locateNode(node, $event)"
-                >
-                  定位
-                </button>
+                  @click="(e) => locateNode(node, e)"
+                />
               </div>
             </div>
           </el-radio>

--- a/apps/web/src/composables/canvasNodeActions.ts
+++ b/apps/web/src/composables/canvasNodeActions.ts
@@ -15,3 +15,7 @@ export const CANVAS_NODE_LOCATE_FLASH_KEY: InjectionKey<Ref<Set<string>>> = Symb
 
 export type CanvasNodeAddAgentFn = (nodeId: string) => void
 export const CANVAS_NODE_ADD_AGENT_KEY: InjectionKey<CanvasNodeAddAgentFn> = Symbol('canvasNodeAddAgent')
+
+export const CANVAS_REF_PICK_ACTIVE_KEY: InjectionKey<Ref<boolean>> = Symbol('canvasRefPickActive')
+export const CANVAS_REF_PICK_NODE_IDS_KEY: InjectionKey<Ref<Set<string>>> = Symbol('canvasRefPickNodeIds')
+export const CANVAS_REF_PICK_REJECT_KEY: InjectionKey<Ref<string | null>> = Symbol('canvasRefPickReject')

--- a/apps/web/src/composables/useCanvasRefPickMode.ts
+++ b/apps/web/src/composables/useCanvasRefPickMode.ts
@@ -1,0 +1,45 @@
+import { computed, ref } from 'vue'
+
+const active = ref(false)
+const pickedNodeIds = ref<Set<string>>(new Set())
+
+/** Agent 🎯 画布引用 Pick 模式 — CanvasPage 与 AgentSideRail 共享 */
+export function useCanvasRefPickMode() {
+  const pickedCount = computed(() => pickedNodeIds.value.size)
+
+  function activate() {
+    active.value = true
+    pickedNodeIds.value = new Set()
+  }
+
+  function deactivate() {
+    active.value = false
+    pickedNodeIds.value = new Set()
+  }
+
+  function toggle() {
+    if (active.value) deactivate()
+    else activate()
+  }
+
+  function markPicked(nodeId: string) {
+    const next = new Set(pickedNodeIds.value)
+    next.add(nodeId)
+    pickedNodeIds.value = next
+  }
+
+  function isPicked(nodeId: string) {
+    return pickedNodeIds.value.has(nodeId)
+  }
+
+  return {
+    active,
+    pickedNodeIds,
+    pickedCount,
+    activate,
+    deactivate,
+    toggle,
+    markPicked,
+    isPicked,
+  }
+}

--- a/apps/web/src/composables/useSidebarAttachments.ts
+++ b/apps/web/src/composables/useSidebarAttachments.ts
@@ -13,6 +13,13 @@ export type FocusNodeLike = {
   data?: Record<string, unknown>
 }
 
+export type CanvasRefAddResult = {
+  added: number
+  empty: number
+  duplicate: number
+  addedNodeIds: string[]
+}
+
 export function assignRefKeysFor(attachments: SidebarAttachment[]): string[] {
   const counters = { text: 0, image: 0, video: 0, audio: 0 }
   return attachments.map((a) => {
@@ -132,9 +139,35 @@ export function useSidebarAttachments() {
     return count
   }
 
+  function addFromCanvasNodesDetailed(nodes: FocusNodeLike[]): CanvasRefAddResult {
+    let added = 0
+    let empty = 0
+    let duplicate = 0
+    const addedNodeIds: string[] = []
+    for (const n of nodes) {
+      if (pendingAttachments.value.length >= SIDEBAR_ATTACHMENT_MAX) break
+      const item = nodeToSidebarAttachment(n)
+      if (!item) {
+        empty += 1
+        continue
+      }
+      const dup = pendingAttachments.value.some(
+        (a) => (item.url && a.url === item.url) || (item.sourceNodeId && a.sourceNodeId === item.sourceNodeId),
+      )
+      if (dup) {
+        duplicate += 1
+        continue
+      }
+      addFromPayload(item)
+      added += 1
+      if (n.id) addedNodeIds.push(n.id)
+    }
+    return { added, empty, duplicate, addedNodeIds }
+  }
+
   function toPayload() {
     return { attachments: [...pendingAttachments.value], refOrder: refOrder.value }
   }
 
-  return { pendingAttachments, refOrder, addFromFile, addFromPayload, addFromCanvasNode, addFromCanvasNodes, remove, reorder, clear, toPayload, assignRefKeys }
+  return { pendingAttachments, refOrder, addFromFile, addFromPayload, addFromCanvasNode, addFromCanvasNodes, addFromCanvasNodesDetailed, remove, reorder, clear, toPayload, assignRefKeys }
 }

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -2938,8 +2938,8 @@ onMounted(() => {
 
 :deep(.vue-flow__selection),
 :deep(.vue-flow__nodesselection-rect) {
-  background: var(--neo-accent-soft);
-  border: 1.5px dashed var(--neo-accent-border);
+  background: color-mix(in srgb, var(--neo-hi-text) 8%, transparent);
+  border: 1.5px dashed color-mix(in srgb, var(--neo-hi-text) 35%, var(--neo-border));
   border-radius: 4px;
 }
 

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, computed, defineAsyncComponent, nextTick, provide, watch } from 'vue'
+import { ref, onMounted, onUnmounted, computed, defineAsyncComponent, nextTick, provide, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import {
   VueFlow,
@@ -62,6 +62,7 @@ import type { FallbackPendingRequest } from '@/composables/useNodeGeneration'
 import { createFallbackConfirmQueue, fallbackConfirmKey } from '@/composables/fallbackConfirmQueue'
 import type { StudioModality } from '@/constants/studioModels'
 import ClickRippleLayer from '@/components/canvas/ClickRippleLayer.vue'
+import CanvasRefPickOverlay from '@/components/canvas/CanvasRefPickOverlay.vue'
 import ConnectNodePicker from '@/components/canvas/ConnectNodePicker.vue'
 import ConnectPickerLine from '@/components/canvas/ConnectPickerLine.vue'
 import { CONNECT_OUT_TARGET_TYPES } from '@/components/canvas/canvasDockMenu'
@@ -102,7 +103,11 @@ import {
   CANVAS_NODE_PATCH_KEY,
   CANVAS_NODE_RENAME_KEY,
   CANVAS_NODE_RETRY_KEY,
+  CANVAS_REF_PICK_ACTIVE_KEY,
+  CANVAS_REF_PICK_NODE_IDS_KEY,
+  CANVAS_REF_PICK_REJECT_KEY,
 } from '@/composables/canvasNodeActions'
+import { useCanvasRefPickMode } from '@/composables/useCanvasRefPickMode'
 import type { CanvasAssetItem } from '@/components/canvas/CanvasAssetPanel.vue'
 import AIImageEditor from '@/components/canvas/AIImageEditor.vue'
 import MediaPreviewOverlay from '@/components/canvas/MediaPreviewOverlay.vue'
@@ -1286,6 +1291,28 @@ function onNodeDragStop(event: NodeDragEvent) {
 }
 
 function onNodeClick(event: NodeMouseEvent) {
+  if (pickMode.active.value) {
+    const nodeId = event.node.id
+    const node = findNodeById(nodeId)
+    if (!node) return
+    const result = agentRailRef.value?.addFromCanvasNodes([{
+      id: node.id,
+      type: node.type,
+      data: (node.data ?? {}) as Record<string, unknown>,
+    }]) ?? { added: 0, empty: 0, duplicate: 0, addedNodeIds: [] }
+    if (result.added > 0) {
+      for (const id of result.addedNodeIds) pickMode.markPicked(id)
+    } else if (result.empty) {
+      pickRejectNodeId.value = nodeId
+      window.setTimeout(() => {
+        if (pickRejectNodeId.value === nodeId) pickRejectNodeId.value = null
+      }, 400)
+    } else if (result.duplicate) {
+      ElMessage.info('该节点已在引用中')
+    }
+    return
+  }
+
   const mouse = event.event as MouseEvent
   const multi = mouse.shiftKey || mouse.metaKey || mouse.ctrlKey
   if (!multi) {
@@ -2211,8 +2238,38 @@ function handleAddToAgentRefs(sourceIds?: string[]) {
       type: node.type,
       data: (node.data ?? {}) as Record<string, unknown>,
     }))
-  agentRailRef.value?.addFromCanvasNodes(focusNodes)
+  const result = agentRailRef.value?.addFromCanvasNodes(focusNodes)
   agentRailRef.value?.openPanel()
+  if (pickMode.active.value && result?.addedNodeIds?.length) {
+    for (const id of result.addedNodeIds) pickMode.markPicked(id)
+  }
+}
+
+function handleCanvasRefPickToggle() {
+  if (pickMode.active.value) {
+    pickMode.deactivate()
+    return
+  }
+  agentRailRef.value?.openPanel()
+  pickMode.activate()
+  const ids = multiSelectedIds.value.length
+    ? [...multiSelectedIds.value]
+    : selectedNodeId.value
+      ? [selectedNodeId.value]
+      : []
+  if (!ids.length) return
+  const focusNodes = ids
+    .map((id) => findNodeById(id))
+    .filter((node): node is EditableFlowNode => node != null)
+    .map((node) => ({
+      id: node.id,
+      type: node.type,
+      data: (node.data ?? {}) as Record<string, unknown>,
+    }))
+  const result = agentRailRef.value?.addFromCanvasNodes(focusNodes)
+  if (result?.addedNodeIds?.length) {
+    for (const id of result.addedNodeIds) pickMode.markPicked(id)
+  }
 }
 
 function handleContextAction(action: string) {
@@ -2604,6 +2661,13 @@ async function loadSessions() {
 const vueFlowRef = ref<InstanceType<typeof VueFlow> | null>(null)
 const canvasAreaRef = ref<HTMLElement | null>(null)
 const agentRailRef = ref<InstanceType<typeof AgentSideRail> | null>(null)
+const pickMode = useCanvasRefPickMode()
+const pickRejectNodeId = ref<string | null>(null)
+let pickModeKeydownHandler: ((event: KeyboardEvent) => void) | null = null
+
+provide(CANVAS_REF_PICK_ACTIVE_KEY, pickMode.active)
+provide(CANVAS_REF_PICK_NODE_IDS_KEY, pickMode.pickedNodeIds)
+provide(CANVAS_REF_PICK_REJECT_KEY, pickRejectNodeId)
 
 onMounted(() => {
   void loadProviderBootstrap().catch(() => {
@@ -2667,14 +2731,36 @@ onMounted(() => {
     })
   }
   window.addEventListener('paste', mediaHandlers.onPaste)
+
+  pickModeKeydownHandler = (event: KeyboardEvent) => {
+    if (event.key === 'Escape' && pickMode.active.value) {
+      pickMode.deactivate()
+    }
+  }
+  window.addEventListener('keydown', pickModeKeydownHandler)
+})
+
+onUnmounted(() => {
+  if (pickModeKeydownHandler) {
+    window.removeEventListener('keydown', pickModeKeydownHandler)
+  }
 })
 </script>
 
 <template>
   <div class="relative h-screen w-full overflow-hidden bg-[var(--neo-bg)]" @click="closeContextMenu">
     <div class="flex h-full min-w-0 overflow-hidden">
-      <div ref="canvasAreaRef" class="relative min-h-0 min-w-0 flex-1">
-        <ClickRippleLayer :container="canvasAreaRef" />
+      <div
+        ref="canvasAreaRef"
+        class="relative min-h-0 min-w-0 flex-1"
+        :class="{ 'canvas-ref-pick-mode': pickMode.active.value }"
+      >
+        <ClickRippleLayer :container="canvasAreaRef" :theme="canvasTheme" />
+        <CanvasRefPickOverlay
+          v-if="pickMode.active.value"
+          :picked-count="pickMode.pickedCount.value"
+          @done="pickMode.deactivate()"
+        />
         <CanvasFloatingChrome
           :title="sessionTitle"
           :saving="saving"
@@ -2885,7 +2971,7 @@ onMounted(() => {
         @undo="handleAgentUndo"
         @redo="handleAgentRedo"
         @open-image-editor="handleAgentOpenImageEditor"
-        @request-canvas-refs="handleAddToAgentRefs()"
+        @canvas-ref-pick-toggle="handleCanvasRefPickToggle"
       />
     </div>
 

--- a/apps/web/src/styles/main.css
+++ b/apps/web/src/styles/main.css
@@ -125,6 +125,71 @@
     color: var(--neo-text-primary);
   }
 
+  /* 左侧 dock 二级面板：卡片行（添加节点、连线选类型等） */
+  .neo-popover-card-item {
+    border: 1px solid transparent;
+    transition:
+      background 0.15s ease,
+      border-color 0.15s ease,
+      box-shadow 0.15s ease,
+      transform 0.1s ease,
+      color 0.15s ease;
+  }
+
+  .neo-popover-card-item:hover {
+    background: var(--neo-hover-bg);
+    border-color: var(--neo-border);
+    color: var(--neo-text-primary);
+  }
+
+  .neo-popover-card-item:active {
+    transform: scale(0.99);
+    background: color-mix(in srgb, var(--neo-hi-bg) 28%, var(--neo-hover-bg));
+    border-color: color-mix(in srgb, var(--neo-hi-text) 14%, var(--neo-border));
+  }
+
+  /* 左侧 dock 二级面板：顶栏 tab（资产库 / 任务生命周期） */
+  .neo-dock-panel-tab {
+    border-radius: 0.5rem;
+    padding: 0.25rem 0.625rem;
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--neo-text-muted);
+    transition: background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+  }
+
+  .neo-dock-panel-tab:hover {
+    background: var(--neo-hover-bg);
+    color: var(--neo-text-secondary);
+  }
+
+  .neo-dock-panel-tab.is-active {
+    background: var(--neo-hi-bg);
+    color: var(--neo-hi-text);
+    box-shadow: var(--neo-hi-shadow);
+  }
+
+  /* 左侧 dock 二级面板：筛选 chip */
+  .neo-dock-panel-chip {
+    border-radius: 9999px;
+    padding: 0.25rem 0.625rem;
+    font-size: 10px;
+    color: var(--neo-text-muted);
+    background: var(--neo-hover-bg);
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  }
+
+  .neo-dock-panel-chip:hover {
+    background: var(--neo-active-bg);
+    color: var(--neo-text-secondary);
+  }
+
+  .neo-dock-panel-chip.is-active {
+    background: var(--neo-active-bg);
+    color: var(--neo-text-primary);
+    border: 1px solid color-mix(in srgb, var(--neo-hi-text) 12%, var(--neo-border));
+  }
+
   /* dock / 工具条上的小控件按钮（模型选择、参数选择等触发器） */
   .neo-ctl {
     border: 1px solid var(--neo-border);
@@ -143,7 +208,7 @@
     border: 1px solid transparent;
     background: transparent;
     color: var(--neo-text-secondary);
-    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+    transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease, transform 0.1s ease;
   }
 
   .dock-ghost-ctl:hover,
@@ -161,6 +226,14 @@
   .dock-ghost-ctl.is-open {
     border-color: var(--neo-border);
     background: var(--neo-hover-bg);
+  }
+
+  .dock-ghost-ctl:active:not(:disabled) {
+    transform: scale(0.96);
+  }
+
+  .neo-ctl:active:not(:disabled) {
+    transform: scale(0.97);
   }
 
   /* 选项 chip：is-on 时品牌色高亮 */
@@ -200,4 +273,13 @@
     color: var(--neo-hi-text);
     box-shadow: var(--neo-hi-shadow);
   }
+}
+
+/* Agent 画布引用 Pick 模式：自定义光标（靶心十字） */
+.canvas-ref-pick-mode .canvas-flow,
+.canvas-ref-pick-mode .canvas-flow .vue-flow__pane {
+  cursor:
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3E%3Ccircle cx='12' cy='12' r='7' stroke='%23fff' stroke-width='1.5' opacity='0.9'/%3E%3Ccircle cx='12' cy='12' r='2' fill='%23fff'/%3E%3Cpath stroke='%23fff' stroke-width='1.5' d='M12 3v4M12 17v4M3 12h4M17 12h4'/%3E%3C/svg%3E")
+      12 12,
+    crosshair !important;
 }

--- a/apps/web/src/styles/main.css
+++ b/apps/web/src/styles/main.css
@@ -74,8 +74,8 @@
   }
 
   .input-field:focus {
-    border-color: var(--neo-accent-border);
-    box-shadow: 0 0 0 2px var(--neo-accent-soft);
+    border-color: var(--neo-border-strong);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--neo-hi-text) 12%, transparent);
   }
 
   /* 画布浮动 chrome：左上返回/标题、右上主题/积分/头像、左侧工具轨 */
@@ -175,7 +175,29 @@
   }
 
   .neo-chip.is-on {
-    background: var(--neo-accent-soft);
-    color: var(--neo-accent-text);
+    background: var(--neo-hi-bg);
+    color: var(--neo-hi-text);
+    box-shadow: var(--neo-hi-shadow);
+  }
+
+  /* dock-studio 内分段切换（模式/effort 等） */
+  .dock-seg-btn {
+    border-radius: 8px;
+    padding: 4px 8px;
+    font-size: 10px;
+    line-height: 1.2;
+    color: var(--neo-text-muted);
+    transition: background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+  }
+
+  .dock-seg-btn:hover:not(:disabled) {
+    background: var(--neo-hover-bg);
+    color: var(--neo-text-secondary);
+  }
+
+  .dock-seg-btn.is-on {
+    background: var(--neo-hi-bg);
+    color: var(--neo-hi-text);
+    box-shadow: var(--neo-hi-shadow);
   }
 }

--- a/apps/web/src/styles/neo-node.css
+++ b/apps/web/src/styles/neo-node.css
@@ -320,6 +320,40 @@
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
+.neo-node-wrapper.is-ref-pick-active .neo-node {
+  transition: box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.neo-node-wrapper.is-ref-pick-active:hover .neo-node {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--neo-hi-bg) 55%, transparent);
+}
+
+.neo-node-wrapper.is-ref-pick-marked .neo-node {
+  box-shadow: 0 0 0 2px var(--neo-hi-bg);
+}
+
+.neo-node-wrapper.is-ref-pick-active:not(.is-ref-pick-marked):hover .neo-node-agent-add--title {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@keyframes neo-ref-pick-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-3px);
+  }
+  75% {
+    transform: translateX(3px);
+  }
+}
+
+.neo-node-wrapper.is-ref-pick-reject .neo-node {
+  animation: neo-ref-pick-shake 0.35s ease;
+}
+
 .neo-node-agent-add {
   display: flex;
   flex-shrink: 0;
@@ -329,7 +363,7 @@
   cursor: pointer;
   background: transparent;
   color: var(--neo-text-muted);
-  transition: transform 0.15s ease, background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  transition: transform 0.15s ease, background 0.15s ease, color 0.15s ease, border-color 0.15s ease, opacity 0.15s ease;
 }
 
 .neo-node-agent-add--title {
@@ -337,6 +371,18 @@
   height: 24px;
   margin-left: auto;
   border-radius: 999px;
+  opacity: 0;
+  pointer-events: none;
+  transform: scale(0.92);
+}
+
+.neo-node-wrapper:hover .neo-node-agent-add--title,
+.neo-node-wrapper.is-hovered .neo-node-agent-add--title,
+.neo-node-wrapper.is-active .neo-node-agent-add--title,
+.neo-node-agent-add--title:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: scale(1);
 }
 
 .neo-node-external-title:hover .neo-node-agent-add--title,

--- a/apps/web/src/styles/neo-node.css
+++ b/apps/web/src/styles/neo-node.css
@@ -555,14 +555,14 @@
 }
 
 .neo-node-placeholder.is-generating {
-  border-color: var(--neo-accent-border);
-  background: var(--neo-accent-soft);
-  box-shadow: inset 0 0 0 1px rgba(138, 125, 255, 0.2);
+  border-color: color-mix(in srgb, var(--neo-hi-text) 28%, var(--neo-border));
+  background: var(--neo-hover-bg);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--neo-hi-text) 10%, transparent);
 }
 
 .neo-node-placeholder.is-uploading {
-  border-color: var(--neo-accent-border);
-  background: var(--neo-accent-soft);
+  border-color: color-mix(in srgb, var(--neo-hi-text) 28%, var(--neo-border));
+  background: var(--neo-hover-bg);
 }
 
 .neo-node-placeholder.is-failed {

--- a/docs/superpowers/specs/2026-08-10-agent-canvas-ref-pick-design.md
+++ b/docs/superpowers/specs/2026-08-10-agent-canvas-ref-pick-design.md
@@ -1,0 +1,98 @@
+# Agent 画布引用 Pick 模式 — 设计规格
+
+> 状态：**已确认**（2026-08-10）  
+> 前置：[2026-08-07-agent-sidebar-material-entry-design.md](./2026-08-07-agent-sidebar-material-entry-design.md)、[2026-08-10-ui-p0-interactions-design.md](./2026-08-10-ui-p0-interactions-design.md)
+
+---
+
+## 1. 决策摘要
+
+| # | 决策 | 说明 |
+|---|------|------|
+| D1 | **🎯 一级显性按钮** | Agent dock 参数行 `[模型▾] [🎯] [＋] [技能▾]`，非 + 子菜单 |
+| D2 | **图标 + tooltip** | 默认 outline；Pick 中 `filled` + `is-active` 高亮 |
+| D3 | **Toggle 退出** | 再点 🎯，或点击 dock 对话区（输入框/引用条），自动变灰退出 Pick |
+| D4 | **默认保持 Pick** | 点选节点后不自动退出；每点一个节点 chip 即时出现 |
+| D5 | **与节点 ★ 并存** | 节点标题栏 🎯 = 单节点快捷加；Agent 🎯 = 批量点选模式 |
+| D6 | **统一引用图标** | `CanvasRefTargetIcon` 🎯 — 引用到 Agent（节点标题 / 资产库 / Agent dock） |
+| D7 | **统一定位图标** | `CanvasLocatePinIcon` 📍 — 画布内定位/聚焦（产出列表 / 任务 / 发布等） |
+
+---
+
+## 2. 布局
+
+```
+AgentRefStrip
+  有 chip → 展示 chip 列表
+  无 chip → 虚线槽「＋ 从画布选节点」（次要入口，点进 Pick）
+
+agent-dock-params
+  [模型▾] [🎯画布引用] [＋] [技能▾]     ← 主入口
+
+Pick 激活时
+  画布：轻遮罩 + 顶栏「点选节点加入引用 · 已选 N · 完成 · Esc」
+  光标：自定义 canvas-pick cursor（准星+靶）
+  侧栏 🎯：filled + is-active
+```
+
+---
+
+## 3. 状态机
+
+```text
+Idle
+  → 点 🎯 / 空态 CTA → PickMode（🎯 高亮 filled）
+  → 画布已有选中 + 点 🎯 → 直接加 chip（可选：仍进 Pick）
+
+PickMode
+  → 点节点 → addFromCanvasNode → chip 即时反馈，保持 Pick
+  → 再点 🎯 → Idle（图标变灰 outline）
+  → 点 dock 对话区（MentionInput / RefStrip / 输入 dock 内）→ Idle
+  → 点「完成」/ Esc → Idle
+  → 点节点标题 🎯 → 单节点加 chip，不强制退出 Pick
+```
+
+---
+
+## 4. 画布 Pick 视觉
+
+| 元素 | 行为 |
+|------|------|
+| 遮罩 | 画布区 `rgba(0,0,0,0.22)`，Agent 侧栏 / 左 dock 不遮 |
+| 顶栏 | canvas 内浮动 pill，显示已选数量 + 完成 |
+| 节点 hover | `--neo-hi` 描边 pulse |
+| 已选节点 | 持续 hi 描边 |
+| 不可引用 | 虚线框 + tooltip「暂无可用内容」 |
+| 光标 | `url(canvas-pick.svg) 12 12, crosshair` |
+
+---
+
+## 5. 节点标题栏 🎯（已实现图标统一）
+
+```
+[类型icon]  标题……  ●status  [🎯]   ← 最右，hover 淡入
+                              ↑
+                    CanvasRefTargetIcon (outline)
+                    点击 → addFromCanvasNode + openPanel
+```
+
+与预览区内 `[存库][下载][替换]` **不重叠**（见 ui-p0 §2）。
+
+---
+
+## 6. 实现任务（待开发）
+
+- [x] `useCanvasRefPickMode` composable（CanvasPage ↔ AgentSideRail）
+- [x] Agent dock 🎯 按钮 + tooltip + filled toggle
+- [x] AgentRefStrip 空态 CTA
+- [x] 画布遮罩 / 顶栏 / cursor / 节点 click 拦截
+- [x] dock 对话区 click → 退出 Pick
+- [x] 从 + 菜单移除「画布节点」（改由 🎯 承担）
+- [x] 定位图标统一为 `CanvasLocatePinIcon`（与 🎯 引用图标区分）
+
+---
+
+## 7. 非目标（本 spec）
+
+- 拖拽节点到引用条（P1）
+- 节点列表 Popover 选取（副入口，后续可选）

--- a/docs/superpowers/specs/2026-08-10-ui-p1-p2-interactions-design.md
+++ b/docs/superpowers/specs/2026-08-10-ui-p1-p2-interactions-design.md
@@ -20,7 +20,8 @@
 - [x] Agent 顶栏 active、drop-target、skill icon
 - [x] 左侧 dock active 态
 - [x] 底栏 seg-btn、group 选中
-- [ ] 全站 token  sweep（main.css chips、selection rect 等）
+- [x] 框选矩形、placeholder、ref chip drag、MentionInput、dock-seg-btn
+- [ ] 主页/Studio 独立页、WorkCard 等站外页面
 
 ### 连线样式自定义 ✅
 
@@ -28,5 +29,6 @@
 
 ### Agent 侧栏 Studio 布局
 
-- [ ] 与 dock-studio 进一步统一（P0 已做 hover 参数条）
+- [x] ghost 单层 dock（#210）
+- [ ] dock-studio 模型选择器同样 ghost 化（可选）
 


### PR DESCRIPTION
## Summary

- **P2 主题 sweep**：框选、placeholder、ref chip、dock seg 等去紫色，改用 hi 白高亮 token
- **画布引用 Pick 模式**：Agent dock 🎯 一键进入点选；画布遮罩 + 顶栏；点节点即时出 chip；Esc/再点 🎯/点 dock 对话区退出
- **图标体系**：🎯 `CanvasRefTargetIcon` = 引用到 Agent；📍 `CanvasLocatePinIcon` = 画布定位（产出/任务/发布/底栏列表等）
- **交互补全**：单击/双击涟漪主题化；左侧 dock 二级面板 tab/chip；节点标题 🎯 引用按钮；移除 `+ → 画布节点`

## Test plan

- [x] `pnpm --filter web build`
- [ ] Agent dock 🎯：进入 Pick → 点节点 → chip 出现 → 完成/Esc 退出
- [ ] 节点标题 🎯 / 资产库 🎯：引用到 Agent，与定位图钉视觉区分
- [ ] 对话产出 / 任务 / 发布弹窗：定位按钮为图钉
- [ ] 暗色/亮色主题下 hi 高亮与左侧二级面板 tab 正常