### PR TITLE
fix: inline reference images for text vision upstream calls

### DIFF
--- a/apps/server/src/studio/studio.integration.test.ts
+++ b/apps/server/src/studio/studio.integration.test.ts
@@ -9,9 +9,14 @@ import {
   generateTextForRefs,
   mergeRefsToPrompt,
 } from '@lnkpi/agent'
+import { inlineUpstreamReferenceImages } from '../media/upstream-ref-inline'
 import { ProviderResolverService } from '../provider/provider-resolver.service'
 import { createStudioService } from './studio.test-utils'
 import type { StudioService } from './studio.service'
+
+vi.mock('../media/upstream-ref-inline', () => ({
+  inlineUpstreamReferenceImages: vi.fn(async (urls: string[]) => urls),
+}))
 
 const imageGenerate = vi.fn(async () => ({
   url: 'https://example.com/a.png',
@@ -324,6 +329,7 @@ describe('StudioService integration (provider params)', () => {
       { refKey: 'i1', mediaType: 'image', url: refUrl },
     ])
 
+    expect(inlineUpstreamReferenceImages).toHaveBeenCalledWith([refUrl])
     expect(generateTextForRefs).toHaveBeenCalledWith(
       'describe dress',
       [refUrl],
@@ -332,6 +338,23 @@ describe('StudioService integration (provider params)', () => {
         apiKey: process.env.OPENAI_API_KEY,
         baseUrl: process.env.OPENAI_BASE_URL,
       }),
+    )
+  })
+
+  it('inlines non-fetchable ref URLs before text vision upstream call', async () => {
+    const refUrl = 'http://119.29.173.89:8888/api/uploads/u1/ref.png'
+    const inlined = 'data:image/png;base64,abc'
+    vi.mocked(inlineUpstreamReferenceImages).mockResolvedValueOnce([inlined])
+
+    await svc.generateText('u1', 'describe packaging', 'gemini-3.1-flash', [
+      { refKey: 'I1', mediaType: 'image', url: refUrl },
+    ])
+
+    expect(inlineUpstreamReferenceImages).toHaveBeenCalledWith([refUrl])
+    expect(generateTextForRefs).toHaveBeenCalledWith(
+      'describe packaging',
+      [inlined],
+      expect.objectContaining({ model: 'gemini-3.1-flash' }),
     )
   })
 })

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -388,7 +388,10 @@ export class StudioService {
         throw new Error('missing api key')
       }
       const opts = providerOpts(resolved)
-      const { text, visionUsed } = await generateTextForRefs(mergedText, referenceImages, {
+      const providerRefs = referenceImages.length
+        ? await inlineUpstreamReferenceImages(referenceImages)
+        : referenceImages
+      const { text, visionUsed } = await generateTextForRefs(mergedText, providerRefs, {
         model: gatewayModelId,
         apiKey: opts?.apiKey ?? process.env.OPENAI_API_KEY,
         baseUrl: opts?.baseUrl ?? process.env.OPENAI_BASE_URL,
@@ -1289,7 +1292,8 @@ export class StudioService {
           text = content
           promptMeta = { mode, content }
         } else if (referenceImages.length > 0) {
-          const result = await generateTextForRefs(record.prompt, referenceImages, {
+          const providerRefs = await inlineUpstreamReferenceImages(referenceImages)
+          const result = await generateTextForRefs(record.prompt, providerRefs, {
             model: gatewayModelId,
             apiKey: process.env.OPENAI_API_KEY,
             baseUrl: process.env.OPENAI_BASE_URL,


### PR DESCRIPTION
## Summary
- 文本 + @I 参考图 Vision 路径在调用 `generateTextForRefs` 前先 `inlineUpstreamReferenceImages`，与图像生成链路一致
- 覆盖主生成路径与 `confirmPlatformFallback` 文本回退路径
- 补 integration 测试：验证 `:8888` upload URL 会先内联再传给上游

## 背景
生产 BYOK apimart 报错 `port 8888 is not allowed`：apimart 拉取参考图 URL 时拒绝非 80/443 端口。图像生成已内联，文本 Vision 遗漏此步骤。

## Test plan
- [x] `pnpm --filter @lnkpi/server exec vitest run src/studio/studio.integration.test.ts`
- [x] `pnpm build`
- [ ] 部署后复测：BYOK apimart + `@I1 这个是产品图，帮我设计一套包装方案`


Made with [Cursor](https://cursor.com)