### PR TITLE
fix: UX-PV signoff closure (A+B footer, delivery groups, merged gate)

### DIFF
--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -68,6 +68,7 @@ import {
   filterAssistantVisibleText,
   filterUserVisibleText,
   isMachineOnlyVisibleText,
+  buildClientDeliveryGroups,
   resolveGatePrimaryActionLabel,
   type AgentInterruptPayload,
   type ImageQaMetrics,
@@ -479,9 +480,50 @@ const showCompletionPresentation = computed(
   () => completionPresentation.value?.kind === 'delivery_summary_table',
 )
 const macroFooterHint = computed(() => {
+  const fromPres = String(gatePresentation.value?.body?.footer_hint ?? '').trim()
+  if (fromPres) return fromPres
   if (!awaitingMacroSchemeSelect.value || macroSelections.value.length < 2) return ''
   const expectedCount = gatePresentation.value?.body?.expected_delivery_count ?? null
   return buildMacroAbFooterHint(macroSelections.value.length, expectedCount)
+})
+const deliveryGroupsForUi = computed(() => {
+  const fromPres = gatePresentation.value?.body?.groups
+  if (fromPres?.length) return fromPres
+  if (!awaitingDeliveryConfirm.value || !productVisualSchemeV2.value) return []
+  return buildClientDeliveryGroups(
+    shotManifest.value,
+    deliveryGenByKey.value,
+    userRequestLabels.value,
+    deliverySelections.value,
+  )
+})
+const deliveryPresentationForUi = computed((): AgentPresentationEnvelope | null => {
+  if (!awaitingDeliveryConfirm.value) return null
+  if (gatePresentation.value?.kind === 'delivery_cards' && deliveryGroupsForUi.value.length) {
+    return {
+      ...gatePresentation.value,
+      body: {
+        ...gatePresentation.value.body,
+        groups: deliveryGroupsForUi.value,
+        footer_hint:
+          gatePresentation.value.body?.footer_hint
+          ?? (deliveryGroupsForUi.value.length
+            ? `确认后将交付 ${deliveryGroupsForUi.value.length} 张定稿图`
+            : undefined),
+      },
+    }
+  }
+  if (!productVisualSchemeV2.value || !deliveryGroupsForUi.value.length) return null
+  return {
+    kind: 'delivery_cards',
+    stepper: { current: 'delivery', completed: ['image_qa', 'scheme_draft', 'macro_select', 'generating'] },
+    body: {
+      hint: '按场景切换定稿图；切换候选不会重新生成。',
+      groups: deliveryGroupsForUi.value,
+      footer_hint: `确认后将交付 ${deliveryGroupsForUi.value.length} 张定稿图`,
+    },
+    primary_action: { label: '确认全部定稿', message: '确认全部定稿' },
+  }
 })
 const gatePrimaryActionLabel = computed(() =>
   resolveGatePrimaryActionLabel(gatePresentation.value, interruptGate.value?.phase ?? null),
@@ -492,10 +534,7 @@ const showGatePresentation = computed(
     (awaitingShotConfirm.value || (awaitingTopoConfirm.value && !awaitingShotConfirm.value)),
 )
 const showDeliveryPresentation = computed(
-  () =>
-    awaitingDeliveryConfirm.value &&
-    gatePresentation.value?.kind === 'delivery_cards' &&
-    Boolean(gatePresentation.value?.body?.groups?.length),
+  () => awaitingDeliveryConfirm.value && Boolean(deliveryPresentationForUi.value),
 )
 const awaitingDeliveryConfirm = computed(() => chipSet.value === 'delivery_confirm')
 const userRequestLabels = ref<string[]>([])
@@ -796,7 +835,10 @@ const isProductVisualSkill = computed(() => activeSkillId.value === 'product-vis
 const skillButtonLabel = computed(() => activeSkill.value?.label ?? '技能')
 const inputPlaceholder = computed(() => agentInputPlaceholder(activeSkill.value))
 const showProductVisualEmptyState = computed(
-  () => isProductVisualSkill.value && !agent.messages.length && !props.readOnly,
+  () =>
+    isProductVisualSkill.value
+    && !props.readOnly
+    && !agent.messages.some((m) => m.role === 'user'),
 )
 const showProductVisualAttachmentHint = computed(
   () => isProductVisualSkill.value && !props.readOnly,
@@ -2231,11 +2273,11 @@ defineExpose({
               @confirm-all="sendDeliveryConfirmAll"
             />
             <div
-              v-else-if="showDeliveryPresentation && gatePresentation"
+              v-else-if="showDeliveryPresentation && deliveryPresentationForUi"
               class="mb-2"
             >
               <AgentPresentationHost
-                :presentation="gatePresentation"
+                :presentation="deliveryPresentationForUi"
                 :delivery-selections="deliverySelections"
                 :disabled="agent.isStreaming"
                 @primary-action="onDeliveryPrimaryAction"
@@ -2243,48 +2285,6 @@ defineExpose({
                 @focus-node="emit('focusNode', $event)"
                 @focus-all="emit('focusAll', $event)"
               />
-            </div>
-            <div
-              v-else-if="awaitingDeliveryConfirm && productVisualSchemeV2 && shotManifest.length && !showDeliveryPresentation"
-              class="mb-2 space-y-2 px-0.5"
-            >
-              <div
-                v-for="shot in shotManifest"
-                :key="shot.shot_id"
-                class="rounded-lg border border-[var(--neo-border)] p-2 text-xs"
-              >
-                <div class="mb-1 font-medium">
-                  {{ shot.label || shot.shot_id }}
-                  <span v-if="shot.macro_scheme_id" class="ml-1 text-[var(--neo-muted)]">
-                    方案{{ shot.macro_scheme_id }}
-                  </span>
-                </div>
-                <div class="flex flex-wrap gap-2">
-                  <button
-                    v-for="variantKey in (
-                      (shot.variant_count ?? 1) === 1
-                        ? [shot.shot_id]
-                        : Array.from({ length: Math.min(3, shot.variant_count ?? 1) }, (_, i) => `${shot.shot_id}__v${i + 1}`)
-                    )"
-                    :key="variantKey"
-                    type="button"
-                    class="neo-ctl rounded px-2 py-1"
-                    :class="{ 'agent-preset-primary font-medium': deliverySelections[shot.shot_id] === variantKey }"
-                    :disabled="agent.isStreaming || !deliveryGenByKey[variantKey]?.url"
-                    @click="sendMessage(buildShotDeliverySwitchMessage(shot.shot_id, variantKey))"
-                  >
-                    {{ variantKey.includes('__v') ? variantKey.split('__v').pop() : '默认' }}
-                  </button>
-                </div>
-              </div>
-              <button
-                type="button"
-                class="neo-ctl agent-preset-primary rounded-lg px-3 py-1.5 text-xs font-medium"
-                :disabled="agent.isStreaming"
-                @click="sendMessage(buildShotDeliveryConfirmMessage(deliverySelections), 'confirm')"
-              >
-                确认全部定稿
-              </button>
             </div>
             <div v-else-if="showCompletionPresentation && completionPresentation" class="mb-2">
               <AgentPresentationHost

--- a/apps/web/src/components/agent/agentInterruptGate.test.ts
+++ b/apps/web/src/components/agent/agentInterruptGate.test.ts
@@ -4,6 +4,7 @@ import {
   defaultDeliverySelections,
   defaultMacroSchemeSelection,
   buildMacroSchemeConfirmMessage,
+  buildClientDeliveryGroups,
   buildMacroAbFooterHint,
   buildRetakeContinueMessage,
   defaultShotDeliverySelections,
@@ -179,6 +180,27 @@ describe('buildMacroSchemeConfirmMessage', () => {
     const msg = buildMacroSchemeConfirmMessage(['A', 'B'])
     expect(msg).toContain('__macro_scheme_decision__')
     expect(msg).toContain('"selected_ids":["A","B"]')
+  })
+})
+
+describe('buildClientDeliveryGroups', () => {
+  it('builds user-language labels and macro subtitles', () => {
+    const groups = buildClientDeliveryGroups(
+      [
+        { shot_id: 'hero__1', type_id: 'packaging_hero', label: '礼盒主视觉', macro_scheme_id: 'A', variant_count: 1 },
+        { shot_id: 'scene__1', type_id: 'lifestyle_gifting', label: '送礼场景', macro_scheme_id: 'B', variant_count: 1 },
+      ],
+      {
+        hero__1: { url: 'https://example.com/a.png', title: '候选 A' },
+        scene__1: { url: 'https://example.com/b.png', title: '候选 B' },
+      },
+      ['礼盒长什么样', '送人场景'],
+      { hero__1: 'hero__1', scene__1: 'scene__1' },
+    )
+    expect(groups).toHaveLength(2)
+    expect(groups[0].label).toBe('礼盒长什么样')
+    expect(groups[0].subtitle).toContain('[方案A]')
+    expect(groups[1].label).toBe('送人场景')
   })
 })
 

--- a/apps/web/src/components/agent/agentInterruptGate.ts
+++ b/apps/web/src/components/agent/agentInterruptGate.ts
@@ -1,7 +1,7 @@
 /** @vitest-environment node */
 
 import type { AgentChipSet } from './agentChipSet'
-import type { AgentPresentationEnvelope } from './presentation/types'
+import type { AgentPresentationEnvelope, DeliveryCardGroup } from './presentation/types'
 
 export interface AgentInterruptPayload {
   node?: string | null
@@ -247,6 +247,48 @@ export function buildMacroAbFooterHint(
       ? String(expectedDeliveryCount)
       : '若干'
   return `已选 ${k} 套风格 → 预计场景图 ${p} 张。不同构图将分别采用 A/B 风格，并非每个场景各出 2 张。`
+}
+
+/** Client-side delivery_cards groups when runtime presentation.groups missing (UX-PV-08). */
+export function buildClientDeliveryGroups(
+  shots: ProductVisualShot[] | null | undefined,
+  genByKey: Record<string, { url?: string | null; title?: string | null }> | null | undefined,
+  userLabels: string[] | null | undefined,
+  selections: Record<string, string>,
+): DeliveryCardGroup[] {
+  const groups: DeliveryCardGroup[] = []
+  const labels = userLabels ?? []
+  const byKey = genByKey ?? {}
+  for (let index = 0; index < (shots ?? []).length; index++) {
+    const shot = shots![index]
+    const shotId = shot.shot_id?.trim()
+    if (!shotId) continue
+    const variants = Math.max(1, Math.min(3, shot.variant_count ?? 1))
+    const keys =
+      variants === 1
+        ? [shotId]
+        : Array.from({ length: variants }, (_, i) => `${shotId}__v${i + 1}`)
+    const ready = keys.filter((k) => Boolean(byKey[k]?.url))
+    if (!ready.length) continue
+    const selected = selections[shotId] || ready[0]
+    const macro = shot.macro_scheme_id?.trim()
+    const shotLabel = shot.label?.trim() || shotId
+    const subtitle = macro ? `[方案${macro}] ${shotLabel}` : shotLabel
+    groups.push({
+      label: labels[index]?.trim() || shotLabel,
+      subtitle,
+      shot_id: shotId,
+      recommended: selected === ready[0],
+      selected_variant_key: selected,
+      candidates: ready.map((variantKey, i) => ({
+        variant_key: variantKey,
+        url: byKey[variantKey]?.url ?? null,
+        title: byKey[variantKey]?.title ?? null,
+        recommended: i === 0,
+      })),
+    })
+  }
+  return groups
 }
 
 /** Default variant key per shot (first ready gen key). */

--- a/deploy/.env.production.example
+++ b/deploy/.env.production.example
@@ -60,10 +60,10 @@ LNKPI_OPENAI_BASE_URL=https://api.openai.com/v1
 LNKPI_OPENAI_CHAT_MODEL=
 LNKPI_IMAGE_GEN_CONCURRENCY=3
 LNKPI_IMAGE_GEN_TIMEOUT_SEC=180
-# Product visual scheme v2 — prose SSOT + macro/shot (UAT 前设为 true，重启 agent-runtime)
-# LNKPI_PRODUCT_VISUAL_SCHEME_V2=true
-# UX-PV-10: merge shot + topo gate (hard stops ≤3); enable after v2 stable
-# LNKPI_PV_MERGED_SHOT_TOPO_GATE=true
+# Product visual scheme v2 — prose SSOT + macro/shot (UAT 必开，重启 agent-runtime)
+LNKPI_PRODUCT_VISUAL_SCHEME_V2=true
+# UX-PV-10: merge shot + topo gate (hard stops ≤3)
+LNKPI_PV_MERGED_SHOT_TOPO_GATE=true
 
 # W23 OTLP tracing（生产默认开启；enable-agent-runtime.sh 写入并连接 Tempo）
 # 复用同机 pintuotuo Tempo：http://pintuotuo-tempo:4318/v1/traces

--- a/deploy/enable-agent-runtime.sh
+++ b/deploy/enable-agent-runtime.sh
@@ -155,6 +155,11 @@ elif [[ -z "$RT_MODEL" ]]; then
   log "WARN: LNKPI_OPENAI_CHAT_MODEL empty — Runtime defaults to gpt-4o"
 fi
 
+# Product visual scheme v2 — prose SSOT + macro/shot (required for UX-PV UAT)
+[[ -n "$(get_env LNKPI_PRODUCT_VISUAL_SCHEME_V2)" ]] || upsert_env LNKPI_PRODUCT_VISUAL_SCHEME_V2 "true"
+upsert_env LNKPI_PV_MERGED_SHOT_TOPO_GATE "true"
+log "LNKPI_PRODUCT_VISUAL_SCHEME_V2 + LNKPI_PV_MERGED_SHOT_TOPO_GATE enabled for UX-PV UAT"
+
 # Optional tunables if missing
 [[ -n "$(get_env LNKPI_IMAGE_GEN_CONCURRENCY)" ]] || upsert_env LNKPI_IMAGE_GEN_CONCURRENCY "3"
 [[ -n "$(get_env LNKPI_IMAGE_GEN_TIMEOUT_SEC)" ]] || upsert_env LNKPI_IMAGE_GEN_TIMEOUT_SEC "180"

--- a/docs/superpowers/specs/2026-08-11-product-visual-phase2-scheme-ssot-uat.md
+++ b/docs/superpowers/specs/2026-08-11-product-visual-phase2-scheme-ssot-uat.md
@@ -378,8 +378,8 @@
 | 生成钮 streaming 取消 | ✅ 已补 | 侧栏 `DockGenerateButton` 点击 → abort SSE + toast；**后端 run 仍可能继续**（见 [中断改意图规格](./2026-08-12-agent-mid-run-interrupt-design.md)） |
 | `shot_table` 表格 UI | ✅ 已补 | `AgentShotTable.vue` + envelope `body.shots[]` |
 | 画布产出默认 5 项折叠 | ✅ 已有 | `COLLAPSE_THRESHOLD=5`（`agentCanvasOutputs.ts`） |
-| 合并门控生产开关 | 📋 待运维 | 代码已就绪；生产设 `LNKPI_PV_MERGED_SHOT_TOPO_GATE=true` 后跑 UAT-UX-PV-10 |
-| §十 正式 Sign-off | ⏳ 待复测 | 2026-08-12 生产浏览器跑通后半段；P0 Fail 见 §10.6，#226 修复 `presentation` checkpoint + machine 文本过滤 |
+| 合并门控生产开关 | ✅ 脚本默认开 | `enable-agent-runtime.sh` 写入 `LNKPI_PV_MERGED_SHOT_TOPO_GATE=true` |
+| §十 正式 Sign-off | ⏳ #227 部署后复测 | 见 §10.6 |
 | 出图中途后端 cancel | ⏳ 规格化 | 见 [2026-08-12-agent-mid-run-interrupt-design.md](./2026-08-12-agent-mid-run-interrupt-design.md) |
 
 ### 10.6 生产浏览器 UAT 记录（2026-08-12，#225 部署后）

--- a/services/agent-runtime/app/graph/nodes/macro_scheme_select_gate.py
+++ b/services/agent-runtime/app/graph/nodes/macro_scheme_select_gate.py
@@ -51,6 +51,7 @@ def build_macro_select_presentation_patch(
         selected,
         state.get("shot_manifest") or [],
         copy=copy,
+        state=state,
     )
     presentation = build_presentation_envelope(
         kind="macro_scheme_cards",
@@ -137,6 +138,7 @@ def apply_macro_scheme_decision(state: dict, decision: dict[str, Any]) -> dict[s
             [str(s) for s in selected],
             state.get("shot_manifest") or [],
             copy=ProductVisualCopy.load_from_skill("ecommerce-product-visual", "1.0.0"),
+            state=state,
         )
         return {
             **applied,

--- a/services/agent-runtime/app/graph/product_visual_v2/delivery.py
+++ b/services/agent-runtime/app/graph/product_visual_v2/delivery.py
@@ -409,7 +409,7 @@ def build_delivery_presentation_patch(state: dict[str, Any]) -> dict[str, Any]:
         for s in (state.get("selected_macro_scheme_ids") or [])
         if str(s).strip()
     ]
-    delivery = compute_expected_delivery(selected, shots, copy=copy)
+    delivery = compute_expected_delivery(selected, shots, copy=copy, state=state)
     expected = state.get("expected_delivery_count")
     if not isinstance(expected, int) or expected <= 0:
         expected = delivery["total_finalize"] or len(build_delivery_groups(state))

--- a/services/agent-runtime/app/graph/product_visual_v2/presentation.py
+++ b/services/agent-runtime/app/graph/product_visual_v2/presentation.py
@@ -224,17 +224,41 @@ def build_shot_table_rows(shots: list[Any]) -> list[dict[str, Any]]:
     return rows
 
 
+def estimate_scene_count(state: dict[str, Any]) -> int:
+    """Best-effort scene count before shot_manifest exists (macro A+B footer UX-PV-03)."""
+    shots = state.get("shot_manifest") or []
+    if isinstance(shots, list):
+        n = len([s for s in shots if isinstance(s, dict)])
+        if n > 0:
+            return n
+    labels = state.get("user_request_labels") or []
+    if isinstance(labels, list):
+        label_n = len([x for x in labels if str(x).strip()])
+        if label_n > 0:
+            return label_n
+    intent = state.get("visual_intent") or {}
+    output_types = intent.get("output_types_requested") or []
+    if isinstance(output_types, list):
+        type_n = len([t for t in output_types if str(t).strip()])
+        if type_n > 0:
+            return type_n
+    return 3
+
+
 def compute_expected_delivery(
     selected_macro_ids: list[str],
     shots: list[dict[str, Any]],
     *,
     allocation_mode: str = "mixed",
     copy: ProductVisualCopy | None = None,
+    state: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Compute finalize count and A+B allocation note for macro selection UX."""
     selected = [str(s).strip() for s in selected_macro_ids if str(s).strip()]
     k = len(selected)
     scene_count = len([s for s in shots if isinstance(s, dict)]) if isinstance(shots, list) else 0
+    if scene_count <= 0 and state is not None:
+        scene_count = estimate_scene_count(state)
 
     if allocation_mode == "full_matrix":
         total_finalize = scene_count * k if scene_count > 0 else 0
@@ -337,6 +361,7 @@ def build_presentation_envelope(
             selected,
             state.get("shot_manifest") or [],
             copy=copy,
+            state=state,
         )
         body: dict[str, Any] = {
             "schemes": normalize_macro_schemes(state.get("macro_schemes") or []),

--- a/services/agent-runtime/tests/test_presentation_envelope.py
+++ b/services/agent-runtime/tests/test_presentation_envelope.py
@@ -289,6 +289,19 @@ def test_compute_expected_delivery_mixed_mode():
     assert "2 套" in delivery["allocation_note"] or "两套" in delivery["allocation_note"]
 
 
+def test_compute_expected_delivery_estimates_from_labels_before_shots():
+    copy = ProductVisualCopy.load_from_skill("ecommerce-product-visual", "1.0.0")
+    state = {
+        "user_request_labels": ["礼盒长什么样", "快递怎么防压", "送人场景"],
+        "shot_manifest": [],
+    }
+    delivery = compute_expected_delivery(["A", "B"], [], copy=copy, state=state)
+    assert delivery["scene_count"] == 3
+    assert delivery["total_finalize"] == 3
+    assert delivery["allocation_note"]
+    assert "3" in delivery["allocation_note"]
+
+
 def test_delivery_envelope_user_request_labels():
     copy = ProductVisualCopy.load_from_skill("ecommerce-product-visual", "1.0.0")
     state = {


### PR DESCRIPTION
## Summary
- **UX-PV-03**: macro A+B footer 在 shot 拆解前用 `user_request_labels` 估算预计张数；优先展示 runtime `footer_hint`
- **UX-PV-08**: 定稿门控统一走 `delivery_cards`（`buildClientDeliveryGroups` 兜底），分组标题为用户原话 + `[方案A/B]` subtitle
- **UX-PV-10**: `enable-agent-runtime.sh` / `.env.production.example` 默认开启 `LNKPI_PV_MERGED_SHOT_TOPO_GATE`
- **UX-PV-13**: 实物产品视觉技能下，只要 thread 尚无用户消息即展示 3 条示例话术

## Test plan
- [x] `pnpm build`
- [x] vitest `agentInterruptGate.test.ts` (38 passed)
- [x] pytest `test_presentation_envelope.py` (estimate from labels)
- [ ] 合并后 CVM 执行 `enable-agent-runtime.sh` 重启 runtime
- [ ] 生产 GATE_ONLY + 浏览器 §10 Sign-off


Made with [Cursor](https://cursor.com)