### PR TITLE
fix(agent): v2 prod hotfix — env flag + macro/shot interrupts

### DIFF
--- a/deploy/prod-product-visual-cvs-v2-live.py
+++ b/deploy/prod-product-visual-cvs-v2-live.py
@@ -219,7 +219,7 @@ def gate_message(ts: dict[str, Any], case: dict[str, Any]) -> str | None:
     if active == "await_image_qa" and interrupted:
         return "生成标准白底图"
 
-    if active == "await_macro_scheme_select" and interrupted:
+    if active == "await_macro_scheme_select" and (interrupted or ts.get("macroSchemes")):
         schemes = ts.get("macroSchemes") or []
         if not schemes:
             return None
@@ -227,10 +227,10 @@ def gate_message(ts: dict[str, Any], case: dict[str, Any]) -> str | None:
         payload = json.dumps({"action": "confirm", "selected_ids": selected}, ensure_ascii=False)
         return f"{MACRO_PREFIX}{payload}"
 
-    if active == "await_shot_confirm" and interrupted:
+    if active == "await_shot_confirm" and (interrupted or ts.get("shotManifest")):
         return "确认出图"
 
-    if active == "await_topo" and interrupted:
+    if active == "await_topo" and (interrupted or phase == "await_topo"):
         return "确认出图"
 
     if active == "await_delivery_confirm" and interrupted:

--- a/services/agent-runtime/app/config.py
+++ b/services/agent-runtime/app/config.py
@@ -38,10 +38,8 @@ class Settings(BaseSettings):
     intent_llm_parse_shadow: bool = Field(default=False, validation_alias="INTENT_LLM_PARSE_SHADOW")
     agent_thinking_ui: bool = Field(default=False, validation_alias="AGENT_THINKING_UI")
     # Product visual scheme v2: prose SSOT + macro/shot decomposition (spec 2026-08-11)
-    product_visual_scheme_v2: bool = Field(
-        default=False,
-        validation_alias="PRODUCT_VISUAL_SCHEME_V2",
-    )
+    # Env: LNKPI_PRODUCT_VISUAL_SCHEME_V2 (no validation_alias — prefix applies correctly)
+    product_visual_scheme_v2: bool = False
 
     class Config:
         env_prefix = "LNKPI_"

--- a/services/agent-runtime/app/graph/builder.py
+++ b/services/agent-runtime/app/graph/builder.py
@@ -120,6 +120,8 @@ def build_agent_graph(
             "await_atomic_confirm",
             "await_image_qa",
             "await_scheme_select",
+            "await_macro_scheme_select",
+            "await_shot_confirm",
             "await_delivery_confirm",
         ],
     )


### PR DESCRIPTION
## Summary

- 修复 `LNKPI_PRODUCT_VISUAL_SCHEME_V2` 无法被 pydantic 读取（移除错误 `validation_alias`）
- 主图 `builder.py` 补注册 `await_macro_scheme_select` / `await_shot_confirm` 的 `interrupt_before`（生产 macro 门控不 pause 的根因）
- 优化 `prod-product-visual-cvs-v2-live.py` 门控检测（phase 已就绪但 interrupt 快照滞后）

## 生产验证（hotfix 前已在 CVM 手工验证）

- `CVS_V2_GATE_ONLY=1 python3 deploy/prod-product-visual-cvs-v2-live.py` → 13 PASS
- gates: `await_image_qa → await_macro_scheme_select → await_shot_confirm → await_topo`

## Test plan

- [x] `pytest tests/test_product_visual*.py tests/test_hitl_resume.py` (90 passed)
- [ ] CI green
- [ ] 合并后 Deploy + Agent Runtime 部署
- [ ] 生产 GATE_ONLY smoke 复测


Made with [Cursor](https://cursor.com)