### PR TITLE
feat(product-visual): journey trace — 九步工作流持久化与执行记录一体化

### DIFF
--- a/apps/server/prisma/migrations/20260813120000_agent_message_metadata/migration.sql
+++ b/apps/server/prisma/migrations/20260813120000_agent_message_metadata/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "AgentMessage" ADD COLUMN "metadata" TEXT;

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -211,6 +211,8 @@ model AgentMessage {
   attachments   String?
   /** JSON: LinkedCanvasOutput[] — 本轮 assistant 产出的可定位节点 */
   linkedOutputs String?
+  /** JSON: AgentMessageMetadata */
+  metadata      String?
   createdAt     DateTime    @default(now())
 
   @@index([threadId, createdAt])

--- a/apps/server/src/agent/agent.service.journey-trace.test.ts
+++ b/apps/server/src/agent/agent.service.journey-trace.test.ts
@@ -1,0 +1,173 @@
+import 'reflect-metadata'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { JourneyTraceSnapshot } from '@lnkpi/shared'
+import { JOURNEY_STEP_LABELS } from '@lnkpi/shared'
+import { AgentService } from './agent.service'
+import { AgentRuntimeClient } from './agent-runtime.client'
+
+const JOURNEY_STEP_ORDER = [
+  'image_qa',
+  'scheme_draft',
+  'macro_select',
+  'ssot_persist',
+  'shot_plan',
+  'topo_preview',
+  'generating',
+  'delivery',
+  'done',
+] as const
+
+function buildMockJourneySnapshot(current: (typeof JOURNEY_STEP_ORDER)[number] = 'macro_select'): JourneyTraceSnapshot {
+  const now = '2026-08-13T04:00:00Z'
+  return {
+    version: 1,
+    flowMode: 'product_visual',
+    current,
+    startedAt: now,
+    updatedAt: now,
+    steps: JOURNEY_STEP_ORDER.map((id) => ({
+      id,
+      label: JOURNEY_STEP_LABELS[id],
+      status: id === current ? 'running' : JOURNEY_STEP_ORDER.indexOf(id) < JOURNEY_STEP_ORDER.indexOf(current) ? 'done' : 'pending',
+    })),
+  }
+}
+
+describe('AgentService journey trace persistence', () => {
+  const agentMessageCreate = vi.fn()
+  const agentMessageFindMany = vi.fn()
+  const agentThreadFindUnique = vi.fn()
+  const agentThreadUpsert = vi.fn()
+  const agentThreadUpdate = vi.fn()
+  const sessionFindUnique = vi.fn()
+  const sessionUpdate = vi.fn()
+  const idempotencyRecordCreate = vi.fn()
+  const idempotencyRecordFindUnique = vi.fn()
+  const idempotencyRecordUpdateMany = vi.fn()
+  const idempotencyRecordDeleteMany = vi.fn()
+
+  let service: AgentService
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    process.env.AGENT_RUNTIME_URL = 'http://127.0.0.1:8000'
+
+    agentMessageCreate.mockResolvedValue({})
+    agentMessageFindMany.mockResolvedValue([])
+    agentThreadFindUnique.mockResolvedValue({ id: 's1:thread-a' })
+    agentThreadUpdate.mockResolvedValue({})
+    agentThreadUpsert.mockResolvedValue({})
+    sessionFindUnique.mockResolvedValue({ id: 's1', canvasData: null })
+    sessionUpdate.mockResolvedValue({})
+    idempotencyRecordCreate.mockResolvedValue({})
+    idempotencyRecordFindUnique.mockResolvedValue(null)
+    idempotencyRecordUpdateMany.mockResolvedValue({ count: 1 })
+    idempotencyRecordDeleteMany.mockResolvedValue({ count: 0 })
+
+    service = new AgentService(
+      {
+        agentMessage: {
+          create: agentMessageCreate,
+          findMany: agentMessageFindMany,
+        },
+        agentThread: {
+          findUnique: agentThreadFindUnique,
+          upsert: agentThreadUpsert,
+          update: agentThreadUpdate,
+        },
+        session: {
+          findUnique: sessionFindUnique,
+          update: sessionUpdate,
+        },
+        idempotencyRecord: {
+          create: idempotencyRecordCreate,
+          findUnique: idempotencyRecordFindUnique,
+          updateMany: idempotencyRecordUpdateMany,
+          deleteMany: idempotencyRecordDeleteMany,
+        },
+      } as never,
+      { create: vi.fn() } as never,
+      { createFromAgent: vi.fn() } as never,
+      { resolveForGeneration: vi.fn() } as never,
+    )
+  })
+
+  it('persists journeyTrace in assistant message metadata on finalizeTurn', async () => {
+    const snapshot = buildMockJourneySnapshot()
+    const streamRun = vi.fn(async function* () {
+      yield { type: 'journey_update', data: { snapshot } }
+      yield { type: 'text_delta', data: { text: '方案已生成' } }
+      yield { type: 'done', data: {} }
+    })
+
+    vi.spyOn(service, 'createRuntimeClient').mockReturnValue({
+      healthOk: vi.fn().mockResolvedValue(true),
+      streamRun,
+    } as unknown as AgentRuntimeClient)
+
+    for await (const _event of service.streamConversation('s1', '营销', 'u1', 's1:thread-a')) {
+      // drain
+    }
+
+    const assistantCreate = agentMessageCreate.mock.calls.find(
+      (call) => (call[0] as { data: { role: string } }).data.role === 'assistant',
+    )
+    expect(assistantCreate).toBeDefined()
+
+    const metadataRaw = (assistantCreate![0] as { data: { metadata?: string } }).data.metadata
+    expect(metadataRaw).toBeTruthy()
+    const metadata = JSON.parse(metadataRaw!) as { journeyTrace?: JourneyTraceSnapshot }
+    expect(metadata.journeyTrace?.steps).toHaveLength(9)
+    expect(metadata.journeyTrace?.flowMode).toBe('product_visual')
+  })
+
+  it('creates placeholder assistant message when text empty but journeyTrace exists', async () => {
+    const snapshot = buildMockJourneySnapshot('image_qa')
+    const streamRun = vi.fn(async function* () {
+      yield { type: 'journey_update', data: { snapshot } }
+      yield { type: 'done', data: {} }
+    })
+
+    vi.spyOn(service, 'createRuntimeClient').mockReturnValue({
+      healthOk: vi.fn().mockResolvedValue(true),
+      streamRun,
+    } as unknown as AgentRuntimeClient)
+
+    for await (const _event of service.streamConversation('s1', '营销', 'u1', 's1:thread-a')) {
+      // drain
+    }
+
+    const assistantCreate = agentMessageCreate.mock.calls.find(
+      (call) => (call[0] as { data: { role: string } }).data.role === 'assistant',
+    )
+    expect(assistantCreate).toBeDefined()
+    expect((assistantCreate![0] as { data: { content: string } }).data.content).toBe(' ')
+  })
+
+  it('uses last journey_update snapshot when multiple events arrive', async () => {
+    const first = buildMockJourneySnapshot('image_qa')
+    const last = buildMockJourneySnapshot('generating')
+    const streamRun = vi.fn(async function* () {
+      yield { type: 'journey_update', data: { snapshot: first } }
+      yield { type: 'journey_update', data: { snapshot: last } }
+      yield { type: 'done', data: {} }
+    })
+
+    vi.spyOn(service, 'createRuntimeClient').mockReturnValue({
+      healthOk: vi.fn().mockResolvedValue(true),
+      streamRun,
+    } as unknown as AgentRuntimeClient)
+
+    for await (const _event of service.streamConversation('s1', '营销', 'u1', 's1:thread-a')) {
+      // drain
+    }
+
+    const assistantCreate = agentMessageCreate.mock.calls.find(
+      (call) => (call[0] as { data: { role: string } }).data.role === 'assistant',
+    )
+    const metadata = JSON.parse(
+      (assistantCreate![0] as { data: { metadata: string } }).data.metadata,
+    ) as { journeyTrace?: JourneyTraceSnapshot }
+    expect(metadata.journeyTrace?.current).toBe('generating')
+  })
+})

--- a/apps/server/src/agent/agent.service.ts
+++ b/apps/server/src/agent/agent.service.ts
@@ -1,6 +1,13 @@
 import { BadRequestException, Inject, Injectable } from '@nestjs/common'
 import { applyCanvasActions, type AgentStreamEvent } from '@lnkpi/agent'
