### PR TITLE
fix(web): restore top-right image preview toolbar

### DIFF
--- a/apps/web/src/components/canvas/CanvasNodeImage.vue
+++ b/apps/web/src/components/canvas/CanvasNodeImage.vue
@@ -120,13 +120,13 @@ function saveToLibrary() {
         <img :src="displayUrl" alt="" class="pointer-events-none" draggable="false">
         <button
           type="button"
-          class="neo-gen-image-preview-btn nodrag"
+          class="neo-node-preview-btn nodrag"
           title="预览大图"
           @pointerdown.stop
           @mousedown.stop
           @click.stop="openPreview"
         >
-          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2">
+          <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2">
             <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z" />
             <circle cx="12" cy="12" r="3" />
           </svg>

--- a/apps/web/src/styles/neo-node.css
+++ b/apps/web/src/styles/neo-node.css
@@ -478,34 +478,19 @@
   transform: translate(-50%, -50%) scale(1.05);
 }
 
-.neo-gen-preview .neo-gen-image-preview-btn {
+.neo-gen-preview::after {
+  content: '';
   position: absolute;
-  top: 50%;
-  left: 50%;
-  z-index: 1;
-  display: inline-flex;
-  width: 44px;
-  height: 44px;
-  align-items: center;
-  justify-content: center;
-  border: none;
-  border-radius: 50%;
-  background: rgba(0, 0, 0, 0.55);
-  color: rgba(255, 255, 255, 0.92);
+  inset: 0;
+  z-index: 0;
+  background: rgba(0, 0, 0, 0.06);
   opacity: 0;
-  transform: translate(-50%, -50%);
-  transition: opacity 0.15s ease, background 0.15s ease, transform 0.15s ease;
+  transition: opacity 0.15s ease;
   pointer-events: none;
 }
 
-.neo-gen-preview:hover .neo-gen-image-preview-btn {
+.neo-node-upload-target:hover .neo-gen-preview::after {
   opacity: 1;
-  pointer-events: auto;
-}
-
-.neo-gen-preview .neo-gen-image-preview-btn:hover {
-  background: rgba(0, 0, 0, 0.72);
-  transform: translate(-50%, -50%) scale(1.05);
 }
 
 .neo-gen-video-exit-btn {
@@ -607,15 +592,34 @@
   color: rgba(255, 255, 255, 0.85);
 }
 
+/* 预览按钮：排在存库按钮左侧，与右上工具条同款规格 */
+.neo-node-preview-btn {
+  position: absolute;
+  top: 6px;
+  right: 90px;
+  z-index: 2;
+  display: none;
+  width: 24px;
+  height: 24px;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.55);
+  color: rgba(255, 255, 255, 0.85);
+}
+
 .neo-node-upload-target:hover .neo-node-replace-btn,
 .neo-node-upload-target:hover .neo-node-download-btn,
-.neo-node-upload-target:hover .neo-node-save-btn {
+.neo-node-upload-target:hover .neo-node-save-btn,
+.neo-node-upload-target:hover .neo-node-preview-btn {
   display: inline-flex;
 }
 
 .neo-node-replace-btn:hover,
 .neo-node-download-btn:hover,
-.neo-node-save-btn:hover {
+.neo-node-save-btn:hover,
+.neo-node-preview-btn:hover {
   background: rgba(0, 0, 0, 0.8);
   color: #fff;
 }


### PR DESCRIPTION
## Summary
- 恢复 PR #234 的图片节点预览眼睛按钮：24px 右上角，与存库/下载/替换齐平
- 保留 PR #244 的拖拽修复：预览区无 `nodrag`、`<img>` 使用 `pointer-events-none`、操作按钮保留 `nodrag`
- 移除 PR #240 意外回滚的中央 44px 大 overlay 预览按钮

## Context
PR #240（test 改动）在合并时误把 `neo-node-preview-btn` 改回 `neo-gen-image-preview-btn` 中央布局。本 PR 只恢复 UI 布局，不改变拖拽行为。

## Test plan
- [x] `pnpm build`
- [ ] hover 图片节点：右上角出现预览/存库/下载/替换四个 24px 按钮
- [ ] 点击图片预览区（非按钮）可拖动节点
- [ ] 双击预览区仍可打开大图

Made with [Cursor](https://cursor.com)