### PR TITLE
fix(agent-runtime): journey trace 随 phase 实时合并推进

### DIFF
--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -53,19 +53,19 @@ async def emit_journey_update(emit: EmitFn, state: dict[str, Any]) -> None:
 
 
 def _resolve_journey_trace(vals: dict[str, Any]) -> dict[str, Any] | None:
-    """Return journey_trace from checkpoint or synthesize for product_visual reconnect."""
+    """Return journey_trace merged with current phase (never return a stale checkpoint snap)."""
     snap = vals.get("journey_trace")
-    if isinstance(snap, dict) and snap.get("flowMode") == "product_visual":
-        return snap
-    if vals.get("flow_mode") != "product_visual":
+    is_pv_snap = isinstance(snap, dict) and snap.get("flowMode") == "product_visual"
+    is_pv_flow = vals.get("flow_mode") == "product_visual"
+    if not is_pv_snap and not is_pv_flow:
         return None
     phase = vals.get("phase")
     if phase is None:
-        return None
+        return snap if is_pv_snap else None
     from app.graph.product_visual_v2.journey_trace import merge_journey_trace
 
     return merge_journey_trace(
-        snap if isinstance(snap, dict) else None,
+        snap if is_pv_snap else None,
         vals,
         phase=str(phase),
     )
