### PR TITLE
fix(agent): vision QA gate + product visual phase1 fixes

### DIFF
--- a/apps/server/src/agent/agent-canvas-tools.controller.ts
+++ b/apps/server/src/agent/agent-canvas-tools.controller.ts
@@ -263,6 +263,36 @@ class RunImageGenerationDto {
   nodeId!: string
 }
 
+class RunVisionQaDto {
+  @IsString()
+  sessionId!: string
+
+  @IsString()
+  userId!: string
+
+  @IsArray()
+  @IsString({ each: true })
+  imageUrls!: string[]
+
+  @IsString()
+  systemPrompt!: string
+
+  @IsString()
+  userContent!: string
+
+  @IsOptional()
+  @IsString()
+  userText?: string
+
+  @IsOptional()
+  @IsString()
+  sceneKind?: string
+
+  @IsOptional()
+  @IsString()
+  model?: string
+}
+
 class WaitImageGenerationDto {
   @IsString()
   sessionId!: string
@@ -754,6 +784,12 @@ export class AgentCanvasToolsController {
   @Post('run-audio-generation')
   async runAudioGeneration(@Body() dto: RunImageGenerationDto) {
     const data = await this.tools.runAudioGeneration(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('run-vision-qa')
+  async runVisionQa(@Body() dto: RunVisionQaDto) {
+    const data = await this.tools.runVisionQa(dto)
     return { code: 0, message: 'ok', data }
   }
 

--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -180,6 +180,32 @@ function pickString(value: unknown, fallback: string): string {
   return typeof value === 'string' && value.trim() ? value : fallback
 }
 
+function parseVisionQaJson(raw: string): {
+  pass: boolean
+  reason: string
+  isWhiteBg?: boolean
+  isSharpEnough?: boolean
+  productIdentifiable?: boolean
+} {
+  const cleaned = raw.replace(/```json|```/g, '').trim()
+  try {
+    const data = JSON.parse(cleaned) as Record<string, unknown>
+    return {
+      pass: Boolean(data.pass),
+      reason: String(data.reason ?? '').trim() || '图源审核完成',
+      isWhiteBg: typeof data.is_white_bg === 'boolean' ? data.is_white_bg : undefined,
+      isSharpEnough: typeof data.is_sharp_enough === 'boolean' ? data.is_sharp_enough : undefined,
+      productIdentifiable:
+        typeof data.product_identifiable === 'boolean' ? data.product_identifiable : undefined,
+    }
+  } catch {
+    return {
+      pass: false,
+      reason: '识图模型返回格式异常，请重试或更换参考图',
+    }
+  }
+}
+
 function parseRecordText(metadata: string | null | undefined, prompt: string): string {
   if (!metadata) return prompt
   try {
@@ -2277,6 +2303,36 @@ export class AgentCanvasToolsService {
       data: { stagedActions: null, stagedAt: null },
     })
     return { cleared: true }
+  }
+
+  async runVisionQa(input: {
+    sessionId: string
+    userId: string
+    imageUrls: string[]
+    userText?: string
+    sceneKind?: string
+    systemPrompt: string
+    userContent: string
+    model?: string
+  }): Promise<{
+    pass: boolean
+    reason: string
+    visionUsed: boolean
+    isWhiteBg?: boolean
+    isSharpEnough?: boolean
+    productIdentifiable?: boolean
+  }> {
+    await this.loadOwnedSession(input.sessionId, input.userId)
+    const prefs = await this.loadAccountGenPrefs(input.userId)
+    const textModel = pickString(input.model, prefs.defaultTextModel) || undefined
+    const { text, visionUsed } = await this.studio.runVisionQaInternal(input.userId, {
+      systemPrompt: input.systemPrompt,
+      userContent: input.userContent,
+      imageUrls: input.imageUrls,
+      model: textModel,
+    })
+    const parsed = parseVisionQaJson(text)
+    return { ...parsed, visionUsed }
   }
 
   private async expireStaleStage(sessionId: string): Promise<void> {

--- a/apps/server/src/agent/agent-runtime.client.ts
+++ b/apps/server/src/agent/agent-runtime.client.ts
@@ -49,6 +49,14 @@ export interface RuntimeThreadState {
   productVisualSchemeV2?: boolean | null
   deliverySelections?: Record<string, string> | null
   deliveryGenByKey?: Record<string, { node_id?: string | null; url?: string | null; title?: string | null }> | null
+  imageQaReason?: string | null
+  imageQaMetrics?: {
+    is_white_bg?: boolean | null
+    is_sharp_enough?: boolean | null
+    product_identifiable?: boolean | null
+    vision_used?: boolean | null
+  } | null
+  visionUsed?: boolean | null
 }
 
 export interface ProductVisualScheme {

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -339,6 +339,37 @@ export class StudioService {
     return resolveModelKey(modality, requested).entry.gatewayModelId
   }
 
+  /** Internal agent path: vision QA for product_visual — no points charge. */
+  async runVisionQaInternal(
+    userId: string,
+    params: {
+      systemPrompt: string
+      userContent: string
+      imageUrls: string[]
+      model?: string
+    },
+  ): Promise<{ text: string; visionUsed: boolean }> {
+    const resolved = await this.resolver.resolveForGeneration(userId, params.model, 'text')
+    const { entry } = resolveModelKey('text', resolved.modelName)
+    const gatewayModelId =
+      resolved.source === 'user' ? resolved.modelName : entry.gatewayModelId
+    if (resolved.source === 'user' && !resolved.credentials.apiKey) {
+      throw new Error('missing api key')
+    }
+    const opts = providerOpts(resolved)
+    const urls = params.imageUrls.map((u) => u.trim()).filter(Boolean)
+    if (!urls.length) {
+      throw new BadRequestException('imageUrls 不能为空')
+    }
+    const providerRefs = await inlineUpstreamReferenceImages(urls)
+    const prompt = `${params.systemPrompt.trim()}\n\n${params.userContent.trim()}`
+    return generateTextForRefs(prompt, providerRefs, {
+      model: gatewayModelId,
+      apiKey: opts?.apiKey ?? process.env.OPENAI_API_KEY,
+      baseUrl: opts?.baseUrl ?? process.env.OPENAI_BASE_URL,
+    })
+  }
+
   async generateText(
     userId: string,
     prompt: string,

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -50,10 +50,12 @@ import {
   buildShotDeliverySwitchMessage,
   defaultDeliverySelections,
   defaultMacroSchemeSelection,
+  toggleMacroSchemeSelection,
   defaultSchemeSelections,
   defaultShotDeliverySelections,
   selectableImageTypes,
   type AgentInterruptPayload,
+  type ImageQaMetrics,
   type ProductVisualMacroScheme,
   type ProductVisualPlan,
   type ProductVisualShot,
@@ -412,6 +414,8 @@ const macroSchemes = ref<ProductVisualMacroScheme[]>([])
 const macroSelections = ref<string[]>([])
 const shotManifest = ref<ProductVisualShot[]>([])
 const productVisualSchemeV2 = ref(false)
+const imageQaReason = ref<string | null>(null)
+const imageQaMetrics = ref<ImageQaMetrics | null>(null)
 const schemeSelections = ref<Record<string, string[]>>({})
 const deliverySelections = ref<Record<string, string>>({})
 const deliveryGenByKey = ref<Record<string, { node_id?: string | null; url?: string | null; title?: string | null }>>({})
@@ -434,17 +438,12 @@ function syncShotManifest(shots: ProductVisualShot[] | null | undefined) {
 }
 
 function toggleMacroSelection(schemeId: string, checked: boolean) {
-  const current = new Set(macroSelections.value)
-  if (checked) {
-    current.add(schemeId)
-    if (current.size > 2) {
-      const first = macroSelections.value[0]
-      if (first) current.delete(first)
-    }
-  } else {
-    current.delete(schemeId)
-  }
-  macroSelections.value = [...current]
+  macroSelections.value = toggleMacroSchemeSelection(
+    macroSelections.value,
+    schemeId,
+    checked,
+    macroSchemes.value,
+  )
 }
 
 async function sendMacroSchemeConfirm() {
@@ -842,9 +841,14 @@ async function refreshThreadCheckpoint() {
         productVisualSchemeV2?: boolean | null
         deliverySelections?: Record<string, string> | null
         deliveryGenByKey?: Record<string, { node_id?: string | null; url?: string | null; title?: string | null }> | null
+        imageQaReason?: string | null
+        imageQaMetrics?: ImageQaMetrics | null
+        visionUsed?: boolean | null
       }
     }
     hasAtomicCheckpoint.value = Boolean(json.data?.hasAtomicCheckpoint)
+    imageQaReason.value = json.data?.imageQaReason ?? null
+    imageQaMetrics.value = json.data?.imageQaMetrics ?? null
     if (json.data?.productVisualSchemeV2 != null) {
       productVisualSchemeV2.value = Boolean(json.data.productVisualSchemeV2)
     }
@@ -1382,13 +1386,24 @@ function handleEvent(event: { type: string; data: unknown }) {
     case 'ping':
       break
     case 'interrupt': {
-      const data = event.data as AgentInterruptPayload
+      const data = event.data as AgentInterruptPayload & {
+        imageQaReason?: string | null
+        imageQaMetrics?: ImageQaMetrics | null
+        visionUsed?: boolean | null
+      }
       interruptGate.value = {
         interrupted: data.interrupted ?? true,
         phase: data.phase ?? null,
         node: data.node ?? null,
+        imageQaReason: data.imageQaReason ?? null,
+        imageQaMetrics: data.imageQaMetrics ?? null,
+        visionUsed: data.visionUsed ?? null,
       }
+      if (data.imageQaReason) imageQaReason.value = data.imageQaReason
+      if (data.imageQaMetrics) imageQaMetrics.value = data.imageQaMetrics
       if (
+        data.phase === 'await_image_qa' ||
+        data.node === 'await_image_qa' ||
         data.phase === 'await_scheme_select' ||
         data.node === 'await_scheme_select' ||
         data.phase === 'await_macro_scheme_select' ||
@@ -1796,18 +1811,39 @@ defineExpose({
                 取消
               </button>
             </div>
-            <div v-else-if="awaitingImageQa" class="mb-2 flex flex-wrap gap-2 px-0.5">
+            <div v-else-if="awaitingImageQa" class="mb-2 px-0.5">
+              <div
+                v-if="imageQaReason || imageQaMetrics"
+                class="mb-2 rounded-lg border border-[var(--neo-border)] bg-[var(--neo-surface)] p-2 text-xs text-[var(--neo-text-secondary)]"
+              >
+                <p v-if="imageQaReason" class="mb-1.5 leading-relaxed">
+                  {{ imageQaReason }}
+                </p>
+                <ul v-if="imageQaMetrics" class="space-y-0.5 text-[var(--neo-muted)]">
+                  <li v-if="imageQaMetrics.is_sharp_enough != null">
+                    清晰度：{{ imageQaMetrics.is_sharp_enough ? '✓ 足够' : '✗ 不足' }}
+                  </li>
+                  <li v-if="imageQaMetrics.is_white_bg != null">
+                    白底背景：{{ imageQaMetrics.is_white_bg ? '✓ 符合' : '✗ 非白底或杂底' }}
+                  </li>
+                  <li v-if="imageQaMetrics.product_identifiable != null">
+                    产品可辨：{{ imageQaMetrics.product_identifiable ? '✓ 可识别' : '✗ 难以识别' }}
+                  </li>
+                </ul>
+              </div>
+              <div class="flex flex-wrap gap-2">
               <button
                 v-for="opt in IMAGE_QA_OPTIONS"
                 :key="opt.id"
                 type="button"
                 class="neo-ctl rounded-lg px-3 py-1.5 text-xs"
-                :class="{ 'agent-preset-primary font-medium': opt.id === 'ai_white_bg' }"
+                :class="{ 'agent-preset-primary font-medium': opt.id === 'confirm_pass' }"
                 :disabled="agent.isStreaming"
                 @click="sendPreset(opt.message)"
               >
                 {{ opt.label }}
               </button>
+              </div>
             </div>
             <div v-else-if="awaitingMacroSchemeSelect && macroSchemes.length" class="mb-2 px-0.5">
               <div class="space-y-2">

--- a/apps/web/src/components/agent/agentInterruptGate.test.ts
+++ b/apps/web/src/components/agent/agentInterruptGate.test.ts
@@ -6,6 +6,7 @@ import {
   buildMacroSchemeConfirmMessage,
   defaultShotDeliverySelections,
   interruptPayloadFromThreadState,
+  toggleMacroSchemeSelection,
 } from './agentInterruptGate'
 
 describe('chipSetFromInterrupt', () => {
@@ -86,6 +87,27 @@ describe('defaultMacroSchemeSelection', () => {
       { id: 'C', recommended: true },
     ]
     expect(defaultMacroSchemeSelection(schemes)).toEqual(['B', 'C'])
+  })
+})
+
+describe('toggleMacroSchemeSelection', () => {
+  const schemes = [
+    { id: 'A', recommended: true },
+    { id: 'B', recommended: false },
+    { id: 'C', recommended: false },
+  ]
+
+  it('keeps recommended A when adding B then C', () => {
+    let sel = defaultMacroSchemeSelection(schemes)
+    expect(sel).toEqual(['A'])
+    sel = toggleMacroSchemeSelection(sel, 'B', true, schemes)
+    expect(sel).toEqual(['A', 'B'])
+    sel = toggleMacroSchemeSelection(sel, 'C', true, schemes)
+    expect(sel).toEqual(['A', 'C'])
+  })
+
+  it('removes unchecked scheme', () => {
+    expect(toggleMacroSchemeSelection(['A', 'B'], 'B', false, schemes)).toEqual(['A'])
   })
 })
 

--- a/apps/web/src/components/agent/agentInterruptGate.ts
+++ b/apps/web/src/components/agent/agentInterruptGate.ts
@@ -6,6 +6,9 @@ export interface AgentInterruptPayload {
   node?: string | null
   phase?: string | null
   interrupted?: boolean
+  imageQaReason?: string | null
+  imageQaMetrics?: ImageQaMetrics | null
+  visionUsed?: boolean | null
 }
 
 export interface ProductVisualScheme {
@@ -61,7 +64,15 @@ const GATE_TO_CHIP: Record<string, AgentChipSet> = {
   await_delivery_confirm: 'delivery_confirm',
 }
 
+export interface ImageQaMetrics {
+  is_white_bg?: boolean | null
+  is_sharp_enough?: boolean | null
+  product_identifiable?: boolean | null
+  vision_used?: boolean | null
+}
+
 export const IMAGE_QA_OPTIONS = [
+  { id: 'confirm_pass', label: '确认可用，继续', message: '已是白底图，继续使用' },
   { id: 'retake', label: '重新拍摄', message: '我重新拍摄上传' },
   { id: 'ai_white_bg', label: '生成白底图', message: '生成标准白底图' },
 ] as const
@@ -122,6 +133,31 @@ export function defaultMacroSchemeSelection(
   const recommended = list.filter((s) => s.recommended).map((s) => s.id)
   if (recommended.length) return recommended.slice(0, 2)
   return [list[0].id]
+}
+
+/** Toggle macro checkbox; evict non-recommended ids before recommended when over max. */
+export function toggleMacroSchemeSelection(
+  current: string[],
+  schemeId: string,
+  checked: boolean,
+  schemes: ProductVisualMacroScheme[] | null | undefined,
+  max = 2,
+): string[] {
+  if (!checked) return current.filter((id) => id !== schemeId)
+  if (current.includes(schemeId)) return current
+
+  const recommended = new Set(
+    (schemes ?? []).filter((s) => s.recommended).map((s) => s.id),
+  )
+  const next = [...current, schemeId]
+  if (next.length <= max) return next
+
+  for (const id of current) {
+    if (!recommended.has(id)) {
+      return [...current.filter((x) => x !== id), schemeId]
+    }
+  }
+  return [...current.slice(1), schemeId]
 }
 
 export function buildMacroSchemeConfirmMessage(selectedIds: string[]): string {

--- a/packages/agent/src/prompt-modes/classify.test.ts
+++ b/packages/agent/src/prompt-modes/classify.test.ts
@@ -36,4 +36,12 @@ describe('classifyPromptMode without API key', () => {
     const res = await classifyPromptMode('你好')
     expect(res.mode).toBe('generic')
   })
+
+  it('does not classify product SKU turnaround as character', async () => {
+    delete process.env.OPENAI_API_KEY
+    const res = await classifyPromptMode(
+      '单张横排四格拼图：最左近景特写，后接正/侧/背；同一产品锁定材质比例与外观，禁止每格换款；干净背景，商业摄影',
+    )
+    expect(res.mode).toBe('generic')
+  })
 })

--- a/packages/agent/src/prompt-modes/classify.ts
+++ b/packages/agent/src/prompt-modes/classify.ts
@@ -5,9 +5,17 @@ export function tryRuleShortcut(_prompt: string): PromptModeId | null {
   return null
 }
 
+/** Product SKU turnaround — must not use character_turnaround expansion. */
+function isProductTurnaroundPrompt(prompt: string): boolean {
+  return /同一\s*SKU|同一产品|产品四视图|产品三视图|禁止每格换款|白底主图|电商主图|SKU\s*外观|商业摄影.*四格|四格拼图.*产品/.test(
+    prompt,
+  )
+}
+
 /** 仅无 Key / Placeholder 路径使用；不用于跳过有 Key 时的 Call-1 */
 export function heuristicMode(prompt: string): PromptModeId {
   const p = prompt.toLowerCase()
+  if (isProductTurnaroundPrompt(prompt)) return 'generic'
   if (/三视图|多视图|正侧背|turnaround|模特图|角色设定|模特定妆|四视图|q版|q萌|chibi|二头身|洛丽塔|lolita|婚纱|战术|军事|牛仔|皮克斯|绘本|水彩/.test(p)) return 'character_turnaround'
   if (/商业分镜|品牌分镜|品牌广告|营销战役|TVC|问界|AITO|汽车广告|15秒|30秒|60秒|抖音前贴|发布会暖场|品牌形象片|闪电切割|AIDA/.test(p))
     return 'commercial_storyboard'

--- a/services/agent-runtime/app/graph/builder.py
+++ b/services/agent-runtime/app/graph/builder.py
@@ -59,6 +59,7 @@ def build_agent_graph(
     llm: Any,
     skills_dir: str | Path,
     checkpointer: Any | None = None,
+    vision_creds: dict[str, str | None] | None = None,
 ):
     """Compile intake → confirm_gate → split → copy_gate → topo_gate → done."""
     skills_path = Path(skills_dir)
@@ -77,7 +78,7 @@ def build_agent_graph(
     register_topo_gate(graph, nest=nest)
     register_single_node_gate(graph, nest=nest)
     register_atomic_create_gate(graph, nest=nest, llm=llm)
-    register_product_visual_gate(graph, nest=nest, llm=llm, skills_dir=skills_path)
+    register_product_visual_gate(graph, nest=nest, llm=llm, skills_dir=skills_path, vision_creds=vision_creds)
 
     graph.add_edge(START, "intake")
     graph.add_conditional_edges(

--- a/services/agent-runtime/app/graph/hitl_resume.py
+++ b/services/agent-runtime/app/graph/hitl_resume.py
@@ -254,10 +254,13 @@ def interrupt_event_payload(
     *,
     next_nodes: list[str],
     phase: str | None,
+    extra: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """SSE payload when the graph pauses at an interrupt gate."""
     node = next_nodes[0] if next_nodes else None
     data: dict[str, Any] = {"node": node, "interrupted": True}
     if phase:
         data["phase"] = phase
+    if extra:
+        data.update(extra)
     return {"type": "interrupt", "data": data}

--- a/services/agent-runtime/app/graph/nodes/image_qa_gate.py
+++ b/services/agent-runtime/app/graph/nodes/image_qa_gate.py
@@ -2,20 +2,24 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Callable
 
 from langchain_core.messages import AIMessage
 
 from app.graph.phase1_seed import PHASE1_ASSET_KEYS, ensure_phase1_seed_chain
 from app.graph.product_visual_v2.routing import is_v2_enabled
-
-QA_FAIL_TIP = (
-    "当前成图效果可能不够清晰或未在白底上拍摄。"
-    "请选择：重新拍摄上传，或生成标准白底图后继续。"
+from app.graph.product_visual_v2.vision_qa import (
+    VisionQAResult,
+    build_qa_fail_message,
+    evaluate_vision_qa_v2,
 )
-RETAKE_MSG = "好的，请重新拍摄并上传产品图后再试。"
+from app.graph.product_visual_v2.vision_qa_client import image_urls_from_state, run_vision_qa
+
 REMEDIATE_PROGRESS_MSG = "正在生成标准白底图与四视图…"
 REMEDIATE_DONE_MSG = "已生成标准白底图与四视图，继续策划视觉方案…"
+REMEDIATE_PROGRESS_MSG_V2 = "正在准备标准白底图与四视图节点…"
+REMEDIATE_DONE_MSG_V2 = "已创建标准白底图与四视图节点，出图将在方案确认后进行…"
 
 _PRODUCT_VISUAL_ABORT_CLEAR: dict[str, Any] = {
     "product_visual_plan": None,
@@ -33,6 +37,7 @@ _PRODUCT_VISUAL_ABORT_CLEAR: dict[str, Any] = {
     "visual_intent": None,
     "requires_standard_product_assets": None,
     "image_qa_reason": None,
+    "image_qa_metrics": None,
     "vision_used": None,
 }
 
@@ -43,7 +48,7 @@ def clear_product_visual_abort_state(state: dict) -> dict:
 
 
 def derive_qa_metrics(state: dict) -> dict[str, Any]:
-    """Derive QA metrics from route_context / sidebar_attachments heuristics."""
+    """Derive auxiliary QA signals from route_context / sidebar_attachments."""
     route_ctx = state.get("route_context") or {}
     attachments = list(state.get("sidebar_attachments") or route_ctx.get("sidebar_attachments") or [])
 
@@ -77,7 +82,7 @@ def derive_qa_metrics(state: dict) -> dict[str, Any]:
 
 
 def evaluate_image_qa(metrics: dict) -> dict:
-    """AC-1/AC-2/AC-3: sharpness + white_bg; interior scenes relax white-bg (CVS-03)."""
+    """Legacy heuristic QA (fallback when vision unavailable)."""
     is_interior = metrics.get("scene_kind") == "interior"
     white_ok = metrics.get("has_white_bg") or is_interior
     sharp_ok = metrics.get("sharpness", 0) >= 0.5
@@ -90,6 +95,8 @@ def classify_image_qa_decision(text: str) -> str:
     t = (text or "").strip().lower()
     if not t:
         return "none"
+    if any(k in t for k in ("已是白底", "继续使用", "确认可用", "继续策划", "confirm_pass")):
+        return "confirm_pass"
     if any(k in t for k in ("重新拍", "重拍", "retake", "我重新拍", "重新拍摄")):
         return "retake"
     if any(k in t for k in ("白底", "ai_white_bg", "生成标准白底", "生成白底")):
@@ -98,6 +105,8 @@ def classify_image_qa_decision(text: str) -> str:
         return "retake"
     if t in ("2", "b"):
         return "ai_white_bg"
+    if t in ("3", "c"):
+        return "confirm_pass"
     return "none"
 
 
@@ -117,10 +126,67 @@ def _last_role(messages: list[Any]) -> str | None:
     return getattr(last, "type", None) or (last.get("role") if isinstance(last, dict) else None)
 
 
-def make_image_qa_check_node(*, nest: Any | None = None) -> Callable:
+async def _run_qa_check(
+    state: dict,
+    *,
+    nest: Any | None,
+    skills_dir: Path | None,
+    vision_creds: dict[str, str | None] | None,
+) -> dict[str, Any]:
+    metrics = derive_qa_metrics(state)
+    v2 = is_v2_enabled(state)
+    urls = image_urls_from_state(state)
+    vision = None
+
+    if urls and skills_dir is not None:
+        state_with_metrics = {**state, "_qa_metrics": metrics}
+        vision = await run_vision_qa(
+            nest=nest,
+            state=state_with_metrics,
+            skills_dir=skills_dir,
+            vision_creds=vision_creds,
+        )
+        if v2 or vision.vision_used:
+            return evaluate_vision_qa_v2(vision, metrics)
+
+    if v2:
+        return evaluate_vision_qa_v2(
+            vision
+            or VisionQAResult(
+                pass_=False,
+                reason="缺少产品参考图或未配置识图模型",
+                vision_used=False,
+            ),
+            metrics,
+        )
+
+    result = evaluate_image_qa(metrics)
+    out = dict(result)
+    if vision and vision.vision_used:
+        out["image_qa_reason"] = vision.reason
+        out["vision_used"] = True
+        out["image_qa_metrics"] = {
+            "is_white_bg": vision.is_white_bg,
+            "is_sharp_enough": vision.is_sharp_enough,
+            "product_identifiable": vision.product_identifiable,
+            "vision_used": True,
+        }
+    return out
+
+
+def make_image_qa_check_node(
+    *,
+    nest: Any | None = None,
+    skills_dir: Path | None = None,
+    vision_creds: dict[str, str | None] | None = None,
+) -> Callable:
+    resolved_skills = skills_dir
+
     async def image_qa_check(state: dict) -> dict:
+        result = await _run_qa_check(
+            state, nest=nest, skills_dir=resolved_skills, vision_creds=vision_creds
+        )
         metrics = derive_qa_metrics(state)
-        result = evaluate_image_qa(metrics)
         out: dict[str, Any] = {"phase": "image_qa", **result}
         if result["image_qa_result"] == "pass":
             if is_v2_enabled(state):
@@ -133,7 +199,17 @@ def make_image_qa_check_node(*, nest: Any | None = None) -> Callable:
                 out["phase1_asset_keys"] = list(PHASE1_ASSET_KEYS)
                 out["split_manifest"] = manifest
         elif result["image_qa_result"] == "fail":
-            out["messages"] = [AIMessage(content=QA_FAIL_TIP)]
+            m = result.get("image_qa_metrics") or {}
+            vision_stub = VisionQAResult(
+                pass_=False,
+                reason=str(result.get("image_qa_reason") or ""),
+                vision_used=bool(result.get("vision_used")),
+                is_white_bg=m.get("is_white_bg"),
+                is_sharp_enough=m.get("is_sharp_enough"),
+                product_identifiable=m.get("product_identifiable"),
+            )
+            fail_tip = build_qa_fail_message(vision_stub, metrics)
+            out["messages"] = [AIMessage(content=fail_tip)]
         return out
 
     return image_qa_check
@@ -151,7 +227,11 @@ def make_await_image_qa_node() -> Callable:
             "image_qa_decision": decision,
         }
         if decision == "none":
-            out["messages"] = [AIMessage(content=QA_FAIL_TIP)]
+            metrics = derive_qa_metrics(state)
+            fail_tip = build_qa_fail_message(None, metrics)
+            if state.get("image_qa_reason"):
+                fail_tip = f"识图结论：{state['image_qa_reason']}\n{fail_tip}"
+            out["messages"] = [AIMessage(content=fail_tip)]
         return out
 
     return await_image_qa
@@ -165,12 +245,24 @@ def make_image_qa_remedy_node(*, nest: Any | None = None) -> Callable:
             return {
                 **{k: cleared[k] for k in _PRODUCT_VISUAL_ABORT_CLEAR},
                 "phase": "done",
-                "messages": [AIMessage(content=RETAKE_MSG)],
+                "messages": [AIMessage(content="好的，请重新拍摄并上传产品图后再试。")],
+            }
+        if decision == "confirm_pass":
+            v2 = is_v2_enabled(state)
+            return {
+                "image_qa_result": "pass",
+                "image_qa_reason": "用户确认当前图源可用",
+                "phase": "dialog_draft" if v2 else "plan_product_visual",
+                "product_visual_scheme_v2": v2 or None,
+                "messages": [AIMessage(content="已确认使用当前产品图，继续策划视觉方案…")],
             }
         if decision == "ai_white_bg":
-            progress = [AIMessage(content=REMEDIATE_PROGRESS_MSG)]
+            v2 = is_v2_enabled(state)
+            progress_msg = REMEDIATE_PROGRESS_MSG_V2 if v2 else REMEDIATE_PROGRESS_MSG
+            done_msg = REMEDIATE_DONE_MSG_V2 if v2 else REMEDIATE_DONE_MSG
+            progress = [AIMessage(content=progress_msg)]
             manifest, err = await ensure_phase1_seed_chain(
-                nest, state, run_generation=True
+                nest, state, run_generation=not v2
             )
             if err:
                 return {**err, "messages": progress + list(err.get("messages") or [])}
@@ -178,11 +270,10 @@ def make_image_qa_remedy_node(*, nest: Any | None = None) -> Callable:
                 "image_qa_result": "remediated",
                 "phase1_asset_keys": list(PHASE1_ASSET_KEYS),
                 "split_manifest": manifest,
-                "phase": "dialog_draft" if is_v2_enabled(state) else "plan_product_visual",
-                "product_visual_scheme_v2": is_v2_enabled(state) or None,
-                "messages": progress + [AIMessage(content=REMEDIATE_DONE_MSG)],
+                "phase": "dialog_draft" if v2 else "plan_product_visual",
+                "product_visual_scheme_v2": v2 or None,
+                "messages": progress + [AIMessage(content=done_msg)],
             }
         return {"phase": "await_image_qa", "image_qa_decision": "none"}
 
     return image_qa_remedy
-

--- a/services/agent-runtime/app/graph/phase1_seed.py
+++ b/services/agent-runtime/app/graph/phase1_seed.py
@@ -37,7 +37,7 @@ PHASE1_MANIFEST_TEMPLATE: list[dict[str, Any]] = [
             "同一产品锁定材质比例与外观，禁止每格换款；干净背景，商业摄影…"
         ),
         "gen_mode": "i2i",
-        "pipeline": "turnaround_image",
+        "imageAspect": "2:1",
     },
 ]
 
@@ -67,9 +67,10 @@ def _batch_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
         }
         if item.get("pipeline"):
             entry["pipeline"] = item["pipeline"]
-        if item["key"] == "product_turnaround":
-            entry.setdefault("pipeline", "turnaround_image")
-            entry.setdefault("imageAspect", "2:1")
+        if item.get("imageAspect"):
+            entry["imageAspect"] = item["imageAspect"]
+        elif item["key"] == "product_turnaround":
+            entry["imageAspect"] = "2:1"
         batch.append(entry)
     return batch
 

--- a/services/agent-runtime/app/graph/product_visual_v2/vision_qa.py
+++ b/services/agent-runtime/app/graph/product_visual_v2/vision_qa.py
@@ -11,8 +11,49 @@ class VisionQAResult(BaseModel):
     pass_: bool = Field(alias="pass")
     reason: str = ""
     vision_used: bool = False
+    is_white_bg: bool | None = None
+    is_sharp_enough: bool | None = None
+    product_identifiable: bool | None = None
 
     model_config = {"populate_by_name": True}
+
+
+def vision_qa_metrics_from_result(vision: VisionQAResult) -> dict[str, Any]:
+    return {
+        "is_white_bg": vision.is_white_bg,
+        "is_sharp_enough": vision.is_sharp_enough,
+        "product_identifiable": vision.product_identifiable,
+        "vision_used": vision.vision_used,
+    }
+
+
+def build_qa_fail_message(
+    vision: VisionQAResult | None,
+    metrics: dict[str, Any] | None = None,
+) -> str:
+    """User-facing fail tip with specific vision/heuristic reasons."""
+    metrics = metrics or {}
+    lines: list[str] = []
+
+    if vision and vision.vision_used and vision.reason:
+        lines.append(f"识图结论：{vision.reason}")
+    elif vision and not vision.vision_used:
+        lines.append("未能完成识图审核，请检查是否已选择支持视觉的文本模型（如 Gemini）。")
+
+    checks: list[str] = []
+    if vision and vision.is_sharp_enough is not None:
+        checks.append(f"清晰度：{'✓ 足够' if vision.is_sharp_enough else '✗ 不足'}")
+    if vision and vision.is_white_bg is not None:
+        checks.append(f"白底背景：{'✓ 符合' if vision.is_white_bg else '✗ 非白底或杂底'}")
+    if vision and vision.product_identifiable is not None:
+        checks.append(f"产品可辨：{'✓ 可识别' if vision.product_identifiable else '✗ 难以识别'}")
+    if checks:
+        lines.append("检查项：" + "；".join(checks))
+    elif not metrics.get("has_white_bg") and metrics.get("sharpness", 0) >= 0.5:
+        lines.append("检查项：清晰度尚可；白底背景未确认（需识图或用户确认）。")
+
+    lines.append("请选择：确认当前图可用并继续、重新拍摄上传，或生成标准白底图后继续。")
+    return "\n".join(lines)
 
 
 def evaluate_vision_qa_v2(
@@ -21,28 +62,44 @@ def evaluate_vision_qa_v2(
 ) -> dict[str, Any]:
     """
     V2 QA requires vision_used=True. Heuristic metrics alone cannot pass.
-    Interior white-bg relaxation still applies when vision passes.
+    Interior white-bg relaxation when vision confirms sharp + identifiable product.
     """
     metrics = metrics or {}
     if not vision.vision_used:
         return {
             "image_qa_result": "fail",
             "phase": "await_image_qa",
-            "image_qa_reason": "识图模型未调用，无法完成准入审核",
+            "image_qa_reason": vision.reason or "识图模型未调用，无法完成准入审核",
+            "image_qa_metrics": vision_qa_metrics_from_result(vision),
         }
+
     is_interior = metrics.get("scene_kind") == "interior"
-    if vision.pass_:
+    interior_ok = (
+        is_interior
+        and vision.is_sharp_enough is not False
+        and vision.product_identifiable is not False
+    )
+
+    if vision.pass_ or interior_ok:
+        reason = vision.reason
+        if interior_ok and not vision.pass_:
+            reason = f"{vision.reason}（室内场景已放宽白底要求）".strip()
         return {
             "image_qa_result": "pass",
-            "phase": "dialog_draft" if not metrics.get("requires_standard_product_assets") else "phase1_seed_eager",
-            "image_qa_reason": vision.reason,
+            "phase": "dialog_draft"
+            if not metrics.get("requires_standard_product_assets")
+            else "phase1_seed_eager",
+            "image_qa_reason": reason,
             "vision_used": True,
             "scene_kind": metrics.get("scene_kind"),
-            "interior_relaxed": is_interior,
+            "interior_relaxed": interior_ok and not vision.pass_,
+            "image_qa_metrics": vision_qa_metrics_from_result(vision),
         }
+
     return {
         "image_qa_result": "fail",
         "phase": "await_image_qa",
         "image_qa_reason": vision.reason or "图源未通过识图审核",
         "vision_used": True,
+        "image_qa_metrics": vision_qa_metrics_from_result(vision),
     }

--- a/services/agent-runtime/app/graph/product_visual_v2/vision_qa_client.py
+++ b/services/agent-runtime/app/graph/product_visual_v2/vision_qa_client.py
@@ -1,0 +1,204 @@
+"""Vision QA client — calls Nest internal vision endpoint or direct chat/completions."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from app.config import settings
+from app.graph.product_visual_v2.vision_qa import VisionQAResult
+from app.graph.product_visual_v2_prompt import build_vision_qa_user_content, load_vision_qa_prompt
+
+logger = logging.getLogger(__name__)
+
+_VISION_MODEL = re.compile(
+    r"(?:^|[/:])(?:gemini|gpt-4o|gpt-4-turbo|gpt-4-vision|gpt-5|claude-(?:opus|sonnet|haiku|3)|agnes)(?:[-./]|$)",
+    re.I,
+)
+_NON_VISION = re.compile(
+    r"(?:^|[/:])(?:deepseek|o[134](?:-|$|-mini|-pro)|text-embedding|whisper|tts|dall-e)(?:[-./]|$)",
+    re.I,
+)
+
+
+def supports_vision_model(model: str | None) -> bool:
+    if not model or not str(model).strip():
+        return False
+    m = str(model).strip()
+    if _NON_VISION.search(m):
+        return False
+    return bool(_VISION_MODEL.search(m))
+
+
+def image_urls_from_state(state: dict) -> list[str]:
+    route_ctx = state.get("route_context") or {}
+    attachments = list(state.get("sidebar_attachments") or route_ctx.get("sidebar_attachments") or [])
+    urls: list[str] = []
+    for att in attachments:
+        if not isinstance(att, dict):
+            continue
+        if str(att.get("mediaType") or "").lower() not in ("image",):
+            continue
+        url = str(att.get("url") or "").strip()
+        if url and url not in urls:
+            urls.append(url)
+    return urls
+
+
+def _parse_vision_json(raw: str) -> VisionQAResult:
+    text = (raw or "").strip()
+    text = re.sub(r"^```(?:json)?|```$", "", text, flags=re.MULTILINE).strip()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return VisionQAResult(
+            pass_=False,
+            reason="识图模型返回格式异常，请重试或换一张更清晰的产品图",
+            vision_used=True,
+        )
+    if not isinstance(data, dict):
+        return VisionQAResult(pass_=False, reason="识图审核结果无效", vision_used=True)
+    return VisionQAResult(
+        pass_=bool(data.get("pass")),
+        reason=str(data.get("reason") or "").strip() or "图源审核完成",
+        vision_used=True,
+        is_white_bg=data.get("is_white_bg") if "is_white_bg" in data else None,
+        is_sharp_enough=data.get("is_sharp_enough") if "is_sharp_enough" in data else None,
+        product_identifiable=data.get("product_identifiable")
+        if "product_identifiable" in data
+        else None,
+    )
+
+
+async def _call_vision_http(
+    *,
+    system_prompt: str,
+    user_content: str,
+    image_urls: list[str],
+    model: str,
+    api_key: str,
+    base_url: str,
+) -> VisionQAResult:
+    if not api_key:
+        return VisionQAResult(
+            pass_=False,
+            reason="未配置识图模型 API Key，无法完成图源审核",
+            vision_used=False,
+        )
+    if not supports_vision_model(model):
+        return VisionQAResult(
+            pass_=False,
+            reason=f"当前文本模型（{model}）不支持识图，请在 Agent 侧栏选择 Gemini / GPT-4o 等视觉模型",
+            vision_used=False,
+        )
+    url = base_url.rstrip("/") + "/chat/completions"
+    body = {
+        "model": model,
+        "stream": False,
+        "temperature": 0,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": user_content},
+                    *[{"type": "image_url", "image_url": {"url": u}} for u in image_urls],
+                ],
+            },
+        ],
+    }
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        resp = await client.post(
+            url,
+            json=body,
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+    raw = payload.get("choices", [{}])[0].get("message", {}).get("content", "")
+    return _parse_vision_json(str(raw or ""))
+
+
+async def run_vision_qa(
+    *,
+    nest: Any | None,
+    state: dict,
+    skills_dir: Path,
+    vision_creds: dict[str, str | None] | None = None,
+) -> VisionQAResult:
+    """Run vision-first product image QA (R-Vision-QA)."""
+    image_urls = image_urls_from_state(state)
+    if not image_urls:
+        return VisionQAResult(
+            pass_=False,
+            reason="未检测到产品参考图，请上传图片后重试",
+            vision_used=False,
+        )
+
+    route_ctx = state.get("route_context") or {}
+    utterance = str(route_ctx.get("utterance") or "").strip()
+    for msg in reversed(state.get("messages") or []):
+        role = getattr(msg, "type", None) or (msg.get("role") if isinstance(msg, dict) else None)
+        content = getattr(msg, "content", None) or (msg.get("content") if isinstance(msg, dict) else "")
+        if role in ("human", "user") and content:
+            utterance = str(content).strip()
+            break
+
+    metrics = state.get("_qa_metrics") or {}
+    scene_kind = metrics.get("scene_kind") if isinstance(metrics, dict) else None
+    system_prompt, _version = load_vision_qa_prompt(skills_dir)
+    user_content = build_vision_qa_user_content(
+        user_text=utterance,
+        scene_kind=str(scene_kind or ""),
+        image_count=len(image_urls),
+    )
+
+    run_fn = getattr(nest, "run_vision_qa", None) if nest is not None else None
+    if run_fn is not None:
+        try:
+            data = await run_fn(
+                image_urls=image_urls,
+                user_text=utterance,
+                scene_kind=scene_kind,
+                system_prompt=system_prompt,
+                user_content=user_content,
+            )
+            if isinstance(data, dict):
+                return VisionQAResult(
+                    pass_=bool(data.get("pass")),
+                    reason=str(data.get("reason") or "").strip() or "图源审核完成",
+                    vision_used=bool(data.get("visionUsed", data.get("vision_used", True))),
+                    is_white_bg=data.get("isWhiteBg", data.get("is_white_bg")),
+                    is_sharp_enough=data.get("isSharpEnough", data.get("is_sharp_enough")),
+                    product_identifiable=data.get(
+                        "productIdentifiable", data.get("product_identifiable")
+                    ),
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("nest run_vision_qa failed: %s", exc)
+
+    creds = vision_creds or {}
+    model = str(creds.get("model") or settings.openai_chat_model or "gpt-4o")
+    api_key = str(creds.get("api_key") or settings.openai_api_key or "")
+    base_url = str(creds.get("base_url") or settings.openai_base_url or "https://api.openai.com/v1")
+    try:
+        return await _call_vision_http(
+            system_prompt=system_prompt,
+            user_content=user_content,
+            image_urls=image_urls,
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("direct vision QA failed: %s", exc)
+        return VisionQAResult(
+            pass_=False,
+            reason=f"识图审核调用失败：{exc}",
+            vision_used=False,
+        )

--- a/services/agent-runtime/app/graph/product_visual_v2_prompt.py
+++ b/services/agent-runtime/app/graph/product_visual_v2_prompt.py
@@ -34,6 +34,19 @@ def load_decompose_shots_prompt(skills_dir: Path) -> tuple[str, str]:
     )
 
 
+def load_vision_qa_prompt(skills_dir: Path) -> tuple[str, str]:
+    return _load_prompt_body(skills_dir, "assets/prompts/vision-qa/1.0.0.md", "vision_qa")
+
+
+def build_vision_qa_user_content(*, user_text: str, scene_kind: str, image_count: int) -> str:
+    bits = [f"请审核这 {image_count} 张产品参考图是否适合作为电商视觉策划输入。"]
+    if user_text.strip():
+        bits.append(f"【用户说明】\n{user_text.strip()}")
+    if scene_kind == "interior":
+        bits.append("【场景提示】用户任务含室内/空间设计，白底要求可放宽，但主体须清晰可辨。")
+    return "\n\n".join(bits)
+
+
 def build_dialog_draft_user_content(*, user_brief: str, user_text: str, revision_feedback: str | None) -> str:
     bits = ["输出 dialog draft JSON（含 draft_prose 与 macro_schemes）。"]
     if user_brief.strip():

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -209,7 +209,7 @@ class AgentRuntimeState(TypedDict, total=False):
     # ecommerce-product-visual (Phase 1 image-only)
     product_visual_plan: dict | None
     image_qa_result: Literal["pass", "fail", "remediated"] | None
-    image_qa_decision: Literal["none", "retake", "ai_white_bg"] | None
+    image_qa_decision: Literal["none", "retake", "ai_white_bg", "confirm_pass"] | None
     scheme_revision_count: int | None
     phase1_asset_keys: list[str] | None
     delivery_selections: dict[str, str] | None  # type_id -> scheme_id; v2: shot_id -> variant_id
@@ -223,4 +223,5 @@ class AgentRuntimeState(TypedDict, total=False):
     visual_intent: dict | None
     requires_standard_product_assets: bool | None
     image_qa_reason: str | None
+    image_qa_metrics: dict | None
     vision_used: bool | None

--- a/services/agent-runtime/app/graph/subgraphs/product_visual_gate.py
+++ b/services/agent-runtime/app/graph/subgraphs/product_visual_gate.py
@@ -57,7 +57,8 @@ def route_after_await_image_qa(state: AgentRuntimeState) -> str:
 def route_after_image_qa_remedy(state: AgentRuntimeState) -> str:
     if state.get("phase") == "error":
         return "done"
-    if state.get("image_qa_decision") == "ai_white_bg":
+    decision = state.get("image_qa_decision") or "none"
+    if decision in ("ai_white_bg", "confirm_pass"):
         if is_v2_enabled(state):
             return "dialog_draft"
         return "plan_product_visual"
@@ -84,6 +85,7 @@ def register_product_visual_gate(
     llm: Any | None = None,
     skills_dir: Any | None = None,
     nest: Any | None = None,
+    vision_creds: dict[str, str | None] | None = None,
 ) -> None:
     """Register image QA + plan segment nodes and edges on the main graph."""
     from pathlib import Path
@@ -92,7 +94,9 @@ def register_product_visual_gate(
 
     resolved_skills = Path(skills_dir or settings.skills_dir)
 
-    graph.add_node("image_qa_check", make_image_qa_check_node(nest=nest))
+    graph.add_node("image_qa_check", make_image_qa_check_node(
+        nest=nest, skills_dir=resolved_skills, vision_creds=vision_creds,
+    ))
     graph.add_node("await_image_qa", make_await_image_qa_node())
     graph.add_node("image_qa_remedy", make_image_qa_remedy_node(nest=nest))
     graph.add_node(

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -365,6 +365,12 @@ class NestEventProxy:
     async def run_audio_generation(self, node_id: str) -> dict[str, Any]:
         return await self._run_studio_generation(node_id, "run_audio_generation")
 
+    async def run_vision_qa(self, **kwargs: Any) -> dict[str, Any]:
+        inner = getattr(self._inner, "run_vision_qa", None)
+        if inner is None:
+            raise RuntimeError("run_vision_qa_not_supported")
+        return await inner(**kwargs)
+
     async def _run_studio_generation(self, node_id: str, method: str) -> dict[str, Any]:
         await self._emit(
             {"type": "node_status", "data": {"nodeId": node_id, "status": "generating"}}
@@ -520,6 +526,14 @@ async def _save_new_assistant_messages(
         pass
 
 
+def resolve_vision_creds(req: RunRequest) -> dict[str, str | None]:
+    return {
+        "model": req.llm_model or settings.openai_chat_model,
+        "api_key": req.llm_api_key or settings.openai_api_key or None,
+        "base_url": req.llm_base_url or settings.openai_base_url,
+    }
+
+
 async def get_thread_state(
     thread_id: str,
     *,
@@ -563,6 +577,11 @@ async def get_thread_state(
         else None,
         "deliverySelections": delivery_selections if isinstance(delivery_selections, dict) else None,
         "deliveryGenByKey": gen_by_key if isinstance(gen_by_key, dict) else None,
+        "imageQaReason": vals.get("image_qa_reason"),
+        "imageQaMetrics": vals.get("image_qa_metrics")
+        if isinstance(vals.get("image_qa_metrics"), dict)
+        else None,
+        "visionUsed": vals.get("vision_used") if vals.get("vision_used") is not None else None,
         **diag,
     }
 
@@ -643,6 +662,7 @@ async def stream_run_events(
         llm=graph_llm,
         skills_dir=resolve_skills_dir(skills_dir),
         checkpointer=active_checkpointer,
+        vision_creds=resolve_vision_creds(req),
     )
     config = {"configurable": {"thread_id": thread_id}}
 
@@ -847,6 +867,15 @@ async def stream_run_events(
                     interrupt_event_payload(
                         next_nodes=post_next,
                         phase=phase_str,
+                        extra={
+                            k: v
+                            for k, v in {
+                                "imageQaReason": post_vals.get("image_qa_reason"),
+                                "imageQaMetrics": post_vals.get("image_qa_metrics"),
+                                "visionUsed": post_vals.get("vision_used"),
+                            }.items()
+                            if v is not None
+                        },
                     )
                 )
             await emit({"type": "done", "data": {}})

--- a/services/agent-runtime/app/tools/nest_client.py
+++ b/services/agent-runtime/app/tools/nest_client.py
@@ -312,6 +312,35 @@ class NestCanvasClient:
             timeout=timeout_sec,
         )
 
+    async def run_vision_qa(
+        self,
+        *,
+        image_urls: list[str],
+        user_text: str | None = None,
+        scene_kind: str | None = None,
+        system_prompt: str,
+        user_content: str,
+        model: str | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "sessionId": self._session_id,
+            "userId": self._user_id,
+            "imageUrls": image_urls,
+            "systemPrompt": system_prompt,
+            "userContent": user_content,
+        }
+        if user_text:
+            body["userText"] = user_text
+        if scene_kind:
+            body["sceneKind"] = scene_kind
+        if model:
+            body["model"] = model
+        return await self._post(
+            "/agent/internal/run-vision-qa",
+            body,
+            timeout=60.0,
+        )
+
     async def run_text_generation(self, node_id: str) -> dict[str, Any]:
         timeout_sec = float(settings.image_gen_timeout_sec) + IMAGE_GEN_TIMEOUT_BUFFER_SEC
         return await self._post(

--- a/services/agent-runtime/skills/ecommerce-product-visual/assets/prompts/vision-qa/1.0.0.md
+++ b/services/agent-runtime/skills/ecommerce-product-visual/assets/prompts/vision-qa/1.0.0.md
@@ -1,0 +1,28 @@
+你是电商产品图源准入审核员。用户将上传产品参考图（可能附带文字需求），你需要**看图**判断该图是否适合作为后续 AI 视觉策划与出图的输入。
+
+## 输出格式
+
+只输出 JSON（不要 markdown 代码块），字段：
+
+```json
+{
+  "pass": true,
+  "reason": "面向用户的一句话中文结论",
+  "is_white_bg": true,
+  "is_sharp_enough": true,
+  "product_identifiable": true
+}
+```
+
+## 判定标准
+
+- **is_sharp_enough**：主体产品是否清晰、无严重 motion blur / 过度压缩；轻微噪点可接受。
+- **is_white_bg**：背景是否为干净白底或近白底（含浅灰渐变、轻微阴影仍算白底）；明显场景/杂色背景为 false。
+- **product_identifiable**：能否识别出具体产品 SKU/品类（如礼盒、保温杯），而非完全无法辨认。
+- **pass=true** 当：`is_sharp_enough` 且 `product_identifiable` 且（`is_white_bg` 或用户场景为室内/空间设计且主体清晰）。
+- **pass=false** 当：严重模糊、主体被大幅裁切、无法辨认产品、或杂乱背景严重干扰后续 i2i 参考。
+
+## 注意
+
+- 不要因轻微阴影、非纯白而误判；电商常见的浅灰/微渐变白底视为白底。
+- `reason` 必须具体说明是「清晰度」「背景」还是「主体可辨性」哪一项导致 pass/fail，便于用户理解。

--- a/services/agent-runtime/tests/test_phase1_seed.py
+++ b/services/agent-runtime/tests/test_phase1_seed.py
@@ -1,0 +1,58 @@
+"""Phase 1 seed chain tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.graph.phase1_seed import _batch_items, ensure_phase1_seed_chain
+
+
+def test_product_turnaround_batch_has_no_character_pipeline():
+    items = _batch_items(
+        [
+            {
+                "key": "product_turnaround",
+                "title": "产品四视图",
+                "target_type": "image",
+                "prompt_hint": "同一产品四格拼图",
+            }
+        ]
+    )
+    assert len(items) == 1
+    assert "pipeline" not in items[0]
+    assert items[0]["imageAspect"] == "2:1"
+
+
+class FakeNest:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Any]] = []
+
+    async def add_nodes_batch(self, items: list[dict[str, Any]], **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("add_nodes_batch", items))
+        return {
+            "nodes": [
+                {"key": item["key"], "nodeId": f"node-{item['key']}"} for item in items
+            ],
+            "actions": [],
+        }
+
+    async def connect_nodes(self, edges: list[dict[str, str]], **kwargs: Any) -> dict[str, Any]:
+        return {"actions": []}
+
+    async def attach_refs(self, node_id: str, ref_order: list[str], **kwargs: Any) -> dict[str, Any]:
+        return {"nodeId": node_id, "actions": []}
+
+
+@pytest.mark.asyncio
+async def test_ensure_phase1_seed_creates_nodes_without_turnaround_pipeline():
+    nest = FakeNest()
+    manifest, err = await ensure_phase1_seed_chain(nest, {}, run_generation=False)
+    assert err is None
+    batch_call = next(c for c in nest.calls if c[0] == "add_nodes_batch")
+    items = batch_call[1]
+    ta = next(it for it in items if it["key"] == "product_turnaround")
+    assert "pipeline" not in ta
+    assert ta.get("imageAspect") == "2:1"
+    assert {it["key"] for it in manifest} == {"white_bg", "product_turnaround"}

--- a/services/agent-runtime/tests/test_product_visual_qa.py
+++ b/services/agent-runtime/tests/test_product_visual_qa.py
@@ -10,7 +10,9 @@ from langgraph.graph import END, START, StateGraph
 
 from app.graph.nodes.image_qa_gate import (
     REMEDIATE_DONE_MSG,
+    REMEDIATE_DONE_MSG_V2,
     REMEDIATE_PROGRESS_MSG,
+    REMEDIATE_PROGRESS_MSG_V2,
     classify_image_qa_decision,
     clear_product_visual_abort_state,
     evaluate_image_qa,
@@ -172,6 +174,30 @@ async def test_await_image_qa_remedy_ai_white_bg():
     msgs = [m.content for m in remedied.get("messages") or [] if isinstance(m, AIMessage)]
     assert msgs[0] == REMEDIATE_PROGRESS_MSG
     assert msgs[-1] == REMEDIATE_DONE_MSG
+
+
+@pytest.mark.asyncio
+async def test_await_image_qa_remedy_ai_white_bg_v2_lazy_seed():
+    nest = FakeNest()
+    await_node = make_await_image_qa_node()
+    remedy = make_image_qa_remedy_node(nest=nest)
+    decided = await await_node({"messages": [HumanMessage(content="生成标准白底图")]})
+    remedied = await remedy(
+        {
+            **decided,
+            "product_visual_scheme_v2": True,
+            "sidebar_attachments": [{"mediaType": "image", "role": "product", "url": "u1"}],
+        }
+    )
+    assert remedied["image_qa_result"] == "remediated"
+    assert remedied["phase"] == "dialog_draft"
+    assert remedied["product_visual_scheme_v2"] is True
+    gen_calls = [c for c in nest.calls if c[0] == "run_image_generation"]
+    assert gen_calls == []
+    assert any(c[0] == "add_nodes_batch" for c in nest.calls)
+    msgs = [m.content for m in remedied.get("messages") or [] if isinstance(m, AIMessage)]
+    assert msgs[0] == REMEDIATE_PROGRESS_MSG_V2
+    assert msgs[-1] == REMEDIATE_DONE_MSG_V2
 
 
 @pytest.mark.asyncio

--- a/services/agent-runtime/tests/test_product_visual_vision_qa_v2.py
+++ b/services/agent-runtime/tests/test_product_visual_vision_qa_v2.py
@@ -1,0 +1,124 @@
+"""Vision QA integration tests (spec P1-VQA-*)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from app.graph.nodes.image_qa_gate import (
+    classify_image_qa_decision,
+    make_image_qa_check_node,
+    make_image_qa_remedy_node,
+)
+from app.graph.product_visual_v2.vision_qa import VisionQAResult, evaluate_vision_qa_v2
+
+SKILLS = Path(__file__).resolve().parents[1] / "skills"
+
+
+class FakeNestVision:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+        self.calls: list[dict[str, Any]] = []
+
+    async def run_vision_qa(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return self.payload
+
+
+@pytest.mark.asyncio
+async def test_vision_qa_check_pass_with_product_ref():
+    nest = FakeNestVision(
+        {
+            "pass": True,
+            "reason": "大闸蟹礼盒清晰，纯白背景，SKU 可辨",
+            "visionUsed": True,
+            "isWhiteBg": True,
+            "isSharpEnough": True,
+            "productIdentifiable": True,
+        }
+    )
+    node = make_image_qa_check_node(nest=nest, skills_dir=SKILLS)
+    out = await node(
+        {
+            "product_visual_scheme_v2": True,
+            "sidebar_attachments": [
+                {
+                    "id": "a1",
+                    "mediaType": "image",
+                    "sourceKind": "upload",
+                    "label": "产品图",
+                    "url": "https://cdn.example/crab.jpg",
+                    "role": "product",
+                }
+            ],
+            "messages": [HumanMessage(content="中秋大闸蟹包装")],
+        }
+    )
+    assert out["image_qa_result"] == "pass"
+    assert out.get("vision_used") is True
+    assert "大闸蟹" in str(out.get("image_qa_reason") or "")
+    assert nest.calls
+    assert nest.calls[0]["image_urls"] == ["https://cdn.example/crab.jpg"]
+
+
+@pytest.mark.asyncio
+async def test_vision_qa_check_fail_shows_reason():
+    nest = FakeNestVision(
+        {
+            "pass": False,
+            "reason": "主体模糊，难以识别 SKU",
+            "visionUsed": True,
+            "isWhiteBg": True,
+            "isSharpEnough": False,
+            "productIdentifiable": False,
+        }
+    )
+    node = make_image_qa_check_node(nest=nest, skills_dir=SKILLS)
+    out = await node(
+        {
+            "product_visual_scheme_v2": True,
+            "sidebar_attachments": [
+                {
+                    "id": "a1",
+                    "mediaType": "image",
+                    "sourceKind": "upload",
+                    "label": "产品图",
+                    "url": "https://cdn.example/blur.jpg",
+                    "role": "product",
+                }
+            ],
+        }
+    )
+    assert out["image_qa_result"] == "fail"
+    assert out["phase"] == "await_image_qa"
+    msgs = out.get("messages") or []
+    assert msgs
+    assert "模糊" in str(getattr(msgs[0], "content", ""))
+
+
+def test_heuristic_only_cannot_pass_v2():
+    out = evaluate_vision_qa_v2(
+        VisionQAResult(pass_=True, reason="x", vision_used=False),
+        {"has_white_bg": True, "sharpness": 0.9},
+    )
+    assert out["image_qa_result"] == "fail"
+
+
+def test_classify_confirm_pass():
+    assert classify_image_qa_decision("已是白底图，继续使用") == "confirm_pass"
+
+
+@pytest.mark.asyncio
+async def test_confirm_pass_remedy_skips_seed_gen():
+    remedy = make_image_qa_remedy_node(nest=FakeNestVision({}))
+    out = await remedy(
+        {
+            "image_qa_decision": "confirm_pass",
+            "product_visual_scheme_v2": True,
+        }
+    )
+    assert out["image_qa_result"] == "pass"
+    assert out["phase"] == "dialog_draft"


### PR DESCRIPTION
## Summary
- 接入 Gemini/GPT-4o 识图 Vision QA（Nest `run-vision-qa`），替代写死的 `has_white_bg` 元数据检查；fail 时展示清晰度/白底/产品可辨三项结论
- 修复 `product_turnaround` 误用 `turnaround_image` 人物 pipeline；v2 QA remedy 改为 lazy seed（只建节点不出图）
- 宏观方案多选超限时优先保留 recommended；新增「确认可用，继续」QA 选项

## Test plan
- [x] `pnpm build`
- [x] `pnpm --filter @lnkpi/agent test`
- [x] `pytest tests/test_product_visual_vision_qa_v2.py tests/test_phase1_seed.py tests/test_product_visual_qa.py`
- [ ] CI 全绿
- [ ] 生产 `deploy/prod-product-visual-cvs-v2-live.py` smoke


Made with [Cursor](https://cursor.com)