### PR TITLE
fix: UX-PV UAT signoff — presentation checkpoint + machine text filter

### DIFF
--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -66,6 +66,9 @@ import {
   defaultShotDeliverySelections,
   selectableImageTypes,
   filterAssistantVisibleText,
+  filterUserVisibleText,
+  isMachineOnlyVisibleText,
+  resolveGatePrimaryActionLabel,
   type AgentInterruptPayload,
   type ImageQaMetrics,
   type ProductVisualMacroScheme,
@@ -209,6 +212,18 @@ function dismissHistoryReattachCoachmark() {
 function visibleAssistantContent(msg: AgentStreamMessage): string {
   if (msg.role !== 'assistant') return msg.content ?? ''
   return filterAssistantVisibleText(msg.content ?? '')
+}
+
+function visibleUserContent(msg: AgentStreamMessage): string {
+  if (msg.role !== 'user') return msg.content ?? ''
+  return filterUserVisibleText(msg.content ?? '')
+}
+
+function shouldShowMessageBubbleText(msg: AgentStreamMessage): boolean {
+  if (msg.streaming) return true
+  if (msg.role === 'assistant') return Boolean(visibleAssistantContent(msg).trim())
+  if (msg.role === 'user') return !isMachineOnlyVisibleText(msg.content ?? '')
+  return Boolean((msg.content ?? '').trim())
 }
 
 function shouldRenderSchemeDraftProse(msg: AgentStreamMessage): boolean {
@@ -468,6 +483,9 @@ const macroFooterHint = computed(() => {
   const expectedCount = gatePresentation.value?.body?.expected_delivery_count ?? null
   return buildMacroAbFooterHint(macroSelections.value.length, expectedCount)
 })
+const gatePrimaryActionLabel = computed(() =>
+  resolveGatePrimaryActionLabel(gatePresentation.value, interruptGate.value?.phase ?? null),
+)
 const showGatePresentation = computed(
   () =>
     Boolean(gatePresentation.value?.primary_action) &&
@@ -1027,9 +1045,7 @@ async function refreshThreadCheckpoint() {
       )
     }
     const gatePayload = interruptPayloadFromThreadState(json.data)
-    if (gatePayload) {
-      interruptGate.value = gatePayload
-    }
+    interruptGate.value = gatePayload
   } catch {
     // ignore — checkpoint hint is best-effort
   }
@@ -1619,9 +1635,11 @@ function handleEvent(event: { type: string; data: unknown }) {
       const data = event.data as {
         retakePending?: boolean
         effectiveUtterance?: string | null
+        phase?: string | null
         presentation?: AgentPresentationEnvelope | null
       }
       syncRetakeFromPayload(data)
+      syncCompletionPresentation(data.phase ?? null, data.presentation)
       if (data.retakePending && data.presentation) {
         interruptGate.value = {
           interrupted: true,
@@ -1905,8 +1923,12 @@ defineExpose({
                   v-if="shouldRenderSchemeDraftProse(msg)"
                   :content="msg.content"
                 />
-                <p v-else class="whitespace-pre-wrap">
-                  {{ visibleAssistantContent(msg) }}<span v-if="msg.streaming" class="animate-pulse">▊</span>
+                <p v-else-if="shouldShowMessageBubbleText(msg)" class="whitespace-pre-wrap">
+                  {{
+                    msg.role === 'user'
+                      ? visibleUserContent(msg)
+                      : visibleAssistantContent(msg)
+                  }}<span v-if="msg.streaming" class="animate-pulse">▊</span>
                   <span
                     v-if="msg.role === 'assistant' && msg.executionTrace?.totalMs != null && !msg.streaming"
                     class="ml-1 text-[11px] opacity-60"
@@ -2332,7 +2354,7 @@ defineExpose({
                   :disabled="agent.isStreaming"
                   @click="sendShotConfirm()"
                 >
-                  确认出图
+                  {{ gatePrimaryActionLabel }}
                 </button>
                 <button
                   type="button"
@@ -2349,9 +2371,9 @@ defineExpose({
                 type="button"
                 class="neo-ctl agent-preset-primary rounded-lg px-3 py-1.5 text-xs font-medium"
                 :disabled="agent.isStreaming"
-                @click="sendPreset('确认出图')"
+                @click="sendPreset(gatePresentation?.primary_action?.message ?? '确认出图')"
               >
-                确认出图
+                {{ gatePrimaryActionLabel }}
               </button>
               <button
                 type="button"

--- a/apps/web/src/components/agent/agentInterruptGate.test.ts
+++ b/apps/web/src/components/agent/agentInterruptGate.test.ts
@@ -8,6 +8,8 @@ import {
   buildRetakeContinueMessage,
   defaultShotDeliverySelections,
   filterAssistantVisibleText,
+  filterUserVisibleText,
+  resolveGatePrimaryActionLabel,
   IMAGE_QA_OPTIONS,
   interruptPayloadFromThreadState,
   isRetakePendingPhase,
@@ -213,6 +215,40 @@ describe('filterAssistantVisibleText', () => {
     expect(
       filterAssistantVisibleText('__macro_scheme_decision__{"action":"confirm"}'),
     ).toBe('')
+  })
+
+  it('strips quoted machine payload lines (user confirm bubbles)', () => {
+    expect(
+      filterUserVisibleText(
+        '"__macro_scheme_decision__{\\"action\\":\\"confirm\\",\\"selected_ids\\":[\\"A\\",\\"B\\"]}"',
+      ),
+    ).toBe('')
+  })
+
+  it('filters internal QA error strings from assistant text', () => {
+    expect(
+      filterAssistantVisibleText('识图模型返回格式异常，请重试\n自动识图暂时不可用'),
+    ).toBe('自动识图暂时不可用')
+  })
+})
+
+describe('resolveGatePrimaryActionLabel', () => {
+  it('prefers presentation primary_action label', () => {
+    expect(
+      resolveGatePrimaryActionLabel(
+        {
+          kind: 'shot_table',
+          stepper: { current: 'shot_plan', completed: [] },
+          primary_action: { label: '确认构图，生成预览', message: '确认出图' },
+        },
+        'await_shot_confirm',
+      ),
+    ).toBe('确认构图，生成预览')
+  })
+
+  it('falls back to phase defaults when presentation missing', () => {
+    expect(resolveGatePrimaryActionLabel(null, 'await_shot_confirm')).toBe('确认构图，生成预览')
+    expect(resolveGatePrimaryActionLabel(null, 'await_topo')).toBe('开始出图')
   })
 })
 

--- a/apps/web/src/components/agent/agentInterruptGate.ts
+++ b/apps/web/src/components/agent/agentInterruptGate.ts
@@ -100,16 +100,57 @@ const MACHINE_PAYLOAD_PREFIXES = [
   DELIVERY_DECISION_PREFIX,
 ] as const
 
-/** Strip machine-only resume payloads from assistant visible text (spec §2.3). */
-export function filterAssistantVisibleText(content: string): string {
+const INTERNAL_QA_ERROR_SNIPPETS = [
+  '识图模型返回格式异常',
+  'vision_format_error',
+  'format_error',
+] as const
+
+function lineHasMachinePayload(line: string): boolean {
+  const trimmed = line.trimStart().replace(/^["']+|["']+$/g, '')
+  return MACHINE_PAYLOAD_PREFIXES.some((prefix) => trimmed.startsWith(prefix))
+}
+
+function filterMachinePayloadLines(content: string): string {
   return content
     .split('\n')
-    .filter(
-      (line) =>
-        !MACHINE_PAYLOAD_PREFIXES.some((prefix) => line.trimStart().startsWith(prefix)),
-    )
+    .filter((line) => !lineHasMachinePayload(line))
     .join('\n')
     .trim()
+}
+
+/** Strip machine-only resume payloads from visible text (spec §2.3). */
+export function filterUserVisibleText(content: string): string {
+  return filterMachinePayloadLines(content)
+}
+
+/** True when bubble content is only machine resume JSON (hide user/assistant bubble). */
+export function isMachineOnlyVisibleText(content: string): boolean {
+  return !filterMachinePayloadLines(content).trim()
+}
+
+/** Strip machine payloads and internal QA error strings from assistant visible text. */
+export function filterAssistantVisibleText(content: string): string {
+  return filterMachinePayloadLines(content)
+    .split('\n')
+    .filter((line) => !INTERNAL_QA_ERROR_SNIPPETS.some((snippet) => line.includes(snippet)))
+    .join('\n')
+    .trim()
+}
+
+export function resolveGatePrimaryActionLabel(
+  presentation: AgentPresentationEnvelope | null | undefined,
+  phase: string | null | undefined,
+): string {
+  const fromPres = String(presentation?.primary_action?.label ?? '').trim()
+  if (fromPres) return fromPres
+  if (phase === 'await_shot_confirm') return '确认构图，生成预览'
+  if (phase === 'await_shot_topo_confirm' || phase === 'await_topo') {
+    const eta = presentation?.body?.eta_min
+    if (typeof eta === 'number' && eta > 0) return `开始出图（约 ${eta} 分钟）`
+    return '开始出图'
+  }
+  return '确认出图'
 }
 
 /** Default checkbox state: recommended per type, else first scheme. */

--- a/docs/superpowers/specs/2026-08-11-product-visual-phase2-scheme-ssot-uat.md
+++ b/docs/superpowers/specs/2026-08-11-product-visual-phase2-scheme-ssot-uat.md
@@ -379,8 +379,26 @@
 | `shot_table` 表格 UI | ✅ 已补 | `AgentShotTable.vue` + envelope `body.shots[]` |
 | 画布产出默认 5 项折叠 | ✅ 已有 | `COLLAPSE_THRESHOLD=5`（`agentCanvasOutputs.ts`） |
 | 合并门控生产开关 | 📋 待运维 | 代码已就绪；生产设 `LNKPI_PV_MERGED_SHOT_TOPO_GATE=true` 后跑 UAT-UX-PV-10 |
-| §十 正式 Sign-off | ⏳ 待跑 | 合并/deploy 后在生产浏览器复跑 §10.1~10.3 |
+| §十 正式 Sign-off | ⏳ 待复测 | 2026-08-12 生产浏览器跑通后半段；P0 Fail 见 §10.6，#226 修复 `presentation` checkpoint + machine 文本过滤 |
 | 出图中途后端 cancel | ⏳ 规格化 | 见 [2026-08-12-agent-mid-run-interrupt-design.md](./2026-08-12-agent-mid-run-interrupt-design.md) |
+
+### 10.6 生产浏览器 UAT 记录（2026-08-12，#225 部署后）
+
+**环境：** `http://119.29.173.89:8888` · 画布 `cmsome3or004as601j0tkzh1u` · CVS-02-AB 口语 · A+B 双选
+
+| UAT-ID | 结果 | 备注 |
+|--------|------|------|
+| UX-PV-01 | ⚠️ | 友好按钮 +「自动识图暂时不可用」；历史气泡仍见内部 reason（#226 前端过滤） |
+| UX-PV-02 | ❌→修 | 两阶段均「确认出图」；根因 `presentation` 未入 checkpoint（#226） |
+| UX-PV-03 | ⚠️ | A+B 可双选；footer 预计张数/分配策略未稳定可见 |
+| UX-PV-04~05 | ✅ | 口语未污染；需求摘要结构正确 |
+| UX-PV-06 | ⚠️ | topo 门控出现；未目视卡片 vs mermaid（presentation 丢失时走 legacy 钮） |
+| UX-PV-07 | ⚠️ | 节点级进度 + 任务列表；非严格 a/b 计数 |
+| UX-PV-08 | ⚠️ | 「确认全部定稿」可用；分组标题多为 shot label /「默认」，缺用户原话 + `[方案A/B]` |
+| UX-PV-09 | ❌→修 | 结束仅「✅ 您的packaging_design视觉稿已就绪」；交付清单表未渲染（#226） |
+| UX-PV-11 | ❌→修 | 用户气泡可见 `__macro_scheme_decision__` / `__delivery_decision__`（#226 隐藏） |
+| §10.5 取消钮 | ✅ | streaming →「取消生成」 |
+| §10.5 画布折叠 | ✅ | 「展开全部 5/23 项」 |
 
 ---
 
@@ -399,6 +417,7 @@
 
 | 日期 | 版本 | 说明 |
 |------|------|------|
+| 2026-08-12 | v1.3 | §10.6 生产 UAT 记录 + #226 修复项追踪 |
 | 2026-08-12 | v1.2 | §10.5 闭环补项追踪；链至中断改意图规格 |
 | 2026-08-11 | v1.1 | 新增 §十 UX-PV-01~13；CVS-02-AB 口语路径；§七 G8~G10 |
 | 2026-08-11 | v1.0 | 初稿：Phase 2 方案层功能 UAT |

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -230,3 +230,5 @@ class AgentRuntimeState(TypedDict, total=False):
     image_qa_reason: str | None
     image_qa_metrics: dict | None
     vision_used: bool | None
+    # UX-PV: structured sidebar envelope (shot/topo/delivery/done gates)
+    presentation: dict | None

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -910,11 +910,18 @@ async def stream_run_events(
                         },
                     )
                 )
-            await emit({"type": "done", "data": {
-                **({"retakePending": True} if post_vals.get("retake_pending") else {}),
-                **({"effectiveUtterance": post_vals.get("effective_utterance")} if post_vals.get("retake_pending") and post_vals.get("effective_utterance") else {}),
-                **({"presentation": post_vals.get("presentation")} if post_vals.get("retake_pending") and isinstance(post_vals.get("presentation"), dict) else {}),
-            }})
+            done_payload: dict[str, Any] = {}
+            if post_vals.get("retake_pending"):
+                done_payload["retakePending"] = True
+                if post_vals.get("effective_utterance"):
+                    done_payload["effectiveUtterance"] = post_vals.get("effective_utterance")
+            post_phase = post_vals.get("phase")
+            if post_phase is not None:
+                done_payload["phase"] = str(post_phase)
+            post_presentation = post_vals.get("presentation")
+            if isinstance(post_presentation, dict):
+                done_payload["presentation"] = post_presentation
+            await emit({"type": "done", "data": done_payload})
         except AgentToolError as exc:
             record_stream_error(exc.error["error_type"])
             await emit({"type": "error", "data": error_to_sse_payload(exc.error)})


### PR DESCRIPTION
## Summary
- 将 `presentation` 纳入 LangGraph checkpoint，修复 shot/topo 门控差异化主按钮与定稿后交付清单表不渲染（UX-PV-02/09 根因）
- SSE `done` 事件携带 `phase` + `presentation`；侧栏 thread-state 刷新时正确清空 interruptGate
- 隐藏用户气泡中的 `__macro_scheme_decision__` / `__delivery_decision__` 等 machine payload；过滤 assistant 内部识图错误文案
- UAT 文档 §10.6 记录生产浏览器后半段验收结果

## Test plan
- [x] `pnpm build`
- [x] vitest: `agentInterruptGate.test.ts`, `presentation.test.ts` (42 passed)
- [ ] 合并部署后生产新建对话复跑 §10.1~10.3 Sign-off


Made with [Cursor](https://cursor.com)