@@ -92,16 +92,16 @@ async def _emit_journey_trace_for_presentation(
     for key, value in delta.items():
         if key != "messages":
             stream_vals[key] = value
-    if not isinstance(stream_vals.get("journey_trace"), dict):
-        phase = stream_vals.get("phase")
-        if phase is not None:
-            from app.graph.product_visual_v2.journey_trace import merge_journey_trace
+    phase = stream_vals.get("phase")
+    if phase is not None:
+        from app.graph.product_visual_v2.journey_trace import merge_journey_trace
 
-            stream_vals["journey_trace"] = merge_journey_trace(
-                stream_vals.get("journey_trace"),
-                stream_vals,
-                phase=str(phase),
-            )
+        prev = stream_vals.get("journey_trace")
+        stream_vals["journey_trace"] = merge_journey_trace(
+            prev if isinstance(prev, dict) else None,
+            stream_vals,
+            phase=str(phase),
+        )
     await emit_journey_update(emit, stream_vals)
 
 logger = logging.getLogger(__name__)

--- a/services/agent-runtime/tests/test_thread_state.py
+++ b/services/agent-runtime/tests/test_thread_state.py
@@ -7,8 +7,16 @@ from langchain_core.messages import HumanMessage
 from langgraph.checkpoint.memory import MemorySaver
 
 from app.graph.builder import build_agent_graph
-from app.graph.product_visual_v2.journey_trace import build_journey_trace_snapshot
-from app.runs import emit_journey_update, get_thread_state
+from app.graph.product_visual_v2.journey_trace import (
+    build_journey_trace_snapshot,
+    patch_macro_select_step,
+)
+from app.runs import (
+    _emit_journey_trace_for_presentation,
+    _resolve_journey_trace,
+    emit_journey_update,
+    get_thread_state,
+)
 
 
 @pytest.mark.asyncio
@@ -53,6 +61,74 @@ async def test_get_thread_state_includes_atomic_checkpoint(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_resolve_journey_trace_merges_stale_checkpoint_with_current_phase():
+    stale = build_journey_trace_snapshot(
+        {
+            "macro_schemes": [
+                {"id": "A", "label": "湖鲜原境风"},
+                {"id": "B", "label": "礼盒臻享风"},
+            ],
+            "selected_macro_scheme_ids": ["A"],
+        },
+        phase="canvas_ssot_commit",
+    )
+    patched = patch_macro_select_step(
+        stale,
+        schemes=[
+            {"id": "A", "label": "湖鲜原境风"},
+            {"id": "B", "label": "礼盒臻享风"},
+        ],
+        selected_ids=["A"],
+    )
+    assert patched["current"] == "ssot_persist"
+
+    resolved = _resolve_journey_trace(
+        {
+            "flow_mode": "chat",
+            "phase": "done",
+            "journey_trace": patched,
+            "selected_macro_scheme_ids": ["A"],
+            "macro_schemes": [
+                {"id": "A", "label": "湖鲜原境风"},
+                {"id": "B", "label": "礼盒臻享风"},
+            ],
+        }
+    )
+    assert isinstance(resolved, dict)
+    assert resolved["current"] == "done"
+    assert all(s["status"] == "done" for s in resolved["steps"])
+    macro = next(s for s in resolved["steps"] if s["id"] == "macro_select")
+    assert macro["summary"] == "已选：湖鲜原境风"
+
+
+@pytest.mark.asyncio
+async def test_emit_journey_trace_for_presentation_advances_existing_trace():
+    events: list[dict] = []
+
+    async def emit(event: dict) -> None:
+        events.append(event)
+
+    stale = build_journey_trace_snapshot(
+        {"macro_schemes": [{"id": "A", "label": "湖鲜原境风"}]},
+        phase="await_macro_scheme_select",
+    )
+    stream_vals = {
+        "phase": "await_shot_topo_confirm",
+        "journey_trace": stale,
+        "macro_schemes": [{"id": "A", "label": "湖鲜原境风"}],
+        "selected_macro_scheme_ids": ["A"],
+    }
+    delta = {"presentation": {"kind": "shot_topo_merged", "stepper": {"current": "topo_preview"}}}
+
+    await _emit_journey_trace_for_presentation(emit, stream_vals, delta)
+
+    assert len(events) == 1
+    snap = events[0]["data"]["snapshot"]
+    assert snap["current"] == "topo_preview"
+    assert stream_vals["journey_trace"]["current"] == "topo_preview"
+
+
+@pytest.mark.asyncio
 async def test_get_thread_state_includes_journey_trace():
     cp = MemorySaver()
     graph = build_agent_graph(
@@ -62,11 +138,17 @@ async def test_get_thread_state_includes_journey_trace():
         checkpointer=cp,
     )
     trace = build_journey_trace_snapshot(
-        {"macro_schemes": [{"id": "A", "label": "湖鲜原境风"}]},
+        {
+            "macro_schemes": [
+                {"id": "A", "label": "湖鲜原境风"},
+                {"id": "B", "label": "礼盒臻享风"},
+            ],
+        },
         phase="await_macro_scheme_select",
     )
     config = {"configurable": {"thread_id": "t-journey"}}
-    await graph.ainvoke(
+    await graph.aupdate_state(
+        config,
         {
             "messages": [HumanMessage(content="帮我做礼盒主视觉")],
             "flow_mode": "product_visual",
@@ -77,7 +159,6 @@ async def test_get_thread_state_includes_journey_trace():
             "session_id": "s1",
             "user_id": "u1",
         },
-        config,
     )
     state = await get_thread_state("t-journey", checkpointer=cp)
     assert state["selectedMacroSchemeIds"] == ["A"]


### PR DESCRIPTION
## Summary
- `_resolve_journey_trace` 不再直接返回 checkpoint 中的 stale 快照，而是始终按当前 `phase` 合并
- `_emit_journey_trace_for_presentation` 在已有 `journey_trace` 时也会继续 merge，修复 macro_select 确认后 SSE 停在 `ssot_persist` 的问题
- 补充单测覆盖 stale checkpoint + done phase、presentation emit 推进

## 根因
`patch_macro_select_step` 写入 `current=ssot_persist` 后，后续 phase 变更因「已有 journey_trace 则跳过 merge」导致 SSE / thread-state 永远停留在第三步。

## Test plan
- [x] `pytest tests/test_thread_state.py::test_resolve_journey_trace_merges_stale_checkpoint_with_current_phase`
- [x] `pytest tests/test_thread_state.py::test_emit_journey_trace_for_presentation_advances_existing_trace`
- [x] `pytest tests/test_journey_trace_snapshot.py`
- [ ] 合并部署后复跑 `deploy/prod-crab-listing-e2e-audit.py`（v6）验证 `journeyTraceOk`


Made with [Cursor](https://cursor.com)