### PR TITLE
fix(agent): UX-PV closure — shot table, stream cancel, interrupt spec

### DIFF
--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -1068,8 +1068,21 @@ function toggleVoice() {
   })
 }
 
+function cancelActiveStream() {
+  if (!agent.isStreaming) return
+  streamAbortController?.abort()
+  agentStream.stop()
+  agent.finishStreaming()
+  ElMessage.info('已停止当前回复，您可以发送新需求')
+}
+
 async function send() {
-  if (!canSubmitComposer.value || agent.isStreaming || isUploading.value) return
+  if (isUploading.value) return
+  if (agent.isStreaming) {
+    cancelActiveStream()
+    return
+  }
+  if (!canSubmitComposer.value) return
   if (!auth.isLoggedIn) {
     auth.openLogin()
     return

--- a/apps/web/src/components/agent/presentation/AgentPresentationHost.vue
+++ b/apps/web/src/components/agent/presentation/AgentPresentationHost.vue
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue'
 import AgentStepper from './AgentStepper.vue'
 import AgentProseBlock from './AgentProseBlock.vue'
 import AgentMacroSchemeCards from './AgentMacroSchemeCards.vue'
+import AgentShotTable from './AgentShotTable.vue'
 import AgentTopoCardList from './AgentTopoCardList.vue'
 import AgentDeliveryCards from './AgentDeliveryCards.vue'
 import AgentDeliverySummaryTable from './AgentDeliverySummaryTable.vue'
@@ -29,6 +30,7 @@ const macroSelections = ref<string[]>(props.macroSelectedIds ?? [])
 
 const isProseBlock = computed(() => props.presentation.kind === 'prose_block')
 const isMacroCards = computed(() => props.presentation.kind === 'macro_scheme_cards')
+const isShotTable = computed(() => props.presentation.kind === 'shot_table')
 const isTopoCards = computed(
   () =>
     props.presentation.kind === 'topo_card_list'
@@ -39,6 +41,7 @@ const isDeliverySummary = computed(() => props.presentation.kind === 'delivery_s
 const hasGateLayout = computed(() => Boolean(props.presentation.primary_action))
 const proseContent = computed(() => String(props.presentation.body?.prose ?? ''))
 const macroSchemes = computed(() => props.presentation.body?.schemes ?? [])
+const shotRows = computed(() => props.presentation.body?.shots ?? [])
 const topoNodes = computed(() => props.presentation.body?.nodes ?? [])
 const deliveryGroups = computed(() => props.presentation.body?.groups ?? [])
 const deliverySelectionsMap = computed(() => props.deliverySelections ?? {})
@@ -108,6 +111,12 @@ function onPrimaryAction() {
         :selected-ids="macroSelections"
         :disabled="disabled"
         @toggle="(id, checked) => emit('macroToggle', id, checked)"
+      />
+      <AgentShotTable
+        v-if="isShotTable && shotRows.length"
+        :shots="shotRows"
+        :disabled="disabled"
+        @focus-node="emit('focusNode', $event)"
       />
       <p
         v-if="presentation.body?.text && isTopoCards && topoNodes.length"

--- a/apps/web/src/components/agent/presentation/AgentShotTable.vue
+++ b/apps/web/src/components/agent/presentation/AgentShotTable.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import CanvasLocatePinIcon from '@/components/shared/CanvasLocatePinIcon.vue'
+import type { ShotTableRow } from './types'
+
+defineProps<{
+  shots: ShotTableRow[]
+  disabled?: boolean
+}>()
+
+const emit = defineEmits<{
+  focusNode: [nodeId: string]
+}>()
+
+function onRowClick(row: ShotTableRow) {
+  if (row.node_id) emit('focusNode', row.node_id)
+}
+</script>
+
+<template>
+  <div class="agent-shot-table overflow-hidden rounded-lg border border-[var(--neo-border)]" data-testid="shot-table">
+    <table class="w-full text-xs">
+      <thead>
+        <tr class="border-b border-[var(--neo-border)] bg-[var(--neo-surface)] text-left text-[var(--neo-muted)]">
+          <th class="px-2 py-1.5 font-medium">场景</th>
+          <th class="px-2 py-1.5 font-medium">类型</th>
+          <th class="hidden px-2 py-1.5 font-medium sm:table-cell">说明</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="row in shots"
+          :key="row.shot_id"
+          class="border-b border-[var(--neo-border)] last:border-b-0"
+          :class="row.node_id ? 'cursor-pointer hover:bg-[var(--neo-hover)]' : ''"
+          :data-shot-id="row.shot_id"
+          @click="onRowClick(row)"
+        >
+          <td class="px-2 py-1.5 font-medium text-[var(--neo-text)]">
+            <span class="inline-flex items-center gap-1">
+              {{ row.label }}
+              <span v-if="row.node_id" class="opacity-60" data-testid="shot-locate-pin">
+                <CanvasLocatePinIcon :size="12" />
+              </span>
+            </span>
+          </td>
+          <td class="px-2 py-1.5 text-[var(--neo-muted)]">{{ row.type }}</td>
+          <td class="hidden px-2 py-1.5 text-[var(--neo-muted)] sm:table-cell">
+            <span class="line-clamp-2">{{ row.summary || '—' }}</span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>

--- a/apps/web/src/components/agent/presentation/presentation.test.ts
+++ b/apps/web/src/components/agent/presentation/presentation.test.ts
@@ -8,7 +8,13 @@ const shotEnvelope: AgentPresentationEnvelope = {
   kind: 'shot_table',
   stepper: { current: 'shot_plan', completed: ['image_qa', 'scheme_draft', 'macro_select', 'ssot_persist'] },
   context_recap: '巨峰葡萄礼盒',
-  body: { text: '共 3 个构图任务；确认后将编排出图顺序，尚未开始生成。' },
+  body: {
+    text: '共 3 个构图任务；确认后将编排出图顺序，尚未开始生成。',
+    shots: [
+      { shot_id: 'packaging_hero__1', label: '礼盒主视觉', type: '包装主视觉', summary: '红金礼盒正面', node_id: 'n1' },
+      { shot_id: 'gift_scene__1', label: '送礼场景', type: '送礼场景', summary: '模特手持礼盒', node_id: 'n2' },
+    ],
+  },
   primary_action: { label: '确认构图，生成预览', message: '确认出图' },
 }
 
@@ -63,11 +69,12 @@ describe('AgentStepper', () => {
 })
 
 describe('AgentPresentationHost', () => {
-  it('renders stepper, recap, and shot primary button label', () => {
+  it('renders stepper, recap, shot table, and primary button label', () => {
     const wrapper = mount(AgentPresentationHost, {
       props: { presentation: shotEnvelope },
     })
     expect(wrapper.find('[data-testid="context-recap"]').text()).toContain('巨峰葡萄礼盒')
+    expect(wrapper.find('[data-testid="shot-table"]').exists()).toBe(true)
     expect(wrapper.find('[data-testid="primary-action"]').text()).toBe('确认构图，生成预览')
     expect(wrapper.find('[data-testid="presentation-hint"]').text()).toContain('3 个构图任务')
   })

--- a/apps/web/src/components/agent/presentation/types.ts
+++ b/apps/web/src/components/agent/presentation/types.ts
@@ -28,6 +28,14 @@ export interface TopoCardNode {
   node_id?: string
 }
 
+export interface ShotTableRow {
+  shot_id: string
+  label: string
+  type: string
+  summary?: string
+  node_id?: string | null
+}
+
 export interface DeliverySummaryFinalizedRow {
   title: string
   macro?: string
@@ -74,6 +82,7 @@ export interface AgentPresentationBody {
   scene_count?: number
   credits_hint?: string
   mermaid?: string
+  shots?: ShotTableRow[]
   headline?: string
   finalized?: DeliverySummaryFinalizedRow[]
   basics?: DeliverySummaryBasicsRow[]

--- a/deploy/.env.production.example
+++ b/deploy/.env.production.example
@@ -62,6 +62,8 @@ LNKPI_IMAGE_GEN_CONCURRENCY=3
 LNKPI_IMAGE_GEN_TIMEOUT_SEC=180
 # Product visual scheme v2 — prose SSOT + macro/shot (UAT 前设为 true，重启 agent-runtime)
 # LNKPI_PRODUCT_VISUAL_SCHEME_V2=true
+# UX-PV-10: merge shot + topo gate (hard stops ≤3); enable after v2 stable
+# LNKPI_PV_MERGED_SHOT_TOPO_GATE=true
 
 # W23 OTLP tracing（生产默认开启；enable-agent-runtime.sh 写入并连接 Tempo）
 # 复用同机 pintuotuo Tempo：http://pintuotuo-tempo:4318/v1/traces

--- a/deploy/AGENT_RUNTIME_PRODUCTION.md
+++ b/deploy/AGENT_RUNTIME_PRODUCTION.md
@@ -46,6 +46,8 @@
 | `LNKPI_IMAGE_GEN_CONCURRENCY` | 否 | `3` | 编排出图并发上限 |
 | `LNKPI_IMAGE_GEN_TIMEOUT_SEC` | 否 | `180` | 单图等待上限（秒） |
 | `LNKPI_PRODUCT_VISUAL_SCHEME_V2` | 否 | `false` | **v2** prose SSOT + macro/shot 路径；UAT 前设为 `true` 并重启 Runtime |
+| `LNKPI_PV_MERGED_SHOT_TOPO_GATE` | 否 | `false` | **UX-PV-10** 合并 shot+topo 门控；v2 UAT G10 通过后可设为 `true` |
+| `LNKPI_PV_FAST_MODE_GATE` | 否 | `false` | 合并门控上的「少确认快速出图」二级选项（可选） |
 
 ### 1.3 与「大模型 Key」对照（避免混）
 

--- a/docs/superpowers/specs/2026-08-11-agent-conversation-ux-product-visual-design.md
+++ b/docs/superpowers/specs/2026-08-11-agent-conversation-ux-product-visual-design.md
@@ -483,6 +483,8 @@ presentation:
 
 **Implementation Plan:** [2026-08-11-agent-conversation-ux-product-visual.md](../plans/2026-08-11-agent-conversation-ux-product-visual.md)
 
+**运行中中断与改意图（后续）：** [2026-08-12-agent-mid-run-interrupt-design.md](./2026-08-12-agent-mid-run-interrupt-design.md) — v2.1 已补前端 SSE cancel；后端 cancel + 改意图协议待 Phase 1。
+
 **研发分工（建议）：**
 
 | 层 | 职责 |

--- a/docs/superpowers/specs/2026-08-11-product-visual-phase2-scheme-ssot-uat.md
+++ b/docs/superpowers/specs/2026-08-11-product-visual-phase2-scheme-ssot-uat.md
@@ -371,6 +371,17 @@
 - 定稿卡片标题为 `packaging_hero__1` 等内部 ID  
 - 流程结束仅「成功 N 失败 M」，无交付清单  
 
+### 10.5 v2.1 闭环补项（2026-08-12）
+
+| 项 | 状态 | 说明 |
+|----|------|------|
+| 生成钮 streaming 取消 | ✅ 已补 | 侧栏 `DockGenerateButton` 点击 → abort SSE + toast；**后端 run 仍可能继续**（见 [中断改意图规格](./2026-08-12-agent-mid-run-interrupt-design.md)） |
+| `shot_table` 表格 UI | ✅ 已补 | `AgentShotTable.vue` + envelope `body.shots[]` |
+| 画布产出默认 5 项折叠 | ✅ 已有 | `COLLAPSE_THRESHOLD=5`（`agentCanvasOutputs.ts`） |
+| 合并门控生产开关 | 📋 待运维 | 代码已就绪；生产设 `LNKPI_PV_MERGED_SHOT_TOPO_GATE=true` 后跑 UAT-UX-PV-10 |
+| §十 正式 Sign-off | ⏳ 待跑 | 合并/deploy 后在生产浏览器复跑 §10.1~10.3 |
+| 出图中途后端 cancel | ⏳ 规格化 | 见 [2026-08-12-agent-mid-run-interrupt-design.md](./2026-08-12-agent-mid-run-interrupt-design.md) |
+
 ---
 
 ## 十一、文档维护
@@ -388,5 +399,6 @@
 
 | 日期 | 版本 | 说明 |
 |------|------|------|
+| 2026-08-12 | v1.2 | §10.5 闭环补项追踪；链至中断改意图规格 |
 | 2026-08-11 | v1.1 | 新增 §十 UX-PV-01~13；CVS-02-AB 口语路径；§七 G8~G10 |
 | 2026-08-11 | v1.0 | 初稿：Phase 2 方案层功能 UAT |

--- a/docs/superpowers/specs/2026-08-12-agent-mid-run-interrupt-design.md
+++ b/docs/superpowers/specs/2026-08-12-agent-mid-run-interrupt-design.md
@@ -1,0 +1,256 @@
+# Agent 运行中中断与改意图 — 设计规格
+
+> **状态**：草案待审  
+> **日期**：2026-08-12  
+> **触发**：UX-PV 交付后用户反馈 — 任务进行中无法随时中断、点生成钮改发新需求、系统识别意图再执行  
+> **读者**：产品、前端、Agent Runtime、Nest API  
+> **前置**：  
+> - [2026-08-11-agent-conversation-ux-product-visual-design.md](./2026-08-11-agent-conversation-ux-product-visual-design.md)  
+> - [2026-08-06-agent-sidebar-copy-design.md](./2026-08-06-agent-sidebar-copy-design.md)  
+> - LangGraph `interrupt_before` + checkpoint（W5 / P0-05）
+
+| 字段 | 值 |
+|------|-----|
+| 文档版本 | v1.0 |
+| 适用范围 | 侧栏 Agent 全 flow（product_visual / campaign / atomic / explore）；**P0 实现聚焦 product_visual v2 + atomic** |
+| 非范围 | 画布 Dock 单节点生成取消（已有 `cancel_generation` explore 路径）；多 thread 并行；Cloud Agent |
+
+---
+
+## 一、问题陈述
+
+### 1.1 用户期望旅程
+
+```
+任务进行中（出图/写方案/任意阶段）
+  → 用户点侧栏右下角「生成」钮（或等价中断）
+  → 当前 run 安全停止
+  → 用户输入新话术
+  → 系统理解新意图（继续 / 修改 / 全新任务）
+  → 执行对应 flow，上下文衔接清晰
+```
+
+### 1.2 现状与缺口
+
+| 环节 | 现状（2026-08-12 前） | v2.1 补丁 | 仍缺 |
+|------|----------------------|-----------|------|
+| 前端取消 | 生成钮文案「点击取消」但 `send()` 直接 return | ✅ abort SSE + toast | 后端 run / 出图未停 |
+| 流式中发新话 | composer disabled | 取消后可输入 | 无统一「改意图」协议 |
+| 门控中改意图 | `should_resume_interrupt` 短句 resume；长句 `@ref` → fresh restart | 部分可用 | 规则不透明、无确认 |
+| 出图阶段 | 无 `interrupt_before` | — | 无法 cancel in-flight gen |
+| 意图路由 | 仅 `intake` 节点 | fresh restart 清 checkpoint | 运行中无 REPL 式改道 |
+
+**根因：** 系统是 **checkpoint 续跑 + 固定 HITL 门控**，不是 **可任意打断的对话式 REPL**。
+
+---
+
+## 二、设计目标与非目标
+
+### 2.1 目标（Must）
+
+1. **任意可见阶段**，用户可显式 **中断当前 Agent turn**（侧栏生成钮 / Esc / 可选「停止」chip）。
+2. 中断后 **≤3s** 内 composer 可输入；发送新话时 **明确识别**：门控回复 / 改意图 / 新任务。
+3. **出图阶段**中断时：停止调度新节点 + 取消进行中的 generation record（best-effort）。
+4. 改意图后 **状态清理可预测**（哪些保留、哪些清空）+ 侧栏 **一句摘要**说明。
+5. product_visual v2 与 atomic_create **UAT 可验收**（§六）。
+
+### 2.2 非目标（Won't，本期）
+
+- 同一 thread 两路 run **并行**执行  
+- 自动猜测用户是否「改主意」（须显式中断或门控规则命中）  
+- 画布 Dock 底部生成栏与侧栏 Agent **统一取消**（可二期对齐 UX）  
+- Campaign 全链路（可复用协议，implementation P2）
+
+---
+
+## 三、方案对比与推荐
+
+### 方案 A — 前端 abort + 后端 noop（现状增强）
+
+仅断 SSE；后端 LangGraph 继续跑到下一 interrupt 或 END。
+
+| 优点 | 缺点 |
+|------|------|
+| 改动最小 | 出图继续、积分消耗、改意图不可靠 |
+| 已部分落地 | 不符合用户「中断任务」语义 |
+
+**结论：** 仅作 **Phase 0 过渡**（v2.1 已做），不是终态。
+
+### 方案 B — Run Cancel Token + Checkpoint 分支（推荐）
+
+引入 **Run 级 cancel flag**；前端 abort 调 `POST /api/agent/runs/cancel`；Runtime 在节点边界 / gen scheduler 轮询 cancel，跳转到 **`intake` 或 `done(aborted)`**；新消息走正常 intake。
+
+| 优点 | 缺点 |
+|------|------|
+| 语义清晰、可测 | 需 Runtime + Nest 协作 |
+| 与 LangGraph checkpoint 兼容 | gen 中途 cancel 需 nest cancel API |
+| 可渐进 rollout | |
+
+### 方案 C — 每轮新 thread
+
+中断 = 新 `threadId`；旧 thread 遗弃。
+
+| 优点 | 缺点 |
+|------|------|
+| 无 checkpoint 污染 | 丢失画布 SSOT / 定稿上下文 |
+| | 与「同画布续聊」产品方向冲突 |
+
+**推荐：方案 B**，分三期交付（§七）。
+
+---
+
+## 四、架构（方案 B）
+
+### 4.1 组件与职责
+
+```mermaid
+sequenceDiagram
+  participant U as 用户
+  participant Web as AgentSideRail
+  participant Nest as Nest API
+  participant RT as Agent Runtime
+  participant Gen as Studio/Gen
+
+  U->>Web: 点击生成钮(取消)
+  Web->>Nest: POST /agent/runs/cancel {threadId}
+  Nest->>RT: POST /v1/runs/cancel
+  RT->>RT: set cancel_flag on thread
+  RT->>Gen: cancel_generation (in-flight nodes)
+  RT-->>Web: SSE run_cancelled (或 abort 后 thread-state)
+  U->>Web: 输入新话术 + 生成
+  Web->>Nest: POST /agent/chat/conversation
+  Nest->>RT: POST /v1/runs {message, threadId}
+  RT->>RT: intake → decide_route → ...
+```
+
+| 层 | 新增/变更 |
+|----|-----------|
+| **Web** | `cancelActiveStream()` 升级为 `cancelAgentRun()`；取消后 composer 解锁；可选 `改意图` callout |
+| **Nest** | 代理 `POST /v1/runs/cancel`；传递 `sessionId` / `threadId` |
+| **Runtime** | `RunCancelRegistry`；`gen_scheduler` / 长节点协作式取消；cancel 后 checkpoint 写入 `phase: cancelled` |
+| **State** | `run_cancelled: bool`、`cancel_reason: user \| timeout` |
+
+### 4.2 中断后新消息的意图分类
+
+在现有 `should_resume_interrupt` **之前**增加：
+
+```
+if run_was_cancelled or explicit_new_task_marker:
+    → Command(goto="intake", update=FRESH_TURN_STATE_CLEAR + message)
+
+elif next_nodes and should_resume_interrupt(message):
+    → 现有 gate resume
+
+elif next_nodes and long_message_with_refs:
+    → 现有 fresh restart
+
+else:
+    → 正常 turn_update（续跑）
+```
+
+**显式新任务标记（任一）：**
+
+- 用户在中断后首条消息 ≥12 字且 **不** 命中门控关键词  
+- 消息以 `@T`/`@I` 引用开头  
+- 用户点「发起新任务」chip（message=`__new_task__`）
+
+**改意图 vs 全新任务（product_visual）：**
+
+| 用户话术倾向 | 策略 | 保留 state |
+|--------------|------|------------|
+| 「换成白底风格」「不要礼盒了」 | 改意图续 thread | `effective_utterance`、附件、`visual_intent` 部分 |
+| 「帮我做另一套耳机主图」 | 新任务 | 清空 SSOT/shot/delivery；保留 session 画布 |
+| 门控短回复「确认出图」 | gate resume | 不清 |
+
+### 4.3 出图阶段取消
+
+1. `gen_scheduler` 每 wave 前读 `cancel_flag` → 停止 Send 新 `gen_node`  
+2. 对已 dispatch 的 node：调 Nest `cancel_generation(node_id)`（与 explore 共用）  
+3. 写 checkpoint：`phase=cancelled`，`presentation` = callout「已停止出图，已完成 a/b」  
+4. `task_progress_card` 标记剩余项 `cancelled`
+
+### 4.4 侧栏 UX 规范
+
+| 状态 | 生成钮 | Composer | 提示 |
+|------|--------|----------|------|
+| streaming | ⏹ 停止 | disabled | — |
+| 已取消 / 门控 | ↑ 发送 | enabled | callout：「已停止。直接说新需求，或点上方按钮继续当前步骤。」 |
+| 出图中 | ⏹ 停止 | disabled | banner 已有「请勿切 tab」 |
+
+**与 UX-PV 关系：** `generating` 阶段主按钮从占位「取消生成」改为 **真实 cancel**（本规格 Phase 1）。
+
+---
+
+## 五、API 草案
+
+### 5.1 `POST /v1/runs/cancel`
+
+```json
+// Request
+{ "thread_id": "...", "session_id": "...", "reason": "user" }
+
+// Response
+{ "ok": true, "cancelled_nodes": ["gen_node:white_bg", "..."], "phase": "cancelled" }
+```
+
+幂等：重复 cancel 返回 `ok: true`。
+
+### 5.2 SSE 事件（可选）
+
+```json
+{ "type": "run_cancelled", "data": { "phase": "cancelled", "completed_tasks": 2, "total_tasks": 5 } }
+```
+
+### 5.3 thread-state 扩展
+
+```json
+{
+  "phase": "cancelled",
+  "run_cancelled": true,
+  "presentation": { "kind": "callout_info", "body": { "text": "..." } }
+}
+```
+
+---
+
+## 六、验收标准（UAT）
+
+| UAT-ID | 场景 | Pass |
+|--------|------|------|
+| UAT-INT-01 | product_visual 出图中途点停止 | ≤5s 内无新节点 dispatch；进度卡停止增长 |
+| UAT-INT-02 | 停止后发全新话术（≥20 字） | 走 intake；旧 SSOT 不阻塞；侧栏无 machine payload |
+| UAT-INT-03 | 拓扑门控停止后点「确认出图」 | 仍 resume topo gate（未发新任务） |
+| UAT-INT-04 | atomic 单节点生成中停止 | `cancel_generation` 调用；节点非 generating |
+| UAT-INT-05 | 停止后立即重连 thread-state | phase=cancelled；composer 可用 |
+
+---
+
+## 七、分期交付
+
+| 阶段 | 范围 | 依赖 |
+|------|------|------|
+| **Phase 0** | 前端 SSE abort + toast | ✅ v2.1 已交付 |
+| **Phase 1** | Cancel API + gen_scheduler 协作 + product_visual | Nest proxy + Runtime registry |
+| **Phase 2** | 改意图分类 + presentation callout + atomic | Phase 1 |
+| **Phase 3** | campaign / 门控中「新任务」确认 chip | Phase 2 |
+
+**Implementation Plan：** Phase 1 通过后由 `writing-plans` 产出 `docs/superpowers/plans/2026-08-12-agent-mid-run-interrupt.md`。
+
+---
+
+## 八、风险与缓解
+
+| 风险 | 缓解 |
+|------|------|
+| cancel 后 checkpoint 半态 | 统一写 `phase=cancelled` + 明确 CLEAR 字段表 |
+| 上游 gen 无法取消 | best-effort + UI 标记「可能仍在生成」 |
+| 与 idempotency-key 冲突 | cancel 后下一轮新 idempotency key |
+| 误触停止 | 停止后 3s 内 toast + 可选 undo chip（P2） |
+
+---
+
+## 九、变更记录
+
+| 日期 | 版本 | 说明 |
+|------|------|------|
+| 2026-08-12 | v1.0 | 初稿：问题、方案 B、API、UAT、分期 |

--- a/services/agent-runtime/app/graph/product_visual_v2/presentation.py
+++ b/services/agent-runtime/app/graph/product_visual_v2/presentation.py
@@ -188,6 +188,42 @@ def mermaid_for_presentation(manifest: list[Any]) -> str:
     return "\n".join(lines)
 
 
+_SHOT_TYPE_LABELS: dict[str, str] = {
+    "packaging_hero": "包装主视觉",
+    "packaging_structure": "包装结构",
+    "lifestyle_gifting": "送礼场景",
+    "product_hero": "产品主图",
+    "white_bg": "白底图",
+    "scene": "场景图",
+}
+
+
+def build_shot_table_rows(shots: list[Any]) -> list[dict[str, Any]]:
+    """Structured rows for shot_table presentation (UX-PV-05)."""
+    rows: list[dict[str, Any]] = []
+    for raw in shots:
+        if not isinstance(raw, dict):
+            continue
+        shot_id = str(raw.get("shot_id") or "").strip()
+        if not shot_id:
+            continue
+        type_id = str(raw.get("type") or raw.get("type_id") or raw.get("shot_type") or "").strip()
+        type_label = _SHOT_TYPE_LABELS.get(type_id, type_id or "构图")
+        label = str(raw.get("label") or shot_id).strip()
+        prose = str(raw.get("shot_prose") or "").strip()
+        summary = prose[:80] + ("…" if len(prose) > 80 else "") if prose else ""
+        rows.append(
+            {
+                "shot_id": shot_id,
+                "label": label,
+                "type": type_label,
+                "summary": summary,
+                "node_id": raw.get("node_id"),
+            }
+        )
+    return rows
+
+
 def compute_expected_delivery(
     selected_macro_ids: list[str],
     shots: list[dict[str, Any]],
@@ -236,11 +272,15 @@ def build_presentation_envelope(
     }
 
     if phase == "await_shot_confirm":
+        shots = state.get("shot_manifest") or []
         n = _shot_count(state)
         hint = copy.get("shot_confirm.hint", n=str(n))
         label = copy.get("shot_confirm.primary_label")
         envelope["primary_action"] = {"label": label, "message": "确认出图"}
-        envelope["body"] = {"text": hint}
+        envelope["body"] = {
+            "text": hint,
+            "shots": build_shot_table_rows(shots if isinstance(shots, list) else []),
+        }
     elif phase == "await_shot_topo_confirm":
         n = _shot_count(state)
         manifest = state.get("split_manifest") or []

--- a/services/agent-runtime/tests/test_presentation_envelope.py
+++ b/services/agent-runtime/tests/test_presentation_envelope.py
@@ -194,6 +194,8 @@ def test_shot_confirm_primary_action_label():
     assert env["primary_action"]["label"] == "确认构图，生成预览"
     assert env["primary_action"]["message"] == "确认出图"
     assert "3" in env["body"]["text"]
+    assert len(env["body"]["shots"]) == 3
+    assert env["body"]["shots"][0]["type"] == "构图"
 
 
 def test_topo_primary_action_label_distinct_from_shot():


### PR DESCRIPTION
## Summary

- 侧栏 streaming 时点击生成钮 → abort SSE + toast（Phase 0 中断）
- 补 `shot_table` 呈现：`AgentShotTable.vue` + envelope `body.shots[]`
- 部署文档增 `LNKPI_PV_MERGED_SHOT_TOPO_GATE` 说明；UAT §10.5 闭环追踪
- 新增「运行中中断与改意图」设计规格 v1.0（实现留 Phase 1）

## Test plan

- [x] `pnpm build`
- [x] `pytest tests/test_presentation_envelope.py tests/test_product_visual_qa_copy.py` — 26 passed
- [x] `vitest presentation.test.ts agentInterruptGate.test.ts` — 38 passed
- [ ] 合并后生产 GATE_ONLY：`deploy/prod-product-visual-cvs-v2-live.py`


Made with [Cursor](https://cursor.com)