### PR TITLE
fix(web): 修复图片节点点击后无法拖拽

### DIFF
--- a/apps/web/src/components/canvas/CanvasNodeImage.vue
+++ b/apps/web/src/components/canvas/CanvasNodeImage.vue
@@ -113,11 +113,11 @@ function saveToLibrary() {
     >
       <div
         v-if="data.url"
-        class="neo-gen-preview nodrag"
+        class="neo-gen-preview"
         title="双击预览大图"
         @dblclick.stop="openPreview"
       >
-        <img :src="displayUrl" alt="" draggable="false">
+        <img :src="displayUrl" alt="" class="pointer-events-none" draggable="false">
         <button
           type="button"
           class="neo-gen-image-preview-btn nodrag"
@@ -173,7 +173,9 @@ function saveToLibrary() {
         </button>
         <button
           type="button"
-          class="absolute bottom-1.5 right-1.5 rounded-xl border-none bg-black/60 px-2.5 py-1 text-[11px] font-medium text-white backdrop-blur-sm transition hover:bg-black/85"
+          class="absolute bottom-1.5 right-1.5 rounded-xl border-none bg-black/60 px-2.5 py-1 text-[11px] font-medium text-white backdrop-blur-sm transition hover:bg-black/85 nodrag"
+          @pointerdown.stop
+          @mousedown.stop
           @click.stop="openEdit"
         >
           编辑


### PR DESCRIPTION
## Summary

- 移除图片预览区 `.neo-gen-preview` 上的 `nodrag`，修复点击图片后无法按住拖动的问题（与视频节点行为对齐）
- `<img>` 使用 `pointer-events-none`，事件由可拖拽父容器接收
- 「编辑」按钮补齐 `nodrag` + mousedown 拦截，避免误触发拖拽

## 根因

Vue Flow 在 mousedown 命中 `.nodrag` 时不启动节点拖拽；图片节点整块预览区误标了 `nodrag`。

## Test plan

- [x] `pnpm build`
- [ ] 画布图片节点：点击图片选中后，按住图片区域可拖动
- [ ] 预览/替换/下载/编辑按钮仍可正常点击


Made with [Cursor](https://cursor.com)