### PR TITLE
chore(runtime): vision QA diagnostic codes + prod diagnose

### DIFF
--- a/apps/web/src/components/agent/agentInterruptGate.ts
+++ b/apps/web/src/components/agent/agentInterruptGate.ts
@@ -8,6 +8,7 @@ export interface AgentInterruptPayload {
   phase?: string | null
   interrupted?: boolean
   imageQaReason?: string | null
+  imageQaCode?: string | null
   imageQaMetrics?: ImageQaMetrics | null
   visionUsed?: boolean | null
   retakePending?: boolean | null

--- a/deploy/prod-vision-qa-diagnose.py
+++ b/deploy/prod-vision-qa-diagnose.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Production diagnose — product visual vision QA (识图) availability.
+
+Runs one product_visual turn with a sample product image and prints:
+  - runtime health
+  - interrupt fields: visionUsed, imageQaReason, imageQaCode
+  - suggested remediation from imageQaCode
+
+Usage:
+  python3 deploy/prod-vision-qa-diagnose.py
+  PV_PRODUCT_URL=https://example.com/product.jpg python3 deploy/prod-vision-qa-diagnose.py
+
+Exit 0 when vision QA passes or gate reached with visionUsed=true.
+Exit 1 when visionUsed=false with actionable code.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import uuid
+from typing import Any
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+BASE = os.environ.get("BASE_URL", "http://119.29.173.89:8888").rstrip("/")
+API = f"{BASE}/api"
+PHONE = os.environ.get("PHONE", "17279698608")
+CODE = os.environ.get("CODE", "123456")
+PRODUCT_URL = os.environ.get(
+    "PV_PRODUCT_URL",
+    "https://picsum.photos/seed/lnkpi-vision-qa/800/800",
+)
+SKILL_ID = os.environ.get("PV_SKILL_ID", "product-visual")
+SSE_TIMEOUT = float(os.environ.get("PV_SSE_TIMEOUT_SEC", "180"))
+
+REMEDIATION: dict[str, str] = {
+    "missing_image": "上传产品实拍图到侧栏引用后再试",
+    "missing_api_key": "在 BYOK / 服务商配置视觉模型 API Key",
+    "model_not_vision": "侧栏规划模型改为 Gemini / GPT-4o 等支持识图的模型",
+    "vision_not_invoked": "检查 agent-runtime 与 Nest run-vision-qa 连通性",
+    "vision_not_used": "检查 LNKPI_PRODUCT_VISUAL_SCHEME_V2 与 runtime 日志",
+    "vision_format_error": "换图重试或检查视觉模型返回 JSON 格式",
+    "vision_call_failed": "检查视觉 API 网络/配额/超时",
+    "quality_fail": "换更清晰白底产品图或使用门控「AI 白底」",
+}
+
+
+def http(m: str, p: str, b: dict | None = None, t: str | None = None) -> Any:
+    h = {"Content-Type": "application/json", "Accept": "application/json"}
+    if t:
+        h["Authorization"] = f"Bearer {t}"
+    r = Request(f"{API}{p}", data=None if b is None else json.dumps(b).encode(), headers=h, method=m)
+    with urlopen(r, timeout=120) as resp:
+        return json.loads(resp.read())
+
+
+def sse_turn(tok: str, sid: str, tid: str, msg: str, attachments: list[dict]) -> dict[str, Any]:
+    body = {
+        "sessionId": sid,
+        "message": msg,
+        "threadId": tid,
+        "skillId": SKILL_ID,
+        "attachments": attachments,
+    }
+    req = Request(
+        f"{API}/agent/chat/conversation",
+        data=json.dumps(body).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {tok}",
+            "Idempotency-Key": str(uuid.uuid4()),
+        },
+        method="POST",
+    )
+    out: dict[str, Any] = {
+        "phases": set(),
+        "visionUsed": None,
+        "imageQaReason": None,
+        "imageQaCode": None,
+        "presentationTitle": None,
+    }
+    deadline = time.time() + SSE_TIMEOUT
+    with urlopen(req, timeout=SSE_TIMEOUT + 30) as resp:
+        buf = ""
+        while time.time() < deadline:
+            chunk = resp.read(4096)
+            if not chunk:
+                break
+            buf += chunk.decode("utf-8", errors="replace")
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                if not line.startswith("data: "):
+                    continue
+                if line == "data: [DONE]":
+                    return out
+                try:
+                    ev = json.loads(line[6:])
+                except json.JSONDecodeError:
+                    continue
+                et = ev.get("type")
+                data = ev.get("data") or {}
+                if et in ("interrupt", "done"):
+                    phase = data.get("phase")
+                    if phase:
+                        out["phases"].add(str(phase))
+                    for key in ("visionUsed", "imageQaReason", "imageQaCode"):
+                        if data.get(key) is not None:
+                            out[key] = data.get(key)
+                    pres = data.get("presentation") or {}
+                    if isinstance(pres, dict) and pres.get("title"):
+                        out["presentationTitle"] = pres.get("title")
+                if et == "error":
+                    out["error"] = data
+                    return out
+    return out
+
+
+def main() -> int:
+    print(f"BASE_URL={BASE}")
+    print(f"PRODUCT_URL={PRODUCT_URL}\n")
+
+    try:
+        health = http("GET", "/agent/runtime-health")
+        print("=== Runtime health ===")
+        print(json.dumps(health, ensure_ascii=False, indent=2))
+        if not (health.get("data") or {}).get("ok"):
+            print("\n❌ Agent runtime 不可用")
+            return 1
+    except Exception as exc:
+        print(f"❌ runtime-health failed: {exc}")
+        return 1
+
+    try:
+        http("POST", "/auth/send-code", {"phone": PHONE})
+    except Exception:
+        pass
+    tok = http("POST", "/auth/login", {"phone": PHONE, "code": CODE})["data"]["token"]
+
+    sess = http("POST", "/sessions", {"title": "vision-qa-diagnose"}, t=tok)["data"]
+    sid = str(sess["id"])
+    tid = f"{sid}:vision-qa-{uuid.uuid4().hex[:8]}"
+    print(f"\nSESSION={sid}\nTHREAD={tid}\n")
+
+    att = [{
+        "id": "diag-img",
+        "mediaType": "image",
+        "sourceKind": "upload",
+        "label": "product.jpg",
+        "url": PRODUCT_URL,
+    }]
+    msg = "为这款产品设计电商主图与详情页视觉，需要包装特写和模特展示"
+    print("=== SSE turn (product_visual + image) ===")
+    result = sse_turn(tok, sid, tid, msg, att)
+    printable = {k: (sorted(v) if isinstance(v, set) else v) for k, v in result.items()}
+    print(json.dumps(printable, ensure_ascii=False, indent=2))
+
+    code = str(result.get("imageQaCode") or "")
+    vision_used = result.get("visionUsed")
+    phases = result.get("phases") or set()
+
+    print("\n=== Diagnosis ===")
+    if code:
+        print(f"imageQaCode: {code}")
+        hint = REMEDIATION.get(code)
+        if hint:
+            print(f"建议: {hint}")
+    if result.get("imageQaReason"):
+        print(f"imageQaReason: {result.get('imageQaReason')}")
+    if result.get("presentationTitle"):
+        print(f"presentation.title: {result.get('presentationTitle')}")
+
+    ts = http("GET", f"/agent/thread-state?threadId={quote(tid, safe='')}", t=tok).get("data") or {}
+    print("\n=== thread-state ===")
+    print(json.dumps(ts, ensure_ascii=False, indent=2)[:2000])
+
+    if "dialog_draft" in phases or "await_macro_scheme_select" in phases:
+        print("\n✅ 识图门控已通过，进入方案阶段")
+        return 0
+    if vision_used is True and code in ("", "pass", "quality_fail"):
+        if code == "quality_fail":
+            print("\n⚠️ 识图已调用但质量未通过（预期内可继续门控）")
+            return 0
+        print("\n✅ visionUsed=true")
+        return 0
+    if code in REMEDIATION:
+        print(f"\n❌ 识图不可用 ({code})")
+        return 1
+    if vision_used is False:
+        print("\n❌ visionUsed=false — 自动识图未生效")
+        return 1
+    print("\n⚠️ 未明确结论，请查看上方 SSE / thread-state")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/superpowers/plans/2026-08-12-pr5-vision-and-macro-count.md
+++ b/docs/superpowers/plans/2026-08-12-pr5-vision-and-macro-count.md
@@ -1,0 +1,16 @@
+# PR-5a: Vision QA diagnostics
+
+**Branch:** `chore/vision-qa-diagnostics`
+
+## Deliverables
+
+- `vision_qa_diagnostics.py` — stable `imageQaCode` classification
+- `evaluate_vision_qa_v2` emits `image_qa_code`
+- SSE / thread-state `imageQaCode` passthrough
+- `deploy/prod-vision-qa-diagnose.py` — production smoke + remediation hints
+
+## Test
+
+```bash
+cd services/agent-runtime && python3 -m pytest tests/test_vision_qa_diagnostics.py tests/test_product_visual_vision_qa_v2.py -v
+```

