### PR TITLE
fix(web): restore agent FAB and image preview toolbar

### DIFF
--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -143,6 +143,7 @@ const emit = defineEmits<{
 }>()
 
 const pickMode = useCanvasRefPickMode()
+const pickModeActive = pickMode.active
 const { isMobileLayout } = useAgentMobileLayout()
 
 const panelTeleported = computed(() => floating.value || isMobileLayout.value)
@@ -1825,7 +1826,7 @@ defineExpose({
       <!-- 收缩态：右下角 agent logo 悬浮按钮 -->
       <Teleport to="body">
         <button
-          v-if="!open && !pickMode.active"
+          v-if="!open && !pickModeActive"
           type="button"
           class="agent-fab"
           :class="{ 'agent-fab-mobile': isMobileLayout }"

--- a/apps/web/src/components/canvas/CanvasNodeImage.vue
+++ b/apps/web/src/components/canvas/CanvasNodeImage.vue
@@ -120,13 +120,13 @@ function saveToLibrary() {
         <img :src="displayUrl" alt="" draggable="false">
         <button
           type="button"
-          class="neo-gen-image-preview-btn nodrag"
+          class="neo-node-preview-btn nodrag"
           title="预览大图"
           @pointerdown.stop
           @mousedown.stop
           @click.stop="openPreview"
         >
-          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+          <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2">
             <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z" />
             <circle cx="12" cy="12" r="3" />
           </svg>

--- a/apps/web/src/components/canvas/CanvasNodeImage.vue
+++ b/apps/web/src/components/canvas/CanvasNodeImage.vue
@@ -111,8 +111,26 @@ function saveToLibrary() {
       @dragleave="onDragLeave"
       @drop="onDrop"
     >
-      <div v-if="data.url" class="neo-gen-preview" title="双击预览大图" @dblclick.stop="openPreview">
-        <img :src="displayUrl" alt="">
+      <div
+        v-if="data.url"
+        class="neo-gen-preview nodrag"
+        title="双击预览大图"
+        @dblclick.stop="openPreview"
+      >
+        <img :src="displayUrl" alt="" draggable="false">
+        <button
+          type="button"
+          class="neo-gen-image-preview-btn nodrag"
+          title="预览大图"
+          @pointerdown.stop
+          @mousedown.stop
+          @click.stop="openPreview"
+        >
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z" />
+            <circle cx="12" cy="12" r="3" />
+          </svg>
+        </button>
         <button
           type="button"
           class="neo-node-replace-btn nodrag"

--- a/apps/web/src/styles/neo-node.css
+++ b/apps/web/src/styles/neo-node.css
@@ -450,6 +450,36 @@
   object-fit: cover;
 }
 
+.neo-gen-preview .neo-gen-image-preview-btn {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  z-index: 1;
+  display: inline-flex;
+  width: 44px;
+  height: 44px;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.55);
+  color: rgba(255, 255, 255, 0.92);
+  opacity: 0;
+  transform: translate(-50%, -50%);
+  transition: opacity 0.15s ease, background 0.15s ease, transform 0.15s ease;
+  pointer-events: none;
+}
+
+.neo-gen-preview:hover .neo-gen-image-preview-btn {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.neo-gen-preview .neo-gen-image-preview-btn:hover {
+  background: rgba(0, 0, 0, 0.72);
+  transform: translate(-50%, -50%) scale(1.05);
+}
+
 .neo-gen-video-poster {
   pointer-events: none;
 }

--- a/apps/web/src/styles/neo-node.css
+++ b/apps/web/src/styles/neo-node.css
@@ -450,34 +450,19 @@
   object-fit: cover;
 }
 
-.neo-gen-preview .neo-gen-image-preview-btn {
+.neo-gen-preview::after {
+  content: '';
   position: absolute;
-  top: 50%;
-  left: 50%;
-  z-index: 1;
-  display: inline-flex;
-  width: 44px;
-  height: 44px;
-  align-items: center;
-  justify-content: center;
-  border: none;
-  border-radius: 50%;
-  background: rgba(0, 0, 0, 0.55);
-  color: rgba(255, 255, 255, 0.92);
+  inset: 0;
+  z-index: 0;
+  background: rgba(0, 0, 0, 0.06);
   opacity: 0;
-  transform: translate(-50%, -50%);
-  transition: opacity 0.15s ease, background 0.15s ease, transform 0.15s ease;
+  transition: opacity 0.15s ease;
   pointer-events: none;
 }
 
-.neo-gen-preview:hover .neo-gen-image-preview-btn {
+.neo-node-upload-target:hover .neo-gen-preview::after {
   opacity: 1;
-  pointer-events: auto;
-}
-
-.neo-gen-preview .neo-gen-image-preview-btn:hover {
-  background: rgba(0, 0, 0, 0.72);
-  transform: translate(-50%, -50%) scale(1.05);
 }
 
 .neo-gen-video-poster {
@@ -607,15 +592,34 @@
   color: rgba(255, 255, 255, 0.85);
 }
 
+/* 预览按钮：排在存库按钮左侧，与右上工具条同款规格 */
+.neo-node-preview-btn {
+  position: absolute;
+  top: 6px;
+  right: 90px;
+  z-index: 2;
+  display: none;
+  width: 24px;
+  height: 24px;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.55);
+  color: rgba(255, 255, 255, 0.85);
+}
+
 .neo-node-upload-target:hover .neo-node-replace-btn,
 .neo-node-upload-target:hover .neo-node-download-btn,
-.neo-node-upload-target:hover .neo-node-save-btn {
+.neo-node-upload-target:hover .neo-node-save-btn,
+.neo-node-upload-target:hover .neo-node-preview-btn {
   display: inline-flex;
 }
 
 .neo-node-replace-btn:hover,
 .neo-node-download-btn:hover,
-.neo-node-save-btn:hover {
+.neo-node-save-btn:hover,
+.neo-node-preview-btn:hover {
   background: rgba(0, 0, 0, 0.8);
   color: #fff;
 }


### PR DESCRIPTION
## Summary
- 修复 PR #233 引入的 Agent FAB 永不显示（`pickMode.active` 模板未解包 Ref）
- 图片节点预览并入右上工具条：预览 | 存库 | 下载 | 替换（24px 同款），hover 轻蒙层；保留双击预览

## Test plan
- [x] `pnpm --filter @lnkpi/web build`
- [ ] PC 画布：右下角 Agent FAB 可见，侧栏可展开
- [ ] 图片节点 hover：右上四颗角标 + 右下「编辑」
- [ ] 点击眼睛 / 双击均可预览大图


Made with [Cursor](https://cursor.com)