### PR TITLE
fix(agent): 复用提示词修复 + img2img 误用历史任务

### DIFF
--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -51,7 +51,7 @@ import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGener
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
 import { useSidebarAttachments, assignRefKeysFor, type FocusNodeLike, type CanvasRefAddResult } from '@/composables/useSidebarAttachments'
-import { parseRefMentions, splitRefMentions } from '@/composables/useRefMentions'
+import { parseRefMentions } from '@/composables/useRefMentions'
 import MentionInput, { type MentionOption } from '@/components/canvas/MentionInput.vue'
 import { copyTextToClipboard } from '@/utils/copyToClipboard'
 import { useClickOutside } from '@/composables/useClickOutside'
@@ -169,30 +169,18 @@ function dismissHistoryReattachCoachmark() {
   }
 }
 
-function stripRefMentionsFromText(text: string): string {
-  return splitRefMentions(text)
-    .filter((segment) => segment.kind === 'text')
-    .map((segment) => segment.value)
-    .join('')
-    .replace(/\s{2,}/g, ' ')
-    .trim()
-}
-
 function canReuseTurn(msg: AgentStreamMessage): boolean {
   if (msg.role !== 'user') return false
   return Boolean(msg.content?.trim()) || (msg.attachments?.length ?? 0) > 0
 }
 
