### PR TITLE
fix(product-visual): decompose 失败直达 done，加固 topo gate 与 E2E 断言

### DIFF
--- a/deploy/prod-crab-listing-e2e-audit.py
+++ b/deploy/prod-crab-listing-e2e-audit.py
@@ -226,6 +226,27 @@ def assert_journey_trace(audit_doc: dict[str, Any]) -> None:
     assert macro.get("summary")
 
 
+def assert_business_success(audit_doc: dict[str, Any]) -> None:
+    final = audit_doc.get("final_thread_state") or audit_doc.get("finalThreadState") or {}
+    pres = final.get("presentation") or {}
+    if isinstance(pres, dict) and pres.get("kind") == "callout_error":
+        body = pres.get("body") or {}
+        raise AssertionError(f"business failed: {(body.get('text') or pres.get('title') or 'callout_error')}")
+
+    for step in audit_doc.get("steps") or []:
+        if step.get("phase") == "error":
+            raise AssertionError(f"step {step.get('step')} ended with phase=error")
+        gate = (step.get("nextNodes") or [None])[0] or step.get("phase")
+        if gate == "await_shot_topo_confirm" and int(step.get("shotManifest_count") or 0) <= 0:
+            raise AssertionError(
+                f"step {step.get('step')} at topo gate with empty shotManifest"
+            )
+
+    shots = final.get("shotManifest") or []
+    if audit_doc.get("status") == "done" and not shots:
+        raise AssertionError("final shotManifest empty on successful done")
+
+
 def record_step(step: int, msg: str, sse: dict[str, Any], ts: dict[str, Any]) -> None:
     pres_events = [
         e.get("data") for e in sse.get("events", [])
@@ -299,6 +320,11 @@ def main() -> int:
         ts = thread_state(tok, tid)
         record_step(step, msg, sse, ts)
 
+        if ts.get("phase") == "error":
+            audit["status"] = "business_error"
+            audit["issues"].append(f"step {step}: phase=error")
+            break
+
         if sse.get("exit") == "error":
             audit["status"] = "error"
             break
@@ -339,6 +365,7 @@ def main() -> int:
         audit["journeyTraceSource"] = journey_source
 
     journey_ok = False
+    business_ok = False
     if audit.get("status") == "done":
         try:
             assert_journey_trace(audit)
@@ -354,13 +381,22 @@ def main() -> int:
             audit["journeyTraceOk"] = False
             audit["issues"].append(f"journeyTrace: {exc}")
             print(f"journeyTrace assertion failed: {exc}", flush=True)
+        try:
+            assert_business_success(audit)
+            business_ok = True
+            audit["businessOk"] = True
+            print("business success checks passed", flush=True)
+        except AssertionError as exc:
+            audit["businessOk"] = False
+            audit["issues"].append(f"business: {exc}")
+            print(f"business assertion failed: {exc}", flush=True)
 
     OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
     OUT_PATH.write_text(json.dumps(audit, ensure_ascii=False, indent=2), encoding="utf-8")
     print(f"\nAudit saved: {OUT_PATH}", flush=True)
     print(f"status={audit.get('status')} gates={audit.get('gates_seen')}", flush=True)
     if audit.get("status") == "done":
-        return 0 if journey_ok else 1
+        return 0 if (journey_ok and business_ok) else 1
     return 1
 
 

--- a/services/agent-runtime/app/graph/nodes/await_shot_topo_confirm.py
+++ b/services/agent-runtime/app/graph/nodes/await_shot_topo_confirm.py
@@ -79,6 +79,17 @@ def make_await_shot_topo_confirm_node(*, skills_dir: Any | None = None) -> Calla
             decision = classify_topo_decision(text)
 
         if decision == "confirm_gen":
+            if not (state.get("shot_manifest") or []):
+                from app.graph.product_visual_v2.errors import format_flow_end_message
+
+                return {
+                    "phase": "error",
+                    "last_error": "shot_manifest_missing",
+                    "user_decision": "none",
+                    "messages": [
+                        AIMessage(content=format_flow_end_message("shot_manifest_missing", state))
+                    ],
+                }
             return {
                 "phase": "orchestrate_shots",
                 "pv_skip_topo_gate": True,

--- a/services/agent-runtime/app/graph/nodes/shot_confirm_gate.py
+++ b/services/agent-runtime/app/graph/nodes/shot_confirm_gate.py
@@ -49,6 +49,17 @@ def make_await_shot_confirm_node() -> Callable:
             decision = classify_topo_decision(text)
 
         if decision == "confirm_gen":
+            if not (state.get("shot_manifest") or []):
+                from app.graph.product_visual_v2.errors import format_flow_end_message
+
+                return {
+                    "phase": "error",
+                    "last_error": "shot_manifest_missing",
+                    "user_decision": "none",
+                    "messages": [
+                        AIMessage(content=format_flow_end_message("shot_manifest_missing", state))
+                    ],
+                }
             return {
                 "phase": "orchestrate_shots",
                 "user_decision": "none",

--- a/services/agent-runtime/app/graph/product_visual_v2/journey_trace.py
+++ b/services/agent-runtime/app/graph/product_visual_v2/journey_trace.py
@@ -35,6 +35,17 @@ JOURNEY_STEP_LABELS: dict[str, str] = {
 _COMPLETED_STATUSES = frozenset({"done", "skipped", "failed"})
 _PRESERVE_FIELDS = ("enteredAt", "completedAt", "ms", "summary", "snapshot")
 
+_ERROR_TO_FAILED_STEP: dict[str, str] = {
+    "decompose_shots_parse_failed": "shot_plan",
+    "plan_node_id_missing": "shot_plan",
+    "upsert_unavailable": "shot_plan",
+    "shot_manifest_missing": "shot_plan",
+    "orchestrate_empty": "generating",
+    "product_visual_plan_missing": "scheme_draft",
+    "dialog_draft_parse_failed": "scheme_draft",
+    "macro_schemes_missing": "macro_select",
+}
+
 
 def _utc_now(now: datetime | None) -> datetime:
     if now is not None:
@@ -97,7 +108,37 @@ def _enrich_macro_select(step: dict[str, Any], state: dict[str, Any]) -> None:
         step["snapshot"] = _macro_select_snapshot(state)
 
 
-def _step_status(step_id: str, *, current: str, completed: list[str], phase: str) -> str:
+def _failed_step_for_state(state: dict[str, Any], *, phase: str, current: str) -> str | None:
+    last_error = str(state.get("last_error") or "").strip()
+    if last_error:
+        mapped = _ERROR_TO_FAILED_STEP.get(last_error)
+        if mapped:
+            return mapped
+    if phase == "error":
+        return current if current in JOURNEY_STEP_ORDER else "scheme_draft"
+    if phase == "done" and last_error:
+        return "shot_plan"
+    return None
+
+
+def _step_status(
+    step_id: str,
+    *,
+    current: str,
+    completed: list[str],
+    phase: str,
+    state: dict[str, Any],
+) -> str:
+    failed_at = _failed_step_for_state(state, phase=phase, current=current)
+    if failed_at and failed_at in JOURNEY_STEP_ORDER:
+        failed_idx = JOURNEY_STEP_ORDER.index(failed_at)
+        step_idx = JOURNEY_STEP_ORDER.index(step_id)
+        if step_idx < failed_idx:
+            return "done"
+        if step_idx == failed_idx:
+            return "failed"
+        return "pending"
+
     if phase == "done":
         return "done"
     if step_id in completed:
@@ -119,11 +160,18 @@ def build_journey_trace_snapshot(
     ts = _utc_now(now)
     current = phase_to_stepper(phase)
     completed = _completed_step_ids(current)
+    failed_at = _failed_step_for_state(state, phase=phase, current=current)
     started_at = _iso(ts)
 
     steps: list[dict[str, Any]] = []
     for step_id in JOURNEY_STEP_ORDER:
-        status = _step_status(step_id, current=current, completed=completed, phase=phase)
+        status = _step_status(
+            step_id,
+            current=current,
+            completed=completed,
+            phase=phase,
+            state=state,
+        )
         step: dict[str, Any] = {
             "id": step_id,
             "label": JOURNEY_STEP_LABELS[step_id],
@@ -135,8 +183,10 @@ def build_journey_trace_snapshot(
             step["enteredAt"] = _iso(ts)
             step["completedAt"] = _iso(ts)
             step["ms"] = 0
-        if step_id == "macro_select" and step_id in completed:
-            if phase == "done":
+        if step_id == "macro_select" and (
+            step_id in completed or (failed_at and step_id in JOURNEY_STEP_ORDER[: JOURNEY_STEP_ORDER.index(failed_at)])
+        ):
+            if phase == "done" and not state.get("last_error"):
                 if should_skip_macro_hitl(state.get("macro_schemes")):
                     step["summary"] = "仅一套方案，已自动选定"
                 else:

--- a/services/agent-runtime/app/graph/product_visual_v2/routing.py
+++ b/services/agent-runtime/app/graph/product_visual_v2/routing.py
@@ -105,3 +105,15 @@ def route_after_macro_scheme_select(state: dict) -> str:
     if decision in ("confirm", "auto"):
         return "canvas_ssot_commit"
     return "end"
+
+
+def route_after_canvas_ssot_commit(state: dict) -> str:
+    if state.get("phase") == "error":
+        return "done"
+    return "decompose_from_ssot"
+
+
+def route_after_decompose_from_ssot(state: dict) -> str:
+    if state.get("phase") == "error":
+        return "done"
+    return shot_confirm_gate_name()

--- a/services/agent-runtime/app/graph/subgraphs/product_visual_v2_gate.py
+++ b/services/agent-runtime/app/graph/subgraphs/product_visual_v2_gate.py
@@ -24,6 +24,8 @@ from app.graph.nodes.await_shot_topo_confirm import (
 )
 from app.graph.product_visual_v2.routing import (
     is_merged_shot_topo_gate_enabled,
+    route_after_canvas_ssot_commit,
+    route_after_decompose_from_ssot,
     route_after_orchestrate_shots,
     shot_confirm_gate_name,
 )
@@ -96,8 +98,22 @@ def register_product_visual_v2_nodes(
             "end": END,
         },
     )
-    graph.add_edge("canvas_ssot_commit", "decompose_from_ssot")
-    graph.add_edge("decompose_from_ssot", shot_gate)
+    graph.add_conditional_edges(
+        "canvas_ssot_commit",
+        route_after_canvas_ssot_commit,
+        {
+            "decompose_from_ssot": "decompose_from_ssot",
+            "done": "done",
+        },
+    )
+    graph.add_conditional_edges(
+        "decompose_from_ssot",
+        route_after_decompose_from_ssot,
+        {
+            shot_gate: shot_gate,
+            "done": "done",
+        },
+    )
     if merged:
         graph.add_conditional_edges(
             "await_shot_topo_confirm",

--- a/services/agent-runtime/tests/test_graph_routes.py
+++ b/services/agent-runtime/tests/test_graph_routes.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from app.graph.builder import route_after_intake, route_after_split
 from app.graph.product_visual_v2.routing import (
     count_hard_stops,
+    route_after_canvas_ssot_commit,
+    route_after_decompose_from_ssot,
     route_after_orchestrate_shots,
     shot_confirm_gate_name,
 )
@@ -70,3 +72,14 @@ def test_v2_gate_count_with_merged_topo():
 
 def test_v2_gate_count_without_merged_topo():
     assert count_hard_stops("CVS-02", merged=False) == 4
+
+
+def test_route_after_canvas_ssot_commit_error_goes_done():
+    assert route_after_canvas_ssot_commit({"phase": "error"}) == "done"
+    assert route_after_canvas_ssot_commit({"phase": "decompose_from_ssot"}) == "decompose_from_ssot"
+
+
+def test_route_after_decompose_error_goes_done():
+    assert route_after_decompose_from_ssot({"phase": "error"}) == "done"
+    gate = shot_confirm_gate_name()
+    assert route_after_decompose_from_ssot({"phase": gate}) == gate

--- a/services/agent-runtime/tests/test_journey_trace_snapshot.py
+++ b/services/agent-runtime/tests/test_journey_trace_snapshot.py
@@ -123,6 +123,17 @@ def test_done_phase_all_steps_complete():
     assert snap["totalMs"] >= 0
 
 
+def test_error_done_marks_failed_step_not_all_complete():
+    snap = build_journey_trace_snapshot(
+        {"last_error": "decompose_shots_parse_failed"},
+        phase="done",
+    )
+    shot_plan = next(s for s in snap["steps"] if s["id"] == "shot_plan")
+    assert shot_plan["status"] == "failed"
+    assert next(s for s in snap["steps"] if s["id"] == "topo_preview")["status"] == "pending"
+    assert next(s for s in snap["steps"] if s["id"] == "done")["status"] == "pending"
+
+
 def test_merge_preserves_completed_step_timestamps():
     prev_time = datetime(2026, 8, 13, 4, 0, 0, tzinfo=timezone.utc)
     later = datetime(2026, 8, 13, 4, 5, 0, tzinfo=timezone.utc)

--- a/services/agent-runtime/tests/test_product_visual_ux_fixes.py
+++ b/services/agent-runtime/tests/test_product_visual_ux_fixes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from app.graph.nodes.await_shot_topo_confirm import make_await_shot_topo_confirm_node
 from app.graph.nodes.done import make_done_node
 from app.graph.product_visual_v2.dialog_draft_fallback import build_fallback_dialog_draft
 from app.graph.product_visual_v2.errors import build_error_presentation, format_flow_end_message
@@ -87,3 +88,18 @@ async def test_done_v2_error_uses_friendly_message():
     assert out["phase"] == "done"
     assert "dialog_draft_parse_failed" not in out["messages"][0].content
     assert out.get("presentation", {}).get("stepper", {}).get("current") == "done"
+
+
+@pytest.mark.asyncio
+async def test_topo_gate_confirm_without_manifest_returns_error():
+    from langchain_core.messages import HumanMessage
+
+    gate = make_await_shot_topo_confirm_node()
+    out = await gate(
+        {
+            "messages": [HumanMessage(content="确认构图并开始出图")],
+            "shot_manifest": [],
+        }
+    )
+    assert out["phase"] == "error"
+    assert out["last_error"] == "shot_manifest_missing"


### PR DESCRIPTION
## Summary
- SSOT / decompose 失败时改走 conditional edge 直达 `done`，展示真实错误（如构图拆解失败），不再 interrupt 在空 topo gate
- topo / shot confirm gate 在 manifest 为空时拒绝 `confirm_gen`，避免次生 `shot_manifest_missing`
- journeyTrace 错误终止时将失败步骤标 `failed`、后续步骤保持 `pending`，修复假绿
- 大闸蟹 E2E 审计增加 `assert_business_success`（拒绝 callout_error、空 manifest）

## Test plan
- [x] `pnpm build`
- [x] `python3 -m pytest services/agent-runtime/tests/test_graph_routes.py services/agent-runtime/tests/test_journey_trace_snapshot.py services/agent-runtime/tests/test_product_visual_ux_fixes.py`
- [ ] CI green
- [ ] 部署后复跑 `AUDIT_OUT=deploy/prod-crab-listing-audit-v7.json python3 deploy/prod-crab-listing-e2e-audit.py`


Made with [Cursor](https://cursor.com)