### PR TITLE
feat(agent): UX followup batch — macro revise, preview, mobile, history

### DIFF
--- a/apps/server/prisma/migrations/20260812193000_agent_message_metadata/migration.sql
+++ b/apps/server/prisma/migrations/20260812193000_agent_message_metadata/migration.sql
@@ -1,0 +1,2 @@
+-- PR-4: Agent turn metadata (presentation + execution trace events)
+ALTER TABLE "AgentMessage" ADD COLUMN "metadata" TEXT;

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -211,6 +211,8 @@ model AgentMessage {
   attachments   String?
   /** JSON: LinkedCanvasOutput[] — 本轮 assistant 产出的可定位节点 */
   linkedOutputs String?
+  /** JSON: presentation + executionEvents for history replay */
+  metadata      String?
   createdAt     DateTime    @default(now())
 
   @@index([threadId, createdAt])

--- a/apps/server/src/agent/agent.service.test.ts
+++ b/apps/server/src/agent/agent.service.test.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CanvasAction } from '@lnkpi/shared'
-import { AgentService, deriveLinkedOutputs } from './agent.service'
+import { AgentService, deriveLinkedOutputs, buildTurnMetadata } from './agent.service'
 import { AgentRuntimeClient } from './agent-runtime.client'
 
 describe('deriveLinkedOutputs', () => {
@@ -59,6 +59,23 @@ describe('deriveLinkedOutputs', () => {
     ]
 
     expect(deriveLinkedOutputs(actions)).toEqual([])
+  })
+})
+
+describe('buildTurnMetadata', () => {
+  it('serializes presentation and execution events', () => {
+    const raw = buildTurnMetadata({
+      presentation: { kind: 'macro_scheme_cards', body: { schemes: [] } },
+      executionEvents: [{ type: 'step', data: { id: 's1', label: 'x', status: 'done' } }],
+    })
+    expect(raw).toBeTruthy()
+    const parsed = JSON.parse(raw!)
+    expect(parsed.presentation.kind).toBe('macro_scheme_cards')
+    expect(parsed.executionEvents).toHaveLength(1)
+  })
+
+  it('returns null when empty', () => {
+    expect(buildTurnMetadata({ executionEvents: [] })).toBeNull()
   })
 })
 
@@ -163,7 +180,13 @@ describe('AgentService streamConversation', () => {
           },
         },
       }
-      yield { type: 'done', data: {} }
+      yield { type: 'step', data: { id: 'dialog_draft', label: '出方案', status: 'done', ms: 10 } }
+      yield {
+        type: 'done',
+        data: {
+          presentation: { kind: 'macro_scheme_cards', stepper: { current: 'macro_select', completed: [] } },
+        },
+      }
     })
 
     vi.spyOn(service, 'createRuntimeClient').mockReturnValue({
@@ -191,6 +214,7 @@ describe('AgentService streamConversation', () => {
     expect(events.map((e) => e.type)).toEqual([
       'text_delta',
       'canvas_action',
+      'step',
       'done',
     ])
     // Runtime path skips canvasData rewrite (Nest tools already wrote)
@@ -206,6 +230,7 @@ describe('AgentService streamConversation', () => {
             status: 'done',
           },
         ]),
+        metadata: expect.stringContaining('macro_scheme_cards'),
       }),
     })
   })

--- a/apps/server/src/agent/agent.service.ts
+++ b/apps/server/src/agent/agent.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common'
 import { applyCanvasActions, type AgentStreamEvent } from '@lnkpi/agent'
