### PR TITLE
feat(u-i2v): Wave 0–2b canvas smoke, Phase 3 cleanup, campaign localRefs

### DIFF
--- a/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
@@ -84,12 +84,8 @@ watch(() => props.node, syncFromNode, { immediate: true, deep: true })
 watch(
   () => props.upstream,
   (ctx) => {
-    if (!referenceImageUrl.value.trim() && ctx.referenceImageUrl) {
-      referenceImageUrl.value = ctx.referenceImageUrl
-      emit('patch', { referenceImageUrl: ctx.referenceImageUrl })
-    }
-    if (!props.node.data?.videoMode) {
-      videoMode.value = ctx.referenceImageUrl ? 'image_to_video' : videoMode.value
+    if (!props.node.data?.videoMode && ctx.referenceImageUrl) {
+      videoMode.value = 'image_to_video'
     }
   },
   { immediate: true, deep: true },
@@ -115,8 +111,6 @@ function onGenerate() {
     videoModel: videoModel.value,
     videoSettings: { ...videoSettings.value },
     videoMode: videoMode.value,
-    referenceImageUrl:
-      videoMode.value === 'image_to_video' ? (effectiveRefUrl.value || undefined) : undefined,
   })
   emit('generate')
 }
@@ -126,7 +120,15 @@ function continueFromLastFrame() {
   if (!url) return
   referenceImageUrl.value = url
   videoMode.value = 'image_to_video'
-  emit('patch', { referenceImageUrl: url, videoMode: 'image_to_video' })
+  const binding: LocalRefBinding = {
+    id: createLocalRefId('last-frame'),
+    mediaType: 'image',
+    sourceKind: 'upload',
+    label: '上一镜末帧',
+    url,
+  }
+  const prev = (props.node.data?.localRefs as LocalRefBinding[]) ?? []
+  emit('patch', { localRefs: [...prev, binding], videoMode: 'image_to_video' })
 }
 
 function toggleVoice() {
@@ -182,7 +184,6 @@ async function onRefFileChange(event: Event) {
     const prev = (props.node.data?.localRefs as LocalRefBinding[]) ?? []
     emit('patch', {
       localRefs: [...prev, binding],
-      referenceImageUrl: url,
       videoMode: 'image_to_video',
     })
   } catch (err) {
@@ -198,7 +199,11 @@ async function onRefFileChange(event: Event) {
 function clearReferenceImage() {
   referenceImageUrl.value = ''
   videoMode.value = 'text_to_video'
-  emit('patch', { referenceImageUrl: '', videoMode: 'text_to_video' })
+  const prev = (props.node.data?.localRefs as LocalRefBinding[]) ?? []
+  emit('patch', {
+    localRefs: prev.filter((r) => r.mediaType !== 'image'),
+    videoMode: 'text_to_video',
+  })
 }
 
 function onRefReorder(refIds: string[]) {

--- a/apps/web/src/composables/useNodeGeneration.test.ts
+++ b/apps/web/src/composables/useNodeGeneration.test.ts
@@ -701,6 +701,36 @@ describe('useNodeGeneration', () => {
     )
   })
 
+  it('canvas video start does not patch referenceImageUrl', async () => {
+    const node = createNode('video', {
+      prompt: 'motion',
+      videoSettings: { duration: 15, aspectRatio: '16:9', resolution: '720p', crop: 'none' },
+      localRefs: [
+        { id: 'r1', mediaType: 'image', sourceKind: 'upload', label: 'ref', url: 'https://example.com/ref.png' },
+      ],
+    })
+    const { api, deps } = createDeps([node])
+    vi.mocked(studioApi.startVideoGeneration).mockResolvedValue(
+      mockAxiosResponse({
+        data: {
+          ...completedRecord,
+          type: 'video',
+          id: 'rec-video-1',
+          status: 'generating',
+          generationStartedAt: '2026-08-14T12:00:00.000Z',
+        },
+      }),
+    )
+
+    await api.generateForNode(node)
+
+    expect(studioApi.startVideoGeneration).toHaveBeenCalled()
+    const patchCalls = vi.mocked(deps.patchNodeData).mock.calls
+    const finalPatch = patchCalls[patchCalls.length - 1]?.[1] as Record<string, unknown> | undefined
+    expect(finalPatch?.referenceImageUrl).toBeUndefined()
+    expect(finalPatch?.generationRecordId).toBe('rec-video-1')
+  })
+
   it('passes shot-linked video child params to canvasApi.generateVideo', async () => {
     const shot = createNode('shot', { title: 'Shot', prompt: 'motion' }, 'shot-1')
     const video = createNode('video', {

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -748,7 +748,7 @@ async function cancelRemoteGeneration(nodeId: string) {
       mentionedKeys,
       settings?.resolution,
       settings?.crop,
-      refImage || undefined,
+      undefined,
       signal,
       canvasScope(node.id),
       videoMode,
@@ -760,7 +760,6 @@ async function cancelRemoteGeneration(nodeId: string) {
         ? res.data.generationStartedAt
         : startedAtPatch().generationStartedAt
     deps.patchNodeData(node.id, {
-      referenceImageUrl: refImage || undefined,
       generationRecordId: res.data.id,
       generationStartedAt: startedAt,
     })

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -1559,7 +1559,7 @@ function previewPatchForLocalRef(
   url: string,
 ): Record<string, unknown> {
   if (mediaType === 'image' && nodeType === 'image') return { url, status: 'completed' }
-  if (mediaType === 'image' && nodeType === 'video') return { referenceImageUrl: url }
+  if (mediaType === 'image' && nodeType === 'video') return { videoMode: 'image_to_video' }
   if (mediaType === 'video' && nodeType === 'video') return { url, status: 'completed' }
   if (mediaType === 'audio' && nodeType === 'audio') return { url, status: 'completed' }
   // audio → video：仅作引用芯片，不覆盖成片 url

--- a/deploy/prod-canvas-i2v-video-verify.py
+++ b/deploy/prod-canvas-i2v-video-verify.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Production verify: Canvas dock paths 1 & 2 → 15s video (U-I2V Wave 0).
+
+Path 1 — upload/localRefs: video node with localRefs → POST /studio/video/start
+Path 2 — upstream edge: image node + edge → video node → start
+
+Checks (each path):
+  - start response has generationRecordId + generationStartedAt
+  - generation record poll reaches completed|generating|fallback_pending
+
+Usage:
+  python3 deploy/prod-canvas-i2v-video-verify.py
+  GEN_POLL_SEC=120 python3 deploy/prod-canvas-i2v-video-verify.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import uuid
+from typing import Any
+from urllib.request import Request, urlopen
+
+BASE = os.environ.get("BASE_URL", "http://119.29.173.89:8888").rstrip("/")
+API = f"{BASE}/api"
+PHONE = os.environ.get("PHONE", "17279698608")
+CODE = os.environ.get("CODE", "123456")
+GEN_POLL_SEC = float(os.environ.get("GEN_POLL_SEC", "90"))
+REF_URL = os.environ.get(
+    "I2V_REF_URL",
+    "https://picsum.photos/seed/lnkpi-canvas-i2v/768/768",
+)
+
+PASS = FAIL = 0
+
+
+def record(case: str, ok: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if ok:
+        PASS += 1
+        icon = "✅"
+    else:
+        FAIL += 1
+        icon = "❌"
+    line = f"{icon} {case}"
+    if detail:
+        line += f" — {detail[:240]}"
+    print(line)
+
+
+def http(m: str, p: str, b: dict | None = None, t: str | None = None) -> Any:
+    h = {"Content-Type": "application/json", "Accept": "application/json"}
+    if t:
+        h["Authorization"] = f"Bearer {t}"
+    r = Request(f"{API}{p}", data=None if b is None else json.dumps(b).encode(), headers=h, method=m)
+    with urlopen(r, timeout=120) as resp:
+        return json.loads(resp.read())
+
+
+def put_canvas(tok: str, sid: str, nodes: list[dict], edges: list[dict]) -> None:
+    sess = http("GET", f"/sessions/{sid}", t=tok)["data"]
+    canvas = sess.get("canvasData") or {"nodes": [], "edges": [], "viewport": {"x": 0, "y": 0, "zoom": 1}}
+    patch = {
+        "nodes": nodes,
+        "edges": edges,
+        "viewport": canvas.get("viewport") or {"x": 0, "y": 0, "zoom": 1},
+    }
+    http("PUT", f"/sessions/{sid}", {"canvasData": patch}, t=tok)
+
+
+def start_video(
+    tok: str,
+    *,
+    sid: str,
+    node_id: str,
+    prompt: str,
+) -> dict[str, Any]:
+    body = {
+        "prompt": prompt,
+        "duration": 15,
+        "aspectRatio": "16:9",
+        "resolution": "720p",
+        "crop": "none",
+        "videoMode": "image_to_video",
+        "sessionId": sid,
+        "nodeId": node_id,
+    }
+    return http("POST", "/studio/video/start", body, t=tok)["data"]
+
+
+def poll_generation(tok: str, record_id: str) -> str | None:
+    terminal = None
+    deadline = time.time() + GEN_POLL_SEC
+    while time.time() < deadline:
+        try:
+            rec = http("GET", f"/studio/generations/{record_id}", t=tok)["data"]
+            terminal = str(rec.get("status") or "")
+            if terminal in ("completed", "failed", "error", "fallback_pending", "timeout"):
+                return terminal
+        except Exception as exc:  # noqa: BLE001
+            record("Poll generation record", False, str(exc))
+            return None
+        time.sleep(5)
+    return terminal
+
+
+def verify_path(tok: str, label: str, nodes: list[dict], edges: list[dict], video_id: str) -> None:
+    sid = http("POST", "/sessions", {"title": f"canvas-i2v-{label}-{int(time.time())}"}, t=tok)["data"]["id"]
+    put_canvas(tok, sid, nodes, edges)
+
+    prompt = f"U-I2V canvas {label} 产品展示 15秒"
+    try:
+        data = start_video(tok, sid=sid, node_id=video_id, prompt=prompt)
+    except Exception as exc:  # noqa: BLE001
+        record(f"{label}: video/start", False, str(exc))
+        return
+
+    record_id = str(data.get("id") or "")
+    started_at = data.get("generationStartedAt")
+    record(
+        f"{label}: start returns recordId",
+        bool(record_id.strip()),
+        f"id={record_id}",
+    )
+    record(
+        f"{label}: start returns generationStartedAt",
+        isinstance(started_at, str) and bool(str(started_at).strip()),
+        f"startedAt={started_at}",
+    )
+
+    if not record_id:
+        return
+
+    terminal = poll_generation(tok, record_id)
+    record(
+        f"{label}: generation poll ({GEN_POLL_SEC}s cap)",
+        terminal in ("completed", "generating", "fallback_pending"),
+        f"status={terminal}",
+    )
+    if terminal == "completed":
+        rec = http("GET", f"/studio/generations/{record_id}", t=tok)["data"]
+        record(f"{label}: video URL present", bool(rec.get("url")), str(rec.get("url") or "")[:80])
+
+
+def main() -> int:
+    print("=== U-I2V production verify (Canvas path1 upload + path2 edge) ===")
+    print(f"BASE={BASE}\n")
+
+    try:
+        http("POST", "/auth/send-code", {"phone": PHONE})
+    except Exception:
+        pass
+    try:
+        tok = http("POST", "/auth/login", {"phone": PHONE, "code": CODE})["data"]["token"]
+        record("Login", True)
+    except Exception as exc:  # noqa: BLE001
+        record("Login", False, str(exc))
+        return 1
+
+    ts = int(time.time())
+    video_local = f"video-local-{ts}"
+    verify_path(
+        tok,
+        "path1-localRefs",
+        [
+            {
+                "id": video_local,
+                "type": "video",
+                "position": {"x": 400, "y": 300},
+                "data": {
+                    "prompt": "产品展示",
+                    "status": "draft",
+                    "videoSettings": {"duration": 15, "aspectRatio": "16:9", "resolution": "720p", "crop": "none"},
+                    "videoMode": "image_to_video",
+                    "localRefs": [
+                        {
+                            "id": f"upload-{uuid.uuid4().hex[:8]}",
+                            "mediaType": "image",
+                            "sourceKind": "upload",
+                            "label": "ref.jpg",
+                            "url": REF_URL,
+                        }
+                    ],
+                },
+            }
+        ],
+        [],
+        video_local,
+    )
+
+    video_edge = f"video-edge-{ts}"
+    image_up = f"image-up-{ts}"
+    verify_path(
+        tok,
+        "path2-edge",
+        [
+            {
+                "id": image_up,
+                "type": "image",
+                "position": {"x": 100, "y": 300},
+                "data": {"url": REF_URL, "status": "completed"},
+            },
+            {
+                "id": video_edge,
+                "type": "video",
+                "position": {"x": 400, "y": 300},
+                "data": {
+                    "prompt": "产品展示",
+                    "status": "draft",
+                    "videoSettings": {"duration": 15, "aspectRatio": "16:9", "resolution": "720p", "crop": "none"},
+                    "videoMode": "image_to_video",
+                },
+            },
+        ],
+        [{"id": f"edge-{ts}", "source": image_up, "target": video_edge}],
+        video_edge,
+    )
+
+    print(f"\n=== Summary: PASS={PASS} FAIL={FAIL} ===")
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/prod-sidebar-attachments-verify.py
+++ b/deploy/prod-sidebar-attachments-verify.py
@@ -383,20 +383,22 @@ def verify_campaign_attach_edges(tok: str) -> None:
 
     canvas = canvas_data(tok, sid)
     nodes = canvas.get("nodes") or []
-    media_inputs = [n for n in nodes if n.get("type") == "mediaInput"]
-    seed_node, media_sources = _seed_image_with_media_edges(canvas)
-    ref_url_ok = any(
-        str((n.get("data") or {}).get("url") or "") == MOCK_REF_URL for n in media_inputs
+    seed_node = next(
+        (
+            n
+            for n in nodes
+            if n.get("type") == "image"
+            and any(str((r or {}).get("url") or "") == MOCK_REF_URL for r in ((n.get("data") or {}).get("localRefs") or []) if isinstance(r, dict))
+        ),
+        None,
     )
+    seed_data = (seed_node or {}).get("data") or {}
+    local_refs = seed_data.get("localRefs") or []
+    ref_url_ok = any(str(r.get("url") or "") == MOCK_REF_URL for r in local_refs if isinstance(r, dict))
     record(
-        "campaign mediaInput materialized",
-        len(media_inputs) >= 1 and ref_url_ok,
-        f"mediaInput={len(media_inputs)} exit1={exit1}",
-    )
-    record(
-        "campaign seed image has ref edges",
-        seed_node is not None and len(media_sources) >= 1,
-        f"seed={seed_node.get('id') if seed_node else None} sources={media_sources[:3]}",
+        "campaign seed image localRefs",
+        seed_node is not None and len(local_refs) >= 1 and ref_url_ok,
+        f"seed={seed_node.get('id') if seed_node else None} refs={len(local_refs)} exit1={exit1}",
     )
 
 

--- a/docs/superpowers/specs/2026-08-14-unified-image-to-video-pipeline-design.md
+++ b/docs/superpowers/specs/2026-08-14-unified-image-to-video-pipeline-design.md
@@ -1,7 +1,7 @@
 # 统一图生视频管线（Unified I2V Pipeline）产品与技术规格
 
-> 状态：**规格已定 / 待开发**  
-> 日期：2026-08-14  
+> 状态：**P0–P2 已上线（PR #246）· P3/Wave 1–2 进行中**  
+> 日期：2026-08-14 · 更新：2026-08-14  
 > 范围：将画布三种图生视频入口（节点内引图、上游连线、Agent 侧栏芯片）收敛为 **同一套语义模型 + 同一套 async 生成编排**；新增显式中间层 `RefBinding → CanonicalRefs → VideoGenerationOrchestrator`  
 > 前置：`2026-07-18-node-data-flow-refs-design.md`（refs SSOT）、`2026-08-08-seedance-agnes-video-adapter-design.md`（provider adapter）、`fix/agent-video-generation-polling` 分支热修（start/wait 拆分 + 660s 轮询）  
 > 后续：Campaign `attach_edges` 收敛（Phase 2）、`referenceImageUrl` 字段退役（Phase 3）
@@ -339,7 +339,7 @@ Internal 与 Studio 公开 API **共用** 同一 Orchestrator 实例。
 | 阶段 | atomic-create | campaign |
 |---|---|---|
 | Phase 1 | `localRefs` | 保持 `attach_edges` |
-| Phase 2 | — | 评估迁移至 `localRefs` 或统一 `attach_edges` + 文档化 |
+| Phase 2 | — | ✅ 迁移至 `localRefs`（Wave 2b） |
 
 ---
 
@@ -409,10 +409,11 @@ Internal 与 Studio 公开 API **共用** 同一 Orchestrator 实例。
 
 | Phase | 内容 | 产出 |
 |---|---|---|
-| **P0 热修** | start/wait split、660s poll、recordId、startedAt merge | ✅ 分支 `fix/agent-video-generation-polling` |
-| **P1 Orchestrator** | 抽出 `VideoGenerationOrchestrator` + `resolveCanonicalVideoRequest` | ✅ 本分支 |
-| **P2 画布接入** | `studio/video/start` + web 改 async | ✅ 本分支 |
-| **P3 清理** | 停写 `referenceImageUrl`；deprecated 一站式 generateVideo | 文档 + lint 规则 |
+| **P0 热修** | start/wait split、660s poll、recordId、startedAt merge | ✅ PR #246 |
+| **P1 Orchestrator** | 抽出 `VideoGenerationOrchestrator` + `resolveCanonicalVideoRequest` | ✅ PR #246 |
+| **P2 画布接入** | `studio/video/start` + web 改 async | ✅ PR #246 |
+| **P3 清理** | 停写 `referenceImageUrl`；deprecated 一站式 generateVideo | 🚧 Wave 1 |
+| **Phase 2 Campaign** | `attach_edges` → `localRefs` 收敛 | 🚧 Wave 2 |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "pnpm -r build",
     "lint": "pnpm -r lint",
     "test": "pnpm -r --if-present test",
-    "verify-contract": "npx tsx scripts/verify-contract.ts"
+    "verify-contract": "npx tsx scripts/verify-contract.ts",
+    "verify-u-i2v-phase3": "npx tsx scripts/verify-u-i2v-phase3.ts"
   },
   "devDependencies": {
     "tsx": "^4.7.0",

--- a/packages/shared/src/nodeRefs.ts
+++ b/packages/shared/src/nodeRefs.ts
@@ -67,6 +67,21 @@ function resolveUrlPayload(data: Record<string, unknown>): string {
   return trimString(data.url)
 }
 
+function resolveImageUrlFromNode(data: Record<string, unknown>): string {
+  const direct = resolveUrlPayload(data)
+  if (direct) return direct
+  const localRefs = data.localRefs
+  if (!Array.isArray(localRefs)) return ''
+  for (const item of localRefs) {
+    if (!item || typeof item !== 'object') continue
+    const binding = item as LocalRefBinding
+    if (binding.mediaType !== 'image') continue
+    const url = trimString(binding.url)
+    if (url) return url
+  }
+  return ''
+}
+
 function resolveEdgeRef(
   edge: { id: string; source: string; target: string },
   sourceNode: { id: string; type?: string; data?: Record<string, unknown> },
@@ -91,7 +106,7 @@ function resolveEdgeRef(
   }
 
   if (type === 'image' || type === 'mediaInput') {
-    const url = resolveUrlPayload(data)
+    const url = resolveImageUrlFromNode(data)
     return {
       refId,
       mediaType: 'image',

--- a/packages/shared/src/videoGeneration/resolveCanonicalVideoRequest.test.ts
+++ b/packages/shared/src/videoGeneration/resolveCanonicalVideoRequest.test.ts
@@ -1,5 +1,6 @@
 /** @vitest-environment node */
 import { describe, expect, it } from 'vitest'
+import type { CanvasData } from '../index'
 import { resolveCanonicalVideoRequest } from './resolveCanonicalVideoRequest'
 
 const IMG = 'https://cdn.example/ref.png'
@@ -77,6 +78,73 @@ describe('resolveCanonicalVideoRequest', () => {
     })
     expect(req.refs[0].url).toBe(IMG)
     expect(req.mentionedKeys).toEqual(['I1'])
+  })
+
+  it('path3b: campaign mediaInput edge → same canonical url as localRefs', () => {
+    const localReq = resolveCanonicalVideoRequest({
+      node: {
+        ...baseVideoNode,
+        data: {
+          ...baseVideoNode.data,
+          localRefs: [
+            { id: 'a1', mediaType: 'image', sourceKind: 'upload', label: '图', url: IMG },
+          ],
+        },
+      },
+      canvas: { nodes: [baseVideoNode], edges: [] },
+    })
+    const edgeReq = resolveCanonicalVideoRequest({
+      node: baseVideoNode,
+      canvas: {
+        nodes: [
+          baseVideoNode,
+          {
+            id: 'm1',
+            type: 'mediaInput',
+            position: { x: 0, y: 0 },
+            data: { url: IMG, mediaKind: 'image' },
+          },
+        ],
+        edges: [{ id: 'e1', source: 'm1', target: 'v1' }],
+      } as CanvasData,
+    })
+    expect(edgeReq.refs[0].url).toBe(IMG)
+    expect(edgeReq.refs.map((r) => r.url)).toEqual(localReq.refs.map((r) => r.url))
+    expect(edgeReq.videoMode).toBe(localReq.videoMode)
+  })
+
+  it('path3c: seed image localRefs (campaign target) → same I1 url', () => {
+    const imageSeed = {
+      id: 'seed-1',
+      type: 'image' as const,
+      position: { x: 0, y: 0 },
+      data: {
+        localRefs: [
+          { id: 'brand', mediaType: 'image', sourceKind: 'upload', label: 'brand.jpg', url: IMG },
+        ],
+      },
+    }
+    const req = resolveCanonicalVideoRequest({
+      node: {
+        id: 'v1',
+        type: 'video',
+        position: { x: 280, y: 0 },
+        data: { prompt: '产品展示', videoSettings: { duration: 15 } },
+      },
+      canvas: {
+        nodes: [
+          imageSeed,
+          {
+            id: 'v1',
+            type: 'video',
+            position: { x: 280, y: 0 },
+            data: { prompt: '产品展示', videoSettings: { duration: 15 } },
+          },
+        ],
+        edges: [{ id: 'e1', source: 'seed-1', target: 'v1' }],
+      },
+    })
+    expect(req.refs[0].url).toBe(IMG)
   })
 
   it('falls back to account defaults for missing videoSettings', () => {

--- a/scripts/verify-u-i2v-phase3.ts
+++ b/scripts/verify-u-i2v-phase3.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env npx tsx
+/**
+ * U-I2V Phase 3 guard: video upload paths must not write referenceImageUrl.
+ *
+ * Exit 0 = OK, 1 = forbidden write pattern found.
+ */
+
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const ROOT = join(import.meta.dirname, '..')
+
+const FILES: Array<{ path: string; forbidden: RegExp[] }> = [
+  {
+    path: 'apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue',
+    forbidden: [
+      /emit\s*\(\s*['"]patch['"]\s*,\s*\{[^}]*referenceImageUrl/s,
+    ],
+  },
+  {
+    path: 'apps/web/src/pages/CanvasPage.vue',
+    forbidden: [
+      /nodeType === 'video'\)\s*return\s*\{\s*referenceImageUrl:/,
+    ],
+  },
+  {
+    path: 'apps/web/src/composables/useNodeGeneration.ts',
+    forbidden: [
+      /startVideoGeneration\([\s\S]{0,500}?refImage/s,
+      /startVideoGeneration[\s\S]{0,800}patchNodeData\(node\.id, \{[\s\S]{0,200}referenceImageUrl/s,
+    ],
+  },
+]
+
+let failed = false
+
+for (const { path, forbidden } of FILES) {
+  const full = join(ROOT, path)
+  const src = readFileSync(full, 'utf8')
+  for (const re of forbidden) {
+    if (re.test(src)) {
+      console.error(`❌ ${path}: forbidden referenceImageUrl write pattern: ${re}`)
+      failed = true
+    }
+  }
+}
+
+if (failed) {
+  process.exit(1)
+}
+
+console.log('✅ U-I2V Phase 3: no forbidden referenceImageUrl writes in video paths')
+process.exit(0)

--- a/services/agent-runtime/app/graph/nodes/apply_sidebar_refs.py
+++ b/services/agent-runtime/app/graph/nodes/apply_sidebar_refs.py
@@ -1,3 +1,5 @@
+"""Campaign sidebar attachments — seed nodes use localRefs (U-I2V Wave 2b)."""
+
 from __future__ import annotations
 
 from typing import Any, Callable
@@ -49,16 +51,12 @@ def make_apply_sidebar_refs_node(*, nest: Any) -> Callable:
                 )
             return {}
 
-        result = await apply_fn(
+        await apply_fn(
             node_ids=[target_id],
             attachments=attachments,
             ref_order=state.get("sidebar_ref_order"),
-            mode="attach_edges",
+            mode="localRefs",
         )
-        source_ids = result.get("sourceNodeIds") or []
-        attach_fn = getattr(nest, "attach_refs", None)
-        if source_ids and attach_fn is not None:
-            await attach_fn(target_id, [str(node_id) for node_id in source_ids])
         return {}
 
     return apply_sidebar_refs

--- a/services/agent-runtime/app/graph/phase1_seed.py
+++ b/services/agent-runtime/app/graph/phase1_seed.py
@@ -86,12 +86,8 @@ async def _apply_sidebar_to_seed(nest: Any, state: dict, seed_node_id: str) -> N
         node_ids=[seed_node_id],
         attachments=attachments,
         ref_order=state.get("sidebar_ref_order"),
-        mode="attach_edges",
+        mode="localRefs",
     )
-    source_ids = result.get("sourceNodeIds") or []
-    attach_fn = getattr(nest, "attach_refs", None)
-    if source_ids and attach_fn is not None:
-        await attach_fn(seed_node_id, [str(node_id) for node_id in source_ids])
 
 
 def _is_gen_success(result: Any) -> bool:

--- a/services/agent-runtime/tests/test_campaign_sidebar_refs.py
+++ b/services/agent-runtime/tests/test_campaign_sidebar_refs.py
@@ -1,4 +1,4 @@
-"""Campaign sidebar attachments are materialized as visible canvas references."""
+"""Campaign sidebar attachments use localRefs on seed nodes (U-I2V Wave 2b)."""
 
 from __future__ import annotations
 
@@ -32,7 +32,7 @@ class FakeNest:
                 },
             )
         )
-        return {"sourceNodeIds": ["media-brand"]}
+        return {"sourceNodeIds": []}
 
     async def attach_refs(self, node_id: str, ref_order: list[str]) -> dict[str, Any]:
         self.calls.append(("attach_refs", {"node_id": node_id, "ref_order": ref_order}))
@@ -40,7 +40,7 @@ class FakeNest:
 
 
 @pytest.mark.asyncio
-async def test_campaign_apply_attaches_sidebar_sources_to_seed_node():
+async def test_campaign_apply_writes_local_refs_on_seed_node():
     nest = FakeNest()
     apply_sidebar_refs = make_apply_sidebar_refs_node(nest=nest)
     attachments = [
@@ -77,10 +77,9 @@ async def test_campaign_apply_attaches_sidebar_sources_to_seed_node():
                 "node_ids": ["image-seed"],
                 "attachments": attachments,
                 "ref_order": ["brand"],
-                "mode": "attach_edges",
+                "mode": "localRefs",
             },
         ),
-        ("attach_refs", {"node_id": "image-seed", "ref_order": ["media-brand"]}),
     ]
 
 


### PR DESCRIPTION
## Summary
- **Wave 0**: 新增 `deploy/prod-canvas-i2v-video-verify.py`，生产验证画布 path1（localRefs）与 path2（edge）video/start 返回 recordId + startedAt（7/7 PASS）
- **Wave 1 (Phase 3)**: 视频路径停写 `referenceImageUrl`（VideoDockPanel / useNodeGeneration / CanvasPage）；新增 `pnpm verify-u-i2v-phase3` 防回归
- **Wave 2a**: `resolveNodeRefs` edge 引用继承上游节点 `localRefs` 图片 URL；扩展 canonical 等价单测
- **Wave 2b**: Campaign `apply_sidebar_refs` + Phase1 seed 从 `attach_edges` 迁移至 `localRefs`
- 更新 U-I2V 规格文档 Phase 状态

## Test plan
- [x] `pnpm verify-u-i2v-phase3`
- [x] `pnpm build`
- [x] `vitest` shared canonical + web useNodeGeneration + server sidebar tests
- [x] `pytest tests/test_campaign_sidebar_refs.py`
- [x] 生产 smoke: `python3 deploy/prod-canvas-i2v-video-verify.py` (7/7)


Made with [Cursor](https://cursor.com)