-import type { CanvasAction, CanvasData, LinkedCanvasOutput, SidebarAttachment } from '@lnkpi/shared'
+import type {
+  AgentMessageMetadata,
+  CanvasAction,
+  CanvasData,
+  JourneyTraceSnapshot,
+  LinkedCanvasOutput,
+  SidebarAttachment,
+} from '@lnkpi/shared'
 import {
   IMAGE_MODELS,
   TEXT_MODELS,
@@ -314,6 +321,8 @@ export class AgentService {
   ): AsyncGenerator<AgentStreamEvent> {
     let assistantText = ''
     const canvasActions: CanvasAction[] = []
+    let journeyTrace: JourneyTraceSnapshot | undefined
+    let executionTrace: Record<string, unknown> | undefined
 
     const runtimeSkillId = mapUiSkillId(skillId)
     let llmModel: string | undefined
@@ -353,14 +362,26 @@ export class AgentService {
       if (event.type === 'canvas_action') {
         canvasActions.push(event.data as CanvasAction)
       }
+      if (event.type === 'journey_update') {
+        const snap = (event.data as { snapshot?: JourneyTraceSnapshot }).snapshot
+        if (snap) {
+          journeyTrace = snap
+        }
+      }
       yield event
     }
+
+    const metadata: AgentMessageMetadata | undefined =
+      journeyTrace || executionTrace
+        ? { ...(journeyTrace ? { journeyTrace } : {}), ...(executionTrace ? { executionTrace } : {}) }
+        : undefined
 
     const effectiveThreadId = threadId?.trim() || sessionId
     await this.finalizeTurn(sessionId, effectiveThreadId, userId, assistantText, canvasActions, {
       // Nest internal tools already wrote Session.canvasData; skip re-apply to avoid duplicate add_node
       rewriteCanvasData: false,
       linkedOutputs: deriveLinkedOutputs(canvasActions),
+      metadata,
     })
   }
 
@@ -370,17 +391,19 @@ export class AgentService {
     userId: string | undefined,
     assistantText: string,
     canvasActions: CanvasAction[],
-    opts: { rewriteCanvasData: boolean; linkedOutputs?: LinkedCanvasOutput[] },
+    opts: { rewriteCanvasData: boolean; linkedOutputs?: LinkedCanvasOutput[]; metadata?: AgentMessageMetadata },
   ) {
-    if (assistantText) {
+    const shouldPersistAssistant = Boolean(assistantText || opts.metadata?.journeyTrace)
+    if (shouldPersistAssistant) {
       await this.prisma.agentMessage.create({
         data: {
           sessionId,
           threadId,
           role: 'assistant',
-          content: assistantText,
+          content: assistantText || ' ',
           toolCalls: canvasActions.length ? JSON.stringify(canvasActions) : null,
           linkedOutputs: opts.linkedOutputs?.length ? JSON.stringify(opts.linkedOutputs) : null,
+          metadata: opts.metadata ? JSON.stringify(opts.metadata) : null,
         },
       })
       await this.prisma.agentThread.update({

--- a/apps/web/src/components/agent/AgentExecutionTrace.vue
+++ b/apps/web/src/components/agent/AgentExecutionTrace.vue
@@ -1,12 +1,16 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import AgentJourneyStepList from '@/components/agent/AgentJourneyStepList.vue'
 import type { ExecutionTraceState, ExecutionStep } from '@/components/agent/executionTraceReducer'
 import { formatDuration } from '@/components/agent/executionStepLabels'
+import type { JourneyTraceSnapshot } from '@/components/agent/journeyTraceTypes'
+import { PRESENTATION_STEPS } from '@/components/agent/presentation/types'
 import CanvasLocatePinIcon from '@/components/shared/CanvasLocatePinIcon.vue'
 
 const props = defineProps<{
   trace: ExecutionTraceState
   streaming?: boolean
+  journeySnapshot?: JourneyTraceSnapshot | null
 }>()
 
 const emit = defineEmits<{
@@ -22,13 +26,35 @@ watch(
   },
 )
 
+const workflowSteps = computed(() => props.trace.steps.filter((s) => s.kind === 'workflow_step'))
+const operationSteps = computed(() => props.trace.steps.filter((s) => s.kind !== 'workflow_step'))
+const hasWorkflow = computed(() => workflowSteps.value.length > 0)
 const stepCount = computed(() => props.trace.steps.length)
 
+const currentJourneyStepNumber = computed(() => {
+  const running = workflowSteps.value.find((s) => s.status === 'running')
+  if (running?.journeyStepId) {
+    const idx = PRESENTATION_STEPS.findIndex((step) => step.id === running.journeyStepId)
+    if (idx >= 0) return idx + 1
+  }
+  const current = props.journeySnapshot?.current
+  if (current) {
+    const idx = PRESENTATION_STEPS.findIndex((step) => step.id === current)
+    if (idx >= 0) return idx + 1
+  }
+  return null
+})
+
 const headerLabel = computed(() => {
-  if (props.streaming && stepCount.value === 0) return '执行过程（进行中…）'
-  if (props.streaming) return `执行过程（进行中… · ${stepCount.value} 步）`
-  if (stepCount.value === 0) return '执行过程'
-  return `执行过程（${stepCount.value} 步）`
+  const count = hasWorkflow.value ? 9 : stepCount.value
+  if (props.streaming) {
+    const n = currentJourneyStepNumber.value
+    if (n != null) return `执行过程（进行中… · 第 ${n}/9 步）`
+    if (stepCount.value === 0) return '执行过程（进行中…）'
+    return `执行过程（进行中… · ${stepCount.value} 步）`
+  }
+  if (count === 0) return '执行过程'
+  return `执行过程（${count} 步）`
 })
 
 const durationLabel = computed(() => {
@@ -36,6 +62,10 @@ const durationLabel = computed(() => {
   if (props.trace.totalMs != null) return `· ${formatDuration(props.trace.totalMs)}`
   return ''
 })
+
+const showTrace = computed(
+  () => hasWorkflow.value || operationSteps.value.length > 0 || props.streaming,
+)
 
 function toggle() {
   expanded.value = !expanded.value
@@ -71,7 +101,7 @@ function onStepClick(step: ExecutionStep) {
 </script>
 
 <template>
-  <div v-if="stepCount > 0 || streaming" class="agent-trace mt-1.5 border-t border-white/10 pt-1.5">
+  <div v-if="showTrace" class="agent-trace mt-1.5 border-t border-white/10 pt-1.5">
     <button
       type="button"
       class="agent-trace-toggle flex w-full items-center gap-1 text-left text-[11px] text-[var(--neo-text-muted)] hover:text-[var(--neo-text-primary)]"
@@ -81,26 +111,43 @@ function onStepClick(step: ExecutionStep) {
       <span>{{ headerLabel }}</span>
       <span v-if="durationLabel && !expanded" class="opacity-70">{{ durationLabel }}</span>
     </button>
-    <ul v-if="expanded" class="mt-1 space-y-0.5 pl-4">
-      <li
-        v-for="step in trace.steps"
-        :key="step.id"
-        class="flex items-start gap-1.5 text-[10px] leading-snug"
-        :class="[
-          step.meta?.nodeId ? 'cursor-pointer hover:text-[var(--neo-text-primary)]' : '',
-          step.status === 'failed' ? 'text-red-400/90' : 'text-[var(--neo-text-muted)]',
-          step.status === 'running' ? 'animate-pulse' : '',
-          step.kind === 'thinking' ? 'italic opacity-80' : '',
-          step.kind === 'explore' ? 'opacity-90' : '',
-        ]"
-        @click="onStepClick(step)"
-      >
-        <span class="min-w-0 flex-1">
-          <span>{{ statusIcon(step) }} {{ step.label }}{{ stepDuration(step) }}</span>
-          <p v-if="step.detail" class="mt-0.5 pl-3 opacity-75">{{ step.detail }}</p>
-        </span>
-        <CanvasLocatePinIcon v-if="step.meta?.nodeId" :size="11" class="mt-0.5 shrink-0 opacity-60" />
-      </li>
-    </ul>
+    <div v-if="expanded" class="mt-1 space-y-2 pl-4">
+      <section v-if="hasWorkflow" data-testid="journey-section">
+        <p class="mb-1 text-[10px] font-medium text-[var(--neo-text-muted)]">工作流进度</p>
+        <AgentJourneyStepList
+          :steps="workflowSteps"
+          :journey-steps="journeySnapshot?.steps"
+        />
+      </section>
+      <section v-if="operationSteps.length > 0" data-testid="operation-section">
+        <p class="mb-1 text-[10px] font-medium text-[var(--neo-text-muted)]">操作明细</p>
+        <ul class="space-y-0.5">
+          <li
+            v-for="step in operationSteps"
+            :key="step.id"
+            data-testid="operation-step"
+            class="flex items-start gap-1.5 text-[10px] leading-snug"
+            :class="[
+              step.meta?.nodeId ? 'cursor-pointer hover:text-[var(--neo-text-primary)]' : '',
+              step.status === 'failed' ? 'text-red-400/90' : 'text-[var(--neo-text-muted)]',
+              step.status === 'running' ? 'animate-pulse' : '',
+              step.kind === 'thinking' ? 'italic opacity-80' : '',
+              step.kind === 'explore' ? 'opacity-90' : '',
+            ]"
+            @click="onStepClick(step)"
+          >
+            <span class="min-w-0 flex-1">
+              <span>{{ statusIcon(step) }} {{ step.label }}{{ stepDuration(step) }}</span>
+              <p v-if="step.detail" class="mt-0.5 pl-3 opacity-75">{{ step.detail }}</p>
+            </span>
+            <CanvasLocatePinIcon
+              v-if="step.meta?.nodeId"
+              :size="11"
+              class="mt-0.5 shrink-0 opacity-60"
+            />
+          </li>
+        </ul>
+      </section>
+    </div>
   </div>
 </template>

--- a/apps/web/src/components/agent/AgentJourneyStepList.vue
+++ b/apps/web/src/components/agent/AgentJourneyStepList.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { ProductVisualMacroScheme } from '@/components/agent/agentInterruptGate'
+import type { ExecutionStep } from '@/components/agent/executionTraceReducer'
+import { formatDuration } from '@/components/agent/executionStepLabels'
+import type { JourneyStepId, JourneyStepRecord } from '@/components/agent/journeyTraceTypes'
+import AgentMacroSchemeCards from '@/components/agent/presentation/AgentMacroSchemeCards.vue'
+import { PRESENTATION_STEPS } from '@/components/agent/presentation/types'
+
+const props = defineProps<{
+  steps: ExecutionStep[]
+  journeySteps?: JourneyStepRecord[]
+}>()
+
+const stepById = computed(() => {
+  const map = new Map<JourneyStepId, ExecutionStep>()
+  for (const step of props.steps) {
+    if (step.journeyStepId) map.set(step.journeyStepId, step)
+  }
+  return map
+})
+
+const journeyById = computed(() => {
+  const map = new Map<JourneyStepId, JourneyStepRecord>()
+  for (const record of props.journeySteps ?? []) {
+    map.set(record.id, record)
+  }
+  return map
+})
+
+function statusIcon(status: ExecutionStep['status']): string {
+  switch (status) {
+    case 'done':
+      return '✓'
+    case 'failed':
+      return '✗'
+    case 'running':
+      return '…'
+    case 'waiting_user':
+      return '!'
+    case 'skipped':
+      return '–'
+    default:
+      return '○'
+  }
+}
+
+function stepDuration(step: ExecutionStep | undefined): string {
+  if (!step || step.ms == null || step.status === 'running') return ''
+  if (step.ms === 0) return ''
+  return ` · ${formatDuration(step.ms)}`
+}
+
+function macroSnapshot(record: JourneyStepRecord | undefined): {
+  schemes: ProductVisualMacroScheme[]
+  selectedIds: string[]
+} | null {
+  const snapshot = record?.snapshot
+  if (!snapshot || snapshot.kind !== 'macro_select') return null
+  const schemes = Array.isArray(snapshot.schemes)
+    ? (snapshot.schemes as ProductVisualMacroScheme[])
+    : []
+  const selectedIds = Array.isArray(snapshot.selectedIds)
+    ? (snapshot.selectedIds as string[])
+    : []
+  if (schemes.length === 0) return null
+  return { schemes, selectedIds }
+}
+</script>
+
+<template>
+  <ol class="agent-journey-step-list space-y-1" data-testid="agent-journey-step-list">
+    <li
+      v-for="(def, idx) in PRESENTATION_STEPS"
+      :key="def.id"
+      class="text-[10px] leading-snug"
+      :data-journey-step-id="def.id"
+      :data-journey-step-status="stepById.get(def.id as JourneyStepId)?.status ?? 'pending'"
+    >
+      <span
+        data-testid="journey-step-label"
+        class="inline-flex flex-wrap items-center gap-x-1 rounded px-0.5"
+        :class="{
+          'bg-[var(--neo-accent)] font-medium text-white': stepById.get(def.id as JourneyStepId)?.status === 'running',
+          'text-[var(--neo-text-muted)] line-through opacity-70':
+            stepById.get(def.id as JourneyStepId)?.status === 'done',
+          'text-[var(--neo-text-muted)] opacity-50':
+            (stepById.get(def.id as JourneyStepId)?.status ?? 'pending') === 'pending',
+          'text-red-400/90': stepById.get(def.id as JourneyStepId)?.status === 'failed',
+          'animate-pulse': stepById.get(def.id as JourneyStepId)?.status === 'running',
+        }"
+      >
+        <span>
+          {{ statusIcon(stepById.get(def.id as JourneyStepId)?.status ?? 'pending') }}
+          {{ idx + 1 }}. {{ stepById.get(def.id as JourneyStepId)?.label ?? def.label
+          }}{{ stepDuration(stepById.get(def.id as JourneyStepId)) }}
+        </span>
+      </span>
+      <p
+        v-if="stepById.get(def.id as JourneyStepId)?.detail"
+        class="mt-0.5 pl-3 text-[var(--neo-text-muted)] opacity-75"
+        data-testid="journey-step-summary"
+      >
+        {{ stepById.get(def.id as JourneyStepId)?.detail }}
+      </p>
+      <div
+        v-if="macroSnapshot(journeyById.get(def.id as JourneyStepId))"
+        class="mt-1 pl-3"
+        data-testid="journey-macro-snapshot"
+      >
+        <AgentMacroSchemeCards
+          :schemes="macroSnapshot(journeyById.get(def.id as JourneyStepId))!.schemes"
+          :selected-ids="macroSnapshot(journeyById.get(def.id as JourneyStepId))!.selectedIds"
+          :disabled="true"
+        />
+      </div>
+    </li>
+  </ol>
+</template>

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -107,6 +107,8 @@ import UniversalModelSelector from '@/components/canvas/UniversalModelSelector.v
 import CanvasRefTargetIcon from '@/components/shared/CanvasRefTargetIcon.vue'
 import { useCanvasRefPickMode } from '@/composables/useCanvasRefPickMode'
 import { formatDuration as formatTraceDuration } from '@/components/agent/executionStepLabels'
+import { extractThreadJourney } from '@/components/agent/journeyTraceHelpers'
+import type { JourneyTraceSnapshot } from '@/components/agent/journeyTraceTypes'
 import { formatSessionTime, lastThreadStorageKey } from '@/utils/formatSessionTime'
 import { randomId } from '@/utils/randomId'
 import { ElMessage } from 'element-plus'
@@ -426,6 +428,8 @@ const reconnecting = ref(false)
 const recoveredPhaseHint = ref<string | null>(null)
 /** P0-06: authoritative gate from SSE interrupt or thread-state reconnect */
 const interruptGate = ref<AgentInterruptPayload | null>(null)
+/** Thread-level journey snapshot for Stepper + trace enrichment */
+const threadJourneyTrace = ref<JourneyTraceSnapshot | null>(null)
 /** LangGraph checkpoint: same thread can regenerate/variant on prior atomic node */
 const hasAtomicCheckpoint = ref(false)
 
@@ -1068,6 +1072,7 @@ function newAgentSession() {
   agent.clear()
   taskProgress.value = emptyTaskProgress()
   interruptGate.value = null
+  threadJourneyTrace.value = null
   hasAtomicCheckpoint.value = false
   retakePending.value = false
   effectiveUtterance.value = null
@@ -1103,6 +1108,8 @@ async function refreshThreadCheckpoint() {
         retakePending?: boolean | null
         effectiveUtterance?: string | null
         presentation?: AgentPresentationEnvelope | null
+        selectedMacroSchemeIds?: string[] | null
+        journeyTrace?: JourneyTraceSnapshot | null
       }
     }
     hasAtomicCheckpoint.value = Boolean(json.data?.hasAtomicCheckpoint)
@@ -1115,6 +1122,13 @@ async function refreshThreadCheckpoint() {
     }
     if (json.data?.macroSchemes) {
       syncMacroSchemes(json.data.macroSchemes)
+    }
+    if (json.data?.selectedMacroSchemeIds?.length) {
+      macroSelections.value = [...json.data.selectedMacroSchemeIds]
+    }
+    if (json.data?.journeyTrace) {
+      threadJourneyTrace.value = json.data.journeyTrace
+      agent.trackJourneyUpdate(json.data.journeyTrace)
     }
     if (json.data?.shotManifest) {
       syncShotManifest(json.data.shotManifest)
@@ -1142,6 +1156,7 @@ async function refreshThreadCheckpoint() {
 async function loadHistory() {
   agent.clear()
   taskProgress.value = emptyTaskProgress()
+  threadJourneyTrace.value = null
   try {
     const res = await fetch(
       apiUrl(
@@ -1153,7 +1168,10 @@ async function loadHistory() {
       return
     }
     const json = await res.json()
-    if (json.data?.length) agent.loadHistory(json.data)
+    if (json.data?.length) {
+      agent.loadHistory(json.data)
+      threadJourneyTrace.value = extractThreadJourney(json.data)
+    }
   } catch {
     ElMessage.warning('对话历史加载失败，请检查网络后刷新')
   }
@@ -1437,6 +1455,8 @@ async function reconnectStream() {
         deliveryGenByKey?: Record<string, { node_id?: string | null; url?: string | null; title?: string | null }> | null
         userRequestLabels?: string[] | null
         presentation?: AgentPresentationEnvelope | null
+        selectedMacroSchemeIds?: string[] | null
+        journeyTrace?: JourneyTraceSnapshot | null
       } | null
     }
     const phase = json.data?.phase ?? null
@@ -1447,6 +1467,13 @@ async function reconnectStream() {
     }
     if (json.data?.macroSchemes) {
       syncMacroSchemes(json.data.macroSchemes)
+    }
+    if (json.data?.selectedMacroSchemeIds?.length) {
+      macroSelections.value = [...json.data.selectedMacroSchemeIds]
+    }
+    if (json.data?.journeyTrace) {
+      threadJourneyTrace.value = json.data.journeyTrace
+      agent.trackJourneyUpdate(json.data.journeyTrace)
     }
     if (json.data?.shotManifest) {
       syncShotManifest(json.data.shotManifest)
@@ -1613,6 +1640,13 @@ function handleEvent(event: { type: string; data: unknown }) {
     case 'explore':
       agent.trackExplore(event.data as Parameters<typeof agent.trackExplore>[0])
       break
+    case 'journey_update': {
+      const snap = (event.data as { snapshot: JourneyTraceSnapshot }).snapshot
+      threadJourneyTrace.value = snap
+      agent.trackJourneyUpdate(snap)
+      scrollToBottom()
+      break
+    }
     case 'canvas_command': {
       const cmd = event.data as {
         type: string
@@ -2087,6 +2121,7 @@ defineExpose({
                   v-if="msg.role === 'assistant' && msg.executionTrace"
                   :trace="msg.executionTrace"
                   :streaming="Boolean(msg.streaming)"
+                  :journey-snapshot="msg.journeyTrace ?? threadJourneyTrace"
                   @focus-node="onFocusNode($event)"
                 />
                 <div v-if="msg.toolCalls?.length" class="agent-tools mt-1 space-y-0.5 pt-1">
@@ -2152,6 +2187,7 @@ defineExpose({
             >
               <AgentPresentationHost
                 :presentation="completionPresentation"
+                :journey-snapshot="threadJourneyTrace"
                 :disabled="agent.isStreaming"
                 @focus-node="onFocusNode($event)"
                 @focus-all="onFocusAll($event)"
@@ -2374,6 +2410,7 @@ defineExpose({
             >
               <AgentPresentationHost
                 :presentation="deliveryPresentationForUi"
+                :journey-snapshot="threadJourneyTrace"
                 :delivery-selections="deliverySelections"
                 :disabled="agent.isStreaming"
                 @primary-action="onDeliveryPrimaryAction"
@@ -2385,6 +2422,7 @@ defineExpose({
             <div v-else-if="showGatePresentation && gatePresentation" class="mb-2">
               <AgentPresentationHost
                 :presentation="gatePresentation"
+                :journey-snapshot="threadJourneyTrace"
                 :disabled="agent.isStreaming"
                 @primary-action="onGatePrimaryAction"
                 @focus-node="onFocusNode($event)"

--- a/apps/web/src/components/agent/executionTraceReducer.test.ts
+++ b/apps/web/src/components/agent/executionTraceReducer.test.ts
@@ -1,15 +1,57 @@
 import { describe, expect, it } from 'vitest'
+import type { JourneyTraceSnapshot } from '@/components/agent/journeyTraceTypes'
+import { JOURNEY_STEP_LABELS } from '@/components/agent/journeyTraceTypes'
 import {
   applyCanvasAction,
+  applyJourneyUpdate,
   applyNodeStatus,
   applyPhaseHint,
   applyStep,
+  applyTaskUpdate,
   applyTextReplaceStage,
   applyToolCall,
   createExecutionTrace,
   finalizeExecutionTrace,
+  workflowStepsFromSnapshot,
 } from '@/components/agent/executionTraceReducer'
 import { labelFromTextReplace } from '@/components/agent/executionStepLabels'
+
+const JOURNEY_STEP_ORDER = [
+  'image_qa',
+  'scheme_draft',
+  'macro_select',
+  'ssot_persist',
+  'shot_plan',
+  'topo_preview',
+  'generating',
+  'delivery',
+  'done',
+] as const
+
+function buildMockJourneySnapshot(
+  current: (typeof JOURNEY_STEP_ORDER)[number] = 'macro_select',
+  overrides?: Partial<JourneyTraceSnapshot>,
+): JourneyTraceSnapshot {
+  const now = '2026-08-13T04:00:00Z'
+  return {
+    version: 1,
+    flowMode: 'product_visual',
+    current,
+    startedAt: now,
+    updatedAt: now,
+    steps: JOURNEY_STEP_ORDER.map((id) => ({
+      id,
+      label: JOURNEY_STEP_LABELS[id],
+      status:
+        id === current
+          ? 'running'
+          : JOURNEY_STEP_ORDER.indexOf(id) < JOURNEY_STEP_ORDER.indexOf(current)
+            ? 'done'
+            : 'pending',
+    })),
+    ...overrides,
+  }
+}
 
 describe('executionStepLabels', () => {
   it('maps sidebar copy stages', () => {
@@ -72,5 +114,125 @@ describe('executionTraceReducer', () => {
     const trace = createExecutionTrace()
     applyPhaseHint(trace, { phase: 'await_confirm', label: '等待你确认方案' })
     expect(trace.steps[0]?.status).toBe('waiting_user')
+  })
+})
+
+describe('applyJourneyUpdate', () => {
+  it('creates 9 workflow_step entries from snapshot', () => {
+    const trace = createExecutionTrace()
+    applyJourneyUpdate(trace, buildMockJourneySnapshot('macro_select'))
+
+    const workflowSteps = trace.steps.filter((s) => s.kind === 'workflow_step')
+    expect(workflowSteps).toHaveLength(9)
+    expect(workflowSteps.map((s) => s.journeyStepId)).toEqual([...JOURNEY_STEP_ORDER])
+  })
+
+  it('maps macro_select running and prior steps done', () => {
+    const trace = createExecutionTrace()
+    applyJourneyUpdate(trace, buildMockJourneySnapshot('macro_select'))
+
+    const macro = trace.steps.find((s) => s.journeyStepId === 'macro_select')
+    expect(macro?.status).toBe('running')
+    expect(macro?.label).toBe('选宏观风格')
+
+    const prior = trace.steps.find((s) => s.journeyStepId === 'scheme_draft')
+    expect(prior?.status).toBe('done')
+
+    const next = trace.steps.find((s) => s.journeyStepId === 'ssot_persist')
+    expect(next?.status).toBe('pending')
+  })
+
+  it('maps summary to workflow step detail', () => {
+    const trace = createExecutionTrace()
+    const snapshot = buildMockJourneySnapshot('macro_select')
+    snapshot.steps = snapshot.steps.map((s) =>
+      s.id === 'macro_select'
+        ? { ...s, summary: '已选：A 湖鲜原境风、B 礼盒臻享风' }
+        : s,
+    )
+    applyJourneyUpdate(trace, snapshot)
+
+    const macro = trace.steps.find((s) => s.journeyStepId === 'macro_select')
+    expect(macro?.detail).toBe('已选：A 湖鲜原境风、B 礼盒臻享风')
+  })
+
+  it('maps skipped and failed statuses', () => {
+    const trace = createExecutionTrace()
+    const snapshot = buildMockJourneySnapshot('ssot_persist')
+    snapshot.steps = snapshot.steps.map((s) => {
+      if (s.id === 'macro_select') return { ...s, status: 'skipped' as const }
+      if (s.id === 'image_qa') return { ...s, status: 'failed' as const, summary: '识图失败' }
+      return s
+    })
+    applyJourneyUpdate(trace, snapshot)
+
+    expect(trace.steps.find((s) => s.journeyStepId === 'macro_select')?.status).toBe('skipped')
+    expect(trace.steps.find((s) => s.journeyStepId === 'image_qa')?.status).toBe('failed')
+    expect(trace.steps.find((s) => s.journeyStepId === 'image_qa')?.detail).toBe('识图失败')
+  })
+
+  it('updates existing workflow steps on subsequent snapshot', () => {
+    const trace = createExecutionTrace()
+    applyJourneyUpdate(trace, buildMockJourneySnapshot('macro_select'))
+    applyJourneyUpdate(trace, buildMockJourneySnapshot('ssot_persist'))
+
+    expect(trace.steps.filter((s) => s.kind === 'workflow_step')).toHaveLength(9)
+    expect(trace.steps.find((s) => s.journeyStepId === 'macro_select')?.status).toBe('done')
+    expect(trace.steps.find((s) => s.journeyStepId === 'ssot_persist')?.status).toBe('running')
+  })
+
+  it('attaches text_stage child to running workflow step', () => {
+    const trace = createExecutionTrace()
+    applyJourneyUpdate(trace, buildMockJourneySnapshot('macro_select'))
+    applyTextReplaceStage(trace, '好的，我来生成图片「模特」')
+
+    const macro = trace.steps.find((s) => s.journeyStepId === 'macro_select')
+    const child = trace.steps.find((s) => s.kind === 'text_stage')
+    expect(macro?.id).toBeTruthy()
+    expect(child?.parentStepId).toBe(macro?.id)
+  })
+
+  it('attaches canvas and task children to running workflow step', () => {
+    const trace = createExecutionTrace()
+    applyJourneyUpdate(trace, buildMockJourneySnapshot('generating'))
+
+    applyCanvasAction(trace, {
+      type: 'add_node',
+      payload: { id: 'n1', nodeType: 'image', data: { title: '模特图' } },
+    })
+    applyTaskUpdate(trace, { id: 'task-1', status: 'running', title: '模特' })
+
+    const generating = trace.steps.find((s) => s.journeyStepId === 'generating')
+    const canvas = trace.steps.find((s) => s.kind === 'canvas')
+    const task = trace.steps.find((s) => s.kind === 'task')
+    expect(canvas?.parentStepId).toBe(generating?.id)
+    expect(task?.parentStepId).toBe(generating?.id)
+  })
+
+  it('rebinds orphan child steps when journey advances', () => {
+    const trace = createExecutionTrace()
+    applyJourneyUpdate(trace, buildMockJourneySnapshot('macro_select'))
+    applyTextReplaceStage(trace, '好的，我来生成图片「模特」')
+
+    applyJourneyUpdate(trace, buildMockJourneySnapshot('ssot_persist'))
+    applyCanvasAction(trace, {
+      type: 'add_node',
+      payload: { id: 'n1', nodeType: 'text', data: { title: '方案 SSOT' } },
+    })
+
+    const ssot = trace.steps.find((s) => s.journeyStepId === 'ssot_persist')
+    const canvas = trace.steps.find((s) => s.kind === 'canvas')
+    expect(canvas?.parentStepId).toBe(ssot?.id)
+  })
+})
+
+describe('workflowStepsFromSnapshot', () => {
+  it('returns 9 workflow steps without mutating trace', () => {
+    const snapshot = buildMockJourneySnapshot('macro_select')
+    const steps = workflowStepsFromSnapshot(snapshot)
+
+    expect(steps).toHaveLength(9)
+    expect(steps.every((s) => s.kind === 'workflow_step')).toBe(true)
+    expect(steps.find((s) => s.journeyStepId === 'macro_select')?.status).toBe('running')
   })
 })

--- a/apps/web/src/components/agent/executionTraceReducer.ts
+++ b/apps/web/src/components/agent/executionTraceReducer.ts
@@ -5,6 +5,7 @@ import {
   labelFromTextReplace,
   nodeStatusLabel,
 } from '@/components/agent/executionStepLabels'
+import type { JourneyStepId, JourneyTraceSnapshot } from '@/components/agent/journeyTraceTypes'
 
 export type ExecutionStepStatus =
   | 'pending'
@@ -23,6 +24,7 @@ export type ExecutionStepKind =
   | 'task'
   | 'thinking'
   | 'explore'
+  | 'workflow_step'
 
 export interface ExecutionStep {
   id: string
@@ -33,6 +35,8 @@ export interface ExecutionStep {
   startedAt?: number
   endedAt?: number
   ms?: number
+  parentStepId?: string
+  journeyStepId?: JourneyStepId
   meta?: {
     nodeId?: string
     taskId?: string
@@ -71,6 +75,91 @@ function completeStep(step: ExecutionStep, status: ExecutionStepStatus = 'done')
   if (step.startedAt) step.ms = now - step.startedAt
 }
 
+function journeyStepId(stepId: JourneyStepId): string {
+  return `journey:${stepId}`
+}
+
+function parseIsoMs(iso?: string): number | undefined {
+  if (!iso) return undefined
+  const ms = Date.parse(iso)
+  return Number.isNaN(ms) ? undefined : ms
+}
+
+function runningWorkflowStepId(trace: ExecutionTraceState): string | undefined {
+  return trace.steps.find((s) => s.kind === 'workflow_step' && s.status === 'running')?.id
+}
+
+function attachParentStep(trace: ExecutionTraceState, step: ExecutionStep) {
+  if (step.kind !== 'text_stage' && step.kind !== 'canvas' && step.kind !== 'task') return
+  const parentId = runningWorkflowStepId(trace)
+  if (parentId) step.parentStepId = parentId
+}
+
+function rebindOrphanChildSteps(trace: ExecutionTraceState) {
+  const parentId = runningWorkflowStepId(trace)
+  if (!parentId) return
+  for (const step of trace.steps) {
+    if (
+      (step.kind === 'text_stage' || step.kind === 'canvas' || step.kind === 'task') &&
+      !step.parentStepId
+    ) {
+      step.parentStepId = parentId
+    }
+  }
+}
+
+export function workflowStepsFromSnapshot(snapshot: JourneyTraceSnapshot): ExecutionStep[] {
+  return snapshot.steps.map((record) => {
+    const startedAt = parseIsoMs(record.enteredAt)
+    const endedAt = parseIsoMs(record.completedAt)
+    return {
+      id: journeyStepId(record.id),
+      kind: 'workflow_step',
+      label: record.label,
+      detail: record.summary,
+      status: record.status,
+      journeyStepId: record.id,
+      startedAt,
+      endedAt,
+      ms: record.ms,
+    }
+  })
+}
+
+export function applyJourneyUpdate(trace: ExecutionTraceState, snapshot: JourneyTraceSnapshot) {
+  for (const record of snapshot.steps) {
+    const id = journeyStepId(record.id)
+    let step = trace.steps.find((s) => s.id === id || s.journeyStepId === record.id)
+    const startedAt = parseIsoMs(record.enteredAt)
+    const endedAt = parseIsoMs(record.completedAt)
+    if (!step) {
+      step = {
+        id,
+        kind: 'workflow_step',
+        label: record.label,
+        status: record.status,
+        journeyStepId: record.id,
+        startedAt,
+        endedAt,
+        ms: record.ms,
+        detail: record.summary,
+      }
+      trace.steps.push(step)
+    } else {
+      step.id = id
+      step.kind = 'workflow_step'
+      step.label = record.label
+      step.status = record.status
+      step.journeyStepId = record.id
+      step.detail = record.summary
+      if (startedAt !== undefined) step.startedAt = startedAt
+      if (endedAt !== undefined) step.endedAt = endedAt
+      if (record.ms !== undefined) step.ms = record.ms
+    }
+  }
+  rebindOrphanChildSteps(trace)
+}
+
 function upsertTextStage(trace: ExecutionTraceState, label: string, detail?: string) {
   const last = trace.steps[trace.steps.length - 1]
   if (last?.kind === 'text_stage' && last.label === label && last.status === 'running') {
@@ -82,7 +171,7 @@ function upsertTextStage(trace: ExecutionTraceState, label: string, detail?: str
     return
   }
   const now = Date.now()
-  trace.steps.push({
+  const step: ExecutionStep = {
     id: nextStepId('text'),
     kind: 'text_stage',
     label,
@@ -91,7 +180,9 @@ function upsertTextStage(trace: ExecutionTraceState, label: string, detail?: str
     startedAt: now,
     endedAt: now,
     ms: 0,
-  })
+  }
+  attachParentStep(trace, step)
+  trace.steps.push(step)
 }
 
 function removeDuplicateTextStage(trace: ExecutionTraceState, label: string) {
@@ -247,7 +338,7 @@ export function applyCanvasAction(trace: ExecutionTraceState, action: CanvasActi
   const label = canvasActionLabel(action)
   const nodeId = action.payload?.id
   const now = Date.now()
-  trace.steps.push({
+  const step: ExecutionStep = {
     id: nextStepId('canvas'),
     kind: 'canvas',
     label,
@@ -256,7 +347,9 @@ export function applyCanvasAction(trace: ExecutionTraceState, action: CanvasActi
     endedAt: now,
     ms: 0,
     meta: nodeId ? { nodeId } : undefined,
-  })
+  }
+  attachParentStep(trace, step)
+  trace.steps.push(step)
 }
 
 export function applyNodeStatus(
@@ -349,6 +442,7 @@ export function applyTaskUpdate(
       startedAt: now,
       meta: { taskId: data.id, nodeId: data.nodeId },
     }
+    attachParentStep(trace, step)
     trace.steps.push(step)
   }
   if (data.status === 'running' || data.status === 'retrying') {

--- a/apps/web/src/components/agent/journeyTrace.test.ts
+++ b/apps/web/src/components/agent/journeyTrace.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AgentExecutionTrace from './AgentExecutionTrace.vue'
+import AgentJourneyStepList from './AgentJourneyStepList.vue'
+import {
+  applyCanvasAction,
+  applyJourneyUpdate,
+  applyTextReplaceStage,
+  createExecutionTrace,
+  finalizeExecutionTrace,
+} from './executionTraceReducer'
+import type { JourneyTraceSnapshot } from './journeyTraceTypes'
+import { JOURNEY_STEP_LABELS } from './journeyTraceTypes'
+
+const JOURNEY_STEP_ORDER = [
+  'image_qa',
+  'scheme_draft',
+  'macro_select',
+  'ssot_persist',
+  'shot_plan',
+  'topo_preview',
+  'generating',
+  'delivery',
+  'done',
+] as const
+
+function buildMockJourneySnapshot(
+  current: (typeof JOURNEY_STEP_ORDER)[number] = 'macro_select',
+  overrides?: Partial<JourneyTraceSnapshot>,
+): JourneyTraceSnapshot {
+  const now = '2026-08-13T04:00:00Z'
+  return {
+    version: 1,
+    flowMode: 'product_visual',
+    current,
+    startedAt: now,
+    updatedAt: now,
+    steps: JOURNEY_STEP_ORDER.map((id) => ({
+      id,
+      label: JOURNEY_STEP_LABELS[id],
+      status:
+        id === current
+          ? 'running'
+          : JOURNEY_STEP_ORDER.indexOf(id) < JOURNEY_STEP_ORDER.indexOf(current)
+            ? 'done'
+            : 'pending',
+    })),
+    ...overrides,
+  }
+}
+
+describe('AgentJourneyStepList', () => {
+  it('renders nine workflow steps with done line-through', () => {
+    const trace = createExecutionTrace()
+    applyJourneyUpdate(trace, buildMockJourneySnapshot('macro_select'))
+    const workflowSteps = trace.steps.filter((s) => s.kind === 'workflow_step')
+
+    const wrapper = mount(AgentJourneyStepList, {
+      props: { steps: workflowSteps },
+    })
+
+    expect(wrapper.find('[data-testid="agent-journey-step-list"]').exists()).toBe(true)
+    expect(wrapper.findAll('[data-journey-step-id]').length).toBe(9)
+    expect(
+      wrapper.find('[data-journey-step-id="image_qa"] [data-testid="journey-step-label"]').classes(),
+    ).toContain('line-through')
+    expect(
+      wrapper
+        .find('[data-journey-step-id="macro_select"] [data-testid="journey-step-label"]')
+        .classes(),
+    ).not.toContain('line-through')
+  })
+
+  it('shows macro summary and readonly scheme cards from snapshot', () => {
+    const trace = createExecutionTrace()
+    const snapshot = buildMockJourneySnapshot('ssot_persist')
+    snapshot.steps = snapshot.steps.map((s) =>
+      s.id === 'macro_select'
+        ? {
+            ...s,
+            status: 'done' as const,
+            summary: '已选：A 湖鲜原境风、B 礼盒臻享风',
+            snapshot: {
+              kind: 'macro_select',
+              schemes: [
+                { id: 'A', label: '湖鲜原境风', summary: '湖鲜场景' },
+                { id: 'B', label: '礼盒臻享风', summary: '红金礼盒' },
+              ],
+              selectedIds: ['A', 'B'],
+            },
+          }
+        : s,
+    )
+    applyJourneyUpdate(trace, snapshot)
+    const workflowSteps = trace.steps.filter((s) => s.kind === 'workflow_step')
+
+    const wrapper = mount(AgentJourneyStepList, {
+      props: { steps: workflowSteps, journeySteps: snapshot.steps },
+    })
+
+    const macro = wrapper.find('[data-journey-step-id="macro_select"]')
+    expect(macro.find('[data-testid="journey-step-summary"]').text()).toBe(
+      '已选：A 湖鲜原境风、B 礼盒臻享风',
+    )
+    expect(wrapper.find('[data-testid="macro-scheme-cards"]').exists()).toBe(true)
+    const checkboxes = wrapper.findAll('[data-scheme-id] input[type="checkbox"]')
+    expect(checkboxes.every((cb) => (cb.element as HTMLInputElement).disabled)).toBe(true)
+    expect((checkboxes[0]?.element as HTMLInputElement).checked).toBe(true)
+    expect((checkboxes[1]?.element as HTMLInputElement).checked).toBe(true)
+  })
+})
+
+describe('AgentExecutionTrace', () => {
+  it('renders workflow and operation sections separately', async () => {
+    const trace = createExecutionTrace()
+    applyJourneyUpdate(trace, buildMockJourneySnapshot('generating'))
+    applyTextReplaceStage(trace, '好的，我来生成图片「模特」')
+    applyCanvasAction(trace, {
+      type: 'add_node',
+      payload: { id: 'n1', nodeType: 'image', data: { title: '模特图' } },
+    })
+
+    const wrapper = mount(AgentExecutionTrace, {
+      props: { trace, streaming: false },
+    })
+
+    await wrapper.find('.agent-trace-toggle').trigger('click')
+
+    expect(wrapper.find('[data-testid="journey-section"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="operation-section"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="agent-journey-step-list"]').exists()).toBe(true)
+
+    const operationItems = wrapper.findAll('[data-testid="operation-step"]')
+    expect(operationItems.length).toBe(2)
+    expect(operationItems.some((li) => li.text().includes('理解需求'))).toBe(true)
+    expect(operationItems.some((li) => li.text().includes('添加图片节点'))).toBe(true)
+    expect(wrapper.findAll('[data-journey-step-id]').length).toBe(9)
+  })
+
+  it('shows streaming header with current journey step number', () => {
+    const trace = createExecutionTrace()
+    applyJourneyUpdate(trace, buildMockJourneySnapshot('macro_select'))
+
+    const wrapper = mount(AgentExecutionTrace, {
+      props: { trace, streaming: true },
+    })
+
+    expect(wrapper.find('.agent-trace-toggle').text()).toContain('执行过程（进行中… · 第 3/9 步）')
+  })
+
+  it('shows completed header with nine steps when journey present', () => {
+    const trace = createExecutionTrace()
+    applyJourneyUpdate(trace, buildMockJourneySnapshot('done'))
+    finalizeExecutionTrace(trace)
+
+    const wrapper = mount(AgentExecutionTrace, {
+      props: { trace, streaming: false },
+    })
+
+    expect(wrapper.find('.agent-trace-toggle').text()).toContain('执行过程（9 步）')
+  })
+})

--- a/apps/web/src/components/agent/journeyTraceHelpers.test.ts
+++ b/apps/web/src/components/agent/journeyTraceHelpers.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { extractThreadJourney, stepperFromJourneySnapshot } from './journeyTraceHelpers'
+import type { JourneyTraceSnapshot } from './journeyTraceTypes'
+import { JOURNEY_STEP_LABELS } from './journeyTraceTypes'
+
+function buildSnapshot(current: JourneyTraceSnapshot['current']): JourneyTraceSnapshot {
+  const order = [
+    'image_qa',
+    'scheme_draft',
+    'macro_select',
+    'ssot_persist',
+    'shot_plan',
+    'topo_preview',
+    'generating',
+    'delivery',
+    'done',
+  ] as const
+  const now = '2026-08-13T04:00:00Z'
+  return {
+    version: 1,
+    flowMode: 'product_visual',
+    current,
+    startedAt: now,
+    updatedAt: now,
+    steps: order.map((id) => ({
+      id,
+      label: JOURNEY_STEP_LABELS[id],
+      status: id === current ? 'running' : 'pending',
+    })),
+  }
+}
+
+describe('stepperFromJourneySnapshot', () => {
+  it('derives current and completed from journey snapshot', () => {
+    const stepper = stepperFromJourneySnapshot(buildSnapshot('macro_select'))
+    expect(stepper.current).toBe('macro_select')
+    expect(stepper.completed).toEqual(['image_qa', 'scheme_draft'])
+  })
+})
+
+describe('extractThreadJourney', () => {
+  it('returns the latest assistant journeyTrace from metadata', () => {
+    const snapshot = buildSnapshot('generating')
+    const messages = [
+      {
+        role: 'assistant',
+        metadata: JSON.stringify({ journeyTrace: buildSnapshot('macro_select') }),
+      },
+      { role: 'user', metadata: null },
+      {
+        role: 'assistant',
+        metadata: JSON.stringify({ journeyTrace: snapshot }),
+      },
+    ]
+
+    expect(extractThreadJourney(messages)).toEqual(snapshot)
+  })
+
+  it('returns null when no assistant metadata contains journeyTrace', () => {
+    expect(
+      extractThreadJourney([
+        { role: 'user', metadata: null },
+        { role: 'assistant', metadata: JSON.stringify({ executionTrace: {} }) },
+      ]),
+    ).toBeNull()
+  })
+})

--- a/apps/web/src/components/agent/journeyTraceHelpers.ts
+++ b/apps/web/src/components/agent/journeyTraceHelpers.ts
@@ -1,0 +1,28 @@
+import type { AgentMessageMetadata, JourneyTraceSnapshot } from '@/components/agent/journeyTraceTypes'
+import type { AgentPresentationStepper } from '@/components/agent/presentation/types'
+import { PRESENTATION_STEPS } from '@/components/agent/presentation/types'
+
+export function stepperFromJourneySnapshot(snapshot: JourneyTraceSnapshot): AgentPresentationStepper {
+  const order = PRESENTATION_STEPS.map((step) => step.id)
+  const idx = order.indexOf(snapshot.current)
+  return {
+    current: snapshot.current,
+    completed: idx >= 0 ? order.slice(0, idx) : [],
+  }
+}
+
+export function extractThreadJourney(
+  messages: ReadonlyArray<{ role: string; metadata?: string | null }>,
+): JourneyTraceSnapshot | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]
+    if (message.role !== 'assistant' || !message.metadata) continue
+    try {
+      const meta = JSON.parse(message.metadata) as AgentMessageMetadata
+      if (meta.journeyTrace) return meta.journeyTrace
+    } catch {
+      /* ignore malformed metadata */
+    }
+  }
+  return null
+}

--- a/apps/web/src/components/agent/journeyTraceTypes.ts
+++ b/apps/web/src/components/agent/journeyTraceTypes.ts
@@ -1,0 +1,9 @@
+export type {
+  AgentMessageMetadata,
+  JourneyStepId,
+  JourneyStepRecord,
+  JourneyStepStatus,
+  JourneyTraceSnapshot,
+} from '@lnkpi/shared'
+
+export { JOURNEY_STEP_LABELS } from '@lnkpi/shared'

--- a/apps/web/src/components/agent/presentation/AgentPresentationHost.vue
+++ b/apps/web/src/components/agent/presentation/AgentPresentationHost.vue
@@ -7,6 +7,8 @@ import AgentShotTable from './AgentShotTable.vue'
 import AgentTopoCardList from './AgentTopoCardList.vue'
 import AgentDeliveryCards from './AgentDeliveryCards.vue'
 import AgentDeliverySummaryTable from './AgentDeliverySummaryTable.vue'
+import { stepperFromJourneySnapshot } from '@/components/agent/journeyTraceHelpers'
+import type { JourneyTraceSnapshot } from '@/components/agent/journeyTraceTypes'
 import type { AgentPresentationEnvelope, AgentPresentationPrimaryAction } from './types'
 
 const FOCUS_ALL_MESSAGE = '__focus_all_canvas__'
@@ -16,6 +18,7 @@ const props = defineProps<{
   disabled?: boolean
   macroSelectedIds?: string[]
   deliverySelections?: Record<string, string>
+  journeySnapshot?: JourneyTraceSnapshot | null
 }>()
 
 const emit = defineEmits<{
@@ -27,6 +30,19 @@ const emit = defineEmits<{
 }>()
 
 const macroSelections = ref<string[]>(props.macroSelectedIds ?? [])
+
+const stepperCurrent = computed(
+  () =>
+    (props.journeySnapshot
+      ? stepperFromJourneySnapshot(props.journeySnapshot).current
+      : props.presentation.stepper.current),
+)
+const stepperCompleted = computed(
+  () =>
+    (props.journeySnapshot
+      ? stepperFromJourneySnapshot(props.journeySnapshot).completed
+      : props.presentation.stepper.completed),
+)
 
 const isProseBlock = computed(() => props.presentation.kind === 'prose_block')
 const isMacroCards = computed(() => props.presentation.kind === 'macro_scheme_cards')
@@ -81,8 +97,8 @@ function onPrimaryAction() {
   >
     <div class="agent-presentation-host__recap space-y-2">
       <AgentStepper
-        :current="presentation.stepper.current"
-        :completed="presentation.stepper.completed"
+        :current="stepperCurrent"
+        :completed="stepperCompleted"
       />
       <p
         v-if="presentation.context_recap"

--- a/apps/web/src/components/agent/presentation/presentation.test.ts
+++ b/apps/web/src/components/agent/presentation/presentation.test.ts
@@ -3,6 +3,8 @@ import { mount } from '@vue/test-utils'
 import AgentPresentationHost from './AgentPresentationHost.vue'
 import AgentStepper from './AgentStepper.vue'
 import type { AgentPresentationEnvelope } from './types'
+import type { JourneyTraceSnapshot } from '@/components/agent/journeyTraceTypes'
+import { JOURNEY_STEP_LABELS } from '@/components/agent/journeyTraceTypes'
 
 const shotEnvelope: AgentPresentationEnvelope = {
   kind: 'shot_table',
@@ -124,5 +126,33 @@ describe('AgentPresentationHost', () => {
     expect(wrapper.find('[data-testid="primary-action"]').text()).toBe('确认构图并开始出图')
     expect(wrapper.classes()).toContain('agent-presentation-host--gate')
     expect(wrapper.find('.agent-presentation-host__actions').exists()).toBe(true)
+  })
+
+  it('prefers journeySnapshot over presentation stepper when provided', () => {
+    const journeySnapshot: JourneyTraceSnapshot = {
+      version: 1,
+      flowMode: 'product_visual',
+      current: 'macro_select',
+      startedAt: '2026-08-13T04:00:00Z',
+      updatedAt: '2026-08-13T04:00:00Z',
+      steps: [
+        { id: 'image_qa', label: JOURNEY_STEP_LABELS.image_qa, status: 'done' },
+        { id: 'scheme_draft', label: JOURNEY_STEP_LABELS.scheme_draft, status: 'done' },
+        { id: 'macro_select', label: JOURNEY_STEP_LABELS.macro_select, status: 'running' },
+      ],
+    }
+    const wrapper = mount(AgentPresentationHost, {
+      props: {
+        presentation: {
+          ...shotEnvelope,
+          stepper: { current: 'shot_plan', completed: ['image_qa'] },
+        },
+        journeySnapshot,
+      },
+    })
+
+    expect(wrapper.find('[data-step-id="macro_select"]').attributes('data-step-state')).toBe('current')
+    expect(wrapper.find('[data-step-id="scheme_draft"]').attributes('data-step-state')).toBe('done')
+    expect(wrapper.find('[data-step-id="ssot_persist"]').attributes('data-step-state')).toBe('pending')
   })
 })

--- a/apps/web/src/stores/agent.test.ts
+++ b/apps/web/src/stores/agent.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import type { AgentChatMessage, SidebarAttachment } from '@lnkpi/shared'
+import { JOURNEY_STEP_LABELS } from '@/components/agent/journeyTraceTypes'
 import { useAgentStore } from './agent'
 
 type PersistedAgentMessage = AgentChatMessage & { linkedOutputs?: string }
@@ -124,5 +125,62 @@ describe('useAgentStore', () => {
         content: 'new message',
       }),
     )
+  })
+
+  it('restores journeyTrace and executionTrace from assistant metadata', () => {
+    const store = useAgentStore()
+    const journeyTrace = {
+      version: 1 as const,
+      flowMode: 'product_visual' as const,
+      current: 'macro_select' as const,
+      startedAt: '2026-08-13T04:00:00Z',
+      updatedAt: '2026-08-13T04:00:00Z',
+      steps: [
+        {
+          id: 'macro_select' as const,
+          label: JOURNEY_STEP_LABELS.macro_select,
+          status: 'running' as const,
+        },
+      ],
+    }
+
+    store.loadHistory([
+      {
+        id: 'message-1',
+        sessionId: 'session-1',
+        role: 'assistant',
+        content: ' ',
+        metadata: JSON.stringify({ journeyTrace }),
+        createdAt: '2026-08-07T00:00:00.000Z',
+      },
+    ])
+
+    expect(store.messages[0]?.journeyTrace).toEqual(journeyTrace)
+    expect(store.messages[0]?.executionTrace?.steps.some((step) => step.journeyStepId === 'macro_select')).toBe(true)
+  })
+
+  it('applies live journey updates to the latest assistant trace', () => {
+    const store = useAgentStore()
+    store.startAssistantMessage()
+    const snapshot = {
+      version: 1 as const,
+      flowMode: 'product_visual' as const,
+      current: 'generating' as const,
+      startedAt: '2026-08-13T04:00:00Z',
+      updatedAt: '2026-08-13T04:00:00Z',
+      steps: [
+        {
+          id: 'generating' as const,
+          label: JOURNEY_STEP_LABELS.generating,
+          status: 'running' as const,
+        },
+      ],
+    }
+
+    store.trackJourneyUpdate(snapshot)
+
+    const last = store.messages[store.messages.length - 1]
+    expect(last?.journeyTrace).toEqual(snapshot)
+    expect(last?.executionTrace?.steps.some((step) => step.journeyStepId === 'generating')).toBe(true)
   })
 })

--- a/apps/web/src/stores/agent.ts
+++ b/apps/web/src/stores/agent.ts
@@ -12,6 +12,7 @@ import { parsePersistedToolCalls } from '@/components/agent/agentCanvasOutputs'
 import {
   applyCanvasAction,
   applyExplore,
+  applyJourneyUpdate,
   applyNodeStatus,
   applyPhaseHint,
   applyStep,
@@ -24,6 +25,7 @@ import {
   finalizeExecutionTrace,
   type ExecutionTraceState,
 } from '@/components/agent/executionTraceReducer'
+import type { AgentMessageMetadata, JourneyTraceSnapshot } from '@/components/agent/journeyTraceTypes'
 
 export interface AgentStreamMessage {
   id: string
@@ -33,6 +35,7 @@ export interface AgentStreamMessage {
   streaming?: boolean
   textReplaceHistory?: string[]
   executionTrace?: ExecutionTraceState
+  journeyTrace?: JourneyTraceSnapshot
   attachments?: SidebarAttachment[]
   attachmentRefKeys?: string[]
   linkedOutputs?: LinkedCanvasOutput[]
@@ -175,6 +178,16 @@ export const useAgentStore = defineStore('agent', () => {
     if (last?.executionTrace) applyExplore(last.executionTrace, data)
   }
 
+  function trackJourneyUpdate(snapshot: JourneyTraceSnapshot) {
+    ensureExecutionTrace()
+    const last = lastAssistant()
+    if (!last) return
+    last.journeyTrace = snapshot
+    if (last.executionTrace) {
+      applyJourneyUpdate(last.executionTrace, snapshot)
+    }
+  }
+
   function addCanvasAction(action: CanvasAction) {
     trackCanvasAction(action)
     pendingActions.value.push(action)
@@ -221,9 +234,39 @@ export const useAgentStore = defineStore('agent', () => {
     }
   }
 
+  function parseMessageMetadata(raw: string | undefined): AgentMessageMetadata | undefined {
+    if (!raw) return undefined
+    try {
+      return JSON.parse(raw) as AgentMessageMetadata
+    } catch {
+      return undefined
+    }
+  }
+
+  function restoreExecutionTrace(meta: AgentMessageMetadata | undefined): ExecutionTraceState | undefined {
+    const raw = meta?.executionTrace as ExecutionTraceState | undefined
+    if (!raw?.steps?.length) return undefined
+    return {
+      steps: raw.steps,
+      collapsed: raw.collapsed ?? true,
+      turnStartedAt: raw.turnStartedAt ?? Date.now(),
+      turnEndedAt: raw.turnEndedAt,
+      totalMs: raw.totalMs,
+    }
+  }
+
   function loadHistory(history: AgentChatMessage[]) {
     messages.value = history.map((m) => {
       const persisted = m as PersistedAgentMessage
+      const meta = parseMessageMetadata(persisted.metadata)
+      let executionTrace = restoreExecutionTrace(meta)
+      const journeyTrace = meta?.journeyTrace
+      if (journeyTrace) {
+        if (!executionTrace) {
+          executionTrace = createExecutionTrace()
+        }
+        applyJourneyUpdate(executionTrace, journeyTrace)
+      }
       return {
         id: persisted.id,
         role: persisted.role as 'user' | 'assistant',
@@ -231,6 +274,8 @@ export const useAgentStore = defineStore('agent', () => {
         attachments: parseAttachments(persisted.attachments),
         linkedOutputs: parseLinkedOutputs(persisted.linkedOutputs),
         canvasActions: parsePersistedToolCalls(persisted.toolCalls),
+        executionTrace,
+        journeyTrace,
       }
     })
   }
@@ -256,6 +301,7 @@ export const useAgentStore = defineStore('agent', () => {
     trackStructuredError,
     trackThinking,
     trackExplore,
+    trackJourneyUpdate,
     addCanvasAction,
     flushActions,
     finishStreaming,

--- a/deploy/prod-crab-listing-e2e-audit.py
+++ b/deploy/prod-crab-listing-e2e-audit.py
@@ -31,6 +31,7 @@ MACRO_PREFIX = "__macro_scheme_decision__"
 DELIVERY_PREFIX = "__delivery_decision__"
 
 audit: dict[str, Any] = {"steps": [], "gates_seen": [], "issues": []}
+last_journey_snapshot: dict[str, Any] | None = None
 
 
 def http(m: str, p: str, b: dict | None = None, t: str | None = None) -> Any:
@@ -182,6 +183,49 @@ def gate_reply(ts: dict[str, Any]) -> str | None:
     return None
 
 
+def extract_last_journey_snapshot(events: list[dict[str, Any]]) -> dict[str, Any] | None:
+    snap: dict[str, Any] | None = None
+    for ev in events:
+        if ev.get("type") != "journey_update":
+            continue
+        data = ev.get("data")
+        if not isinstance(data, dict):
+            continue
+        candidate = data.get("snapshot")
+        if isinstance(candidate, dict):
+            snap = candidate
+    return snap
+
+
+def absorb_journey_updates(events: list[dict[str, Any]]) -> None:
+    global last_journey_snapshot
+    snap = extract_last_journey_snapshot(events)
+    if snap is not None:
+        last_journey_snapshot = snap
+
+
+def resolve_journey_trace(final_thread_state: dict[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
+    if last_journey_snapshot is not None:
+        return last_journey_snapshot, "sse"
+    ts_snap = final_thread_state.get("journeyTrace")
+    if isinstance(ts_snap, dict):
+        return ts_snap, "thread_state"
+    return None, None
+
+
+def assert_journey_trace(audit_doc: dict[str, Any]) -> None:
+    jt = audit_doc.get("journeyTrace")
+    if not jt:
+        final = audit_doc.get("finalThreadState") or audit_doc.get("final_thread_state") or {}
+        jt = final.get("journeyTrace")
+    assert jt, "missing journeyTrace"
+    assert len(jt.get("steps", [])) == 9
+    assert jt.get("current") == "done"
+    macro = next(s for s in jt["steps"] if s["id"] == "macro_select")
+    assert macro.get("status") in ("done", "skipped")
+    assert macro.get("summary")
+
+
 def record_step(step: int, msg: str, sse: dict[str, Any], ts: dict[str, Any]) -> None:
     pres_events = [
         e.get("data") for e in sse.get("events", [])
@@ -249,6 +293,7 @@ def main() -> int:
     while time.time() < deadline:
         step += 1
         sse = sse_turn(tok, sid, tid, msg, attachments=attachments, skill_id=skill_id)
+        absorb_journey_updates(sse.get("events") or [])
         attachments = None
         skill_id = None
         ts = thread_state(tok, tid)
@@ -287,12 +332,59 @@ def main() -> int:
     audit["final_thread_state"] = thread_state(tok, tid)
     audit["messages"] = agent_messages(tok, sid, tid)
 
+    journey_trace, journey_source = resolve_journey_trace(audit["final_thread_state"])
+    if journey_trace is not None:
+        audit["journeyTrace"] = journey_trace
+    if journey_source:
+        audit["journeyTraceSource"] = journey_source
+
+    journey_ok = False
+    if audit.get("status") == "done":
+        try:
+            assert_journey_trace(audit)
+            journey_ok = True
+            audit["journeyTraceOk"] = True
+            jt = audit.get("journeyTrace") or {}
+            print(
+                f"journeyTrace ok: steps={len(jt.get('steps', []))} "
+                f"current={jt.get('current')} source={journey_source}",
+                flush=True,
+            )
+        except AssertionError as exc:
+            audit["journeyTraceOk"] = False
+            audit["issues"].append(f"journeyTrace: {exc}")
+            print(f"journeyTrace assertion failed: {exc}", flush=True)
+
     OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
     OUT_PATH.write_text(json.dumps(audit, ensure_ascii=False, indent=2), encoding="utf-8")
     print(f"\nAudit saved: {OUT_PATH}", flush=True)
     print(f"status={audit.get('status')} gates={audit.get('gates_seen')}", flush=True)
-    return 0 if audit.get("status") == "done" else 1
+    if audit.get("status") == "done":
+        return 0 if journey_ok else 1
+    return 1
+
+
+def _self_test_assert_journey_trace() -> None:
+    step_ids = [
+        "image_qa",
+        "scheme_draft",
+        "macro_select",
+        "ssot_persist",
+        "shot_plan",
+        "topo_preview",
+        "generating",
+        "delivery",
+        "done",
+    ]
+    steps = [{"id": sid, "status": "done"} for sid in step_ids]
+    steps[2]["summary"] = "已选：湖鲜原境风"
+    mock = {"journeyTrace": {"current": "done", "steps": steps}}
+    assert_journey_trace(mock)
 
 
 if __name__ == "__main__":
+    if os.environ.get("AUDIT_SELF_TEST") == "1":
+        _self_test_assert_journey_trace()
+        print("assert_journey_trace self-test passed", flush=True)
+        raise SystemExit(0)
     raise SystemExit(main())

--- a/docs/superpowers/plans/2026-08-13-product-visual-journey-trace.md
+++ b/docs/superpowers/plans/2026-08-13-product-visual-journey-trace.md
@@ -1,0 +1,539 @@
+# Product Visual 九步旅程 · 执行记录一体化 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 将 product_visual v2 九步 Stepper 与 Agent 执行记录合并为可持久化的 `JourneyTraceSnapshot`，Live 动态展示、历史对话可回放（含宏观方案可选/已选）。
+
+**Architecture:** Runtime 在 phase 变迁时构建 `JourneyTraceSnapshot` 并通过 SSE `journey_update` 下发；前端 `executionTraceReducer.applyJourneyUpdate` 同步九步骨架 + 操作明细；Nest `finalizeTurn` 将 `journeyTrace` + `executionTrace` 写入 `AgentMessage.metadata`；SideRail 门控 Stepper 与 Trace 共用 thread 级快照。
+
+**Tech Stack:** LangGraph (Python 3.11+), pytest, Vue 3 + Vitest, NestJS + Prisma, `@lnkpi/shared` 类型
+
+**Spec:** [2026-08-13-product-visual-journey-trace-design.md](../specs/2026-08-13-product-visual-journey-trace-design.md)
+
+## Global Constraints
+
+- 适用范围：`flow_mode: product_visual` + `product_visual_scheme_v2=true`
+- **禁止** machine payload 出现在 assistant 可见正文或 journey summary：`__macro_scheme_decision__`、`__delivery_decision__`
+- **禁止** 内部 phase 名（`await_*`）出现在用户可见 journey label/summary
+- P0 旅程锚点：**thread 级单快照**（最后一次 `journey_update` 覆盖）
+- 历史 macro 回放：**summary + 只读卡片**（`snapshot.kind === 'macro_select'`）
+- snapshot prose ≤200 字；macro schemes ≤3 套
+- 延续 [侧栏文案规范 v1](../specs/2026-08-06-agent-sidebar-copy-design.md)：主气泡仍只显示最终 `text_replace`
+- Pre-PR 测试：
+  - `cd services/agent-runtime && uv run pytest tests/test_journey_trace*.py tests/test_presentation_envelope.py -v`
+  - `cd apps/web && pnpm exec vitest run src/components/agent/executionTraceReducer.test.ts src/components/agent/journeyTrace*.test.ts`
+  - `cd apps/server && pnpm exec vitest run src/agent/agent.service.journey-trace.test.ts`
+
+---
+
+## 交付阶段总览
+
+| 阶段 | 里程碑 | 可独立验收 |
+|------|--------|------------|
+| **T1** | 共享类型 + Runtime snapshot 构建 + 单测 | pytest `test_journey_trace_snapshot.py` Pass |
+| **T2** | SSE `journey_update` + thread-state 扩展 | interrupt/done 事件含 snapshot |
+| **T3** | Prisma metadata + Nest 持久化 | getMessages 返回 metadata |
+| **T4** | 前端 reducer + Trace UI 九步骨架 | Vitest + 本地 Live 可见 |
+| **T5** | SideRail 集成 + 历史恢复 + macro 回放 | AC-JT-01～05 |
+| **T6** | E2E audit v5 + UAT 条目 | AC-JT-08 |
+
+**建议 PR 切分：** T1–T2 → PR#1（Runtime）；T3 → PR#2（Nest/DB）；T4–T5 → PR#3（Web）；T6 → 随 PR#3 或 deploy 验证
+
+---
+
+## File Map
+
+| File | Action | 职责 |
+|------|--------|------|
+| `packages/shared/src/journeyTrace.ts` | **Create** | `JourneyTraceSnapshot` / `AgentMessageMetadata` SSOT 类型 |
+| `packages/shared/src/index.ts` | Modify | export journey trace 类型 |
+| `services/agent-runtime/app/graph/product_visual_v2/journey_trace.py` | **Create** | `build_journey_trace_snapshot(state, phase)` |
+| `services/agent-runtime/app/graph/product_visual_v2/presentation.py` | Modify | 调用 journey_trace；macro 确认 summary |
+| `services/agent-runtime/app/graph/nodes/macro_scheme_select_gate.py` | Modify | 确认后写入 macro snapshot |
+| `services/agent-runtime/app/graph/state.py` | Modify | `journey_trace: dict \| None` |
+| `services/agent-runtime/app/runs.py` | Modify | emit `journey_update`；thread-state 新字段 |
+| `services/agent-runtime/app/graph/hitl_resume.py` | Modify | interrupt 时附带 journey snapshot |
+| `services/agent-runtime/tests/test_journey_trace_snapshot.py` | **Create** | snapshot 构建单测 |
+| `apps/server/prisma/schema.prisma` | Modify | `AgentMessage.metadata String?` |
+| `apps/server/prisma/migrations/*_agent_message_metadata/` | **Create** | 迁移 |
+| `packages/agent/src/types.ts` | Modify | `AgentStreamEvent` 增加 `journey_update` |
+| `apps/server/src/agent/agent.service.ts` | Modify | 累积 journey/execution trace → metadata |
+| `apps/server/src/agent/agent.service.journey-trace.test.ts` | **Create** | finalizeTurn metadata 单测 |
+| `apps/web/src/components/agent/journeyTraceTypes.ts` | **Create** | 复用 shared 类型 + UI helpers |
+| `apps/web/src/components/agent/executionTraceReducer.ts` | Modify | `workflow_step` + `applyJourneyUpdate` |
+| `apps/web/src/components/agent/executionTraceReducer.test.ts` | Modify | journey update 测试 |
+| `apps/web/src/components/agent/AgentExecutionTrace.vue` | Modify | 九步骨架 section + 操作明细 section |
+| `apps/web/src/components/agent/AgentJourneyStepList.vue` | **Create** | 九步列表（含 summary + macro 只读卡） |
+| `apps/web/src/components/agent/journeyTrace.test.ts` | **Create** | 组件单测 |
+| `apps/web/src/stores/agent.ts` | Modify | loadHistory 恢复 metadata |
+| `apps/web/src/components/agent/AgentSideRail.vue` | Modify | SSE handler、thread 级 journey ref、Stepper 同源 |
+| `deploy/prod-crab-listing-e2e-audit.py` | Modify | 断言 `journeyTrace.steps.length === 9` |
+
+---
+
+## Task 1: 共享类型 SSOT
+
+**Files:**
+- Create: `packages/shared/src/journeyTrace.ts`
+- Modify: `packages/shared/src/index.ts`
+
+**Interfaces — Produces:**
+
+```typescript
+// packages/shared/src/journeyTrace.ts
+export type JourneyStepId =
+  | 'image_qa' | 'scheme_draft' | 'macro_select' | 'ssot_persist'
+  | 'shot_plan' | 'topo_preview' | 'generating' | 'delivery' | 'done'
+
+export type JourneyStepStatus = 'pending' | 'running' | 'done' | 'failed' | 'skipped'
+
+export interface JourneyStepRecord {
+  id: JourneyStepId
+  label: string
+  status: JourneyStepStatus
+  enteredAt?: string
+  completedAt?: string
+  ms?: number
+  summary?: string
+  snapshot?: Record<string, unknown>
+}
+
+export interface JourneyTraceSnapshot {
+  version: 1
+  flowMode: 'product_visual'
+  steps: JourneyStepRecord[]
+  current: JourneyStepId
+  startedAt: string
+  updatedAt: string
+  finishedAt?: string
+  totalMs?: number
+}
+
+export interface AgentMessageMetadata {
+  journeyTrace?: JourneyTraceSnapshot
+  executionTrace?: Record<string, unknown>
+}
+
+export const JOURNEY_STEP_LABELS: Record<JourneyStepId, string> = {
+  image_qa: '检查产品图',
+  scheme_draft: '理解需求 · 出方案',
+  macro_select: '选宏观风格',
+  ssot_persist: '方案落盘',
+  shot_plan: '定构图清单',
+  topo_preview: '预览出图计划',
+  generating: '出图中',
+  delivery: '选定稿',
+  done: '交付完成',
+}
+```
+
+- [ ] **Step 1:** 创建 `journeyTrace.ts` 并 export
+- [ ] **Step 2:** 在 `index.ts` 追加 export
+- [ ] **Step 3:** `cd packages/shared && pnpm build` — 无 TS 错误
+
+---
+
+## Task 2: Runtime `build_journey_trace_snapshot`
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/product_visual_v2/journey_trace.py`
+- Create: `services/agent-runtime/tests/test_journey_trace_snapshot.py`
+- Modify: `services/agent-runtime/app/graph/product_visual_v2/presentation.py`
+
+**Interfaces — Produces:**
+
+```python
+# journey_trace.py
+JOURNEY_STEP_ORDER: list[str]  # mirrors STEPPER_ORDER
+
+def build_journey_trace_snapshot(
+    state: dict[str, Any],
+    *,
+    phase: str,
+    now: datetime | None = None,
+) -> dict[str, Any]: ...
+
+def merge_journey_trace(
+    prev: dict[str, Any] | None,
+    state: dict[str, Any],
+    *,
+    phase: str,
+) -> dict[str, Any]: ...
+```
+
+**Logic rules:**
+- 从 `phase_to_stepper(phase)` 得 `current`；`completed = STEPPER_ORDER[:idx]`
+- 每步 `label` 来自固定中文表（与 `PRESENTATION_STEPS` 一致）
+- `prev` 存在时保留已 completed 步的 `enteredAt`/`completedAt`/`summary`/`snapshot`
+- `macro_select` 完成：读 `selected_macro_scheme_ids` + `macro_schemes` 生成 summary「已选：{labels}」
+- 单方案 skip：`macro_select.status = 'skipped'`，summary「仅一套方案，已自动选定」
+- `phase == 'done'`：全部 9 步 `done`，写 `finishedAt`/`totalMs`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# test_journey_trace_snapshot.py
+def test_build_snapshot_macro_select_running():
+    snap = build_journey_trace_snapshot(
+        {"macro_schemes": [{"id": "A", "label": "湖鲜原境风"}]},
+        phase="await_macro_scheme_select",
+    )
+    assert snap["current"] == "macro_select"
+    assert snap["steps"][2]["status"] == "running"
+    assert snap["steps"][0]["status"] == "done"
+
+def test_macro_confirm_summary():
+    state = {
+        "macro_schemes": [
+            {"id": "A", "label": "湖鲜原境风"},
+            {"id": "B", "label": "礼盒臻享风"},
+        ],
+        "selected_macro_scheme_ids": ["A", "B"],
+    }
+    snap = merge_journey_trace(None, state, phase="canvas_ssot_commit")
+    macro = next(s for s in snap["steps"] if s["id"] == "macro_select")
+    assert macro["status"] == "done"
+    assert "湖鲜原境风" in macro["summary"]
+    assert macro["snapshot"]["selectedIds"] == ["A", "B"]
+```
+
+- [ ] **Step 2:** Run `uv run pytest tests/test_journey_trace_snapshot.py -v` — FAIL
+
+- [ ] **Step 3:** 实现 `journey_trace.py` + 在 `build_presentation_envelope` 末尾调用 `merge_journey_trace` 写入 `state['journey_trace']`
+
+- [ ] **Step 4:** Run pytest — PASS
+
+- [ ] **Step 5:** Commit
+
+```bash
+git add services/agent-runtime/app/graph/product_visual_v2/journey_trace.py \
+  services/agent-runtime/tests/test_journey_trace_snapshot.py \
+  services/agent-runtime/app/graph/product_visual_v2/presentation.py \
+  packages/shared/src/journeyTrace.ts packages/shared/src/index.ts
+git commit -m "feat(runtime): build journey trace snapshot for product_visual v2"
+```
+
+---
+
+## Task 3: SSE `journey_update` + thread-state
+
+**Files:**
+- Modify: `services/agent-runtime/app/runs.py`
+- Modify: `services/agent-runtime/app/graph/hitl_resume.py`
+- Modify: `services/agent-runtime/app/graph/state.py`
+- Modify: `packages/agent/src/types.ts`
+- Modify: `services/agent-runtime/tests/test_thread_state.py`
+
+**Interfaces — Produces:**
+
+```python
+# runs.py — emit helper
+async def emit_journey_update(emit, state: dict) -> None:
+    snap = state.get("journey_trace")
+    if isinstance(snap, dict) and snap.get("flowMode") == "product_visual":
+        await emit({"type": "journey_update", "data": {"snapshot": snap}})
+```
+
+```typescript
+// packages/agent/src/types.ts
+export interface AgentStreamEvent {
+  type: /* ... */ | 'journey_update'
+}
+```
+
+**Emit 时机（在现有 presentation emit 旁）：**
+- `interrupt` 事件前
+- 每个含 `presentation` 的 `text_replace` 后
+- `done` payload 前（终局 snapshot）
+
+**thread-state 新增：**
+
+```python
+return {
+    # ...existing...
+    "selectedMacroSchemeIds": vals.get("selected_macro_scheme_ids"),
+    "journeyTrace": vals.get("journey_trace"),
+}
+```
+
+- [ ] **Step 1:** 扩展 `AgentStreamEvent` 类型
+- [ ] **Step 2:** 写 test：`test_get_thread_state_includes_journey_trace`
+- [ ] **Step 3:** 实现 emit + thread-state 字段
+- [ ] **Step 4:** `uv run pytest tests/test_thread_state.py tests/test_journey_trace_snapshot.py -v` — PASS
+- [ ] **Step 5:** Commit
+
+---
+
+## Task 4: Prisma metadata 迁移
+
+**Files:**
+- Modify: `apps/server/prisma/schema.prisma`
+- Create: migration via `pnpm prisma migrate dev --name agent_message_metadata`
+
+```prisma
+model AgentMessage {
+  // ...
+  metadata String? // JSON: AgentMessageMetadata
+}
+```
+
+- [ ] **Step 1:** 修改 schema
+- [ ] **Step 2:** 生成并应用 migration（dev 环境）
+- [ ] **Step 3:** 确认 `getMessages` 返回 `metadata` 字段（Prisma 默认全字段）
+- [ ] **Step 4:** Commit migration + schema
+
+---
+
+## Task 5: Nest 持久化 journey + execution trace
+
+**Files:**
+- Modify: `apps/server/src/agent/agent.service.ts`
+- Create: `apps/server/src/agent/agent.service.journey-trace.test.ts`
+- Modify: `packages/shared/src/index.ts` — `AgentChatMessage` 增加 `metadata?: string`
+
+**Interfaces — Consumes:** SSE `journey_update` snapshot；Pinia-compatible `executionTrace` object
+
+**Interfaces — Produces:**
+
+```typescript
+// streamFromRuntime 内累积
+let journeyTrace: JourneyTraceSnapshot | undefined
+let executionTrace: Record<string, unknown> | undefined
+
+// finalizeTurn 签名扩展
+private async finalizeTurn(..., opts: {
+  rewriteCanvasData: boolean
+  linkedOutputs?: LinkedCanvasOutput[]
+  metadata?: AgentMessageMetadata
+})
+```
+
+**写入规则：**
+- 每轮 assistant 消息 create 时：`metadata: JSON.stringify({ journeyTrace, executionTrace })`
+- 若 `assistantText` 为空但有 `journeyTrace`：仍 create assistant 占位消息（content=`''` 或 `' '` — 用 `' '` 避免 skip；SideRail 过滤空泡）
+- thread 级：每次覆盖完整 snapshot（非 merge）
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+it('persists journeyTrace in assistant message metadata on finalizeTurn', async () => {
+  // mock stream yielding journey_update + done
+  // assert agentMessage.create called with metadata containing journeyTrace.steps.length === 9
+})
+```
+
+- [ ] **Step 2:** Run vitest — FAIL
+- [ ] **Step 3:** 实现 SSE 累积 + finalizeTurn 写入
+- [ ] **Step 4:** vitest PASS
+- [ ] **Step 5:** Commit
+
+---
+
+## Task 6: 前端 reducer — `applyJourneyUpdate`
+
+**Files:**
+- Modify: `apps/web/src/components/agent/executionTraceReducer.ts`
+- Modify: `apps/web/src/components/agent/executionTraceReducer.test.ts`
+- Create: `apps/web/src/components/agent/journeyTraceTypes.ts`
+
+**Interfaces — Produces:**
+
+```typescript
+export type ExecutionStepKind = /* ... */ | 'workflow_step'
+
+export interface ExecutionStep {
+  // ...
+  parentStepId?: string
+  journeyStepId?: JourneyStepId
+}
+
+export function applyJourneyUpdate(
+  trace: ExecutionTraceState,
+  snapshot: JourneyTraceSnapshot,
+): void
+
+export function workflowStepsFromSnapshot(
+  snapshot: JourneyTraceSnapshot,
+): ExecutionStep[]
+```
+
+**Logic:**
+- 为 snapshot 中 9 步各创建/更新 `kind: 'workflow_step'` 的 ExecutionStep
+- 映射 status：`done`→done, `running`→running, `pending`→pending, `failed`→failed, `skipped`→skipped
+- 后续 `text_stage`/`canvas`/`task` 步骤自动 `parentStepId` = 当前 `running` workflow step 的 id
+- `snapshot.summary` → workflow step 的 `detail`
+
+- [ ] **Step 1:** 写 failing test — macro_select running + 子步骤挂载
+- [ ] **Step 2:** 实现 `applyJourneyUpdate`
+- [ ] **Step 3:** vitest PASS
+- [ ] **Step 4:** Commit
+
+---
+
+## Task 7: `AgentJourneyStepList` + `AgentExecutionTrace` 双 section
+
+**Files:**
+- Create: `apps/web/src/components/agent/AgentJourneyStepList.vue`
+- Create: `apps/web/src/components/agent/journeyTrace.test.ts`
+- Modify: `apps/web/src/components/agent/AgentExecutionTrace.vue`
+
+**UI 行为:**
+- Section 1「工作流进度」：`AgentJourneyStepList` — 九步，done 步 `line-through`
+- macro snapshot：只读 `AgentMacroSchemeCards`（`:disabled="true"`，`:selected-ids="snapshot.selectedIds"`）
+- Section 2「操作明细」：现有 steps 过滤 `kind !== 'workflow_step'`
+- Streaming 标题：`执行过程（进行中… · 第 ${n}/9 步）` — n = current step index + 1
+
+- [ ] **Step 1:** 组件 test — 渲染 9 步 + macro summary
+- [ ] **Step 2:** 实现组件
+- [ ] **Step 3:** 修改 `AgentExecutionTrace.vue` 集成
+- [ ] **Step 4:** vitest PASS
+- [ ] **Step 5:** Commit
+
+---
+
+## Task 8: SideRail 集成 + 历史恢复
+
+**Files:**
+- Modify: `apps/web/src/components/agent/AgentSideRail.vue`
+- Modify: `apps/web/src/stores/agent.ts`
+- Modify: `apps/web/src/components/agent/presentation/AgentPresentationHost.vue`（Stepper 读 thread journey）
+
+**SideRail changes:**
+
+```typescript
+const threadJourneyTrace = ref<JourneyTraceSnapshot | null>(null)
+
+// SSE handler
+if (event.type === 'journey_update') {
+  const snap = (event.data as { snapshot: JourneyTraceSnapshot }).snapshot
+  threadJourneyTrace.value = snap
+  const last = agent.lastAssistant()
+  if (last?.executionTrace) applyJourneyUpdate(last.executionTrace, snap)
+}
+
+// loadHistory
+function extractThreadJourney(messages: PersistedAgentMessage[]): JourneyTraceSnapshot | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i]
+    if (m.role !== 'assistant' || !m.metadata) continue
+    try {
+      const meta = JSON.parse(m.metadata) as AgentMessageMetadata
+      if (meta.journeyTrace) return meta.journeyTrace
+    } catch { /* ignore */ }
+  }
+  return null
+}
+```
+
+**Stepper 同源：**
+- `AgentPresentationHost` 的 `AgentStepper` 优先读 `threadJourneyTrace`（`:current` / `:completed` 从 snapshot 派生）
+- fallback：`presentation.stepper`
+
+**macro 历史回放：**
+- `refreshThreadCheckpoint` 读 `selectedMacroSchemeIds` 同步 `macroSelections`
+- 底部或最后一轮 assistant 下展示 journey（即使非 interrupted）
+
+- [ ] **Step 1:** 扩展 `loadHistory` 恢复 `executionTrace` + `threadJourneyTrace`
+- [ ] **Step 2:** SSE `journey_update` handler
+- [ ] **Step 3:** Stepper 同源改造
+- [ ] **Step 4:** 手动验证：Live macro 门控 AC-JT-01；刷新 AC-JT-04
+- [ ] **Step 5:** Commit
+
+---
+
+## Task 9: macro 确认 snapshot（Runtime 细化）
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/nodes/macro_scheme_select_gate.py`
+- Modify: `services/agent-runtime/app/graph/nodes/dialog_draft.py`（单方案 skip）
+
+**在 `apply_macro_scheme_decision` confirm/auto 分支：**
+
+```python
+from app.graph.product_visual_v2.journey_trace import patch_macro_select_step
+
+result = apply_macro_scheme_decision(...)
+if result.get("macro_scheme_decision") in ("confirm", "auto"):
+    result["journey_trace"] = patch_macro_select_step(
+        state.get("journey_trace"),
+        schemes=state.get("macro_schemes") or [],
+        selected_ids=result.get("selected_macro_scheme_ids") or [],
+    )
+```
+
+- [ ] **Step 1:** test — confirm 后 snapshot 含 schemes + selectedIds
+- [ ] **Step 2:** 实现 `patch_macro_select_step`
+- [ ] **Step 3:** pytest PASS
+- [ ] **Step 4:** Commit
+
+---
+
+## Task 10: E2E audit v5
+
+**Files:**
+- Modify: `deploy/prod-crab-listing-e2e-audit.py`
+
+**追加断言：**
+
+```python
+def assert_journey_trace(audit: dict) -> None:
+    jt = audit.get("journeyTrace") or audit.get("finalThreadState", {}).get("journeyTrace")
+    assert jt, "missing journeyTrace"
+    assert len(jt.get("steps", [])) == 9
+    assert jt.get("current") == "done"
+    macro = next(s for s in jt["steps"] if s["id"] == "macro_select")
+    assert macro.get("status") in ("done", "skipped")
+    assert macro.get("summary")
+```
+
+- [ ] **Step 1:** 扩展 audit 脚本收集最后 `journey_update` / thread-state `journeyTrace`
+- [ ] **Step 2:** 本地 dry-run（mock 或 staging）
+- [ ] **Step 3:** 部署后 `AUDIT_OUT=deploy/prod-crab-listing-audit-v5.json python3 deploy/prod-crab-listing-e2e-audit.py`
+- [ ] **Step 4:** Commit
+
+---
+
+## Task 11: UAT 条目更新
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-08-11-product-visual-phase2-scheme-ssot-uat.md`
+
+追加 §10.10：
+
+| ID | 场景 | 预期 |
+|----|------|------|
+| UAT-JT-01 | Live 全流程 | Trace 展开见九步骨架，当前步高亮 |
+| UAT-JT-02 | 宏观确认 A+B | 第 3 步 summary + 只读卡片 |
+| UAT-JT-03 | 刷新/切 thread | 九步旅程可回放 |
+| UAT-JT-04 | E2E v5 audit | `journeyTrace.steps.length === 9` |
+
+- [ ] **Step 1:** 更新 UAT 文档
+- [ ] **Step 2:** Commit
+
+---
+
+## Spec Coverage Checklist
+
+| AC | Task |
+|----|------|
+| AC-JT-01 | T7, T8 |
+| AC-JT-02 | T2, T9, T7 |
+| AC-JT-03 | T2, T10 |
+| AC-JT-04 | T5, T8 |
+| AC-JT-05 | T8 |
+| AC-JT-06 | T2, T9 |
+| AC-JT-07 | 既有 sidebar_copy 测试不回退 |
+| AC-JT-08 | T10 |
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-08-13-product-visual-journey-trace.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven（推荐）** — 每个 Task 派独立 subagent，Task 间 review
+2. **Inline Execution** — 本会话按 Task 1→11 连续实现，每 Task 末 checkpoint
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-08-11-product-visual-phase2-scheme-ssot-uat.md
+++ b/docs/superpowers/specs/2026-08-11-product-visual-phase2-scheme-ssot-uat.md
@@ -8,7 +8,7 @@
 
 | 字段 | 值 |
 |------|-----|
-| 文档版本 | v1.4 |
+| 文档版本 | v1.6 |
 | 验收对象 | `flow_mode: product_visual` + `product_visual_scheme_v2=true` |
 | 验收方式 | **真实浏览器** + 真实/预发环境；以 **用户可见行为** 为准 |
 | 体验规格 | [2026-08-11-agent-conversation-ux-product-visual-design.md](./2026-08-11-agent-conversation-ux-product-visual-design.md) |
@@ -432,6 +432,51 @@
 
 **Sign-off 结论：** G8 ✅ · G9 ✅（UX-PV-07 非阻塞）· G10 ✅ — **v2.1~v2.3 浏览器 Sign-off 通过**
 
+### 10.9 大闸蟹 Listing 全流程 E2E（2026-08-13，#236 部署后）
+
+**环境：** 生产 `http://119.29.173.89:8888` · 资产库「大闸蟹实拍」· 脚本 `deploy/prod-crab-listing-e2e-audit.py`  
+**话术：** 6 类电商用图（主图/详情/模特/海报/细节/物流）+ 价格产地卖点 · **单选方案 A**  
+**审计：** `deploy/prod-crab-listing-audit-v4.json` · **status=done** · 约 2m48s · 门控 macro → topo → delivery → done
+
+| 修复项 | 结果 | 观察 |
+|--------|------|------|
+| P0 shot>8 硬失败 | ✅ | 拆解 **6** 构图（非 11）；合并 topo 正常，无 `macro 'A' has 11 shots` |
+| P0 dialog_draft 解析失败 | ✅ | 宏观方案 A/B/C 正常生成，未出现 `dialog_draft_parse_failed` |
+| P0 裸 `流程结束.{code}` | ✅ | 完成态 headline 人话化，无 error code 外露 |
+| P1 `__macro_*__` 泄漏 | ✅ | 服务端入库前过滤 machine payload（脚本 step2/4 仍发 machine，UI 应不可见） |
+| P1 QA pass 识图理解 | ✅ | `imageQaMetrics.product_summary` 含大闸蟹白底描述 |
+| P1 6 类图 shot 上限提示 | ⚠️ | 提取 5 个 label（≤8），未触发 `callout_shot_limit`；6 构图在上限内 |
+| P2 context_recap 人话化 | ✅ | `电商 Listing 出图`（非 `packaging_design`） |
+| P2 Listing 路由 | ✅ | `visualIntent.primary_goal=mixed_ecommerce` |
+| P2 done stepper | ✅ | presentation stepper `current=done`，交付清单表 + 基础资产 |
+
+| UAT-ID | 结果 | 备注 |
+|--------|------|------|
+| UX-PV-01 | ✅ Pass | 识图 pass + product_summary；无「格式异常」 |
+| UX-PV-02 | ✅ Pass | 合并门控「确认构图并开始出图」 |
+| UX-PV-03 | ⚠️ Partial | 单选 A 无 A+B footer；6 场景 topo 提示正确 |
+| UX-PV-04~06 | ✅ Pass | context_recap 人话；topo 卡片 6 场景 |
+| UX-PV-07 | ⚠️ Partial | 出图成功；SSE 进度有重复行 |
+| UX-PV-08 | ✅ Pass | 定稿分组为用户原话 + `[方案A]` |
+| UX-PV-09 | ✅ Pass | headline「✅ 您的电商 Listing 出图视觉稿已就绪」+ 清单表 |
+| UX-PV-10~11 | ✅ Pass | 3 硬停 + 无 machine 气泡（#236 服务端过滤） |
+
+**对比 v2（#235 前）：** v2 在 QA 后 `dialog_draft_parse_failed` 中断；v3（#236 部署前）首步即 `done` 无门控；**v4 全流程 Pass**。
+
+### 10.10 九步旅程 Trace（Journey Trace UAT）
+
+> 来源：[2026-08-13-product-visual-journey-trace-design.md](./2026-08-13-product-visual-journey-trace-design.md)  
+> **验收方式：** 侧栏 **「执行过程」** 折叠块展开后可见九步旅程骨架；Live 与历史 thread **同源数据**。
+
+| UAT-ID | 场景 | Pass 标准（用户可见 / 脚本断言） |
+|--------|------|----------------------------------|
+| UAT-JT-01 | Live 全流程 | 展开 Trace 见 **九步骨架**；当前步 **高亮**（`running`），已完成步 **划线** |
+| UAT-JT-02 | 宏观确认 A+B | 第 3 步（宏观选择）含 **人话 summary** + **只读卡片** snapshot（已选 A/B 方案名） |
+| UAT-JT-03 | 刷新/切 thread | 刷新页面或切换 thread 再进入：九步旅程 **完整可回放**，无需重跑 graph |
+| UAT-JT-04 | E2E v5 audit | `deploy/prod-crab-listing-e2e-audit.py` v5 输出：`journeyTrace.steps.length === 9` |
+
+**推荐路径：** CVS-02-AB 口语 · A+B 双选（与 §10.8 同环境）；E2E 见 `deploy/prod-crab-listing-audit-v5.json`。
+
 ---
 
 ## 十一、文档维护
@@ -449,6 +494,8 @@
 
 | 日期 | 版本 | 说明 |
 |------|------|------|
+| 2026-08-13 | v1.6 | §10.10 九步旅程 Trace UAT（UAT-JT-01~04） |
+| 2026-08-13 | v1.5 | §10.9 大闸蟹 Listing E2E（#236 P0-P2 UX 修复 + v4 审计） |
 | 2026-08-12 | v1.4 | §10.8 浏览器完整 Sign-off（#227+#228 部署后新建对话） |
 | 2026-08-12 | v1.3 | §10.6 生产 UAT 记录 + #226 修复项追踪 |
 | 2026-08-12 | v1.2 | §10.5 闭环补项追踪；链至中断改意图规格 |

--- a/docs/superpowers/specs/2026-08-13-product-visual-journey-trace-design.md
+++ b/docs/superpowers/specs/2026-08-13-product-visual-journey-trace-design.md
@@ -1,0 +1,445 @@
+# Product Visual 九步旅程 · 执行记录一体化设计
+
+> **状态**：已批准（2026-08-13）· 实现计划见 [plans/2026-08-13-product-visual-journey-trace.md](../plans/2026-08-13-product-visual-journey-trace.md)  
+> **日期**：2026-08-13  
+> **触发**：UAT / 生产 E2E 复盘 — 用户无法在**历史对话**中回放九步进度、宏观方案选择、Agent 执行过程  
+> **读者**：产品、前端、Nest、Agent Runtime  
+> **非范围**：Campaign / atomic 全量迁移（本文仅 **product_visual v2** 为 P0；其余 flow 可后续复用骨架）
+
+| 字段 | 值 |
+|------|-----|
+| 文档版本 | v1.0 |
+| 适用范围 | `flow_mode: product_visual` + `product_visual_scheme_v2=true` |
+| 前置规格 | [2026-08-11-agent-conversation-ux-product-visual-design.md](./2026-08-11-agent-conversation-ux-product-visual-design.md)（九步 Stepper + Presentation） |
+|  | [2026-08-06-agent-execution-trace-design.md](./2026-08-06-agent-execution-trace-design.md)（Execution Trace P0–P2） |
+|  | [2026-08-11-product-visual-phase2-scheme-ssot-design.md](./2026-08-11-product-visual-phase2-scheme-ssot-design.md)（L1 宏观方案） |
+|  | [2026-08-06-agent-sidebar-copy-design.md](./2026-08-06-agent-sidebar-copy-design.md)（气泡文案规范） |
+
+---
+
+## 0. 决策摘要
+
+| 项 | 结论 |
+| --- | --- |
+| **用户心智** | 九步 Stepper = **工作流 todo**；用户应感知「当前第几步、Agent 在做什么、已完成步划线」 |
+| **与 Execution Trace 关系** | **合并展示、分层数据**：九步为 **旅程骨架**（`kind: workflow_step`）；现有 canvas / text_stage / task 等为 **子步骤** |
+| **Live 会话** | 每轮 assistant 消息下 **`AgentExecutionTrace`** 默认折叠；展开后 **顶部固定九步旅程**，其下为操作明细 |
+| **门控区 Stepper** | **保留**于 `AgentPresentationHost`（当前门控操作面）；与 Trace 内旅程 **同源数据**，禁止两套状态分叉 |
+| **持久化** | P0 必须：**每 thread 一条旅程快照**写入 `AgentMessage.metadata`（assistant 终局消息或专用 system 消息）；历史加载可完整回放 |
+| **宏观方案** | 确认后写入旅程子步骤 detail（人话：「已选 A 湖鲜原境风、B 礼盒臻享风」）；可选只读卡片 snapshot |
+| **thread-state 扩展** | 补充 `selectedMacroSchemeIds`；`done` 阶段仍返回完整 `presentation.stepper` + 旅程 snapshot |
+| **规格层级** | 本文 **迭代** execution-trace-design §12「DB 持久化 P2+」→ 对 product_visual **提前至 P0** |
+
+---
+
+## 1. 问题陈述
+
+### 1.1 现状（2026-08-13 代码审计）
+
+| 能力 | Live 流式 | 历史回放 |
+|------|-----------|----------|
+| 九步 Stepper（高亮 / 划线 / 置灰） | ✅ 门控区 `AgentStepper` | ❌ `presentation` 不入库 |
+| Agent 执行记录折叠块 | ✅ `AgentExecutionTrace` 挂消息下 | ❌ `loadHistory` 不恢复 |
+| 宏观方案可选卡片 | ✅ `await_macro_scheme_select` 门控 | ❌ 完成后不可见 |
+| 宏观方案已选记录 | ✅ checkpoint `selected_macro_scheme_ids` | ❌ DB / API / UI 均无 |
+| 用户 machine 决策 | ✅ resume 用 | ❌ `__macro_*__` 过滤不入库 |
+| `thread-timeline` | ✅ 后端有 | ❌ 前端未消费 |
+
+### 1.2 用户期望（已确认）
+
+1. 九步是 **product_visual 工作流 todo**，不是 internal routing 名称。  
+2. 执行过程中 **动态更新**当前步与已完成步（完成后 **划线**）。  
+3. 上述进度属于 **Agent 执行记录**，可在「执行过程」折叠块中查看。  
+4. **历史对话**打开后，仍能看到完整九步轨迹及关键决策（含宏观方案可选 / 已选）。
+
+### 1.3 成功标准
+
+1. Live：用户展开「执行过程」可见九步骨架 + 子步骤；当前步 `running`，已完成 `done` + 划线样式。  
+2. 宏观选择：确认后在 trace 第 3 步下出现人话 detail；历史 thread 可回放。  
+3. 刷新 / 切换 thread 再进入：九步旅程与终局摘要均可恢复，无需重跑 graph。  
+4. 不破坏 sidebar_copy：主气泡仍只显示最终阶段文案；内部 phase / machine payload 不出现在气泡。  
+5. 生产 smoke：`prod-crab-listing-e2e-audit.py` 断言 `journeyTrace.completed` 含 9 步 ID 或等价 snapshot。
+
+---
+
+## 2. 方案比选
+
+### 方案 A — 仅前端合并 UI（不推荐）
+
+- Live 时将 SSE `presentation.stepper` 写入 Pinia `executionTrace`；历史仍丢失。  
+- **优点**：改动小。  
+- **缺点**：不解决历史回放；刷新即失；与用户需求不符。
+
+### 方案 B — 旅程快照持久化 + Trace UI 一体化（**推荐**）
+
+- 定义 `JourneyTraceSnapshot` JSON；Runtime 在 phase 变迁时 emit `journey_update`；Nest `finalizeTurn` 写入 `AgentMessage.metadata`。  
+- 前端 reducer 维护骨架 + 子步骤；`loadHistory` 恢复。  
+- **优点**：满足 Live + 历史；单源；可渐进扩展 Campaign。  
+- **缺点**：需 DB 字段 + 前后端协议小扩展。
+
+### 方案 C — Replay 页独占（不推荐为 P0）
+
+- 历史只在 `/replay/:sessionId` 用 `thread-timeline` + checkpoint 重建。  
+- **优点**：不改 AgentMessage schema。  
+- **缺点**：侧栏历史体验仍空；用户主路径是 SideRail。
+
+**结论：采用方案 B。**
+
+---
+
+## 3. 信息架构
+
+### 3.1 侧栏单轮消息结构（Live & History 一致）
+
+```text
+┌─ Assistant 气泡 ─────────────────────────────┐
+│ 最终人话文案（text_replace 末条）              · 2m48s │
+└──────────────────────────────────────────────┘
+▸ 执行过程（9 步 · 2m48s）          ← 默认 collapsed
+  ▾ 展开后：
+  ┌─ 旅程骨架（Workflow Journey）──────────────┐
+  │ ✓ 1. 检查产品图 · 8s                        │
+  │     └ 识图通过：大闸蟹礼盒                   │
+  │ ✓ 2. 理解需求 · 出方案 · 32s                │
+  │ ✓ 3. 选宏观风格 · 5s                        │
+  │     └ 已选：A 湖鲜原境风、B 礼盒臻享风       │
+  │ ✓ 4. 方案落盘 · 12s                         │
+  │ …                                           │
+  │ ✓ 9. 交付完成 · 1s                          │
+  └─────────────────────────────────────────────┘
+  ┌─ 操作明细（现有 ExecutionStep）─────────────┐
+  │ ✓ 理解需求 · 1.2s                           │
+  │ ✓ 添加文本节点「方案 SSOT」· 0.8s            │
+  │ ✓ 节点出图中 · 48s                          │
+  └─────────────────────────────────────────────┘
+
+┌─ 门控区（仅 interrupted / 当前 turn）─────────┐
+│ [AgentStepper — 与 Trace 骨架同源]             │
+│ [宏观卡片 / shot 表 / 定稿卡 …]                │
+└──────────────────────────────────────────────┘
+```
+
+### 3.2 两层步骤的职责
+
+| 层 | ID 空间 | 来源 | 用途 |
+|----|---------|------|------|
+| **旅程骨架** | `image_qa` … `done`（固定 9 个） | `presentation.stepper` + `journey_update` | 工作流 todo、历史回放主时间线 |
+| **操作明细** | 动态 `text_stage` / `canvas` / `task` … | 现有 SSE 事件 | Agent 具体做了什么 |
+
+**规则：**
+
+- 骨架步 **enter** `running` 当 `stepper.current` 变为该 ID。  
+- 骨架步 **complete** `done` 当 ID 进入 `stepper.completed`。  
+- 操作明细 **挂载**在对应骨架步之下（`parentStepId`），而非与骨架平铺混淆。
+
+### 3.3 九步标签（SSOT）
+
+与 [agent-conversation-ux-product-visual-design §1](./2026-08-11-agent-conversation-ux-product-visual-design.md) 及 `PRESENTATION_STEPS` 保持一致：
+
+| # | ID | 标签 |
+|---|-----|------|
+| 1 | `image_qa` | 检查产品图 |
+| 2 | `scheme_draft` | 理解需求 · 出方案 |
+| 3 | `macro_select` | 选宏观风格 |
+| 4 | `ssot_persist` | 方案落盘 |
+| 5 | `shot_plan` | 定构图清单 |
+| 6 | `topo_preview` | 预览出图计划 |
+| 7 | `generating` | 出图中 |
+| 8 | `delivery` | 选定稿 |
+| 9 | `done` | 交付完成 |
+
+---
+
+## 4. 数据模型
+
+### 4.1 `JourneyTraceSnapshot`（持久化 / SSE）
+
+```typescript
+/** 单 thread 内 product_visual 旅程的权威快照 */
+interface JourneyTraceSnapshot {
+  version: 1
+  flowMode: 'product_visual'
+  /** 九步固定顺序，每步一条 */
+  steps: JourneyStepRecord[]
+  current: JourneyStepId
+  startedAt: string // ISO
+  updatedAt: string // ISO
+  finishedAt?: string // ISO — phase === done 时写入
+  totalMs?: number
+}
+
+type JourneyStepId =
+  | 'image_qa' | 'scheme_draft' | 'macro_select' | 'ssot_persist'
+  | 'shot_plan' | 'topo_preview' | 'generating' | 'delivery' | 'done'
+
+interface JourneyStepRecord {
+  id: JourneyStepId
+  label: string // 冗余存储，防前端常量漂移
+  status: 'pending' | 'running' | 'done' | 'failed' | 'skipped'
+  enteredAt?: string
+  completedAt?: string
+  ms?: number
+  /** 人话摘要，供历史回放；禁止 machine payload */
+  summary?: string
+  /** 结构化只读 replay 数据（可选） */
+  snapshot?: JourneyStepSnapshot
+}
+
+/** 各步可选 snapshot — 仅含用户可见字段 */
+type JourneyStepSnapshot =
+  | { kind: 'image_qa'; understanding?: string; checks?: Array<{ label: string; ok: boolean }> }
+  | { kind: 'scheme_draft'; proseExcerpt?: string } // ≤200 字
+  | { kind: 'macro_select'; schemes: Array<{ id: string; label: string; summary?: string; recommended?: boolean }>; selectedIds: string[] }
+  | { kind: 'ssot_persist'; planNodeId?: string; title?: string }
+  | { kind: 'shot_plan'; shotCount: number; typeLabels?: string[] }
+  | { kind: 'topo_preview'; sceneCount: number; etaMin?: number }
+  | { kind: 'generating'; completed: number; total: number }
+  | { kind: 'delivery'; finalizedCount: number }
+  | { kind: 'done'; deliveryCount: number }
+```
+
+### 4.2 `AgentMessage.metadata` 扩展
+
+Prisma **不新增列**；使用现有 `AgentMessage` 表，Nest 增加 JSON 字符串列 **`metadata`**（迁移一次）：
+
+```prisma
+model AgentMessage {
+  // ... existing fields
+  metadata String? // JSON: AgentMessageMetadata
+}
+```
+
+```typescript
+interface AgentMessageMetadata {
+  journeyTrace?: JourneyTraceSnapshot
+  executionTrace?: ExecutionTraceState // 操作明细，结构与 Pinia 一致
+}
+```
+
+**写入策略：**
+
+| 时机 | 行为 |
+|------|------|
+| 每轮 SSE `done` | 合并更新该 thread 最新 assistant 消息的 `metadata.journeyTrace` |
+| phase → `done` | 同时写入 `metadata.executionTrace` 全量快照 |
+| 仅 user 消息、无 assistant 文本 | 仍可在最后一条 assistant 或 **thread 级 anchor 消息** 写入（Nest 保证至少一条 carrier） |
+
+**读取策略：**
+
+- `loadHistory`：取 thread 内 **最后一条** 含 `metadata.journeyTrace` 的 assistant 消息，挂载到 **该 thread 最后一轮** assistant UI（或独立「旅程摘要」锚点，见 §5.3）。  
+- 未完成 thread：`refreshThreadCheckpoint` + `journeyTrace` 合并，以 **updatedAt 较新者** 为准。
+
+### 4.3 Runtime checkpoint 补充
+
+`get_thread_state` 响应增加：
+
+```typescript
+selectedMacroSchemeIds?: string[]
+journeyTrace?: JourneyTraceSnapshot // 与 checkpoint 同步，供重连
+```
+
+checkpoint `state` 新增可选键 `journey_trace`（与 presentation 同步更新，避免双源）。
+
+---
+
+## 5. 协议与数据流
+
+### 5.1 新 SSE 事件：`journey_update`
+
+Runtime 在 `presentation` envelope 构建 **同时** emit（Nest 透传）：
+
+```json
+{
+  "type": "journey_update",
+  "data": {
+    "snapshot": { /* JourneyTraceSnapshot */ }
+  }
+}
+```
+
+**Emit 时机：**
+
+- 每次 `build_presentation_envelope` 且 stepper 变化；  
+- `macro_scheme_select` 确认后（含 `selectedIds` + schemes 快照）；  
+- `collect_gen` 进度 tick（仅更新 `generating` 步 summary，节流 ≥2s）；  
+- `done` 终局。
+
+### 5.2 宏观方案确认 — 人话 summary 生成
+
+Runtime `apply_macro_scheme_decision` 成功后：
+
+```python
+# 伪代码
+labels = [scheme_label(id) for id in selected_ids]
+summary = f"已选：{'、'.join(labels)}"
+snapshot = {
+    "kind": "macro_select",
+    "schemes": normalize_macro_schemes(macro_schemes),  # 全量可选
+    "selectedIds": selected_ids,
+}
+journey_step_complete("macro_select", summary=summary, snapshot=snapshot)
+```
+
+**禁止**在 summary 中出现 `__macro_scheme_decision__` JSON。
+
+### 5.3 历史 UI 锚点
+
+**问题**：一条 thread 多轮 user 消息，但 product_visual 旅程通常 **跨多轮单线推进**。
+
+**规则：**
+
+- **P0**：整个 thread **共享一条** `JourneyTraceSnapshot`（最后一次 `journey_update` 覆盖）；侧栏在 **消息列表底部**（或最后一轮 assistant 下）渲染 **「本对话旅程」** 折叠块。  
+- 门控区 Stepper 仍仅 **当前 interrupted** 时显示在输入区上方。  
+- **P1 可选**：按 turn 切片 `journeyTrace` 版本历史（YAGNI，不在 P0）。
+
+### 5.4 数据流图
+
+```mermaid
+sequenceDiagram
+  participant RT as Agent Runtime
+  participant Nest as Nest SSE
+  participant Web as AgentSideRail
+  participant DB as AgentMessage
+
+  RT->>Nest: presentation + journey_update
+  Nest->>Web: SSE events
+  Web->>Web: executionTraceReducer.applyJourneyUpdate
+  Note over Web: 门控 Stepper 与 Trace 骨架同源
+
+  RT->>Nest: done
+  Nest->>DB: finalizeTurn + metadata.journeyTrace
+  Web->>DB: loadHistory (later)
+  DB->>Web: messages + metadata
+  Web->>Web: restore JourneyTrace + ExecutionTrace
+```
+
+---
+
+## 6. 前端组件变更
+
+### 6.1 `executionTraceReducer.ts`
+
+- 新增 `ExecutionStepKind: 'workflow_step'`。  
+- 新增 `applyJourneyUpdate(trace, snapshot)`：  
+  - 同步/创建 9 个骨架 `ExecutionStep`；  
+  - 将现有子步骤 `parentStepId` 绑定到当前 `running` 骨架步。  
+- `finalizeExecutionTrace` 时固化 `totalMs`。
+
+### 6.2 `AgentExecutionTrace.vue`
+
+- 展开时分 **两个 section**：  
+  1. **工作流进度**（九步，样式复用 `AgentStepper` 状态色 + 子 summary）；  
+  2. **操作明细**（现有列表，可折叠）。  
+- Streaming 中：标题 `执行过程（进行中… · 第 N/9 步）`。
+
+### 6.3 `AgentSideRail.vue`
+
+- SSE handler 增加 `journey_update`。  
+- `loadHistory` 后从 metadata 恢复；若无 metadata，`refreshThreadCheckpoint` 回退。  
+- **移除**门控 Stepper 与 Trace 骨架的状态分叉（共用 `journeyTraceRef`）。
+
+### 6.4 `agent.ts` store
+
+- `loadHistory` 映射 `metadata.executionTrace` → `msg.executionTrace`。  
+- Thread 级 `journeyTrace` ref，供底部旅程摘要与门控 Stepper 读取。
+
+---
+
+## 7. 后端变更
+
+### 7.1 Nest `agent.service.ts`
+
+- `finalizeTurn`：接收本轮累积的 `journeyTrace` / `executionTrace`，序列化入 `metadata`。  
+- SSE 代理：累积 `journey_update` 事件。
+
+### 7.2 Nest `agentMessageSanitize.ts`
+
+- **不变**：user machine payload 仍不入库。  
+- 新增：assistant **可选**写入 `metadata` 内的 `macro_select` snapshot（非 content 字段）。
+
+### 7.3 Runtime `presentation.py` / `runs.py`
+
+- 抽取 `build_journey_trace_snapshot(state, phase) -> dict`。  
+- `get_thread_state` 返回 `selectedMacroSchemeIds`、`journeyTrace`。  
+- 单方案跳过 `macro_select` 时：该步 `status: skipped`，summary「仅一套方案，已自动选定」。
+
+---
+
+## 8. 错误与边界
+
+| 场景 | 行为 |
+|------|------|
+| 识图失败 / 用户终止 | 当前骨架步 `failed`；summary 用人话错误（复用 `errors.py` presentation） |
+| 宏观修订回 2a | `macro_select` 回退 `pending`；保留历史 snapshot 版本于 metadata 内 **不** P0 要求 |
+| thread 未完成即关闭 | checkpoint + 最后 metadata 可恢复到中断步 |
+| 非 product_visual flow | 不 emit `journey_update`；Execution Trace 保持现有行为 |
+| metadata 过大 | snapshot prose ≤200 字；schemes 最多 3 套；gzip 不 P0 |
+
+---
+
+## 9. 验收标准（AC）
+
+| ID | Given | Then |
+|----|-------|------|
+| AC-JT-01 | Live macro 门控 | Trace 展开见第 3 步 `running`；门控 Stepper 与 Trace 当前步一致 |
+| AC-JT-02 | 用户确认 A+B | 第 3 步 `done` + summary 含 A、B 中文 label；无 JSON payload |
+| AC-JT-03 | 全流程 done | 九步均为 `done`；第 9 步 summary 含交付数量 |
+| AC-JT-04 | 刷新页面 | `loadHistory` 后 Trace 九步仍可展开回放 |
+| AC-JT-05 | 切换历史 thread | 同上，且 macro snapshot 可只读展示 schemes + selected |
+| AC-JT-06 | 单宏观方案 | 第 3 步 `skipped` 或 `done`（自动选定），不 interrupt 门控 |
+| AC-JT-07 | sidebar_copy | assistant 主气泡无 `await_` / `__macro_` 字样 |
+| AC-JT-08 | E2E audit | v5 audit JSON 含 `journeyTrace.steps.length === 9` |
+
+---
+
+## 10. 测试计划
+
+| 层 | 内容 |
+|----|------|
+| Unit | `applyJourneyUpdate` reducer；`build_journey_trace_snapshot` Python |
+| Component | `AgentExecutionTrace` 九步渲染；history restore |
+| Integration | Nest metadata 读写；thread-state 新字段 |
+| E2E | 扩展 `deploy/prod-crab-listing-e2e-audit.py` 断言 journeyTrace |
+
+---
+
+## 11. 分期
+
+| 期 | 交付 |
+|----|------|
+| **P0（本文）** | journey_update SSE；Trace UI 合并九步；metadata 持久化；macro 已选回放；thread-state 扩展 |
+| **P1** | generating 步实时进度 summary；delivery 步 snapshot 缩略图 |
+| **P2** | Campaign / atomic 复用骨架；Replay 页与 SideRail 共用组件；thread-timeline 补全耗时 |
+
+---
+
+## 12. 与既有规格的关系
+
+| 既有文档 | 本文处理 |
+|----------|----------|
+| agent-conversation-ux §1 Stepper | **保留**门控区 Stepper；数据改由 `JourneyTraceSnapshot` 驱动 |
+| execution-trace-design §12 DB P2+ | product_visual **提前**持久化；其他 flow 仍 P2 |
+| scheme-ssot-design §2.4 | SSOT 仍在画布；本文增加 **对话层索引**（summary + planNodeId） |
+| sidebar-copy | 不变；轨迹与气泡分离 |
+
+---
+
+## 13. 已确认项（2026-08-13）
+
+- [x] P0 旅程锚点：**thread 级单快照**（§5.3）
+- [x] 历史 macro 回放：**summary + 只读卡片**
+- [x] `AgentMessage.metadata` 迁移与本功能同批上线
+
+---
+
+## 14. 附录：方案对比记录（Brainstorming）
+
+| 方案 | 历史回放 | 改动面 | 结论 |
+|------|----------|--------|------|
+| A 仅前端合并 | ❌ | 小 | 否决 |
+| B 快照持久化 + Trace 一体化 | ✅ | 中 | **采纳** |
+| C 仅 Replay 页 | ⚠️ 非主路径 | 中 | P2 补充 |
+
+---
+
+*实现计划： [2026-08-13-product-visual-journey-trace.md](../plans/2026-08-13-product-visual-journey-trace.md)*

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -58,6 +58,7 @@ export interface AgentStreamEvent {
     | 'thinking'
     | 'explore'
     | 'interrupt'
+    | 'journey_update'
     | 'force_choice'
     | 'ping'
     | 'done'

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,6 +18,7 @@ export * from './agentContract'
 export * from './sidebarAttachments'
 export * from './agentIntent'
 export * from './promptContent'
+export * from './journeyTrace'
 
 export type GenerationType = 'text' | 'image' | 'video'
 
@@ -267,6 +268,8 @@ export interface AgentChatMessage {
   attachments?: string
   /** JSON: LinkedCanvasOutput[] — assistant turn canvas outputs for relocation */
   linkedOutputs?: string
+  /** JSON: AgentMessageMetadata */
+  metadata?: string
   createdAt: string
 }
 

--- a/packages/shared/src/journeyTrace.ts
+++ b/packages/shared/src/journeyTrace.ts
@@ -1,0 +1,44 @@
+export type JourneyStepId =
+  | 'image_qa' | 'scheme_draft' | 'macro_select' | 'ssot_persist'
+  | 'shot_plan' | 'topo_preview' | 'generating' | 'delivery' | 'done'
+
+export type JourneyStepStatus = 'pending' | 'running' | 'done' | 'failed' | 'skipped'
+
+export interface JourneyStepRecord {
+  id: JourneyStepId
+  label: string
+  status: JourneyStepStatus
+  enteredAt?: string
+  completedAt?: string
+  ms?: number
+  summary?: string
+  snapshot?: Record<string, unknown>
+}
+
+export interface JourneyTraceSnapshot {
+  version: 1
+  flowMode: 'product_visual'
+  steps: JourneyStepRecord[]
+  current: JourneyStepId
+  startedAt: string
+  updatedAt: string
+  finishedAt?: string
+  totalMs?: number
+}
+
+export interface AgentMessageMetadata {
+  journeyTrace?: JourneyTraceSnapshot
+  executionTrace?: Record<string, unknown>
+}
+
+export const JOURNEY_STEP_LABELS: Record<JourneyStepId, string> = {
+  image_qa: '检查产品图',
+  scheme_draft: '理解需求 · 出方案',
+  macro_select: '选宏观风格',
+  ssot_persist: '方案落盘',
+  shot_plan: '定构图清单',
+  topo_preview: '预览出图计划',
+  generating: '出图中',
+  delivery: '选定稿',
+  done: '交付完成',
+}

--- a/services/agent-runtime/app/graph/hitl_resume.py
+++ b/services/agent-runtime/app/graph/hitl_resume.py
@@ -56,6 +56,8 @@ FRESH_TURN_STATE_CLEAR: dict[str, Any] = {
     "macro_scheme_decision": None,
     "shot_manifest": None,
     "visual_intent": None,
+    "presentation": None,
+    "journey_trace": None,
 }
 
 

--- a/services/agent-runtime/app/graph/nodes/dialog_draft.py
+++ b/services/agent-runtime/app/graph/nodes/dialog_draft.py
@@ -10,6 +10,7 @@ from langchain_core.messages import AIMessage
 
 from app.graph.nodes.plan._shared import latest_user_text
 from app.graph.product_visual_v2.models import DialogDraftOutput, parse_dialog_draft_output
+from app.graph.product_visual_v2.journey_trace import patch_macro_select_step
 from app.graph.product_visual_v2.macro_select import default_macro_selection, should_skip_macro_hitl
 from app.graph.product_visual_v2.routing import route_after_dialog_draft
 from app.graph.nodes.macro_scheme_select_gate import build_macro_select_presentation_patch
@@ -88,6 +89,11 @@ def make_dialog_draft_node(*, llm: Any, skills_dir: Path) -> Callable:
         if should_skip_macro_hitl(macro_schemes):
             out["selected_macro_scheme_ids"] = default_macro_selection(macro_schemes)
             out["macro_scheme_decision"] = "auto"
+            out["journey_trace"] = patch_macro_select_step(
+                state.get("journey_trace"),
+                schemes=macro_schemes,
+                selected_ids=out["selected_macro_scheme_ids"],
+            )
         elif next_phase == "await_macro_scheme_select":
             out.update(build_macro_select_presentation_patch(out))
         return out

--- a/services/agent-runtime/app/graph/nodes/macro_scheme_select_gate.py
+++ b/services/agent-runtime/app/graph/nodes/macro_scheme_select_gate.py
@@ -10,6 +10,7 @@ from langchain_core.messages import AIMessage
 
 from app.graph.limits import MAX_SCHEME_REVISE
 from app.graph.product_visual_copy import ProductVisualCopy
+from app.graph.product_visual_v2.journey_trace import patch_macro_select_step
 from app.graph.product_visual_v2.macro_select import (
     apply_macro_selection,
     default_macro_selection,
@@ -140,24 +141,36 @@ def apply_macro_scheme_decision(state: dict, decision: dict[str, Any]) -> dict[s
             copy=ProductVisualCopy.load_from_skill("ecommerce-product-visual", "1.0.0"),
             state=state,
         )
-        return {
+        result = {
             **applied,
             "macro_scheme_decision": "confirm",
             "expected_delivery_count": delivery["total_finalize"],
             "messages": [AIMessage(content=_CONFIRM_ACK)],
         }
+        result["journey_trace"] = patch_macro_select_step(
+            state.get("journey_trace"),
+            schemes=schemes,
+            selected_ids=result.get("selected_macro_scheme_ids") or [],
+        )
+        return result
 
     if action == "revise":
         count = int(state.get("scheme_revision_count") or 0)
         if count >= MAX_SCHEME_REVISE:
             selected = default_macro_selection(schemes)
             applied = apply_macro_selection(schemes, selected)
-            return {
+            result = {
                 **applied,
                 "macro_scheme_decision": "auto",
                 "assistant_note": _FORCE_SSOT_NOTE,
                 "messages": [AIMessage(content=_FORCE_SSOT_NOTE)],
             }
+            result["journey_trace"] = patch_macro_select_step(
+                state.get("journey_trace"),
+                schemes=schemes,
+                selected_ids=result.get("selected_macro_scheme_ids") or [],
+            )
+            return result
         feedback = str(decision.get("feedback") or "").strip()
         out: dict[str, Any] = {
             "scheme_revision_count": count + 1,

--- a/services/agent-runtime/app/graph/product_visual_v2/journey_trace.py
+++ b/services/agent-runtime/app/graph/product_visual_v2/journey_trace.py
@@ -1,0 +1,260 @@
+"""Journey trace snapshot builder for product_visual v2 sidebar UX."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from app.graph.product_visual_v2.macro_select import should_skip_macro_hitl
+from app.graph.product_visual_v2.scheme_draft import normalize_macro_schemes
+
+JOURNEY_STEP_ORDER: list[str] = [
+    "image_qa",
+    "scheme_draft",
+    "macro_select",
+    "ssot_persist",
+    "shot_plan",
+    "topo_preview",
+    "generating",
+    "delivery",
+    "done",
+]
+
+JOURNEY_STEP_LABELS: dict[str, str] = {
+    "image_qa": "检查产品图",
+    "scheme_draft": "理解需求 · 出方案",
+    "macro_select": "选宏观风格",
+    "ssot_persist": "方案落盘",
+    "shot_plan": "定构图清单",
+    "topo_preview": "预览出图计划",
+    "generating": "出图中",
+    "delivery": "选定稿",
+    "done": "交付完成",
+}
+
+_COMPLETED_STATUSES = frozenset({"done", "skipped", "failed"})
+_PRESERVE_FIELDS = ("enteredAt", "completedAt", "ms", "summary", "snapshot")
+
+
+def _utc_now(now: datetime | None) -> datetime:
+    if now is not None:
+        return now if now.tzinfo is not None else now.replace(tzinfo=timezone.utc)
+    return datetime.now(timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _ms_between(start: datetime, end: datetime) -> int:
+    return max(0, int((end - start).total_seconds() * 1000))
+
+
+def _completed_step_ids(current: str) -> list[str]:
+    if current not in JOURNEY_STEP_ORDER:
+        return []
+    idx = JOURNEY_STEP_ORDER.index(current)
+    return JOURNEY_STEP_ORDER[:idx]
+
+
+def _macro_select_labels(state: dict[str, Any]) -> list[str]:
+    schemes = state.get("macro_schemes") or []
+    id_to_label = {
+        str(s.get("id") or ""): str(s.get("label") or s.get("id") or "").strip()
+        for s in schemes
+        if isinstance(s, dict) and str(s.get("id") or "").strip()
+    }
+    selected = [
+        str(s).strip()
+        for s in (state.get("selected_macro_scheme_ids") or [])
+        if str(s).strip()
+    ]
+    return [id_to_label.get(sid, sid) for sid in selected]
+
+
+def _macro_select_snapshot(state: dict[str, Any]) -> dict[str, Any]:
+    schemes = state.get("macro_schemes") or []
+    selected = [
+        str(s).strip()
+        for s in (state.get("selected_macro_scheme_ids") or [])
+        if str(s).strip()
+    ]
+    return {
+        "kind": "macro_select",
+        "schemes": normalize_macro_schemes(schemes if isinstance(schemes, list) else []),
+        "selectedIds": selected,
+    }
+
+
+def _enrich_macro_select(step: dict[str, Any], state: dict[str, Any]) -> None:
+    if should_skip_macro_hitl(state.get("macro_schemes")):
+        step["status"] = "skipped"
+        step["summary"] = "仅一套方案，已自动选定"
+        return
+    labels = _macro_select_labels(state)
+    if labels:
+        step["summary"] = f"已选：{'、'.join(labels)}"
+        step["snapshot"] = _macro_select_snapshot(state)
+
+
+def _step_status(step_id: str, *, current: str, completed: list[str], phase: str) -> str:
+    if phase == "done":
+        return "done"
+    if step_id in completed:
+        return "done"
+    if step_id == current:
+        return "running"
+    return "pending"
+
+
+def build_journey_trace_snapshot(
+    state: dict[str, Any],
+    *,
+    phase: str,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build a fresh journey trace snapshot from runtime state and phase."""
+    from app.graph.product_visual_v2.presentation import phase_to_stepper
+
+    ts = _utc_now(now)
+    current = phase_to_stepper(phase)
+    completed = _completed_step_ids(current)
+    started_at = _iso(ts)
+
+    steps: list[dict[str, Any]] = []
+    for step_id in JOURNEY_STEP_ORDER:
+        status = _step_status(step_id, current=current, completed=completed, phase=phase)
+        step: dict[str, Any] = {
+            "id": step_id,
+            "label": JOURNEY_STEP_LABELS[step_id],
+            "status": status,
+        }
+        if status == "running":
+            step["enteredAt"] = _iso(ts)
+        elif status in _COMPLETED_STATUSES or status == "done":
+            step["enteredAt"] = _iso(ts)
+            step["completedAt"] = _iso(ts)
+            step["ms"] = 0
+        if step_id == "macro_select" and step_id in completed:
+            if phase == "done":
+                if should_skip_macro_hitl(state.get("macro_schemes")):
+                    step["summary"] = "仅一套方案，已自动选定"
+                else:
+                    labels = _macro_select_labels(state)
+                    if labels:
+                        step["summary"] = f"已选：{'、'.join(labels)}"
+                        step["snapshot"] = _macro_select_snapshot(state)
+            else:
+                _enrich_macro_select(step, state)
+        steps.append(step)
+
+    snapshot: dict[str, Any] = {
+        "version": 1,
+        "flowMode": "product_visual",
+        "steps": steps,
+        "current": current,
+        "startedAt": started_at,
+        "updatedAt": _iso(ts),
+    }
+
+    if phase == "done":
+        snapshot["finishedAt"] = _iso(ts)
+        snapshot["totalMs"] = 0
+
+    return snapshot
+
+
+def patch_macro_select_step(
+    prev: dict[str, Any] | None,
+    *,
+    schemes: list[Any],
+    selected_ids: list[str],
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Patch macro_select step after confirm/auto without rebuilding the full trace."""
+    ts = _utc_now(now)
+    state = {
+        "macro_schemes": schemes,
+        "selected_macro_scheme_ids": selected_ids,
+    }
+
+    if not isinstance(prev, dict) or prev.get("flowMode") != "product_visual":
+        prev = build_journey_trace_snapshot(state, phase="canvas_ssot_commit", now=ts)
+
+    trace: dict[str, Any] = {
+        **prev,
+        "steps": [{**s} if isinstance(s, dict) else s for s in (prev.get("steps") or [])],
+        "updatedAt": _iso(ts),
+        "current": "ssot_persist",
+    }
+
+    for i, step in enumerate(trace["steps"]):
+        if not isinstance(step, dict) or step.get("id") != "macro_select":
+            continue
+        patched: dict[str, Any] = {**step}
+        if should_skip_macro_hitl(schemes):
+            patched["status"] = "skipped"
+            patched["summary"] = "仅一套方案，已自动选定"
+            patched.pop("snapshot", None)
+        else:
+            patched["status"] = "done"
+            labels = _macro_select_labels(state)
+            if labels:
+                patched["summary"] = f"已选：{'、'.join(labels)}"
+                patched["snapshot"] = _macro_select_snapshot(state)
+        if patched.get("completedAt") is None:
+            patched["completedAt"] = _iso(ts)
+        if patched.get("enteredAt") is None:
+            patched["enteredAt"] = _iso(ts)
+        if patched.get("ms") is None:
+            try:
+                entered = datetime.fromisoformat(str(patched["enteredAt"]).replace("Z", "+00:00"))
+                patched["ms"] = _ms_between(entered, ts)
+            except ValueError:
+                patched["ms"] = 0
+        trace["steps"][i] = patched
+        break
+
+    return trace
+
+
+def merge_journey_trace(
+    prev: dict[str, Any] | None,
+    state: dict[str, Any],
+    *,
+    phase: str,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Merge a new snapshot with a previous one, preserving completed step history."""
+    ts = _utc_now(now)
+    snapshot = build_journey_trace_snapshot(state, phase=phase, now=ts)
+
+    if isinstance(prev, dict) and prev.get("flowMode") == "product_visual":
+        if prev.get("startedAt"):
+            snapshot["startedAt"] = prev["startedAt"]
+        prev_steps = {
+            str(s.get("id") or ""): s
+            for s in (prev.get("steps") or [])
+            if isinstance(s, dict) and str(s.get("id") or "").strip()
+        }
+        for step in snapshot["steps"]:
+            step_id = str(step.get("id") or "")
+            prev_step = prev_steps.get(step_id)
+            if not isinstance(prev_step, dict):
+                continue
+            if prev_step.get("status") not in _COMPLETED_STATUSES:
+                continue
+            if step.get("status") not in _COMPLETED_STATUSES and step.get("status") != "done":
+                continue
+            for field in _PRESERVE_FIELDS:
+                if prev_step.get(field) is not None:
+                    step[field] = prev_step[field]
+
+    if phase == "done" and snapshot.get("startedAt"):
+        try:
+            started = datetime.fromisoformat(str(snapshot["startedAt"]).replace("Z", "+00:00"))
+            snapshot["totalMs"] = _ms_between(started, ts)
+        except ValueError:
+            snapshot["totalMs"] = 0
+
+    return snapshot

--- a/services/agent-runtime/app/graph/product_visual_v2/presentation.py
+++ b/services/agent-runtime/app/graph/product_visual_v2/presentation.py
@@ -427,4 +427,11 @@ def build_presentation_envelope(
             "message": "确认全部定稿",
         }
 
+    from app.graph.product_visual_v2.journey_trace import merge_journey_trace
+
+    state["journey_trace"] = merge_journey_trace(
+        state.get("journey_trace"),
+        state,
+        phase=phase,
+    )
     return envelope

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -232,3 +232,5 @@ class AgentRuntimeState(TypedDict, total=False):
     vision_used: bool | None
     # UX-PV: structured sidebar envelope (shot/topo/delivery/done gates)
     presentation: dict | None
+    # UX-PV: journey trace snapshot (synced with presentation stepper)
+    journey_trace: dict | None

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -44,6 +44,66 @@ from app.tools.nest_client import NestCanvasClient
 
 EmitFn = Callable[[dict[str, Any]], Awaitable[None]]
 
+
+async def emit_journey_update(emit: EmitFn, state: dict[str, Any]) -> None:
+    """Emit journey_update SSE when product_visual journey_trace is present."""
+    snap = state.get("journey_trace")
+    if isinstance(snap, dict) and snap.get("flowMode") == "product_visual":
+        await emit({"type": "journey_update", "data": {"snapshot": snap}})
+
+
+def _resolve_journey_trace(vals: dict[str, Any]) -> dict[str, Any] | None:
+    """Return journey_trace from checkpoint or synthesize for product_visual reconnect."""
+    snap = vals.get("journey_trace")
+    if isinstance(snap, dict) and snap.get("flowMode") == "product_visual":
+        return snap
+    if vals.get("flow_mode") != "product_visual":
+        return None
+    phase = vals.get("phase")
+    if phase is None:
+        return None
+    from app.graph.product_visual_v2.journey_trace import merge_journey_trace
+
+    return merge_journey_trace(
+        snap if isinstance(snap, dict) else None,
+        vals,
+        phase=str(phase),
+    )
+
+
+def _sync_journey_trace(vals: dict[str, Any]) -> dict[str, Any]:
+    """Ensure vals carries journey_trace when product_visual checkpoint lacks persisted trace."""
+    trace = _resolve_journey_trace(vals)
+    if trace is None:
+        return vals
+    if vals.get("journey_trace") is trace:
+        return vals
+    return {**vals, "journey_trace": trace}
+
+
+async def _emit_journey_trace_for_presentation(
+    emit: EmitFn,
+    stream_vals: dict[str, Any],
+    delta: dict[str, Any],
+) -> None:
+    """After a node delta with presentation, merge trace and emit journey_update."""
+    if not isinstance(delta.get("presentation"), dict):
+        return
+    for key, value in delta.items():
+        if key != "messages":
+            stream_vals[key] = value
+    if not isinstance(stream_vals.get("journey_trace"), dict):
+        phase = stream_vals.get("phase")
+        if phase is not None:
+            from app.graph.product_visual_v2.journey_trace import merge_journey_trace
+
+            stream_vals["journey_trace"] = merge_journey_trace(
+                stream_vals.get("journey_trace"),
+                stream_vals,
+                phase=str(phase),
+            )
+    await emit_journey_update(emit, stream_vals)
+
 logger = logging.getLogger(__name__)
 
 
@@ -596,6 +656,8 @@ async def get_thread_state(
         if vals.get("retake_pending") is not None
         else None,
         "presentation": vals.get("presentation") if isinstance(vals.get("presentation"), dict) else None,
+        "selectedMacroSchemeIds": vals.get("selected_macro_scheme_ids"),
+        "journeyTrace": _resolve_journey_trace(vals),
         **diag,
     }
 
@@ -761,6 +823,7 @@ async def stream_run_events(
         last_text_delta: str | None = None
         executed_nodes: set[str] = set()
         stream_input: Any = input_state
+        stream_vals: dict[str, Any] = dict(pre_vals)
         try:
             for pass_idx in range(2):
                 async for update in graph.astream(stream_input, config, stream_mode="updates"):
@@ -809,6 +872,7 @@ async def stream_run_events(
                                             continue
                                         last_text_delta = text
                                         await emit({"type": "text_replace", "data": {"text": text}})
+                            await _emit_journey_trace_for_presentation(emit, stream_vals, delta)
                             explore = delta.get("explore_summary")
                             if isinstance(explore, dict):
                                 await emit({"type": "explore", "data": explore})
@@ -892,6 +956,8 @@ async def stream_run_events(
                 hint = phase_hint_event(phase=phase_str, gate_node=gate)
                 if hint:
                     await emit(hint)
+                emit_vals = _sync_journey_trace(post_vals)
+                await emit_journey_update(emit, emit_vals)
                 await emit(
                     interrupt_event_payload(
                         next_nodes=post_next,
@@ -921,6 +987,8 @@ async def stream_run_events(
             post_presentation = post_vals.get("presentation")
             if isinstance(post_presentation, dict):
                 done_payload["presentation"] = post_presentation
+            emit_vals = _sync_journey_trace(post_vals)
+            await emit_journey_update(emit, emit_vals)
             await emit({"type": "done", "data": done_payload})
         except AgentToolError as exc:
             record_stream_error(exc.error["error_type"])

--- a/services/agent-runtime/tests/test_journey_trace_snapshot.py
+++ b/services/agent-runtime/tests/test_journey_trace_snapshot.py
@@ -1,0 +1,164 @@
+"""Journey trace snapshot builder for product_visual v2."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.graph.product_visual_v2.journey_trace import (
+    JOURNEY_STEP_ORDER,
+    build_journey_trace_snapshot,
+    merge_journey_trace,
+    patch_macro_select_step,
+)
+from app.graph.product_visual_copy import ProductVisualCopy
+from app.graph.product_visual_v2.presentation import build_presentation_envelope
+
+
+def test_journey_step_order_matches_stepper():
+    from app.graph.product_visual_v2.presentation import STEPPER_ORDER
+
+    assert JOURNEY_STEP_ORDER == STEPPER_ORDER
+
+
+def test_build_snapshot_macro_select_running():
+    snap = build_journey_trace_snapshot(
+        {"macro_schemes": [{"id": "A", "label": "湖鲜原境风"}]},
+        phase="await_macro_scheme_select",
+    )
+    assert snap["version"] == 1
+    assert snap["flowMode"] == "product_visual"
+    assert snap["current"] == "macro_select"
+    assert snap["steps"][2]["status"] == "running"
+    assert snap["steps"][0]["status"] == "done"
+    assert snap["steps"][0]["label"] == "检查产品图"
+    assert snap["steps"][2]["label"] == "选宏观风格"
+
+
+def test_patch_macro_select_step_confirm():
+    prev = build_journey_trace_snapshot(
+        {
+            "macro_schemes": [
+                {"id": "A", "label": "湖鲜原境风"},
+                {"id": "B", "label": "礼盒臻享风"},
+            ],
+        },
+        phase="await_macro_scheme_select",
+    )
+    patched = patch_macro_select_step(
+        prev,
+        schemes=[
+            {"id": "A", "label": "湖鲜原境风", "summary": "原境"},
+            {"id": "B", "label": "礼盒臻享风", "summary": "礼盒"},
+        ],
+        selected_ids=["A", "B"],
+    )
+    macro = next(s for s in patched["steps"] if s["id"] == "macro_select")
+    assert macro["status"] == "done"
+    assert macro["summary"] == "已选：湖鲜原境风、礼盒臻享风"
+    assert macro["snapshot"]["kind"] == "macro_select"
+    assert macro["snapshot"]["selectedIds"] == ["A", "B"]
+    assert len(macro["snapshot"]["schemes"]) == 2
+    assert macro["snapshot"]["schemes"][0]["id"] == "A"
+    assert patched["current"] == "ssot_persist"
+    assert patched["steps"][0]["status"] == "done"
+
+
+def test_patch_macro_select_step_skip():
+    prev = build_journey_trace_snapshot(
+        {"macro_schemes": [{"id": "A", "label": "湖鲜原境风"}]},
+        phase="dialog_draft",
+    )
+    patched = patch_macro_select_step(
+        prev,
+        schemes=[{"id": "A", "label": "湖鲜原境风"}],
+        selected_ids=["A"],
+    )
+    macro = next(s for s in patched["steps"] if s["id"] == "macro_select")
+    assert macro["status"] == "skipped"
+    assert macro["summary"] == "仅一套方案，已自动选定"
+    assert "snapshot" not in macro
+
+
+def test_macro_confirm_summary():
+    state = {
+        "macro_schemes": [
+            {"id": "A", "label": "湖鲜原境风"},
+            {"id": "B", "label": "礼盒臻享风"},
+        ],
+        "selected_macro_scheme_ids": ["A", "B"],
+    }
+    snap = merge_journey_trace(None, state, phase="canvas_ssot_commit")
+    macro = next(s for s in snap["steps"] if s["id"] == "macro_select")
+    assert macro["status"] == "done"
+    assert "湖鲜原境风" in macro["summary"]
+    assert "礼盒臻享风" in macro["summary"]
+    assert macro["summary"].startswith("已选：")
+    assert "__macro_scheme_decision__" not in macro["summary"]
+    assert macro["snapshot"]["selectedIds"] == ["A", "B"]
+    assert macro["snapshot"]["kind"] == "macro_select"
+
+
+def test_single_macro_scheme_skipped():
+    state = {
+        "macro_schemes": [{"id": "A", "label": "湖鲜原境风"}],
+        "selected_macro_scheme_ids": ["A"],
+    }
+    snap = merge_journey_trace(None, state, phase="canvas_ssot_commit")
+    macro = next(s for s in snap["steps"] if s["id"] == "macro_select")
+    assert macro["status"] == "skipped"
+    assert macro["summary"] == "仅一套方案，已自动选定"
+
+
+def test_done_phase_all_steps_complete():
+    fixed = datetime(2026, 8, 13, 4, 0, 0, tzinfo=timezone.utc)
+    snap = build_journey_trace_snapshot(
+        {"expected_delivery_count": 3},
+        phase="done",
+        now=fixed,
+    )
+    assert snap["current"] == "done"
+    assert all(s["status"] == "done" for s in snap["steps"])
+    assert snap["finishedAt"] is not None
+    assert snap["totalMs"] is not None
+    assert snap["totalMs"] >= 0
+
+
+def test_merge_preserves_completed_step_timestamps():
+    prev_time = datetime(2026, 8, 13, 4, 0, 0, tzinfo=timezone.utc)
+    later = datetime(2026, 8, 13, 4, 5, 0, tzinfo=timezone.utc)
+    prev = build_journey_trace_snapshot({}, phase="await_image_qa", now=prev_time)
+    image_qa = prev["steps"][0]
+    image_qa["status"] = "done"
+    image_qa["enteredAt"] = prev_time.isoformat()
+    image_qa["completedAt"] = prev_time.isoformat()
+    image_qa["summary"] = "识图通过"
+
+    snap = merge_journey_trace(
+        prev,
+        {"visual_intent": {"primary_goal": "礼盒"}},
+        phase="await_macro_scheme_select",
+        now=later,
+    )
+    kept = next(s for s in snap["steps"] if s["id"] == "image_qa")
+    assert kept["summary"] == "识图通过"
+    assert kept["enteredAt"] == prev_time.isoformat()
+    assert kept["completedAt"] == prev_time.isoformat()
+
+
+def test_presentation_envelope_sets_journey_trace_on_state():
+    copy = ProductVisualCopy.load_from_skill("ecommerce-product-visual", "1.0.0")
+    state = {
+        "visual_intent": {"primary_goal": "巨峰葡萄礼盒"},
+        "route_context": {"utterance": "帮我做巨峰葡萄礼盒主视觉"},
+    }
+    build_presentation_envelope(
+        kind="callout_info",
+        phase="await_image_qa",
+        state=state,
+        copy=copy,
+    )
+    trace = state.get("journey_trace")
+    assert isinstance(trace, dict)
+    assert trace["flowMode"] == "product_visual"
+    assert trace["current"] == "image_qa"
+    assert len(trace["steps"]) == 9

--- a/services/agent-runtime/tests/test_thread_state.py
+++ b/services/agent-runtime/tests/test_thread_state.py
@@ -7,7 +7,8 @@ from langchain_core.messages import HumanMessage
 from langgraph.checkpoint.memory import MemorySaver
 
 from app.graph.builder import build_agent_graph
-from app.runs import get_thread_state
+from app.graph.product_visual_v2.journey_trace import build_journey_trace_snapshot
+from app.runs import emit_journey_update, get_thread_state
 
 
 @pytest.mark.asyncio
@@ -49,3 +50,65 @@ async def test_get_thread_state_includes_atomic_checkpoint(tmp_path):
     assert state["hasAtomicCheckpoint"] is True
     assert state["atomicNodeId"] == "node-x"
     assert state["atomicTargetType"] == "image"
+
+
+@pytest.mark.asyncio
+async def test_get_thread_state_includes_journey_trace():
+    cp = MemorySaver()
+    graph = build_agent_graph(
+        nest=type("_N", (), {"close": lambda self: None})(),
+        llm=None,
+        skills_dir=__import__("pathlib").Path(__file__).resolve().parents[1] / "skills",
+        checkpointer=cp,
+    )
+    trace = build_journey_trace_snapshot(
+        {"macro_schemes": [{"id": "A", "label": "湖鲜原境风"}]},
+        phase="await_macro_scheme_select",
+    )
+    config = {"configurable": {"thread_id": "t-journey"}}
+    await graph.ainvoke(
+        {
+            "messages": [HumanMessage(content="帮我做礼盒主视觉")],
+            "flow_mode": "product_visual",
+            "phase": "await_macro_scheme_select",
+            "selected_macro_scheme_ids": ["A"],
+            "journey_trace": trace,
+            "thread_id": "t-journey",
+            "session_id": "s1",
+            "user_id": "u1",
+        },
+        config,
+    )
+    state = await get_thread_state("t-journey", checkpointer=cp)
+    assert state["selectedMacroSchemeIds"] == ["A"]
+    jt = state["journeyTrace"]
+    assert isinstance(jt, dict)
+    assert jt["flowMode"] == "product_visual"
+    assert jt["current"] == "macro_select"
+    assert len(jt["steps"]) == 9
+
+
+@pytest.mark.asyncio
+async def test_emit_journey_update_emits_product_visual_snapshot():
+    events: list[dict] = []
+
+    async def emit(event: dict) -> None:
+        events.append(event)
+
+    trace = build_journey_trace_snapshot({}, phase="await_image_qa")
+    await emit_journey_update(emit, {"journey_trace": trace})
+    assert len(events) == 1
+    assert events[0]["type"] == "journey_update"
+    assert events[0]["data"]["snapshot"]["flowMode"] == "product_visual"
+
+
+@pytest.mark.asyncio
+async def test_emit_journey_update_skips_missing_or_non_pv():
+    events: list[dict] = []
+
+    async def emit(event: dict) -> None:
+        events.append(event)
+
+    await emit_journey_update(emit, {})
+    await emit_journey_update(emit, {"journey_trace": {"flowMode": "campaign"}})
+    assert events == []


### PR DESCRIPTION
## Summary

- 将 product_visual v2 **九步 Stepper** 与 **Agent 执行记录**合并：Live 动态展示当前步骤（已完成划线），历史对话可回放
- Runtime 新增 `JourneyTraceSnapshot`，SSE 事件 `journey_update`；Nest 写入 `AgentMessage.metadata`
- 前端 `AgentExecutionTrace` 双 section（工作流进度 + 操作明细）；SideRail 历史恢复；宏观方案确认后 summary + 只读卡片回放
- E2E audit 扩展 `journeyTrace` 断言；UAT 新增 §10.10

## Spec / Plan

- [design](docs/superpowers/specs/2026-08-13-product-visual-journey-trace-design.md)
- [plan](docs/superpowers/plans/2026-08-13-product-visual-journey-trace.md)

## Test plan

- [x] pytest journey_trace + presentation — 33 pass
- [x] vitest journeyTrace + reducer + store — 30 pass
- [x] vitest agent.service.journey-trace — 3 pass
- [ ] CI pnpm build
- [ ] Prisma migrate deploy: `20260813120000_agent_message_metadata`
- [ ] 部署后 `AUDIT_OUT=deploy/prod-crab-listing-audit-v5.json python3 deploy/prod-crab-listing-e2e-audit.py`

## 已知 follow-up (P1)

- `executionTrace` 操作明细尚未持久化到 metadata（仅九步骨架）
- `done` 步交付数量 summary 可再 enrich

Made with [Cursor](https://cursor.com)