### PR TITLE
chore(deploy): 大闸蟹 batch 连跑 + decompose 恢复验证

### DIFF
--- a/deploy/prod-crab-listing-audit-batch.py
+++ b/deploy/prod-crab-listing-audit-batch.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Run N consecutive production crab listing E2E audits and summarize."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+ROUNDS = int(os.environ.get("AUDIT_BATCH_ROUNDS", "5"))
+START_INDEX = int(os.environ.get("AUDIT_BATCH_START", "10"))
+SCRIPT = Path(__file__).with_name("prod-crab-listing-e2e-audit.py")
+OUT_DIR = Path(os.environ.get("AUDIT_BATCH_DIR", "deploy"))
+
+
+def run_round(index: int) -> dict[str, Any]:
+    out_path = OUT_DIR / f"prod-crab-listing-audit-v{index}.json"
+    env = {**os.environ, "AUDIT_OUT": str(out_path.resolve())}
+    print(f"\n=== batch round v{index} -> {out_path} ===", flush=True)
+    started = time.time()
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT.resolve())],
+        env=env,
+        cwd=str(Path(__file__).resolve().parents[1]),
+        capture_output=False,
+    )
+    elapsed = round(time.time() - started, 1)
+    row: dict[str, Any] = {
+        "round": f"v{index}",
+        "out": str(out_path),
+        "exit_code": proc.returncode,
+        "elapsed_sec": elapsed,
+    }
+    if out_path.exists():
+        doc = json.loads(out_path.read_text(encoding="utf-8"))
+        row.update(
+            {
+                "status": doc.get("status"),
+                "threadId": doc.get("threadId"),
+                "journeyTraceOk": doc.get("journeyTraceOk"),
+                "businessOk": doc.get("businessOk"),
+                "issues": doc.get("issues") or [],
+                "steps": len(doc.get("steps") or []),
+                "shotManifest_final": len(
+                    (doc.get("final_thread_state") or {}).get("shotManifest") or []
+                ),
+            }
+        )
+        final = doc.get("final_thread_state") or {}
+        pres = final.get("presentation") or {}
+        row["presentation_kind"] = pres.get("kind") if isinstance(pres, dict) else None
+    else:
+        row["error"] = "audit output missing"
+    return row
+
+
+def main() -> int:
+    print(f"=== crab listing batch: {ROUNDS} rounds (v{START_INDEX}..v{START_INDEX + ROUNDS - 1}) ===", flush=True)
+    results: list[dict[str, Any]] = []
+    for i in range(START_INDEX, START_INDEX + ROUNDS):
+        results.append(run_round(i))
+
+    passed = sum(1 for r in results if r.get("exit_code") == 0)
+    summary = {
+        "rounds": ROUNDS,
+        "passed": passed,
+        "failed": ROUNDS - passed,
+        "results": results,
+        "finished_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    summary_path = OUT_DIR / f"prod-crab-listing-audit-batch-v{START_INDEX}-{START_INDEX + ROUNDS - 1}.json"
+    summary_path.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"\n=== batch summary: {passed}/{ROUNDS} passed ===", flush=True)
+    for r in results:
+        print(
+            f"  {r['round']}: exit={r.get('exit_code')} status={r.get('status')} "
+            f"shots={r.get('shotManifest_final')} journey={r.get('journeyTraceOk')} "
+            f"business={r.get('businessOk')} ({r.get('elapsed_sec')}s)",
+            flush=True,
+        )
+    print(f"Summary saved: {summary_path}", flush=True)
+    return 0 if passed == ROUNDS else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/prod-decompose-failure-recovery-verify.py
+++ b/deploy/prod-decompose-failure-recovery-verify.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Verify decompose failure handling (local) and revise recovery (production)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+_AUDIT_MOD_PATH = Path(__file__).with_name("prod-crab-listing-e2e-audit.py")
+_spec = importlib.util.spec_from_file_location("prod_crab_listing_e2e_audit", _AUDIT_MOD_PATH)
+assert _spec and _spec.loader
+_audit = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_audit)
+
+CODE = _audit.CODE
+PHONE = _audit.PHONE
+UTTERANCE = _audit.UTTERANCE
+absorb_journey_updates = _audit.absorb_journey_updates
+find_crab_asset = _audit.find_crab_asset
+http = _audit.http
+sse_turn = _audit.sse_turn
+thread_state = _audit.thread_state
+
+OUT_PATH = Path(
+    os.environ.get(
+        "DECOMPOSE_VERIFY_OUT",
+        "deploy/prod-decompose-failure-recovery-verify.json",
+    )
+)
+RUNTIME_ROOT = Path(__file__).resolve().parents[1] / "services" / "agent-runtime"
+
+
+def run_local_pytests() -> dict[str, Any]:
+    tests = [
+        "tests/test_decompose_failure_recovery.py",
+        "tests/test_graph_routes.py::test_route_after_decompose_error_goes_done",
+        "tests/test_journey_trace_snapshot.py::test_error_done_marks_failed_step_not_all_complete",
+    ]
+    cmd = [sys.executable, "-m", "pytest", *tests, "-q"]
+    print("=== local pytest: decompose failure recovery ===", flush=True)
+    proc = subprocess.run(cmd, cwd=str(RUNTIME_ROOT), capture_output=True, text=True)
+    ok = proc.returncode == 0
+    print(proc.stdout, flush=True)
+    if proc.stderr:
+        print(proc.stderr, flush=True)
+    return {
+        "ok": ok,
+        "exit_code": proc.returncode,
+        "stdout_tail": proc.stdout[-2000:],
+    }
+
+
+def assert_decompose_error_shape(ts: dict[str, Any]) -> None:
+    pres = ts.get("presentation") or {}
+    if ts.get("phase") == "done":
+        assert isinstance(pres, dict), "expected presentation on done"
+        assert pres.get("kind") == "callout_error", f"expected callout_error, got {pres.get('kind')}"
+        body = pres.get("body") or {}
+        text = str(body.get("text") or "")
+        assert "构图" in text or "拆解" in text or "未能" in text, f"unexpected error text: {text!r}"
+        jt = ts.get("journeyTrace") or {}
+        steps = jt.get("steps") or []
+        shot_plan = next((s for s in steps if s.get("id") == "shot_plan"), None)
+        if shot_plan:
+            assert shot_plan.get("status") == "failed", f"shot_plan should be failed, got {shot_plan}"
+        return
+    if ts.get("phase") == "error":
+        assert not ts.get("interrupted") or not (
+            (ts.get("nextNodes") or [None])[0] == "await_shot_topo_confirm"
+            and len(ts.get("shotManifest") or []) == 0
+        ), "v6 regression: error at empty topo gate interrupt"
+        raise AssertionError(f"unexpected phase=error without done: {ts.get('nextNodes')}")
+
+
+def prod_revise_recovery(tok: str) -> dict[str, Any]:
+    crab = find_crab_asset(tok)
+    sid = http("POST", "/sessions", {"title": f"decompose-recover-{int(time.time())}"}, t=tok)["data"]["id"]
+    tid = f"craba_{uuid.uuid4().hex[:10]}"
+    attachment = {
+        "id": f"att-{uuid.uuid4().hex[:8]}",
+        "mediaType": "image",
+        "sourceKind": "asset",
+        "role": "product",
+        "label": crab.get("label") or "大闸蟹实拍",
+        "url": crab["url"],
+    }
+    steps: list[dict[str, Any]] = []
+
+    def snap(step: int, msg: str, sse: dict[str, Any], ts: dict[str, Any]) -> None:
+        entry = {
+            "step": step,
+            "user_message": msg[:160],
+            "sse_exit": sse.get("exit"),
+            "phase": ts.get("phase"),
+            "nextNodes": ts.get("nextNodes"),
+            "shotManifest_count": len(ts.get("shotManifest") or []),
+            "presentation_kind": (ts.get("presentation") or {}).get("kind"),
+        }
+        steps.append(entry)
+        print(
+            f"[recover step {step}] phase={entry['phase']} shots={entry['shotManifest_count']} "
+            f"pres={entry['presentation_kind']}",
+            flush=True,
+        )
+
+    # Step 1 — reach topo gate
+    ts0 = thread_state(tok, tid)
+    sse1 = sse_turn(
+        tok,
+        sid,
+        tid,
+        UTTERANCE,
+        attachments=[attachment],
+        skill_id="product-visual",
+        ts_before=ts0,
+    )
+    absorb_journey_updates(sse1.get("events") or [])
+    ts1 = thread_state(tok, tid)
+    snap(1, UTTERANCE, sse1, ts1)
+
+    if ts1.get("phase") == "done" and (ts1.get("presentation") or {}).get("kind") == "callout_error":
+        assert_decompose_error_shape(ts1)
+        return {
+            "mode": "natural_decompose_failure",
+            "threadId": tid,
+            "sessionId": sid,
+            "steps": steps,
+            "passed": True,
+            "note": "Observed natural decompose failure; error shape OK (no empty topo gate)",
+        }
+
+    assert ts1.get("phase") in ("await_shot_topo_confirm", "await_shot_confirm"), ts1.get("phase")
+    assert len(ts1.get("shotManifest") or []) > 0, "step1 shotManifest empty"
+    count_before = len(ts1.get("shotManifest") or [])
+
+    # Step 2 — revise triggers decompose rerun
+    revise_msg = "调整构图，去掉营销海报，其他保持不变"
+    ts_before = ts1
+    sse2 = sse_turn(tok, sid, tid, revise_msg, ts_before=ts_before)
+    absorb_journey_updates(sse2.get("events") or [])
+    ts2 = thread_state(tok, tid)
+    snap(2, revise_msg, sse2, ts2)
+    assert len(ts2.get("shotManifest") or []) > 0, "revise left shotManifest empty"
+    assert ts2.get("phase") in ("await_shot_topo_confirm", "await_shot_confirm", "decompose_from_ssot"), ts2
+
+    # Step 3 — confirm gen after recovery
+    confirm_msg = "确认构图并开始出图"
+    ts_before = ts2
+    sse3 = sse_turn(tok, sid, tid, confirm_msg, ts_before=ts_before)
+    absorb_journey_updates(sse3.get("events") or [])
+    ts3 = thread_state(tok, tid)
+    snap(3, confirm_msg, sse3, ts3)
+    assert ts3.get("phase") != "error", "confirm after revise should not error"
+    assert ts3.get("phase") in (
+        "await_delivery_confirm",
+        "start_gen",
+        "orchestrate_gen",
+        "collect_gen",
+        "done",
+    ), f"unexpected phase after confirm: {ts3.get('phase')}"
+
+    return {
+        "mode": "revise_recovery",
+        "threadId": tid,
+        "sessionId": sid,
+        "steps": steps,
+        "shot_count_before": count_before,
+        "shot_count_after_revise": len(ts2.get("shotManifest") or []),
+        "passed": True,
+    }
+
+
+def main() -> int:
+    report: dict[str, Any] = {"checks": []}
+
+    local = run_local_pytests()
+    report["local_pytest"] = local
+    report["checks"].append({"name": "local_pytest", "ok": local["ok"]})
+
+    try:
+        try:
+            http("POST", "/auth/send-code", {"phone": PHONE})
+        except Exception:
+            pass
+        tok = http("POST", "/auth/login", {"phone": PHONE, "code": CODE})["data"]["token"]
+        prod = prod_revise_recovery(tok)
+        report["prod_revise_recovery"] = prod
+        report["checks"].append({"name": "prod_revise_recovery", "ok": bool(prod.get("passed"))})
+    except Exception as exc:  # noqa: BLE001
+        report["prod_revise_recovery"] = {"passed": False, "error": str(exc)}
+        report["checks"].append({"name": "prod_revise_recovery", "ok": False, "error": str(exc)})
+
+    report["passed"] = all(c.get("ok") for c in report["checks"])
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUT_PATH.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"\nVerify saved: {OUT_PATH}", flush=True)
+    print(f"Overall: {'PASS' if report['passed'] else 'FAIL'}", flush=True)
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/agent-runtime/tests/test_decompose_failure_recovery.py
+++ b/services/agent-runtime/tests/test_decompose_failure_recovery.py
@@ -1,0 +1,126 @@
+"""Decompose parse failure routing and topo-gate revise recovery."""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from app.graph.nodes.await_shot_topo_confirm import make_await_shot_topo_confirm_node
+from app.graph.nodes.decompose_from_ssot import make_decompose_from_ssot_node
+from app.graph.product_visual_v2.routing import route_after_decompose_from_ssot
+from app.graph.product_visual_v2.journey_trace import build_journey_trace_snapshot
+
+
+class BadLLM:
+    async def ainvoke(self, messages):  # noqa: ANN001, ARG002
+        return type("R", (), {"content": "not valid json at all"})()
+
+
+class FakeNest:
+    async def upsert_prompt_node(self, *, prompt: str, content: str):  # noqa: ARG002
+        return {"nodeId": "prompt-1"}
+
+
+GOOD_SHOT = {
+    "shot_id": "packaging_hero__1",
+    "type_id": "packaging_hero",
+    "label": "主图",
+    "macro_scheme_id": "A",
+    "variant_count": 1,
+    "variant_eligible": False,
+    "shot_prose": "主视觉构图",
+    "refs_policy": {"requires": ["white_bg"], "optional": []},
+}
+
+
+class GoodLLM:
+    async def ainvoke(self, messages):  # noqa: ANN001, ARG002
+        import json
+
+        return type("R", (), {"content": json.dumps({"shots": [GOOD_SHOT]}, ensure_ascii=False)})()
+
+
+@pytest.mark.asyncio
+async def test_decompose_parse_failure_routes_to_done():
+    from pathlib import Path
+
+    from app.config import settings
+
+    node = make_decompose_from_ssot_node(
+        llm=BadLLM(),
+        skills_dir=Path(settings.skills_dir),
+        nest=FakeNest(),
+    )
+    out = await node(
+        {
+            "plan_node_id": "node-ssot-1",
+            "macro_scheme_draft": "方案正文" * 20,
+            "selected_macro_scheme_ids": ["A"],
+            "messages": [HumanMessage(content="大闸蟹 listing")],
+        }
+    )
+    assert out["phase"] == "error"
+    assert out["last_error"] == "decompose_shots_parse_failed"
+    assert route_after_decompose_from_ssot(out) == "done"
+
+
+def test_journey_trace_marks_shot_plan_failed_on_decompose_error():
+    snap = build_journey_trace_snapshot(
+        {"last_error": "decompose_shots_parse_failed"},
+        phase="done",
+    )
+    shot_plan = next(s for s in snap["steps"] if s["id"] == "shot_plan")
+    assert shot_plan["status"] == "failed"
+    assert next(s for s in snap["steps"] if s["id"] == "done")["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_decompose_revise_after_successful_first_pass():
+    from pathlib import Path
+
+    from app.config import settings
+
+    node = make_decompose_from_ssot_node(
+        llm=GoodLLM(),
+        skills_dir=Path(settings.skills_dir),
+        nest=FakeNest(),
+    )
+    base_state = {
+        "plan_node_id": "node-ssot-1",
+        "macro_scheme_draft": "方案正文" * 20,
+        "selected_macro_scheme_ids": ["A"],
+        "messages": [HumanMessage(content="大闸蟹 listing")],
+    }
+    first = await node(base_state)
+    assert first.get("shot_manifest")
+    assert first["phase"] in ("await_shot_topo_confirm", "await_shot_confirm")
+
+    gate = make_await_shot_topo_confirm_node()
+    revise = await gate(
+        {
+            **base_state,
+            "shot_manifest": first["shot_manifest"],
+            "messages": [
+                HumanMessage(content="大闸蟹 listing"),
+                HumanMessage(content="调整构图，去掉营销海报"),
+            ],
+        }
+    )
+    assert revise["phase"] == "decompose_from_ssot"
+
+    second = await node({**base_state, "messages": revise["messages"]})
+    assert second.get("shot_manifest")
+    assert second["phase"] in ("await_shot_topo_confirm", "await_shot_confirm")
+
+
+@pytest.mark.asyncio
+async def test_topo_gate_blocks_confirm_when_manifest_empty():
+    gate = make_await_shot_topo_confirm_node()
+    out = await gate(
+        {
+            "messages": [HumanMessage(content="确认构图并开始出图")],
+            "shot_manifest": [],
+        }
+    )
+    assert out["phase"] == "error"
+    assert out["last_error"] == "shot_manifest_missing"


### PR DESCRIPTION
## Summary
- `prod-crab-listing-audit-batch.py`：连跑 N 轮 E2E 并输出汇总 JSON
- `prod-decompose-failure-recovery-verify.py`：本地 pytest + 生产 revise 重拆解恢复
- `test_decompose_failure_recovery.py`：parse 失败路由 / journey failed / gate 防御

## 生产验证（已跑过）
- batch v10–v14：5/5 全绿
- decompose recovery verify：PASS（revise 6→7 shots → delivery）

## Test plan
- [x] `pytest tests/test_decompose_failure_recovery.py`
- [ ] CI green


Made with [Cursor](https://cursor.com)