-function reattachTurnFromHistory(msg: AgentStreamMessage) {
+async function reattachTurnFromHistory(msg: AgentStreamMessage) {
   if (props.readOnly || !canReuseTurn(msg)) return
 
   dismissHistoryReattachCoachmark()
   sidebar.clear()
 
   const items = makeAttachmentItems(msg.attachments, msg.attachmentRefKeys)
-  const plainText = stripRefMentionsFromText(msg.content ?? '')
-  input.value = plainText
-
   for (const { attachment } of items) {
     if (sidebar.pendingAttachments.value.length >= SIDEBAR_ATTACHMENT_MAX) {
       ElMessage.warning(`最多 ${SIDEBAR_ATTACHMENT_MAX} 个引用，已跳过其余项`)
@@ -201,12 +189,19 @@ function reattachTurnFromHistory(msg: AgentStreamMessage) {
     sidebar.addFromPayload({ ...attachment, id: randomId() })
   }
 
-  const keys = sidebar.assignRefKeys()
-  for (const key of keys) {
-    insertRefMention(key)
+  sidebar.assignRefKeys()
+
+  const original = (msg.content ?? '').trim()
+  if (original) {
+    // 保留原始 @ 提及与提示词顺序；避免 insertText 与 v-model 竞态导致只剩引用
+    input.value = original
+  } else {
+    const keys = sidebar.assignRefKeys()
+    input.value = keys.map((key) => `@${key}`).join(' ')
   }
 
-  nextTick(() => composerRef.value?.focus())
+  await nextTick()
+  composerRef.value?.focus()
   ElMessage.success('已复用本轮提示词与引用')
 }
 

--- a/deploy/prod-agent-intent-diagnose.py
+++ b/deploy/prod-agent-intent-diagnose.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Production diagnose — agent executed wrong intent (stale checkpoint / gate resume).
+
+Searches recent agent threads for:
+  - User utterance containing img2img keywords (模特 + 衣服 / 穿上)
+  - Assistant reply referencing @T* when user cited @I*
+  - Thread checkpoint still interrupted at a gate
+
+Usage:
+  python3 deploy/prod-agent-intent-diagnose.py
+  SESSION_ID=cmsxxx python3 deploy/prod-agent-intent-diagnose.py
+  SEARCH=模特,穿上这件衣服 python3 deploy/prod-agent-intent-diagnose.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from typing import Any
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+BASE = os.environ.get("BASE_URL", "http://119.29.173.89:8888").rstrip("/")
+API = f"{BASE}/api"
+PHONE = os.environ.get("PHONE", "17279698608")
+CODE = os.environ.get("CODE", "123456")
+SESSION_ID = os.environ.get("SESSION_ID", "").strip()
+SEARCH_TERMS = [t.strip() for t in os.environ.get("SEARCH", "模特,穿上这件衣服,这个是文案").split(",") if t.strip()]
+
+REF_I = re.compile(r"@I\d+", re.I)
+REF_T = re.compile(r"@T\d+", re.I)
+
+
+def http(m: str, p: str, b: dict | None = None, t: str | None = None) -> Any:
+    h = {"Content-Type": "application/json", "Accept": "application/json"}
+    if t:
+        h["Authorization"] = f"Bearer {t}"
+    r = Request(f"{API}{p}", data=None if b is None else json.dumps(b).encode(), headers=h, method=m)
+    with urlopen(r, timeout=120) as resp:
+        return json.loads(resp.read())
+
+
+def preview(s: str, n: int = 90) -> str:
+    s = (s or "").replace("\n", " ").strip()
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def list_threads(t: str, sid: str) -> list[dict[str, Any]]:
+    return http("GET", f"/agent/chat/threads?sessionId={quote(sid, safe='')}", t=t).get("data") or []
+
+
+def get_messages(t: str, sid: str, tid: str) -> list[dict[str, Any]]:
+    path = f"/agent/chat/user/messages?sessionId={quote(sid, safe='')}&threadId={quote(tid, safe='')}"
+    return http("GET", path, t=t).get("data") or []
+
+
+def thread_state(t: str, tid: str) -> dict[str, Any] | None:
+    try:
+        return http("GET", f"/agent/thread-state?threadId={quote(tid, safe='')}", t=t).get("data")
+    except HTTPError:
+        return None
+
+
+def thread_timeline(t: str, tid: str) -> dict[str, Any] | None:
+    try:
+        return http("GET", f"/agent/thread-timeline?threadId={quote(tid, safe='')}", t=t).get("data")
+    except HTTPError:
+        return None
+
+
+def matches_search(text: str) -> bool:
+    t = text or ""
+    return any(term in t for term in SEARCH_TERMS)
+
+
+def diagnose_turn(user: dict[str, Any], assistant: dict[str, Any] | None) -> list[str]:
+    findings: list[str] = []
+    u = str(user.get("content") or "")
+    a = str((assistant or {}).get("content") or "")
+    if not u:
+        return findings
+    if REF_I.search(u) and REF_T.search(a) and not REF_T.search(u):
+        findings.append("assistant_ref_mismatch: user cited @I* but reply/title uses @T*")
+    if "穿上" in u and "这个是文案" in a:
+        findings.append("intent_mismatch: img2img dress request vs T1 copy task")
+    if "标题顺序" in a and "标题顺序" not in u:
+        findings.append("stale_prompt: assistant used prior T1 sequential copy task")
+    return findings
+
+
+def main() -> int:
+    print("=== Agent intent mismatch diagnose ===")
+    print(f"BASE={BASE}")
+    print(f"SEARCH={SEARCH_TERMS}\n")
+
+    try:
+        http("POST", "/auth/send-code", {"phone": PHONE})
+    except Exception:
+        pass
+    tok = http("POST", "/auth/login", {"phone": PHONE, "code": CODE})["data"]["token"]
+    print("✅ Login OK\n")
+
+    sessions: list[str] = []
+    if SESSION_ID:
+        sessions = [SESSION_ID]
+    else:
+        try:
+            rows = http("GET", "/sessions?limit=20", t=tok).get("data") or []
+            sessions = [str(r.get("id") or "") for r in rows if r.get("id")]
+        except HTTPError as exc:
+            print(f"❌ Cannot list sessions: HTTP {exc.code}")
+            return 1
+
+    hit = 0
+    for sid in sessions[:20]:
+        try:
+            http("GET", f"/sessions/{sid}", t=tok)
+        except HTTPError:
+            continue
+        threads = list_threads(tok, sid)
+        if not threads:
+            continue
+        for th in threads[:15]:
+            tid = str(th.get("id") or "")
+            if not tid:
+                continue
+            msgs = get_messages(tok, sid, tid)
+            for i, m in enumerate(msgs):
+                if m.get("role") != "user":
+                    continue
+                u_text = str(m.get("content") or "")
+                if not matches_search(u_text):
+                    continue
+                assistant = msgs[i + 1] if i + 1 < len(msgs) and msgs[i + 1].get("role") == "assistant" else None
+                findings = diagnose_turn(m, assistant)
+                if not findings and not matches_search(str((assistant or {}).get("content") or "")):
+                    continue
+                hit += 1
+                print(f"--- Hit #{hit} session={sid[-8:]} thread={tid[-16:]} ---")
+                print(f"  thread title: {preview(str(th.get('title') or ''), 60)}")
+                print(f"  user: {preview(u_text)}")
+                if assistant:
+                    print(f"  assistant: {preview(str(assistant.get('content') or ''))}")
+                for f in findings:
+                    print(f"  ⚠️  {f}")
+                st = thread_state(tok, tid)
+                if st:
+                    print(
+                        f"  checkpoint: phase={st.get('phase')!r} interrupted={st.get('interrupted')} "
+                        f"next={st.get('nextNodes')} atomic={preview(str(st.get('atomicSpec') or st.get('checkpoint') or ''), 70)}"
+                    )
+                tl = thread_timeline(tok, tid)
+                if tl and tl.get("checkpoints"):
+                    last = tl["checkpoints"][0]
+                    vals = last.get("values") or {}
+                    print(
+                        f"  timeline: step={last.get('step')} phase={vals.get('phase')!r} "
+                        f"flow={vals.get('flow_mode')!r} atomic_title={preview(str((vals.get('atomic_spec') or {}).get('title') or ''), 60)}"
+                    )
+                print()
+
+    if hit == 0:
+        print("No matching turns found. Set SESSION_ID to the canvas session or broaden SEARCH=…")
+        return 0
+    print(f"=== Found {hit} candidate turn(s) ===")
+    print(
+        "Likely root cause when user @I* img2img but assistant @T* copy:\n"
+        "  1) LangGraph interrupt_before gate still pending → new message resumed OLD gate/checkpoint\n"
+        "  2) atomic_regenerate reused prior atomic_spec instead of re-parsing utterance\n"
+        "Fix: should_resume_interrupt + fresh restart at intake (runs.py / hitl_resume.py)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/agent-runtime/app/graph/hitl_resume.py
+++ b/services/agent-runtime/app/graph/hitl_resume.py
@@ -14,11 +14,98 @@ inject new messages and the gate classifier will not see the user's reply.
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from langchain_core.messages import HumanMessage
+from langgraph.types import Command
 
 GATE_DECISION_CLEAR = {"user_decision": "none", "force_choice": None}
+
+REF_MENTION_RE = re.compile(r"@[TIVA]\d+", re.IGNORECASE)
+
+# Cleared when a new user task arrives while a HITL gate is still pending.
+FRESH_TURN_STATE_CLEAR: dict[str, Any] = {
+    **GATE_DECISION_CLEAR,
+    "phase": None,
+    "flow_mode": None,
+    "mode": None,
+    "atomic_spec": None,
+    "atomic_items": None,
+    "atomic_node_id": None,
+    "atomic_record_id": None,
+    "clarify_context": None,
+    "clarify_question": None,
+    "route_clarify": False,
+    "pre_parsed_intent": None,
+    "route_decision": None,
+    "route_context": None,
+    "split_manifest": None,
+    "last_error": None,
+}
+
+
+def should_resume_interrupt(
+    message: str,
+    next_nodes: list[str] | tuple[str, ...],
+    *,
+    user_decision: str | None = None,
+) -> bool:
+    """Return True when *message* is a gate reply; False for a fresh task."""
+    if not next_nodes:
+        return False
+    if user_decision and str(user_decision).strip().lower() not in ("", "none"):
+        return True
+
+    text = (message or "").strip()
+    if not text:
+        return False
+
+    gate = str(next_nodes[0])
+
+    from app.graph.atomic_intent import atomic_create_intent, classify_atomic_confirm
+    from app.graph.intent import classify_topo_decision, classify_user_decision
+
+    if gate == "await_confirm":
+        decision = classify_user_decision(text)
+        if decision is not None:
+            return True
+        # Long @ref task while plan gate is open → restart intake, not confirm/revise.
+        if len(text) >= 12 and REF_MENTION_RE.search(text) and atomic_create_intent(text):
+            return False
+        return len(text) <= 16
+
+    if gate == "await_topo":
+        if classify_topo_decision(text) != "none":
+            return True
+        if len(text) >= 12 and REF_MENTION_RE.search(text):
+            return False
+        return len(text) <= 16
+
+    if gate == "await_copy_confirm":
+        lowered = text.lower()
+        from app.graph.intent import COPY_CONFIRM_HINTS
+
+        if any(h in text for h in COPY_CONFIRM_HINTS):
+            return True
+        if len(text) >= 12 and REF_MENTION_RE.search(text):
+            return False
+        return len(text) <= 20
+
+    if gate == "await_atomic_confirm":
+        if classify_atomic_confirm(text) != "none":
+            return True
+        if len(text) >= 12 and REF_MENTION_RE.search(text):
+            return False
+        return len(text) <= 16
+
+    # Unknown gate: only resume short gate-like replies.
+    return len(text) <= 16 and not REF_MENTION_RE.search(text)
+
+
+def build_fresh_turn_command(*, update: dict[str, Any]) -> Command:
+    """Jump back to intake with cleared gate / atomic checkpoint fields."""
+    return Command(goto="intake", update={**FRESH_TURN_STATE_CLEAR, **update})
 
 
 def build_interrupt_state_update(

--- a/services/agent-runtime/app/graph/nodes/intake.py
+++ b/services/agent-runtime/app/graph/nodes/intake.py
@@ -10,6 +10,7 @@ from app.graph.atomic_clarify import is_affirmative_clarify_reply, pending_atomi
 from app.graph.route_context import assemble_route_context, latest_user_text
 from app.graph.route_decide import ROUTE_CLARIFY_ORCHESTRATION, decide_route
 from app.graph.route_trace import serialize_route_decision
+from app.graph.context_packet import should_include_prior_task
 from app.graph.state import BRIEF_RESET_PREFIX
 from app.skills.loader import discover_skills
 
@@ -167,6 +168,16 @@ def make_intake_node(skills_dir: Path) -> Callable:
             out["focus_node_id"] = focus_node_id
         if proposed_brief is not None:
             out["user_brief"] = proposed_brief
+        prior_spec = state.get("atomic_spec") if isinstance(state.get("atomic_spec"), dict) else None
+        if (
+            resolved_flow == "atomic_create"
+            and prior_spec
+            and not should_include_prior_task(text, prior_spec)
+        ):
+            out["atomic_spec"] = None
+            out["atomic_node_id"] = None
+            out["atomic_items"] = None
+            out["atomic_record_id"] = None
         return out
 
     return intake

--- a/services/agent-runtime/app/graph/route_precedence.py
+++ b/services/agent-runtime/app/graph/route_precedence.py
@@ -354,8 +354,8 @@ def _rule_default_chat(
 PRECEDENCE_RULES: list[tuple[str, RuleFn]] = [
     ("modify_existing_plan", _rule_modify_existing_plan),
     ("regen_no_checkpoint", _rule_regen_no_checkpoint),
-    ("checkpoint_regen", _rule_checkpoint_regen),
     ("sidebar_img2img", _rule_sidebar_img2img),
+    ("checkpoint_regen", _rule_checkpoint_regen),
     ("ref_backed_generate", _rule_ref_backed_generate),
     ("focus_gen", _rule_focus_gen),
     ("explicit_skill_orch", _rule_explicit_skill),

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -20,9 +20,10 @@ from app.checkpoint_observability import checkpoint_diagnostics
 from app.errors import AgentToolError, error_to_sse_payload, from_exception
 from app.graph.builder import build_agent_graph
 from app.graph.hitl_resume import (
-    GATE_DECISION_CLEAR,
+    build_fresh_turn_command,
     interrupt_event_payload,
     prepare_interrupt_resume,
+    should_resume_interrupt,
 )
 from app.graph.step_copy import phase_hint_event, step_event
 from app.graph.route_trace import route_decision_event
@@ -640,7 +641,25 @@ async def stream_run_events(
         bool(next_nodes),
         checkpoint_diagnostics(pre_vals),
     )
-    if next_nodes:
+    history = await _load_history(inner_nest, thread_id)
+    input_messages = history + [HumanMessage(content=req.message)]
+    turn_update = {
+        "messages": input_messages,
+        "session_id": req.session_id,
+        "user_id": req.user_id,
+        "thread_id": thread_id,
+        "requested_skill_id": req.skill_id,
+        "focus_node_id": req.focus_node_id,
+        "sidebar_attachments": normalized_attachments,
+        "sidebar_ref_order": req.sidebar_ref_order,
+        "sidebar_mentioned_keys": normalized_mentioned_keys,
+    }
+
+    if next_nodes and should_resume_interrupt(
+        req.message,
+        list(next_nodes),
+        user_decision=req.user_decision,
+    ):
         # interrupt_before: inject user message, then continue with input=None.
         # See app/graph/hitl_resume.py — Command(resume=...) is for in-node interrupt() only.
         input_state, _ = await prepare_interrupt_resume(
@@ -649,21 +668,17 @@ async def stream_run_events(
             req.message,
             user_decision=req.user_decision,
         )
+    elif next_nodes:
+        # Fresh @ref task while a gate is still pending — restart at intake.
+        logger.info(
+            "agent_turn_fresh_restart thread_id=%s session_id=%s gate=%s",
+            thread_id,
+            req.session_id,
+            list(next_nodes),
+        )
+        input_state = build_fresh_turn_command(update=turn_update)
     else:
-        # 新对话或已完成：加载历史并创建 input_state (C1 decision)
-        history = await _load_history(inner_nest, thread_id)
-        input_messages = history + [HumanMessage(content=req.message)]
-        input_state = {
-            "messages": input_messages,
-            "session_id": req.session_id,
-            "user_id": req.user_id,
-            "thread_id": thread_id,
-            "requested_skill_id": req.skill_id,
-            "focus_node_id": req.focus_node_id,
-            "sidebar_attachments": normalized_attachments,
-            "sidebar_ref_order": req.sidebar_ref_order,
-            "sidebar_mentioned_keys": normalized_mentioned_keys,
-        }
+        input_state = turn_update
 
     async def run_graph() -> None:
         last_text_delta: str | None = None

--- a/services/agent-runtime/tests/test_hitl_resume.py
+++ b/services/agent-runtime/tests/test_hitl_resume.py
@@ -11,6 +11,7 @@ from app.graph.hitl_resume import (
     build_interrupt_state_update,
     interrupt_event_payload,
     prepare_interrupt_resume,
+    should_resume_interrupt,
 )
 from app.graph.nodes.await_confirm import make_await_confirm_node
 from langgraph.graph import END, START, StateGraph
@@ -63,3 +64,21 @@ async def test_prepare_interrupt_resume_continues_gate():
 def test_gate_decision_clear_keys():
     assert GATE_DECISION_CLEAR["user_decision"] == "none"
     assert GATE_DECISION_CLEAR["force_choice"] is None
+
+
+def test_should_resume_interrupt_img2img_at_topo_gate():
+    msg = "@I1 这个是模特， @I2 这个是衣服，请让模特穿上这件衣服出图"
+    assert should_resume_interrupt(msg, ["await_topo"]) is False
+
+
+def test_should_resume_interrupt_confirm_at_topo_gate():
+    assert should_resume_interrupt("确认出图", ["await_topo"]) is True
+
+
+def test_should_resume_interrupt_long_plan_at_confirm_gate():
+    msg = "@I1 这个是模特， @I2 这个是衣服，请让模特穿上这件衣服出图"
+    assert should_resume_interrupt(msg, ["await_confirm"]) is False
+
+
+def test_should_resume_interrupt_short_confirm_at_confirm_gate():
+    assert should_resume_interrupt("确认", ["await_confirm"]) is True


### PR DESCRIPTION
## Summary

- **复用本轮**：直接恢复完整 `msg.content`，避免 `MentionInput.insertText` 与 v-model 竞态导致只剩 @ 引用、丢失提示词
- **Agent 误路由**：生产已证实同 thread 内 @I1/@I2 换装请求被执行为旧 @T1 文案出图任务
  - gate pending 时长句 @ref 任务不再误恢复 interrupt，改为 `Command(goto=intake)` 清空 checkpoint 重跑
  - intake 在 topic switch 时清除残留 `atomic_spec` / `atomic_node_id`
  - 路由优先级：`sidebar_img2img` 先于 `checkpoint_regen`
- 新增 `deploy/prod-agent-intent-diagnose.py` 用于生产检索 intent 错配证据

## Test plan

- [x] `pnpm build`
- [x] `pnpm --filter @lnkpi/agent test` (109 passed)
- [x] `pytest tests/test_hitl_resume.py tests/test_route_precedence.py tests/test_img2img_clarify_followup.py` (24 passed)
- [ ] 画布 Agent：历史消息点「复用本轮」应带回中文提示词 + @ 引用
- [ ] 同 thread 先 T1 文案任务再 @I1/@I2 换装，应走 img2img 而非 T1 标题出图


Made with [Cursor](https://cursor.com)