--- a/services/agent-runtime/app/graph/product_visual_v2/vision_qa.py
+++ b/services/agent-runtime/app/graph/product_visual_v2/vision_qa.py
@@ -6,6 +6,11 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from app.graph.product_visual_v2.vision_qa_diagnostics import (
+    VISION_QA_CODE_PASS,
+    classify_vision_qa_failure_code,
+)
+
 
 class VisionQAResult(BaseModel):
     pass_: bool = Field(alias="pass")
@@ -98,10 +103,16 @@ def evaluate_vision_qa_v2(
     """
     metrics = metrics or {}
     if not vision.vision_used:
+        reason = vision.reason or "识图模型未调用，无法完成准入审核"
         return {
             "image_qa_result": "fail",
             "phase": "await_image_qa",
-            "image_qa_reason": vision.reason or "识图模型未调用，无法完成准入审核",
+            "image_qa_reason": reason,
+            "image_qa_code": classify_vision_qa_failure_code(
+                reason=reason,
+                vision_used=False,
+                metrics=metrics,
+            ),
             "image_qa_metrics": vision_qa_metrics_from_result(vision),
         }
 
@@ -122,16 +133,24 @@ def evaluate_vision_qa_v2(
             if not metrics.get("requires_standard_product_assets")
             else "phase1_seed_eager",
             "image_qa_reason": reason,
+            "image_qa_code": VISION_QA_CODE_PASS,
             "vision_used": True,
             "scene_kind": metrics.get("scene_kind"),
             "interior_relaxed": interior_ok and not vision.pass_,
             "image_qa_metrics": vision_qa_metrics_from_result(vision),
         }
 
+    fail_reason = vision.reason or "图源未通过识图审核"
+    fail_metrics = vision_qa_metrics_from_result(vision)
     return {
         "image_qa_result": "fail",
         "phase": "await_image_qa",
-        "image_qa_reason": vision.reason or "图源未通过识图审核",
+        "image_qa_reason": fail_reason,
+        "image_qa_code": classify_vision_qa_failure_code(
+            reason=fail_reason,
+            vision_used=True,
+            metrics={**metrics, **fail_metrics},
+        ),
         "vision_used": True,
-        "image_qa_metrics": vision_qa_metrics_from_result(vision),
+        "image_qa_metrics": fail_metrics,
     }

--- a/services/agent-runtime/app/graph/product_visual_v2/vision_qa_diagnostics.py
+++ b/services/agent-runtime/app/graph/product_visual_v2/vision_qa_diagnostics.py
@@ -1,0 +1,78 @@
+"""Vision QA failure classification for ops diagnostics and SSE passthrough."""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Stable codes for logs, deploy scripts, and frontend diagnostics.
+VISION_QA_CODE_PASS = "pass"
+VISION_QA_CODE_MISSING_IMAGE = "missing_image"
+VISION_QA_CODE_MISSING_API_KEY = "missing_api_key"
+VISION_QA_CODE_MODEL_NOT_VISION = "model_not_vision"
+VISION_QA_CODE_VISION_NOT_INVOKED = "vision_not_invoked"
+VISION_QA_CODE_VISION_NOT_USED = "vision_not_used"
+VISION_QA_CODE_FORMAT_ERROR = "vision_format_error"
+VISION_QA_CODE_CALL_FAILED = "vision_call_failed"
+VISION_QA_CODE_QUALITY_FAIL = "quality_fail"
+VISION_QA_CODE_UNKNOWN = "unknown"
+
+_VISION_QA_CODE_LABELS: dict[str, str] = {
+    VISION_QA_CODE_PASS: "识图审核通过",
+    VISION_QA_CODE_MISSING_IMAGE: "未检测到产品参考图",
+    VISION_QA_CODE_MISSING_API_KEY: "未配置识图 API Key",
+    VISION_QA_CODE_MODEL_NOT_VISION: "当前模型不支持识图",
+    VISION_QA_CODE_VISION_NOT_INVOKED: "识图模型未调用",
+    VISION_QA_CODE_VISION_NOT_USED: "识图未启用",
+    VISION_QA_CODE_FORMAT_ERROR: "识图返回格式异常",
+    VISION_QA_CODE_CALL_FAILED: "识图接口调用失败",
+    VISION_QA_CODE_QUALITY_FAIL: "图源质量未通过",
+    VISION_QA_CODE_UNKNOWN: "未知识图失败",
+}
+
+
+def vision_qa_code_label(code: str | None) -> str:
+    if not code:
+        return _VISION_QA_CODE_LABELS[VISION_QA_CODE_UNKNOWN]
+    return _VISION_QA_CODE_LABELS.get(str(code), _VISION_QA_CODE_LABELS[VISION_QA_CODE_UNKNOWN])
+
+
+def classify_vision_qa_failure_code(
+    *,
+    reason: str,
+    vision_used: bool,
+    pass_: bool = False,
+    metrics: dict[str, Any] | None = None,
+) -> str:
+    """Map internal QA reason to a stable diagnostic code."""
+    if pass_:
+        return VISION_QA_CODE_PASS
+
+    text = (reason or "").strip()
+    metrics = metrics or {}
+
+    if not vision_used:
+        if any(k in text for k in ("未检测到产品参考图", "缺少产品参考图", "未选择", "缺少产品")):
+            return VISION_QA_CODE_MISSING_IMAGE
+        if "未配置" in text and "API Key" in text:
+            return VISION_QA_CODE_MISSING_API_KEY
+        if "不支持识图" in text:
+            return VISION_QA_CODE_MODEL_NOT_VISION
+        if "识图模型未调用" in text:
+            return VISION_QA_CODE_VISION_NOT_INVOKED
+        if "调用失败" in text:
+            return VISION_QA_CODE_CALL_FAILED
+        return VISION_QA_CODE_VISION_NOT_USED
+
+    if any(k in text for k in ("格式异常", "结果无效", "format_error")):
+        return VISION_QA_CODE_FORMAT_ERROR
+    if "调用失败" in text:
+        return VISION_QA_CODE_CALL_FAILED
+
+    if metrics.get("is_sharp_enough") is False or metrics.get("product_identifiable") is False:
+        return VISION_QA_CODE_QUALITY_FAIL
+    if metrics.get("is_white_bg") is False and metrics.get("scene_kind") != "interior":
+        return VISION_QA_CODE_QUALITY_FAIL
+
+    if text and not pass_:
+        return VISION_QA_CODE_QUALITY_FAIL
+    return VISION_QA_CODE_UNKNOWN

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -582,6 +582,7 @@ async def get_thread_state(
         "deliverySelections": delivery_selections if isinstance(delivery_selections, dict) else None,
         "deliveryGenByKey": gen_by_key if isinstance(gen_by_key, dict) else None,
         "imageQaReason": vals.get("image_qa_reason"),
+        "imageQaCode": vals.get("image_qa_code"),
         "imageQaMetrics": vals.get("image_qa_metrics")
         if isinstance(vals.get("image_qa_metrics"), dict)
         else None,
@@ -903,6 +904,7 @@ async def stream_run_events(
                             k: v
                             for k, v in {
                                 "imageQaReason": post_vals.get("image_qa_reason"),
+                                "imageQaCode": post_vals.get("image_qa_code"),
                                 "imageQaMetrics": post_vals.get("image_qa_metrics"),
                                 "visionUsed": post_vals.get("vision_used"),
                             }.items()

--- a/services/agent-runtime/tests/test_vision_qa_diagnostics.py
+++ b/services/agent-runtime/tests/test_vision_qa_diagnostics.py
@@ -1,0 +1,66 @@
+"""Tests for vision QA diagnostic codes."""
+
+from __future__ import annotations
+
+from app.graph.product_visual_v2.vision_qa_diagnostics import (
+    VISION_QA_CODE_MISSING_API_KEY,
+    VISION_QA_CODE_MISSING_IMAGE,
+    VISION_QA_CODE_MODEL_NOT_VISION,
+    VISION_QA_CODE_PASS,
+    VISION_QA_CODE_QUALITY_FAIL,
+    VISION_QA_CODE_FORMAT_ERROR,
+    classify_vision_qa_failure_code,
+    vision_qa_code_label,
+)
+
+
+def test_classify_missing_image():
+    code = classify_vision_qa_failure_code(
+        reason="未检测到产品参考图，请上传图片后重试",
+        vision_used=False,
+    )
+    assert code == VISION_QA_CODE_MISSING_IMAGE
+
+
+def test_classify_missing_api_key():
+    code = classify_vision_qa_failure_code(
+        reason="未配置识图模型 API Key，无法完成图源审核",
+        vision_used=False,
+    )
+    assert code == VISION_QA_CODE_MISSING_API_KEY
+
+
+def test_classify_model_not_vision():
+    code = classify_vision_qa_failure_code(
+        reason="当前文本模型（deepseek-chat）不支持识图，请在 Agent 侧栏选择 Gemini / GPT-4o 等视觉模型",
+        vision_used=False,
+    )
+    assert code == VISION_QA_CODE_MODEL_NOT_VISION
+
+
+def test_classify_quality_fail():
+    code = classify_vision_qa_failure_code(
+        reason="产品图不够清晰",
+        vision_used=True,
+        metrics={"is_sharp_enough": False},
+    )
+    assert code == VISION_QA_CODE_QUALITY_FAIL
+
+
+def test_classify_format_error():
+    code = classify_vision_qa_failure_code(
+        reason="识图模型返回格式异常，请重试或换一张更清晰的产品图",
+        vision_used=True,
+    )
+    assert code == VISION_QA_CODE_FORMAT_ERROR
+
+
+def test_classify_pass():
+    assert (
+        classify_vision_qa_failure_code(reason="ok", vision_used=True, pass_=True)
+        == VISION_QA_CODE_PASS
+    )
+
+
+def test_code_label():
+    assert "参考图" in vision_qa_code_label(VISION_QA_CODE_MISSING_IMAGE)


### PR DESCRIPTION
## Summary

- 新增 `vision_qa_diagnostics.py`：识图失败稳定错误码（`missing_image` / `model_not_vision` 等）
- `evaluate_vision_qa_v2` 写入 `image_qa_code`；SSE interrupt / thread-state 透传 `imageQaCode`
- 生产诊断脚本 `deploy/prod-vision-qa-diagnose.py`：一键跑 product_visual + 样例图，输出 remediation

## Test plan

- [x] `python3 -m pytest tests/test_vision_qa_diagnostics.py tests/test_product_visual_vision_qa_v2.py -v`
- [ ] 生产：`python3 deploy/prod-vision-qa-diagnose.py` 查看 imageQaCode

## Related

Wave 3 PR-5b（宏观方案数量 prompt）单独 PR


Made with [Cursor](https://cursor.com)