### PR TITLE
feat(web): agent enter-to-send, history reattach, dock auto-hide

### DIFF
--- a/apps/web/src/components/agent/AgentCanvasOutputs.vue
+++ b/apps/web/src/components/agent/AgentCanvasOutputs.vue
@@ -100,7 +100,7 @@ function isPulsing(nodeId: string): boolean {
 </script>
 
 <template>
-  <div v-if="outputs.length" class="agent-canvas-outputs mt-1.5 border-t border-[var(--agent-assistant-border)] pt-1.5">
+  <div v-if="outputs.length" class="agent-canvas-outputs mt-1.5 border-t border-[var(--agent-assistant-divider)] pt-1.5">
     <div class="mb-1 flex items-center justify-between gap-2 text-[11px] text-[var(--neo-text-muted)]">
       <span>画布产出 · {{ outputs.length }}</span>
       <CanvasLocateButton

--- a/apps/web/src/components/agent/AgentRefStrip.vue
+++ b/apps/web/src/components/agent/AgentRefStrip.vue
@@ -98,6 +98,7 @@ function onChipMention(refKey: string) {
         v-for="refItem in refs"
         :key="refItem.refId"
         :ref-item="refItem"
+        :variant="historyInteractive ? 'history' : 'composer'"
         :clickable="removable !== false || historyInteractive === true"
         :draggable="canReorder"
         :dragging="dragRefId === refItem.refId"

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -53,6 +53,7 @@ import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
 import { useSidebarAttachments, assignRefKeysFor, type FocusNodeLike, type CanvasRefAddResult } from '@/composables/useSidebarAttachments'
 import { parseRefMentions, splitRefMentions } from '@/composables/useRefMentions'
 import MentionInput, { type MentionOption } from '@/components/canvas/MentionInput.vue'
+import { copyTextToClipboard } from '@/utils/copyToClipboard'
 import { useClickOutside } from '@/composables/useClickOutside'
 import { useProviderBootstrap } from '@/composables/useProviderBootstrap'
 import {
@@ -207,6 +208,46 @@ function reattachTurnFromHistory(msg: AgentStreamMessage) {
 
   nextTick(() => composerRef.value?.focus())
   ElMessage.success('已复用本轮提示词与引用')
+}
+
+const messageFeedback = ref<Record<string, 'up' | 'down'>>({})
+const copiedMessageId = ref<string | null>(null)
+let copiedMessageTimer: number | null = null
+
+function canShowMessageActions(msg: AgentStreamMessage): boolean {
+  if (msg.role !== 'assistant' || msg.streaming) return false
+  if (isLiveTurnMessage(msg) && (agent.isStreaming || showTaskCard.value)) return false
+  return Boolean(
+    msg.content.trim()
+    || (assistantOutputsById.value.get(msg.id)?.length ?? 0) > 0
+    || msg.executionTrace,
+  )
+}
+
+function toggleMessageFeedback(msgId: string, vote: 'up' | 'down') {
+  if (messageFeedback.value[msgId] === vote) {
+    const next = { ...messageFeedback.value }
+    delete next[msgId]
+    messageFeedback.value = next
+    return
+  }
+  messageFeedback.value = { ...messageFeedback.value, [msgId]: vote }
+}
+
+async function copyAssistantMessage(msg: AgentStreamMessage) {
+  const text = msg.content.trim()
+  if (!text) return
+  try {
+    await copyTextToClipboard(text)
+    copiedMessageId.value = msg.id
+    if (copiedMessageTimer !== null) window.clearTimeout(copiedMessageTimer)
+    copiedMessageTimer = window.setTimeout(() => {
+      if (copiedMessageId.value === msg.id) copiedMessageId.value = null
+      copiedMessageTimer = null
+    }, 1600)
+  } catch {
+    ElMessage.error('复制失败')
+  }
 }
 
 const threadHasReattachableHistory = computed(() =>
@@ -1378,19 +1419,19 @@ defineExpose({
           </div>
 
           <!-- 消息列表 -->
-          <div ref="chatContainer" class="min-h-0 flex-1 overflow-y-auto space-y-3 px-3 py-3">
-            <div v-if="!agent.messages.length" class="agent-empty py-10 text-center">
+          <div ref="chatContainer" class="agent-chat-scroll min-h-0 flex-1 overflow-y-auto py-3">
+            <div v-if="!agent.messages.length" class="agent-empty px-3 py-10 text-center">
               <p class="text-sm">描述你的创意</p>
               <p class="mt-1 text-[11px] opacity-70">我会驱动画布创建节点、连线与生成任务</p>
             </div>
             <div
               v-for="msg in agent.messages"
               :key="msg.id"
-              class="flex"
-              :class="msg.role === 'user' ? 'justify-end' : 'justify-start'"
+              class="agent-turn"
+              :class="msg.role === 'user' ? 'agent-turn--user' : 'agent-turn--assistant'"
             >
               <div
-                class="agent-bubble max-w-[94%] rounded-2xl px-3 py-2 text-[13px] leading-relaxed"
+                class="agent-bubble text-[13px] leading-relaxed"
                 :class="msg.role === 'user' ? 'agent-bubble-user' : 'agent-bubble-assistant'"
               >
                 <p class="whitespace-pre-wrap">
@@ -1435,10 +1476,56 @@ defineExpose({
                 <div v-if="msg.toolCalls?.length" class="agent-tools mt-1 space-y-0.5 pt-1">
                   <div v-for="(tc, i) in msg.toolCalls" :key="i" class="text-[10px] text-[var(--neo-text-secondary)]">⚙ {{ tc.name }}</div>
                 </div>
+                <div
+                  v-if="canShowMessageActions(msg)"
+                  class="agent-msg-actions"
+                >
+                  <button
+                    type="button"
+                    class="agent-msg-action-btn"
+                    :class="{ 'is-active': messageFeedback[msg.id] === 'up' }"
+                    title="有帮助"
+                    aria-label="有帮助"
+                    @click="toggleMessageFeedback(msg.id, 'up')"
+                  >
+                    <svg viewBox="0 0 24 24" class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.75">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M7 11v8m0-8V7a2 2 0 0 1 2-2h1.5a1.5 1.5 0 0 1 1.4 1.02l1.12 3.36a2 2 0 0 0 1.9 1.34H17a2 2 0 0 1 2 2v1a2 2 0 0 1-2 2h-1.5l-.84 2.52A1.5 1.5 0 0 1 13.18 21H10a2 2 0 0 1-2-2v-8z" />
+                    </svg>
+                  </button>
+                  <button
+                    type="button"
+                    class="agent-msg-action-btn"
+                    :class="{ 'is-active': messageFeedback[msg.id] === 'down' }"
+                    title="无帮助"
+                    aria-label="无帮助"
+                    @click="toggleMessageFeedback(msg.id, 'down')"
+                  >
+                    <svg viewBox="0 0 24 24" class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.75">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M17 13V5m0 8v3a2 2 0 0 1-2 2h-1.5a1.5 1.5 0 0 1-1.4-1.02l-1.12-3.36a2 2 0 0 0-1.9-1.34H7a2 2 0 0 0-2 2v1a2 2 0 0 0 2 2h1.5l.84-2.52A1.5 1.5 0 0 0 10.82 3H14a2 2 0 0 1 2 2v8z" />
+                    </svg>
+                  </button>
+                  <button
+                    type="button"
+                    class="agent-msg-action-btn"
+                    :class="{ 'is-active': copiedMessageId === msg.id }"
+                    :title="copiedMessageId === msg.id ? '已复制' : '复制回复'"
+                    aria-label="复制回复"
+                    @click="copyAssistantMessage(msg)"
+                  >
+                    <svg v-if="copiedMessageId !== msg.id" viewBox="0 0 24 24" class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.75">
+                      <rect x="9" y="9" width="11" height="11" rx="2" />
+                      <path stroke-linecap="round" d="M5 15V5a2 2 0 0 1 2-2h10" />
+                    </svg>
+                    <svg v-else viewBox="0 0 24 24" class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="1.75">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+                    </svg>
+                  </button>
+                </div>
               </div>
             </div>
             <AgentTaskProgressCard
               v-if="showTaskCard"
+              class="mx-3"
               :progress="taskProgress"
               @focus-node="emit('focusNode', $event)"
             />
@@ -1901,52 +1988,92 @@ defineExpose({
   background: rgba(251, 191, 36, 0.28);
 }
 
-/* ---- 消息气泡 ---- */
+/* ---- 消息列表 ---- */
+.agent-chat-scroll {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.agent-turn--user {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 12px;
+}
+
+.agent-turn--assistant {
+  width: 100%;
+  padding: 0 12px;
+}
+
 .agent-empty {
   color: var(--neo-text-muted);
 }
 
 .agent-bubble-user {
+  max-width: 88%;
   border: 1px solid var(--agent-user-border);
+  border-radius: 16px;
   background: var(--agent-user-bg);
   color: var(--agent-user-text);
   box-shadow: var(--agent-user-shadow);
+  padding: 8px 12px;
 }
 
 .agent-bubble-assistant {
-  position: relative;
-  border: 1px solid var(--agent-assistant-border);
-  background: var(--agent-assistant-bg);
+  width: 100%;
+  max-width: none;
+  border: none;
+  border-radius: 0;
+  background: transparent;
   color: var(--agent-assistant-text);
-  box-shadow: var(--agent-assistant-shadow);
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
-}
-
-.agent-bubble-assistant::before {
-  content: '';
-  position: absolute;
-  top: 10px;
-  bottom: 10px;
-  left: 0;
-  width: 2px;
-  border-radius: 0 2px 2px 0;
-  background: var(--agent-assistant-accent);
-  opacity: 0.85;
-}
-
-.agent-bubble-assistant:hover {
-  border-color: color-mix(in srgb, var(--agent-assistant-accent) 35%, var(--agent-assistant-border));
-  box-shadow:
-    var(--agent-assistant-shadow),
-    0 0 0 1px color-mix(in srgb, var(--agent-assistant-accent) 12%, transparent);
+  box-shadow: none;
+  padding: 4px 0 8px;
 }
 
 .agent-bubble-assistant :deep(.agent-tools) {
-  border-color: color-mix(in srgb, var(--agent-assistant-text) 12%, transparent);
+  border-color: var(--agent-assistant-divider);
 }
 
 .agent-bubble-assistant :deep(.agent-canvas-outputs) {
-  border-color: color-mix(in srgb, var(--agent-assistant-text) 12%, transparent);
+  border-color: var(--agent-assistant-divider);
+}
+
+.agent-msg-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-top: 8px;
+  opacity: 0.55;
+  transition: opacity 0.15s ease;
+}
+
+.agent-turn--assistant:hover .agent-msg-actions,
+.agent-msg-actions:focus-within {
+  opacity: 1;
+}
+
+.agent-msg-action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--agent-assistant-muted);
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.agent-msg-action-btn:hover {
+  background: var(--neo-hover-bg);
+  color: var(--neo-text-primary);
+}
+
+.agent-msg-action-btn.is-active {
+  background: var(--neo-active-bg);
+  color: var(--neo-text-primary);
 }
 
 /* 用户气泡内引用 chip：棋盘底 + 描边，白/浅图也能辨认 */

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -51,7 +51,7 @@ import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGener
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
 import { useSidebarAttachments, assignRefKeysFor, type FocusNodeLike, type CanvasRefAddResult } from '@/composables/useSidebarAttachments'
-import { parseRefMentions } from '@/composables/useRefMentions'
+import { parseRefMentions, splitRefMentions } from '@/composables/useRefMentions'
 import MentionInput, { type MentionOption } from '@/components/canvas/MentionInput.vue'
 import { useClickOutside } from '@/composables/useClickOutside'
 import { useProviderBootstrap } from '@/composables/useProviderBootstrap'
@@ -140,12 +140,90 @@ function reattachFromHistory(attachment: SidebarAttachment) {
     ElMessage.warning(`最多 ${SIDEBAR_ATTACHMENT_MAX} 个引用`)
     return
   }
+  dismissHistoryReattachCoachmark()
   sidebar.addFromPayload({ ...attachment, id: randomId() })
   const keys = sidebar.assignRefKeys()
   const idx = sidebar.pendingAttachments.value.length - 1
   if (keys[idx]) insertRefMention(keys[idx])
   nextTick(() => composerRef.value?.focus())
 }
+
+const HISTORY_REATTACH_HINT_KEY = 'agent-history-reattach-hint'
+const historyReattachHintSeen = ref(false)
+
+onMounted(() => {
+  try {
+    historyReattachHintSeen.value = localStorage.getItem(HISTORY_REATTACH_HINT_KEY) === '1'
+  } catch {
+    historyReattachHintSeen.value = false
+  }
+})
+
+function dismissHistoryReattachCoachmark() {
+  historyReattachHintSeen.value = true
+  try {
+    localStorage.setItem(HISTORY_REATTACH_HINT_KEY, '1')
+  } catch {
+    /* ignore quota / private mode */
+  }
+}
+
+function stripRefMentionsFromText(text: string): string {
+  return splitRefMentions(text)
+    .filter((segment) => segment.kind === 'text')
+    .map((segment) => segment.value)
+    .join('')
+    .replace(/\s{2,}/g, ' ')
+    .trim()
+}
+
+function canReuseTurn(msg: AgentStreamMessage): boolean {
+  if (msg.role !== 'user') return false
+  return Boolean(msg.content?.trim()) || (msg.attachments?.length ?? 0) > 0
+}
+
+function reattachTurnFromHistory(msg: AgentStreamMessage) {
+  if (props.readOnly || !canReuseTurn(msg)) return
+
+  dismissHistoryReattachCoachmark()
+  sidebar.clear()
+
+  const items = makeAttachmentItems(msg.attachments, msg.attachmentRefKeys)
+  const plainText = stripRefMentionsFromText(msg.content ?? '')
+  input.value = plainText
+
+  for (const { attachment } of items) {
+    if (sidebar.pendingAttachments.value.length >= SIDEBAR_ATTACHMENT_MAX) {
+      ElMessage.warning(`最多 ${SIDEBAR_ATTACHMENT_MAX} 个引用，已跳过其余项`)
+      break
+    }
+    sidebar.addFromPayload({ ...attachment, id: randomId() })
+  }
+
+  const keys = sidebar.assignRefKeys()
+  for (const key of keys) {
+    insertRefMention(key)
+  }
+
+  nextTick(() => composerRef.value?.focus())
+  ElMessage.success('已复用本轮提示词与引用')
+}
+
+const threadHasReattachableHistory = computed(() =>
+  agent.messages.some((msg) => canReuseTurn(msg)),
+)
+
+const showHistoryReattachCoachmark = computed(
+  () => !props.readOnly && !historyReattachHintSeen.value && threadHasReattachableHistory.value,
+)
+
+const showComposerReattachHint = computed(
+  () =>
+    !props.readOnly
+    && pendingAttachmentItems.value.length === 0
+    && !input.value.trim()
+    && threadHasReattachableHistory.value,
+)
 
 const pendingAttachmentItems = computed(() =>
   makeAttachmentItems(sidebar.pendingAttachments.value, sidebar.assignRefKeys()),
@@ -1330,6 +1408,18 @@ defineExpose({
                   history-interactive
                   @reattach="reattachFromHistory"
                 />
+                <div
+                  v-if="!readOnly && canReuseTurn(msg)"
+                  class="agent-bubble-reuse mt-1.5 flex justify-end"
+                >
+                  <button
+                    type="button"
+                    class="agent-bubble-reuse-btn"
+                    @click="reattachTurnFromHistory(msg)"
+                  >
+                    ↺ 复用本轮（提示词 + 引用）
+                  </button>
+                </div>
                 <AgentCanvasOutputs
                   v-if="msg.role === 'assistant' && (assistantOutputsById.get(msg.id)?.length ?? 0) > 0"
                   :outputs="assistantOutputsById.get(msg.id) ?? []"
@@ -1452,7 +1542,29 @@ defineExpose({
               @drop.prevent="onDrop"
               @pointerdown="onInputDockPointerDown"
             >
+              <div
+                v-if="showHistoryReattachCoachmark"
+                class="agent-history-coachmark mx-0.5 mb-2 flex items-start gap-2 rounded-xl border px-3 py-2 text-[11px] leading-snug"
+                role="status"
+              >
+                <span class="min-w-0 flex-1 text-[var(--neo-text-secondary)]">
+                  点击历史消息中的 ↺ 引用可再次加入输入框；也可点「复用本轮」一键带回提示词与全部引用。
+                </span>
+                <button
+                  type="button"
+                  class="agent-history-coachmark__dismiss shrink-0 rounded-md px-2 py-0.5 text-[10px] font-medium"
+                  @click="dismissHistoryReattachCoachmark"
+                >
+                  知道了
+                </button>
+              </div>
               <div class="agent-composer">
+                <p
+                  v-if="showComposerReattachHint"
+                  class="agent-composer-reattach-hint mb-1.5 px-0.5 text-[10px] leading-snug text-[var(--neo-text-muted)]"
+                >
+                  点击上方历史消息中的 ↺ 引用，或「复用本轮」，可再次加入本次对话
+                </p>
                 <AgentRefStrip
                   v-if="pendingAttachmentItems.length"
                   class="agent-composer__refs"
@@ -1471,6 +1583,7 @@ defineExpose({
                     :placeholder="inputPlaceholder"
                     :disabled="agent.isStreaming"
                     :leading-inset="readOnly ? 0 : COMPOSER_PICK_INSET"
+                    submit-on-enter
                     @submit="send"
                   />
                   <button
@@ -1866,6 +1979,40 @@ defineExpose({
 .agent-bubble-user :deep(.dock-ref-chip:not(.has-media) .dock-ref-chip__key) {
   color: var(--agent-user-text);
   text-shadow: none;
+}
+
+.agent-bubble-reuse-btn {
+  border: 1px dashed color-mix(in srgb, var(--agent-user-text) 22%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--agent-user-text) 6%, transparent);
+  padding: 2px 8px;
+  font-size: 10px;
+  line-height: 1.4;
+  color: color-mix(in srgb, var(--agent-user-text) 78%, transparent);
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.agent-bubble-reuse-btn:hover {
+  border-color: color-mix(in srgb, var(--agent-user-text) 35%, transparent);
+  background: color-mix(in srgb, var(--agent-user-text) 12%, transparent);
+  color: var(--agent-user-text);
+}
+
+.agent-history-coachmark {
+  border-color: color-mix(in srgb, var(--neo-hi-text) 14%, var(--neo-border));
+  background: color-mix(in srgb, var(--neo-hi-bg) 8%, var(--neo-hover-bg));
+}
+
+.agent-history-coachmark__dismiss {
+  border: 1px solid var(--neo-border);
+  background: var(--neo-hi-bg);
+  color: var(--neo-hi-text);
+  box-shadow: var(--neo-hi-shadow);
+}
+
+.agent-composer-reattach-hint {
+  border-left: 2px solid color-mix(in srgb, var(--neo-hi-text) 18%, transparent);
+  padding-left: 8px;
 }
 
 .agent-tools {

--- a/apps/web/src/components/agent/AgentSidebarRefChip.vue
+++ b/apps/web/src/components/agent/AgentSidebarRefChip.vue
@@ -13,6 +13,8 @@ const props = defineProps<{
   draggable?: boolean
   dragging?: boolean
   dragOver?: boolean
+  /** composer = 输入区（hover 预览）；history = 历史气泡（仅点击引用） */
+  variant?: 'composer' | 'history'
 }>()
 
 const emit = defineEmits<{
@@ -50,7 +52,15 @@ function clearHoverTimer() {
   }
 }
 
+const isHistory = computed(() => props.variant === 'history')
+
+const chipTitle = computed(() => {
+  if (isHistory.value) return `再次引用 ${props.refItem.refKey}`
+  return `${props.refItem.refKey} · ${props.refItem.label}`
+})
+
 function onEnter(event: MouseEvent) {
+  if (isHistory.value) return
   clearHoverTimer()
   const el = event.currentTarget
   if (el instanceof HTMLElement) {
@@ -62,6 +72,7 @@ function onEnter(event: MouseEvent) {
 }
 
 function onLeave() {
+  if (isHistory.value) return
   clearHoverTimer()
   hoverTimer.value = window.setTimeout(() => {
     if (!isHoveringPreview.value) previewOpen.value = false
@@ -93,6 +104,7 @@ function onClick() {
   <div
     class="dock-ref-chip"
     :class="{
+      'dock-ref-chip--history': isHistory,
       'is-stale': refItem.stale,
       'has-media': !!thumbUrl,
       'is-readonly': !clickable,
@@ -100,7 +112,7 @@ function onClick() {
       'is-drag-over': dragOver,
     }"
     :draggable="draggable"
-    :title="`${refItem.refKey} · ${refItem.label}`"
+    :title="chipTitle"
     role="button"
     tabindex="0"
     @mouseenter="onEnter"
@@ -113,6 +125,8 @@ function onClick() {
     @drop="emit('drop', $event)"
     @dragend="emit('dragend')"
   >
+    <span v-if="isHistory" class="dock-ref-chip__reattach-badge" aria-hidden="true">↺</span>
+    <span v-if="isHistory" class="dock-ref-chip__reattach-tip">再次引用</span>
     <span class="dock-ref-chip__key">{{ refItem.refKey }}</span>
 
     <img
@@ -136,6 +150,7 @@ function onClick() {
     </span>
 
     <button
+      v-if="!isHistory"
       type="button"
       class="dock-ref-chip__remove"
       aria-label="移除引用"
@@ -148,7 +163,7 @@ function onClick() {
   </div>
 
   <AgentRefHoverPreview
-    v-if="previewOpen && previewAnchor"
+    v-if="!isHistory && previewOpen && previewAnchor"
     :ref-item="refItem"
     :anchor="previewAnchor"
     @mouseenter="onPreviewEnter"
@@ -175,7 +190,61 @@ function onClick() {
   transition:
     border-color 0.15s ease,
     background 0.15s ease,
-    opacity 0.15s ease;
+    opacity 0.15s ease,
+    transform 0.12s ease;
+}
+
+.dock-ref-chip--history {
+  border-style: dashed;
+  border-color: color-mix(in srgb, var(--neo-text-primary) 22%, var(--neo-border));
+}
+
+.dock-ref-chip--history:not(.is-stale):hover {
+  border-color: color-mix(in srgb, var(--neo-hi-text) 32%, var(--neo-border));
+  transform: scale(1.05);
+}
+
+.dock-ref-chip__reattach-badge {
+  position: absolute;
+  right: 1px;
+  bottom: 1px;
+  z-index: 2;
+  display: flex;
+  width: 12px;
+  height: 12px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--neo-bg) 72%, transparent);
+  font-size: 8px;
+  line-height: 1;
+  color: var(--neo-text-primary);
+  pointer-events: none;
+}
+
+.dock-ref-chip__reattach-tip {
+  position: absolute;
+  bottom: calc(100% + 5px);
+  left: 50%;
+  z-index: 3;
+  padding: 3px 7px;
+  border: 1px solid var(--neo-border);
+  border-radius: 6px;
+  background: var(--neo-popover-bg);
+  font-size: 9px;
+  line-height: 1.2;
+  white-space: nowrap;
+  color: var(--neo-text-secondary);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateX(-50%) translateY(2px);
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  box-shadow: var(--neo-popover-shadow);
+}
+
+.dock-ref-chip--history:hover .dock-ref-chip__reattach-tip {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
 }
 
 .dock-ref-chip.is-readonly {

--- a/apps/web/src/components/canvas/MentionInput.vue
+++ b/apps/web/src/components/canvas/MentionInput.vue
@@ -15,6 +15,8 @@ const props = defineProps<{
   disabled?: boolean
   /** 左侧预留内边距（与外部 prefix 控件并排时使用） */
   leadingInset?: number
+  /** Enter 发送；Shift+Enter 换行（Agent 侧栏等对话场景） */
+  submitOnEnter?: boolean
 }>()
 
 const emit = defineEmits<{ 'update:modelValue': [v: string]; submit: [] }>()
@@ -120,23 +122,35 @@ function focus() {
 defineExpose({ focus, insertText })
 
 function onKeydown(e: KeyboardEvent) {
-  if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+  if (showMenu.value && filteredMentions.value.length) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      selectedIndex.value = (selectedIndex.value + 1) % filteredMentions.value.length
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      selectedIndex.value = (selectedIndex.value - 1 + filteredMentions.value.length) % filteredMentions.value.length
+    } else if (e.key === 'Enter' || e.key === 'Tab') {
+      e.preventDefault()
+      insertMention(filteredMentions.value[selectedIndex.value])
+    } else if (e.key === 'Escape') {
+      showMenu.value = false
+    }
+    return
+  }
+
+  if (e.key !== 'Enter') return
+
+  const cmdEnter = e.metaKey || e.ctrlKey
+  if (props.submitOnEnter) {
+    if (e.shiftKey) return
     e.preventDefault()
     emit('submit')
     return
   }
-  if (!showMenu.value || !filteredMentions.value.length) return
-  if (e.key === 'ArrowDown') {
+
+  if (cmdEnter) {
     e.preventDefault()
-    selectedIndex.value = (selectedIndex.value + 1) % filteredMentions.value.length
-  } else if (e.key === 'ArrowUp') {
-    e.preventDefault()
-    selectedIndex.value = (selectedIndex.value - 1 + filteredMentions.value.length) % filteredMentions.value.length
-  } else if (e.key === 'Enter' || e.key === 'Tab') {
-    e.preventDefault()
-    insertMention(filteredMentions.value[selectedIndex.value])
-  } else if (e.key === 'Escape') {
-    showMenu.value = false
+    emit('submit')
   }
 }
 </script>

--- a/apps/web/src/components/canvas/NodePanelDock.vue
+++ b/apps/web/src/components/canvas/NodePanelDock.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { CANVAS_DOCK_MENU_ITEMS } from '@/components/canvas/canvasDockMenu'
 import CanvasAssetPanel, { type CanvasAssetItem } from '@/components/canvas/CanvasAssetPanel.vue'
 import CanvasTaskHistoryPanel from '@/components/canvas/CanvasTaskHistoryPanel.vue'
@@ -28,12 +28,72 @@ const emit = defineEmits<{
   'history-retry': [nodeId: string]
 }>()
 
+const DOCK_PINNED_KEY = 'lnkpi:canvas-dock-pinned'
+
 const showMenu = ref(false)
 const showAssets = ref(false)
 const showHistory = ref(false)
 const rootRef = ref<HTMLElement | null>(null)
+const dockPinned = ref(true)
+const dockRevealed = ref(true)
+let dockHideTimer: number | null = null
 
 const menuItems = CANVAS_DOCK_MENU_ITEMS
+
+const popoverOpen = computed(() => showMenu.value || showAssets.value || showHistory.value)
+const dockExpanded = computed(() => dockPinned.value || dockRevealed.value || popoverOpen.value)
+
+onMounted(() => {
+  try {
+    const stored = localStorage.getItem(DOCK_PINNED_KEY)
+    if (stored === '0') {
+      dockPinned.value = false
+      dockRevealed.value = false
+    }
+  } catch {
+    /* ignore */
+  }
+})
+
+watch(popoverOpen, (open) => {
+  if (open) revealDock()
+  else if (!dockPinned.value) scheduleHideDock()
+})
+
+function clearDockHideTimer() {
+  if (dockHideTimer !== null) {
+    window.clearTimeout(dockHideTimer)
+    dockHideTimer = null
+  }
+}
+
+function revealDock() {
+  clearDockHideTimer()
+  dockRevealed.value = true
+}
+
+function scheduleHideDock() {
+  if (dockPinned.value || popoverOpen.value) return
+  clearDockHideTimer()
+  dockHideTimer = window.setTimeout(() => {
+    dockRevealed.value = false
+    dockHideTimer = null
+  }, 320)
+}
+
+function toggleDockPinned() {
+  dockPinned.value = !dockPinned.value
+  try {
+    localStorage.setItem(DOCK_PINNED_KEY, dockPinned.value ? '1' : '0')
+  } catch {
+    /* ignore */
+  }
+  if (dockPinned.value) {
+    revealDock()
+  } else {
+    scheduleHideDock()
+  }
+}
 
 function add(type: DockNodeType) {
   emit('add', type)
@@ -50,18 +110,21 @@ function toggleMenu() {
   const next = !showMenu.value
   closePopovers()
   showMenu.value = next
+  if (next) revealDock()
 }
 
 function toggleAssets() {
   const next = !showAssets.value
   closePopovers()
   showAssets.value = next
+  if (next) revealDock()
 }
 
 function toggleHistory() {
   const next = !showHistory.value
   closePopovers()
   showHistory.value = next
+  if (next) revealDock()
 }
 
 useClickOutside(rootRef, closePopovers)
@@ -73,8 +136,20 @@ useClickOutside(rootRef, closePopovers)
     ref="rootRef"
     class="node-panel-dock pointer-events-none absolute left-3 top-[60px] z-[50]"
   >
-    <div class="pointer-events-auto relative">
-      <!-- 竖向面板：添加节点 + 资产库 + 任务 + 模型设置 -->
+    <!-- 自动隐藏：左侧热区（绝对定位，不参与布局，避免推开面板） -->
+    <div
+      v-if="!dockPinned"
+      class="dock-auto-hide-zone pointer-events-auto"
+      @mouseenter="revealDock"
+    />
+
+    <div
+      class="dock-panel-wrap pointer-events-auto relative"
+      :class="{ 'is-collapsed': !dockExpanded }"
+      @mouseenter="revealDock"
+      @mouseleave="scheduleHideDock"
+    >
+      <!-- 竖向面板：添加节点 + 资产库 + 任务 + 模型设置 + 常驻开关 -->
       <div
         class="vertical-capsule neo-glass-lite flex flex-col items-stretch gap-0.5 rounded-2xl p-1"
       >
@@ -85,7 +160,7 @@ useClickOutside(rootRef, closePopovers)
           title="添加节点"
           @click.stop="toggleMenu"
         >
-          <span class="rail-circle rail-circle-primary">
+          <span class="rail-circle rail-circle-prominent">
             <svg
               class="h-[18px] w-[18px] transition-transform duration-200"
               :class="showMenu ? 'rotate-45' : ''"
@@ -96,7 +171,7 @@ useClickOutside(rootRef, closePopovers)
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.25" d="M12 4v16m8-8H4" />
             </svg>
           </span>
-          <span class="rail-btn-label rail-btn-label-primary">添加</span>
+          <span class="rail-btn-label rail-btn-label-prominent">添加</span>
         </button>
 
         <button
@@ -159,6 +234,42 @@ useClickOutside(rootRef, closePopovers)
             </svg>
           </span>
           <span class="rail-btn-label">设置</span>
+        </button>
+
+        <span class="mx-auto my-0.5 h-px w-8 bg-[var(--neo-border)]" />
+
+        <button
+          type="button"
+          class="rail-btn dock-pin-toggle"
+          :class="{ 'is-active': !dockPinned }"
+          :title="dockPinned ? '菜单常驻（点击切换为隐藏）' : '菜单隐藏（移入左侧唤起，点击切换为常驻）'"
+          :aria-pressed="!dockPinned"
+          @click.stop="toggleDockPinned"
+        >
+          <span class="rail-circle">
+            <svg
+              v-if="dockPinned"
+              class="h-[16px] w-[16px]"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.75"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.964-7.178Z" />
+              <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+            </svg>
+            <svg
+              v-else
+              class="h-[16px] w-[16px]"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.75"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88" />
+            </svg>
+          </span>
+          <span class="rail-btn-label">{{ dockPinned ? '常驻' : '隐藏' }}</span>
         </button>
       </div>
 
@@ -225,18 +336,35 @@ useClickOutside(rootRef, closePopovers)
 </template>
 
 <style scoped>
+.dock-auto-hide-zone {
+  position: absolute;
+  left: -12px;
+  top: 0;
+  width: 18px;
+  min-height: 120px;
+  height: 100%;
+}
+
+.dock-panel-wrap {
+  transition:
+    transform 0.28s cubic-bezier(0.32, 0.72, 0, 1),
+    opacity 0.22s ease;
+  transform: translateX(0);
+  opacity: 1;
+}
+
+.dock-panel-wrap.is-collapsed {
+  transform: translateX(calc(-100% - 8px));
+  opacity: 0;
+  pointer-events: none;
+}
+
 .rail-btn {
   @apply relative flex w-[52px] flex-col items-center justify-center gap-1 rounded-xl px-1 py-1.5 transition;
   color: var(--neo-text-muted);
 }
 .rail-btn:hover {
-  background: var(--neo-hover-bg);
   color: var(--neo-text-primary);
-}
-.rail-btn.is-active {
-  background: var(--neo-hi-bg);
-  color: var(--neo-hi-text);
-  box-shadow: var(--neo-hi-shadow);
 }
 
 /* 统一大小的圆形图标底座 */
@@ -251,28 +379,29 @@ useClickOutside(rootRef, closePopovers)
 }
 .rail-btn.is-active .rail-circle {
   border-color: color-mix(in srgb, var(--neo-hi-text) 30%, var(--neo-border));
-  background: var(--neo-active-bg);
-}
-
-/* 添加节点：白色高亮凸显（浅色主题下自动转深色高亮） */
-.rail-circle-primary,
-.rail-btn:hover .rail-circle-primary,
-.rail-btn.is-active .rail-circle-primary {
-  border-color: transparent;
   background: var(--neo-hi-bg);
   color: var(--neo-hi-text);
   box-shadow: var(--neo-hi-shadow);
 }
-.rail-btn:hover .rail-circle-primary {
-  filter: brightness(1.06);
+
+/* 添加节点：常驻弱高亮（比点击激活略暗），提醒高频入口 */
+.rail-circle-prominent {
+  border-color: color-mix(in srgb, var(--neo-hi-text) 16%, var(--neo-border));
+  background: color-mix(in srgb, var(--neo-hi-bg) 62%, var(--neo-hover-bg));
+  color: var(--neo-hi-text);
+  box-shadow: 0 1px 5px color-mix(in srgb, var(--neo-hi-text) 10%, transparent);
+}
+.rail-btn:hover .rail-circle-prominent {
+  border-color: color-mix(in srgb, var(--neo-hi-text) 22%, var(--neo-border));
+  background: color-mix(in srgb, var(--neo-hi-bg) 78%, var(--neo-hover-bg));
+}
+
+.rail-btn-label-prominent {
+  color: var(--neo-text-primary);
 }
 
 .rail-btn-label {
   @apply text-[10px] leading-none;
-}
-
-.rail-btn-label-primary {
-  color: var(--neo-text-primary);
 }
 
 .popover-caption {

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -3024,9 +3024,9 @@ onUnmounted(() => {
 
 :deep(.vue-flow__selection),
 :deep(.vue-flow__nodesselection-rect) {
-  background: color-mix(in srgb, var(--neo-hi-text) 8%, transparent);
-  border: 1.5px dashed color-mix(in srgb, var(--neo-hi-text) 35%, var(--neo-border));
-  border-radius: 4px;
+  background: var(--neo-canvas-selection-fill);
+  border: 1.25px dashed var(--neo-canvas-selection-border);
+  border-radius: 6px;
 }
 
 :deep(.vue-flow__node) {

--- a/apps/web/src/styles/neowow-tokens.css
+++ b/apps/web/src/styles/neowow-tokens.css
@@ -66,6 +66,10 @@
   --neo-edge-hover: rgba(178, 181, 210, 0.55);
   --neo-edge-selected: #8a7dff;
 
+  /* ---- 画布框选 / 多选包围框 ---- */
+  --neo-canvas-selection-fill: rgba(255, 255, 255, 0.05);
+  --neo-canvas-selection-border: rgba(148, 151, 180, 0.48);
+
   /* ---- 毛玻璃 dock：高透明度 + 低模糊（透过卡片能看清画布），
           立体感靠内侧顶部高光 + 内侧底部暗边 + 双层投影 ---- */
   --neo-glass-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.06) 0%, rgba(10, 10, 14, 0.42) 45%, rgba(10, 10, 14, 0.58) 100%);
@@ -148,6 +152,9 @@
   --neo-edge: rgba(23, 25, 35, 0.22);
   --neo-edge-hover: rgba(23, 25, 35, 0.45);
   --neo-edge-selected: #6d5dfc;
+
+  --neo-canvas-selection-fill: rgba(23, 25, 35, 0.05);
+  --neo-canvas-selection-border: rgba(23, 25, 35, 0.34);
 
   --neo-glass-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.62) 0%, rgba(255, 255, 255, 0.44) 50%, rgba(248, 249, 253, 0.56) 100%);
   --neo-glass-border: rgba(23, 25, 35, 0.12);

--- a/apps/web/src/styles/neowow-tokens.css
+++ b/apps/web/src/styles/neowow-tokens.css
@@ -102,18 +102,16 @@
   --neo-hi-shadow: 0 2px 10px rgba(0, 0, 0, 0.32), 0 0 14px rgba(255, 255, 255, 0.22);
 
   /* ---- Agent 对话气泡（与用户/助手差异化；避免纯白底吞没白图引用） ---- */
-  --agent-user-bg: linear-gradient(145deg, #e4e8f0 0%, #d6dce8 52%, #ccd3e0 100%);
-  --agent-user-text: #1a1d26;
-  --agent-user-border: rgba(255, 255, 255, 0.28);
-  --agent-user-shadow: 0 2px 10px rgba(0, 0, 0, 0.24), 0 0 0 1px rgba(255, 255, 255, 0.06);
-  --agent-user-media-bg: #c4cad6;
-  --agent-user-media-checker: rgba(0, 0, 0, 0.07);
+  --agent-user-bg: linear-gradient(160deg, rgba(255, 255, 255, 0.1) 0%, rgba(255, 255, 255, 0.06) 100%);
+  --agent-user-text: rgba(255, 255, 255, 0.9);
+  --agent-user-border: rgba(255, 255, 255, 0.1);
+  --agent-user-shadow: none;
+  --agent-user-media-bg: rgba(255, 255, 255, 0.12);
+  --agent-user-media-checker: rgba(255, 255, 255, 0.07);
 
-  --agent-assistant-bg: linear-gradient(165deg, rgba(40, 40, 52, 0.96) 0%, rgba(28, 28, 38, 0.98) 100%);
   --agent-assistant-text: var(--neo-text-primary);
-  --agent-assistant-border: rgba(255, 255, 255, 0.1);
-  --agent-assistant-shadow: 0 1px 4px rgba(0, 0, 0, 0.22);
-  --agent-assistant-accent: rgba(255, 255, 255, 0.22);
+  --agent-assistant-muted: var(--neo-text-secondary);
+  --agent-assistant-divider: rgba(255, 255, 255, 0.08);
 }
 
 /* ============================================================
@@ -182,16 +180,14 @@
   --neo-hi-text: #ffffff;
   --neo-hi-shadow: 0 2px 10px rgba(23, 25, 35, 0.28);
 
-  --agent-user-bg: linear-gradient(145deg, #22242e 0%, #17181d 55%, #121318 100%);
-  --agent-user-text: #f4f6fb;
-  --agent-user-border: rgba(255, 255, 255, 0.1);
-  --agent-user-shadow: 0 2px 10px rgba(23, 25, 35, 0.2), 0 0 0 1px rgba(255, 255, 255, 0.04);
-  --agent-user-media-bg: rgba(255, 255, 255, 0.08);
-  --agent-user-media-checker: rgba(255, 255, 255, 0.1);
+  --agent-user-bg: linear-gradient(160deg, rgba(23, 25, 35, 0.07) 0%, rgba(23, 25, 35, 0.045) 100%);
+  --agent-user-text: var(--neo-text-primary);
+  --agent-user-border: rgba(23, 25, 35, 0.08);
+  --agent-user-shadow: none;
+  --agent-user-media-bg: rgba(23, 25, 35, 0.06);
+  --agent-user-media-checker: rgba(23, 25, 35, 0.05);
 
-  --agent-assistant-bg: linear-gradient(165deg, #ffffff 0%, #f6f7fb 100%);
   --agent-assistant-text: var(--neo-text-primary);
-  --agent-assistant-border: rgba(23, 25, 35, 0.1);
-  --agent-assistant-shadow: 0 1px 4px rgba(23, 25, 35, 0.08);
-  --agent-assistant-accent: rgba(23, 25, 35, 0.16);
+  --agent-assistant-muted: var(--neo-text-secondary);
+  --agent-assistant-divider: rgba(23, 25, 35, 0.08);
 }


### PR DESCRIPTION
## Summary
- Agent 侧栏：`Enter` 发送、`Shift+Enter` 换行；历史引用 chip 二次引用与「复用本轮（提示词 + 引用）」
- 画布左侧菜单：常驻/隐藏（眼睛图标）切换，隐藏时左边缘 hover 唤起（Dock 效果）
- 框选/多选包围框：主题化虚线边框，对比度与粗细优化

## Test plan
- [x] `pnpm build`
- [ ] Agent 侧栏输入后按 Enter 发送；Shift+Enter 换行
- [ ] 历史消息引用 chip 点击再次加入 composer；复用本轮按钮可用
- [ ] 画布菜单常驻/隐藏切换，隐藏模式左边缘 hover 展开
- [ ] 框选多个节点时虚线边框清晰可见（暗/亮主题）


Made with [Cursor](https://cursor.com)