-import type { CanvasAction, CanvasData, LinkedCanvasOutput, SidebarAttachment } from '@lnkpi/shared'
+import type { CanvasAction, CanvasData, LinkedCanvasOutput, SidebarAttachment, AgentMessageMetadata } from '@lnkpi/shared'
 import {
   IMAGE_MODELS,
   TEXT_MODELS,
@@ -14,6 +14,30 @@ import { PrismaService } from '../prisma/prisma.service'
 import { ProviderResolverService } from '../provider/provider-resolver.service'
 import { AgentRuntimeClient } from './agent-runtime.client'
 import { mapUiSkillId } from './agent-skill-map'
+
+const TRACE_PERSIST_EVENT_TYPES = new Set([
+  'step',
+  'text_replace',
+  'phase_hint',
+  'tool_call',
+  'tool_result',
+  'canvas_action',
+  'node_status',
+  'task_update',
+  'thinking',
+  'explore',
+  'error',
+])
+
+export function buildTurnMetadata(input: {
+  presentation?: Record<string, unknown>
+  executionEvents: Array<{ type: string; data: unknown }>
+}): string | null {
+  const metadata: AgentMessageMetadata = {}
+  if (input.presentation) metadata.presentation = input.presentation
+  if (input.executionEvents.length) metadata.executionEvents = input.executionEvents
+  return Object.keys(metadata).length ? JSON.stringify(metadata) : null
+}
 
 export function deriveLinkedOutputs(actions: CanvasAction[]): LinkedCanvasOutput[] {
   return actions
@@ -310,6 +334,8 @@ export class AgentService {
   ): AsyncGenerator<AgentStreamEvent> {
     let assistantText = ''
     const canvasActions: CanvasAction[] = []
+    const executionEvents: Array<{ type: string; data: unknown }> = []
+    let turnPresentation: Record<string, unknown> | undefined
 
     const runtimeSkillId = mapUiSkillId(skillId)
     let llmModel: string | undefined
@@ -340,6 +366,15 @@ export class AgentService {
       refOrder,
       mentionedKeys,
     })) {
+      if (TRACE_PERSIST_EVENT_TYPES.has(event.type)) {
+        executionEvents.push({ type: event.type, data: event.data })
+      }
+      if (event.type === 'interrupt' || event.type === 'done') {
+        const pres = (event.data as { presentation?: unknown })?.presentation
+        if (pres && typeof pres === 'object' && !Array.isArray(pres)) {
+          turnPresentation = pres as Record<string, unknown>
+        }
+      }
       if (event.type === 'text_delta') {
         assistantText += (event.data as { text: string }).text
       }
@@ -357,6 +392,7 @@ export class AgentService {
       // Nest internal tools already wrote Session.canvasData; skip re-apply to avoid duplicate add_node
       rewriteCanvasData: false,
       linkedOutputs: deriveLinkedOutputs(canvasActions),
+      metadata: buildTurnMetadata({ presentation: turnPresentation, executionEvents }),
     })
   }
 
