### PR TITLE
fix: Command goto for stale await_atomic_confirm checkpoints

### DIFF
--- a/services/agent-runtime/app/graph/hitl_resume.py
+++ b/services/agent-runtime/app/graph/hitl_resume.py
@@ -160,6 +160,23 @@ def build_interrupt_state_update(
     return update
 
 
+# Gates that must resume via Command(goto=...) — astream(None) can no-op on stale checkpoints.
+GATE_RESUME_COMMAND_GOTO: frozenset[str] = frozenset({"await_atomic_confirm"})
+
+
+def build_interrupt_resume_command(
+    gate: str,
+    message: str,
+    *,
+    user_decision: str | None = None,
+) -> Command:
+    """Jump directly to a gate with user reply (fixes interrupt_before no-op resume)."""
+    return Command(
+        goto=gate,
+        update=build_interrupt_state_update(message, user_decision=user_decision),
+    )
+
+
 # interrupt_before gate → last completed node for ambiguous checkpoint updates.
 GATE_RESUME_AS_NODE: dict[str, str] = {
     "await_atomic_confirm": "create_atomic_node",

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -21,7 +21,9 @@ from app.errors import AgentToolError, error_to_sse_payload, from_exception
 from app.graph.builder import build_agent_graph
 from app.graph.hitl_resume import (
     GATE_RESUME_AS_NODE,
+    GATE_RESUME_COMMAND_GOTO,
     build_fresh_turn_command,
+    build_interrupt_resume_command,
     build_interrupt_state_update,
     interrupt_event_payload,
     prepare_interrupt_resume,
@@ -674,12 +676,20 @@ async def stream_run_events(
         # interrupt_before: inject user message, then continue with input=None.
         # See app/graph/hitl_resume.py — Command(resume=...) is for in-node interrupt() only.
         resume_attempt = True
-        input_state, _ = await prepare_interrupt_resume(
-            graph,
-            config,
-            req.message,
-            user_decision=req.user_decision,
-        )
+        gate = str(next_nodes[0])
+        if gate in GATE_RESUME_COMMAND_GOTO:
+            input_state = build_interrupt_resume_command(
+                gate,
+                req.message,
+                user_decision=req.user_decision,
+            )
+        else:
+            input_state, _ = await prepare_interrupt_resume(
+                graph,
+                config,
+                req.message,
+                user_decision=req.user_decision,
+            )
     elif next_nodes:
         # Fresh @ref task while a gate is still pending — restart at intake.
         logger.info(
@@ -791,7 +801,13 @@ async def stream_run_events(
                     gate,
                 )
                 retry_as_node = GATE_RESUME_AS_NODE.get(gate or "")
-                if retry_as_node:
+                if gate in GATE_RESUME_COMMAND_GOTO:
+                    stream_input = build_interrupt_resume_command(
+                        gate,
+                        req.message,
+                        user_decision=req.user_decision,
+                    )
+                elif retry_as_node:
                     await graph.aupdate_state(
                         config,
                         build_interrupt_state_update(
@@ -800,7 +816,9 @@ async def stream_run_events(
                         ),
                         as_node=retry_as_node,
                     )
-                stream_input = None
+                    stream_input = None
+                else:
+                    stream_input = None
 
             post = await graph.aget_state(config)
             post_next = [str(n) for n in (getattr(post, "next", None) or [])]

--- a/services/agent-runtime/tests/test_hitl_resume.py
+++ b/services/agent-runtime/tests/test_hitl_resume.py
@@ -8,6 +8,7 @@ from langgraph.checkpoint.memory import MemorySaver
 
 from app.graph.hitl_resume import (
     GATE_DECISION_CLEAR,
+    build_interrupt_resume_command,
     build_interrupt_state_update,
     interrupt_event_payload,
     prepare_interrupt_resume,
@@ -138,8 +139,8 @@ async def test_prepare_interrupt_resume_atomic_confirm_cancel():
     snap = await graph.aget_state(config)
     assert snap.next == ("await_atomic_confirm",)
 
-    _, _ = await prepare_interrupt_resume(graph, config, "取消", user_decision="revise")
-    result = await graph.ainvoke(None, config)
+    cmd = build_interrupt_resume_command("await_atomic_confirm", "取消", user_decision="revise")
+    result = await graph.ainvoke(cmd, config)
     assert result.get("phase") == "done"
     assert result.get("user_decision") == "revise"
     texts = [
@@ -148,6 +149,12 @@ async def test_prepare_interrupt_resume_atomic_confirm_cancel():
         if getattr(m, "type", None) == "ai"
     ]
     assert any("已取消" in t for t in texts)
+
+
+def test_build_interrupt_resume_command_atomic_confirm():
+    cmd = build_interrupt_resume_command("await_atomic_confirm", "取消", user_decision="revise")
+    assert cmd.goto == "await_atomic_confirm"
+    assert cmd.update["user_decision"] == "revise"
 
 
 def test_should_resume_interrupt_atomic_exit_phrase():


### PR DESCRIPTION
## Summary

- `await_atomic_confirm` resume now uses `Command(goto=gate, update=...)` instead of `prepare_interrupt_resume` + `astream(None)`
- Fixes production threads where checkpoint resume no-ops (re-interrupt ~321ms, no gate execution)
- No-op retry falls back to Command goto for the same gate

Follow-up to #217 — P4-06 passed on fresh threads but stuck thread `cmslxxil2003vlx011ql58n5n:mslxxikl-a76c4170n` still failed until this change.

## Test plan

- [x] `pytest tests/test_hitl_resume.py` — 12 passed
- [ ] Deploy后对该 stuck thread 发「取消」应返回「已取消本次视频/音频生成。」
- [ ] `python3 deploy/prod-atomic-confirm-gate-verify.py`


Made with [Cursor](https://cursor.com)