@@ -366,7 +402,11 @@ export class AgentService {
     userId: string | undefined,
     assistantText: string,
     canvasActions: CanvasAction[],
-    opts: { rewriteCanvasData: boolean; linkedOutputs?: LinkedCanvasOutput[] },
+    opts: {
+      rewriteCanvasData: boolean
+      linkedOutputs?: LinkedCanvasOutput[]
+      metadata?: string | null
+    },
   ) {
     if (assistantText) {
       await this.prisma.agentMessage.create({
@@ -377,6 +417,7 @@ export class AgentService {
           content: assistantText,
           toolCalls: canvasActions.length ? JSON.stringify(canvasActions) : null,
           linkedOutputs: opts.linkedOutputs?.length ? JSON.stringify(opts.linkedOutputs) : null,
+          metadata: opts.metadata ?? null,
         },
       })
       await this.prisma.agentThread.update({

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -18,7 +18,7 @@ onMounted(() => {
   <div class="min-h-screen bg-surface">
     <div v-if="!isImmersiveCanvas" class="pointer-events-none fixed inset-0 bg-hero-gradient" />
     <AppHeader v-if="!isImmersiveCanvas" />
-    <main class="relative" :class="isImmersiveCanvas ? 'h-screen overflow-hidden' : ''">
+    <main class="relative z-10" :class="isImmersiveCanvas ? 'h-screen overflow-hidden' : ''">
       <RouterView />
     </main>
     <LoginDialog />

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -279,7 +279,8 @@ function canShowMessageActions(msg: AgentStreamMessage): boolean {
   return Boolean(
     visibleAssistantContent(msg).trim()
     || (assistantOutputsById.value.get(msg.id)?.length ?? 0) > 0
-    || msg.executionTrace,
+    || msg.executionTrace
+    || msg.presentation,
   )
 }
 
@@ -619,6 +620,19 @@ function syncCompletionPresentation(
   if (phase !== 'done') {
     completionPresentation.value = null
   }
+}
+
+function historyPresentation(msg: AgentStreamMessage): AgentPresentationEnvelope | null {
+  if (msg.role !== 'assistant' || msg.streaming || !msg.presentation) return null
+  return msg.presentation
+}
+
+function historyMacroSelectedIds(presentation: AgentPresentationEnvelope): string[] {
+  const schemes = presentation.body?.schemes ?? []
+  const recommended = schemes.filter((s) => s.recommended).map((s) => String(s.id))
+  if (recommended.length) return recommended
+  const maxSelect = presentation.body?.max_select ?? 2
+  return schemes.slice(0, maxSelect).map((s) => String(s.id))
 }
 
 function syncRetakeFromPayload(data: {
@@ -1977,6 +1991,12 @@ defineExpose({
                 <AgentProseBlock
                   v-if="shouldRenderSchemeDraftProse(msg)"
                   :content="msg.content"
+                />
+                <AgentPresentationHost
+                  v-if="historyPresentation(msg)"
+                  :presentation="historyPresentation(msg)!"
+                  disabled
+                  :macro-selected-ids="historyMacroSelectedIds(historyPresentation(msg)!)"
                 />
                 <p v-else-if="shouldShowMessageBubbleText(msg)" class="whitespace-pre-wrap">
                   {{

--- a/apps/web/src/components/agent/executionTraceReducer.test.ts
+++ b/apps/web/src/components/agent/executionTraceReducer.test.ts
@@ -8,6 +8,7 @@ import {
   applyToolCall,
   createExecutionTrace,
   finalizeExecutionTrace,
+  replayExecutionTraceEvents,
 } from '@/components/agent/executionTraceReducer'
 import { labelFromTextReplace } from '@/components/agent/executionStepLabels'
 
@@ -72,5 +73,14 @@ describe('executionTraceReducer', () => {
     const trace = createExecutionTrace()
     applyPhaseHint(trace, { phase: 'await_confirm', label: '等待你确认方案' })
     expect(trace.steps[0]?.status).toBe('waiting_user')
+  })
+
+  it('replays persisted execution events', () => {
+    const trace = replayExecutionTraceEvents([
+      { type: 'text_replace', data: { text: '好的，我来生成图片「模特」' } },
+      { type: 'step', data: { id: 'n1', label: '理解需求', status: 'done', ms: 12 } },
+    ])
+    expect(trace.steps.some((s) => s.label === '理解需求')).toBe(true)
+    expect(trace.totalMs).toBeGreaterThanOrEqual(0)
   })
 })

--- a/apps/web/src/components/agent/executionTraceReducer.ts
+++ b/apps/web/src/components/agent/executionTraceReducer.ts
@@ -383,3 +383,77 @@ export function finalizeExecutionTrace(trace: ExecutionTraceState) {
 export function visibleStepCount(trace: ExecutionTraceState): number {
   return trace.steps.length
 }
+
+export const EXECUTION_TRACE_PERSIST_EVENT_TYPES = new Set([
+  'step',
+  'text_replace',
+  'phase_hint',
+  'tool_call',
+  'tool_result',
+  'canvas_action',
+  'node_status',
+  'task_update',
+  'thinking',
+  'explore',
+  'error',
+])
+
+/** Rebuild execution trace from persisted SSE events (history load). */
+export function replayExecutionTraceEvents(
+  events: Array<{ type: string; data: unknown }>,
+): ExecutionTraceState {
+  const trace = createExecutionTrace()
+  for (const event of events) {
+    switch (event.type) {
+      case 'text_replace':
+        applyTextReplaceStage(trace, String((event.data as { text?: string })?.text ?? ''))
+        break
+      case 'tool_call':
+        applyToolCall(trace, String((event.data as { name?: string })?.name ?? 'tool'))
+        break
+      case 'tool_result':
+        applyToolCall(
+          trace,
+          String((event.data as { name?: string })?.name ?? 'tool'),
+          (event.data as { result?: unknown })?.result,
+        )
+        break
+      case 'canvas_action':
+        applyCanvasAction(trace, event.data as CanvasAction)
+        break
+      case 'node_status':
+        applyNodeStatus(trace, event.data as { nodeId: string; status: string; url?: string })
+        break
+      case 'step':
+        applyStep(trace, event.data as Parameters<typeof applyStep>[1])
+        break
+      case 'phase_hint':
+        applyPhaseHint(trace, event.data as { phase?: string; label: string })
+        break
+      case 'thinking':
+        applyThinking(trace, event.data as { status: string; summary?: string })
+        break
+      case 'explore':
+        applyExplore(trace, event.data as Parameters<typeof applyExplore>[1])
+        break
+      case 'task_update':
+        applyTaskUpdate(trace, event.data as Parameters<typeof applyTaskUpdate>[1])
+        break
+      case 'error':
+        applyStructuredError(
+          trace,
+          event.data as {
+            message?: string
+            error_type?: string
+            retry_hint?: string
+            tool_name?: string
+          },
+        )
+        break
+      default:
+        break
+    }
+  }
+  finalizeExecutionTrace(trace)
+  return trace
+}

--- a/apps/web/src/components/canvas/CanvasNodeImage.vue
+++ b/apps/web/src/components/canvas/CanvasNodeImage.vue
@@ -111,8 +111,26 @@ function saveToLibrary() {
       @dragleave="onDragLeave"
       @drop="onDrop"
     >
-      <div v-if="data.url" class="neo-gen-preview" title="双击预览大图" @dblclick.stop="openPreview">
-        <img :src="displayUrl" alt="">
+      <div
+        v-if="data.url"
+        class="neo-gen-preview nodrag"
+        title="双击预览大图"
+        @dblclick.stop="openPreview"
+      >
+        <img :src="displayUrl" alt="" draggable="false">
+        <button
+          type="button"
+          class="neo-gen-image-preview-btn nodrag"
+          title="预览大图"
+          @pointerdown.stop
+          @mousedown.stop
+          @click.stop="openPreview"
+        >
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z" />
+            <circle cx="12" cy="12" r="3" />
+          </svg>
+        </button>
         <button
           type="button"
           class="neo-node-replace-btn nodrag"

--- a/apps/web/src/components/layout/AppHeader.vue
+++ b/apps/web/src/components/layout/AppHeader.vue
@@ -39,8 +39,8 @@ function navigate(path: string) {
     class="sticky top-0 z-50 border-b border-white/5 bg-[#141414]/95 backdrop-blur-xl"
     style="height: var(--neo-header-height)"
   >
-    <div class="mx-auto flex h-full max-w-7xl items-center justify-between px-6">
-      <div class="flex items-center gap-8">
+    <div class="mx-auto flex h-full max-w-7xl items-center justify-between px-4 sm:px-6">
+      <div class="flex min-w-0 items-center gap-4 sm:gap-8">
         <button class="flex items-center gap-2" @click="navigate('/workflow')">
           <BrandLogo size="sm" show-name />
         </button>
@@ -58,28 +58,28 @@ function navigate(path: string) {
         </nav>
       </div>
 
-      <div class="flex items-center gap-3">
+      <div class="flex shrink-0 items-center gap-2 sm:gap-3">
         <template v-if="auth.isLoggedIn">
           <button
-            class="rounded-xl bg-[#6366f1]/20 px-3 py-1.5 text-xs text-[#818cf8] transition hover:bg-[#6366f1]/30"
+            class="rounded-xl bg-[#6366f1]/20 px-2.5 py-1.5 text-xs text-[#818cf8] transition hover:bg-[#6366f1]/30 sm:px-3"
             @click="showMembership = true"
           >
             {{ auth.user?.points ?? 0 }} 积分
           </button>
           <button
-            class="flex items-center gap-2 rounded-xl bg-white/5 px-3 py-1.5 transition hover:bg-white/10"
+            class="flex max-w-[9rem] items-center gap-2 rounded-xl bg-white/5 px-2 py-1.5 transition hover:bg-white/10 sm:max-w-none sm:px-3"
             @click="navigate('/profile')"
           >
             <div
-              class="flex h-7 w-7 items-center justify-center rounded-full bg-[#6366f1] text-xs font-medium"
+              class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[#6366f1] text-xs font-medium"
             >
               {{ auth.user?.nickname?.[0] ?? 'U' }}
             </div>
-            <span class="text-sm text-white/80">{{ auth.user?.nickname }}</span>
+            <span class="hidden truncate text-sm text-white/80 sm:inline">{{ auth.user?.nickname }}</span>
           </button>
-          <button class="btn-ghost text-xs" @click="auth.logout()">退出</button>
+          <button class="btn-ghost hidden text-xs sm:inline" @click="auth.logout()">退出</button>
         </template>
-        <button v-else class="btn-ghost" @click="auth.openLogin()">登录</button>
+        <button v-else class="btn-ghost text-sm" @click="auth.openLogin()">登录</button>
       </div>
     </div>
   </header>

--- a/apps/web/src/pages/WorkflowPage.vue
+++ b/apps/web/src/pages/WorkflowPage.vue
@@ -316,12 +316,12 @@ watch(() => auth.isLoggedIn, () => {
 </script>
 
 <template>
-  <div class="mx-auto max-w-7xl px-6 pb-20 pt-8">
-    <section class="mb-12 text-center">
+  <div class="mx-auto max-w-7xl px-4 pb-20 pt-6 sm:px-6 sm:pt-8">
+    <section class="mb-10 text-center sm:mb-12">
       <div class="mb-4 flex justify-center">
         <BrandLogo size="xl" />
       </div>
-      <h1 class="font-display text-3xl font-semibold md:text-4xl">
+      <h1 class="font-display text-2xl font-semibold sm:text-3xl md:text-4xl">
         {{ greeting }}，今天要做点什么呢？
       </h1>
 

--- a/apps/web/src/stores/agent.ts
+++ b/apps/web/src/stores/agent.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import {
   type AgentChatMessage,
+  type AgentMessageMetadata,
   type CanvasAction,
   LinkedCanvasOutputSchema,
   type LinkedCanvasOutput,
@@ -22,8 +23,10 @@ import {
   applyToolCall,
   createExecutionTrace,
   finalizeExecutionTrace,
+  replayExecutionTraceEvents,
   type ExecutionTraceState,
 } from '@/components/agent/executionTraceReducer'
+import type { AgentPresentationEnvelope } from '@/components/agent/presentation/types'
 
 export interface AgentStreamMessage {
   id: string
@@ -33,13 +36,14 @@ export interface AgentStreamMessage {
   streaming?: boolean
   textReplaceHistory?: string[]
   executionTrace?: ExecutionTraceState
+  presentation?: AgentPresentationEnvelope
   attachments?: SidebarAttachment[]
   attachmentRefKeys?: string[]
   linkedOutputs?: LinkedCanvasOutput[]
   canvasActions?: CanvasAction[]
 }
 
-type PersistedAgentMessage = AgentChatMessage & { linkedOutputs?: string | null }
+type PersistedAgentMessage = AgentChatMessage & { linkedOutputs?: string | null; metadata?: string | null }
 
 export const useAgentStore = defineStore('agent', () => {
   const messages = ref<AgentStreamMessage[]>([])
@@ -221,9 +225,33 @@ export const useAgentStore = defineStore('agent', () => {
     }
   }
 
+  function parseMetadata(raw?: string | null): {
+    presentation?: AgentPresentationEnvelope
+    executionTrace?: ExecutionTraceState
+  } {
+    if (!raw?.trim()) return {}
+    try {
+      const parsed = JSON.parse(raw) as AgentMessageMetadata
+      const out: {
+        presentation?: AgentPresentationEnvelope
+        executionTrace?: ExecutionTraceState
+      } = {}
+      if (parsed.presentation && typeof parsed.presentation === 'object') {
+        out.presentation = parsed.presentation as unknown as AgentPresentationEnvelope
+      }
+      if (parsed.executionEvents?.length) {
+        out.executionTrace = replayExecutionTraceEvents(parsed.executionEvents)
+      }
+      return out
+    } catch {
+      return {}
+    }
+  }
+
   function loadHistory(history: AgentChatMessage[]) {
     messages.value = history.map((m) => {
       const persisted = m as PersistedAgentMessage
+      const extras = parseMetadata(persisted.metadata)
       return {
         id: persisted.id,
         role: persisted.role as 'user' | 'assistant',
@@ -231,6 +259,8 @@ export const useAgentStore = defineStore('agent', () => {
         attachments: parseAttachments(persisted.attachments),
         linkedOutputs: parseLinkedOutputs(persisted.linkedOutputs),
         canvasActions: parsePersistedToolCalls(persisted.toolCalls),
+        presentation: extras.presentation,
+        executionTrace: extras.executionTrace,
       }
     })
   }

--- a/apps/web/src/styles/neo-node.css
+++ b/apps/web/src/styles/neo-node.css
@@ -478,6 +478,36 @@
   transform: translate(-50%, -50%) scale(1.05);
 }
 
+.neo-gen-preview .neo-gen-image-preview-btn {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  z-index: 1;
+  display: inline-flex;
+  width: 44px;
+  height: 44px;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.55);
+  color: rgba(255, 255, 255, 0.92);
+  opacity: 0;
+  transform: translate(-50%, -50%);
+  transition: opacity 0.15s ease, background 0.15s ease, transform 0.15s ease;
+  pointer-events: none;
+}
+
+.neo-gen-preview:hover .neo-gen-image-preview-btn {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.neo-gen-preview .neo-gen-image-preview-btn:hover {
+  background: rgba(0, 0, 0, 0.72);
+  transform: translate(-50%, -50%) scale(1.05);
+}
+
 .neo-gen-video-exit-btn {
   position: absolute;
   bottom: 8px;

--- a/docs/superpowers/plans/2026-08-12-pr1-macro-scheme-free-text-revise.md
+++ b/docs/superpowers/plans/2026-08-12-pr1-macro-scheme-free-text-revise.md
@@ -1,0 +1,16 @@
+# PR-1: Macro scheme free-text revise
+
+**Branch:** `fix/macro-scheme-free-text-revise`  
+**Spec:** [2026-08-12-agent-ux-followup-batch-design.md](../specs/2026-08-12-agent-ux-followup-batch-design.md) §2
+
+## Tasks
+
+- [ ] `classify_macro_scheme_decision`: 自由文本修订 fallback
+- [ ] `should_resume_interrupt`: macro gate 长文本默认 resume
+- [ ] Tests: 用户复现用例 + hitl_resume
+
+## Test
+
+```bash
+cd services/agent-runtime && uv run pytest tests/test_hitl_resume.py tests/test_product_visual_v2_nodes.py -v -k macro
+```

--- a/docs/superpowers/plans/2026-08-12-pr2-canvas-image-preview-eye.md
+++ b/docs/superpowers/plans/2026-08-12-pr2-canvas-image-preview-eye.md
@@ -1,0 +1,13 @@
+# PR-2: Canvas image preview eye button
+
+**Branch:** `fix/canvas-image-preview-eye`
+
+## Tasks
+
+- [ ] `CanvasNodeImage.vue`: nodrag, draggable=false, eye button
+- [ ] `neo-node.css`: `.neo-gen-image-preview-btn`
+
+## Test
+
+- 画布图片节点 hover 显示眼睛；单击打开预览
+- 双击仍可用（nodrag 后）

--- a/docs/superpowers/plans/2026-08-12-pr3-mobile-homepage-responsive.md
+++ b/docs/superpowers/plans/2026-08-12-pr3-mobile-homepage-responsive.md
@@ -1,0 +1,13 @@
+# PR-3: Mobile homepage responsive
+
+**Branch:** `fix/mobile-homepage-responsive`
+
+## Tasks
+
+- [ ] `App.vue`: main `z-10`
+- [ ] `AppHeader.vue`: 窄屏 padding、隐藏昵称
+- [ ] `WorkflowPage.vue`: `px-4 sm:px-6`
+
+## Test
+
+- 375px 视口可见 greeting + CreativeLauncher

--- a/docs/superpowers/plans/2026-08-12-pr4-agent-turn-metadata-persist.md
+++ b/docs/superpowers/plans/2026-08-12-pr4-agent-turn-metadata-persist.md
@@ -1,0 +1,18 @@
+# PR-4: Agent turn metadata persist
+
+**Branch:** `feature/agent-turn-metadata-persist`
+
+## Tasks
+
+- [ ] Prisma `AgentMessage.metadata`
+- [ ] `@lnkpi/shared` `AgentMessageMetadata` type
+- [ ] `agent.service.ts` collect + finalizeTurn
+- [ ] `executionTraceReducer.replayExecutionTraceEvents`
+- [ ] `agent.ts` loadHistory + `AgentSideRail` history presentation
+
+## Test
+
+```bash
+pnpm build
+pnpm --filter @lnkpi/server exec vitest run src/agent/agent.service.test.ts
+```

--- a/docs/superpowers/plans/2026-08-12-pr5-vision-and-macro-count.md
+++ b/docs/superpowers/plans/2026-08-12-pr5-vision-and-macro-count.md
@@ -1,0 +1,13 @@
+# PR-5: Vision diagnostics + macro count (Wave 3)
+
+**Branch:** `chore/vision-qa-diagnostics` / `enhancement/macro-scheme-count-flex`
+
+Deferred after PR-1–4 merge.
+
+## PR-5a
+
+- 生产 vision QA 诊断脚本与错误码透传
+
+## PR-5b
+
+- `dialog-draft` prompt 1~3 套引导；产品确认默认数量策略

--- a/docs/superpowers/specs/2026-08-12-agent-ux-followup-batch-design.md
+++ b/docs/superpowers/specs/2026-08-12-agent-ux-followup-batch-design.md
@@ -1,0 +1,79 @@
+# Agent UX 跟进批次 — 设计规格
+
+> **状态**：实现中  
+> **日期**：2026-08-12  
+> **触发**：产品视觉 Sign-off 后用户 7 项体验问题  
+> **策略**：SDD 并行、5 PR 交付（Wave 1–3）
+
+---
+
+## 1. 问题与 PR 映射
+
+| # | 问题 | 根因 | PR |
+|---|------|------|-----|
+| 4 | 宏观门控自由文本修订报错 | `classify_macro_scheme_decision` 关键词过窄 + 长文本走 fresh-turn 清空 `macro_schemes` | PR-1 |
+| 7 | 画布图片双击预览不灵 | Vue Flow 拖拽吞双击；预览区缺 `nodrag` | PR-2 |
+| 6 | 移动端首页不可见 | Header/Launcher 窄屏溢出；main 缺 stacking | PR-3 |
+| 3+5 | 宏观卡片/执行过程不进历史 | `AgentMessage` 仅存纯文本 | PR-4 |
+| 1 | 识图不可用 | 配置/模型降级（by-design） | PR-5a（后续） |
+| 2 | 宏观方案固定 2 套 | Prompt 偏 A/B + `MAX_MACRO_SCHEMES_SELECTED=2` | PR-5b（后续） |
+
+---
+
+## 2. PR-1：宏观自由文本修订
+
+### 2.1 行为
+
+在 `await_macro_scheme_select` 门控下：
+
+- 含修订意图的自由文本（如「商业特写，但是需要增加更多模特…」）→ `action: revise`
+- 长文本（>24 字）且无 `@T/I/V/A` 引用 → **resume 门控**，禁止 fresh-turn
+
+### 2.2 验收
+
+- 复现用例不再出现「宏观方案缺失」与 `INVALID_CONCURRENT_GRAPH_UPDATE`
+- `test_hitl_resume` + `test_product_visual_v2_nodes` 通过
+
+---
+
+## 3. PR-2：图片预览入口
+
+- 预览区加 `nodrag` + `draggable="false"`
+- Hover 显示眼睛按钮（仿 `CanvasNodeVideo` play 按钮）
+
+---
+
+## 4. PR-3：移动端首页
+
+- `main` 加 `relative z-10`
+- Header 窄屏：缩小 padding、隐藏昵称文字
+- `WorkflowPage` / Launcher 移动端 padding 与按钮换行
+
+---
+
+## 5. PR-4：Turn metadata 持久化
+
+### 5.1 Schema
+
+`AgentMessage.metadata` JSON：
+
+```json
+{
+  "presentation": { "kind": "macro_scheme_cards", ... },
+  "executionEvents": [{ "type": "step", "data": {...} }]
+}
+```
+
+### 5.2 写入
+
+Nest `streamFromRuntime` 在 `finalizeTurn` 写入 metadata。
+
+### 5.3 读取
+
+`loadHistory` 反序列化；`replayExecutionTraceEvents` 重建 trace；历史气泡渲染 `AgentPresentationHost`（disabled）。
+
+---
+
+## 6. 合并顺序
+
+PR-1 → PR-2/PR-3（并行）→ PR-4 → PR-5a/5b

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -267,7 +267,15 @@ export interface AgentChatMessage {
   attachments?: string
   /** JSON: LinkedCanvasOutput[] — assistant turn canvas outputs for relocation */
   linkedOutputs?: string
+  /** JSON: AgentMessageMetadata — presentation + execution trace replay events */
+  metadata?: string
   createdAt: string
+}
+
+/** Persisted assistant turn extras (see 2026-08-12-agent-ux-followup-batch-design). */
+export interface AgentMessageMetadata {
+  presentation?: Record<string, unknown>
+  executionEvents?: Array<{ type: string; data: unknown }>
 }
 
 export interface CapabilityItem {

--- a/services/agent-runtime/app/graph/hitl_resume.py
+++ b/services/agent-runtime/app/graph/hitl_resume.py
@@ -156,7 +156,8 @@ def should_resume_interrupt(
             return True
         if len(text) >= 12 and REF_MENTION_RE.search(text):
             return False
-        return len(text) <= 24
+        # Long free-text at macro gate is scheme feedback, not a fresh task.
+        return True
 
     if gate == "await_shot_confirm":
         from app.graph.intent import classify_topo_decision

--- a/services/agent-runtime/app/graph/nodes/macro_scheme_select_gate.py
+++ b/services/agent-runtime/app/graph/nodes/macro_scheme_select_gate.py
@@ -23,6 +23,22 @@ from app.graph.product_visual_v2.presentation import (
 MacroAction = Literal["none", "confirm", "revise"]
 
 _MACRO_DECISION_PREFIX = "__macro_scheme_decision__"
+_MACRO_REVISE_HINTS = (
+    "但是",
+    "需要",
+    "增加",
+    "改成",
+    "改为",
+    "希望",
+    "补充",
+    "更多",
+    "调整",
+    "修改",
+    "不要",
+    "换成",
+    "减少",
+    "去掉",
+)
 _NONE_TIP = "请勾选宏观方案（最多 2 套）后点「确认方案」，或说明要如何调整。"
 _REVISE_ACK = "好的，正在根据你的反馈调整视觉方案…"
 _CONFIRM_ACK = "已确认宏观方案，即将写入画布方案节点…"
@@ -100,6 +116,10 @@ def classify_macro_scheme_decision(
     if user_decision == "revise" or any(k in raw for k in ("调整方案", "修改方案", "revise")):
         feedback = re.sub(r"^(需要调整方案[：:]?|调整方案[：:]?)", "", raw).strip()
         return {"action": "revise", "feedback": feedback or raw}
+    # Free-text revision at macro gate (e.g. "商业特写，但是需要增加更多模特展示图")
+    if len(raw) > 12 and not any(k in raw for k in ("确认方案", "确认宏观", "confirm_macro")):
+        if any(h in raw for h in _MACRO_REVISE_HINTS):
+            return {"action": "revise", "feedback": raw}
     return {"action": "none"}
 
 

--- a/services/agent-runtime/tests/test_hitl_resume.py
+++ b/services/agent-runtime/tests/test_hitl_resume.py
@@ -94,6 +94,16 @@ def test_should_resume_interrupt_macro_scheme_json():
     assert should_resume_interrupt(msg, ["await_macro_scheme_select"]) is True
 
 
+def test_should_resume_interrupt_macro_scheme_free_text_revise():
+    msg = "商业特写，但是需要增加更多模特展示图和包装的各类视角细节"
+    assert should_resume_interrupt(msg, ["await_macro_scheme_select"]) is True
+
+
+def test_should_resume_interrupt_macro_scheme_long_ref_still_fresh_turn():
+    msg = "@I1 这个是模特， @I2 这个是衣服，请让模特穿上这件衣服出图"
+    assert should_resume_interrupt(msg, ["await_macro_scheme_select"]) is False
+
+
 def test_should_resume_interrupt_shot_confirm():
     assert should_resume_interrupt("确认出图", ["await_shot_confirm"]) is True
 

--- a/services/agent-runtime/tests/test_product_visual_v2_nodes.py
+++ b/services/agent-runtime/tests/test_product_visual_v2_nodes.py
@@ -138,6 +138,13 @@ def test_macro_confirm_p2_nocanvas_before_ssot():
     assert out["phase"] == "canvas_ssot_commit"
 
 
+def test_macro_free_text_revise_classifies_as_revise():
+    msg = "商业特写，但是需要增加更多模特展示图和包装的各类视角细节"
+    decision = classify_macro_scheme_decision(msg)
+    assert decision["action"] == "revise"
+    assert "模特" in decision.get("feedback", "")
+
+
 @pytest.mark.asyncio
 async def test_canvas_ssot_commit_upsert():
     nest = FakeNest()


### PR DESCRIPTION
## Summary

SDD 批次交付（Wave 1–2），覆盖用户反馈 7 项中的 5 项可落地修复：

- **PR-1** 宏观门控自由文本修订：长文本不再误走 fresh-turn，口语修订识别为 `revise`
- **PR-2** 画布图片节点：预览区 `nodrag` + hover 眼睛按钮
- **PR-3** 移动端首页：main stacking + Header/Launcher 窄屏适配
- **PR-4** 历史持久化：`AgentMessage.metadata` 存 presentation + executionEvents，刷新后可回放宏观卡片与执行过程

**Deferred (Wave 3):** PR-5a 识图诊断、PR-5b 宏观方案数量策略 — 见 plan 文档

Spec: `docs/superpowers/specs/2026-08-12-agent-ux-followup-batch-design.md`

## Test plan

- [x] `python3 -m pytest tests/test_hitl_resume.py tests/test_product_visual_v2_nodes.py -k "macro or free_text"`
- [x] `pnpm --filter @lnkpi/server exec vitest run src/agent/agent.service.test.ts`
- [x] `pnpm --filter @lnkpi/web exec vitest run src/components/agent/executionTraceReducer.test.ts`
- [x] `pnpm build`
- [ ] 生产部署后跑 migration `20260812193000_agent_message_metadata`
- [ ] 宏观门控：自由文本修订不复现「宏观方案缺失」
- [ ] 刷新会话：宏观卡片 + 执行过程可见


Made with [Cursor](https://cursor.com)