### PR TITLE
feat: Media Inspector P0 + video ref preflight

### DIFF
--- a/apps/server/src/media/media-probe.module.ts
+++ b/apps/server/src/media/media-probe.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common'
+import { MediaProbeService } from './media-probe.service'
+
+@Module({
+  providers: [MediaProbeService],
+  exports: [MediaProbeService],
+})
+export class MediaProbeModule {}

--- a/apps/server/src/media/media-probe.service.test.ts
+++ b/apps/server/src/media/media-probe.service.test.ts
@@ -1,0 +1,155 @@
+import 'reflect-metadata'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Test } from '@nestjs/testing'
+import {
+  MediaProbeService,
+  parseJpegDimensions,
+  parsePngDimensions,
+} from './media-probe.service'
+
+function buildPngBuffer(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(33)
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(buf, 0)
+  buf.writeUInt32BE(13, 8)
+  buf.write('IHDR', 12)
+  buf.writeUInt32BE(width, 16)
+  buf.writeUInt32BE(height, 20)
+  return buf
+}
+
+function buildJpegBuffer(width: number, height: number): Buffer {
+  const buf = Buffer.alloc(20)
+  buf[0] = 0xff
+  buf[1] = 0xd8
+  buf[2] = 0xff
+  buf[3] = 0xc0
+  buf.writeUInt16BE(11, 4)
+  buf[6] = 8
+  buf.writeUInt16BE(height, 7)
+  buf.writeUInt16BE(width, 9)
+  return buf
+}
+
+describe('parsePngDimensions', () => {
+  it('reads width and height from IHDR chunk', () => {
+    expect(parsePngDimensions(buildPngBuffer(640, 480))).toEqual({ width: 640, height: 480 })
+  })
+
+  it('returns null for invalid signature', () => {
+    expect(parsePngDimensions(Buffer.from('not-a-png'))).toBeNull()
+  })
+})
+
+describe('parseJpegDimensions', () => {
+  it('reads width and height from SOF0 marker', () => {
+    expect(parseJpegDimensions(buildJpegBuffer(1920, 1080))).toEqual({ width: 1920, height: 1080 })
+  })
+
+  it('returns null for invalid signature', () => {
+    expect(parseJpegDimensions(Buffer.from('not-a-jpeg'))).toBeNull()
+  })
+})
+
+describe('MediaProbeService.probeUrl', () => {
+  let service: MediaProbeService
+  const fetchMock = vi.fn()
+
+  beforeEach(async () => {
+    vi.stubGlobal('fetch', fetchMock)
+    fetchMock.mockReset()
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [MediaProbeService],
+    }).compile()
+    service = moduleRef.get(MediaProbeService)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('probes image url with HEAD metadata and partial GET for dimensions', async () => {
+    const pngBody = buildPngBuffer(800, 600)
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({
+          'content-type': 'image/png',
+          'content-length': '12345',
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 206,
+        statusText: 'Partial Content',
+        arrayBuffer: async () => pngBody.buffer.slice(pngBody.byteOffset, pngBody.byteOffset + pngBody.byteLength),
+      })
+
+    const result = await service.probeUrl('https://cdn.example/a.png')
+
+    expect(result).toEqual({
+      url: 'https://cdn.example/a.png',
+      probeStatus: 'ok',
+      mimeType: 'image/png',
+      bytes: 12345,
+      width: 800,
+      height: 600,
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ method: 'HEAD' })
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({
+      method: 'GET',
+      headers: { Range: 'bytes=0-65535' },
+    })
+  })
+
+  it('returns failed when HEAD is not ok', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      headers: new Headers(),
+    })
+
+    const result = await service.probeUrl('https://cdn.example/missing.png')
+
+    expect(result.probeStatus).toBe('failed')
+    expect(result.probeError).toBe('HEAD 404 Not Found')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns failed when fetch throws', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network timeout'))
+
+    const result = await service.probeUrl('https://cdn.example/timeout.png')
+
+    expect(result.probeStatus).toBe('failed')
+    expect(result.probeError).toBe('network timeout')
+  })
+
+  it('probes non-image url with bytes and mime only', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({
+        'content-type': 'video/mp4',
+        'content-length': '999999',
+      }),
+    })
+
+    const result = await service.probeUrl('https://cdn.example/a.mp4')
+
+    expect(result).toEqual({
+      url: 'https://cdn.example/a.mp4',
+      probeStatus: 'ok',
+      mimeType: 'video/mp4',
+      bytes: 999999,
+      width: undefined,
+      height: undefined,
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/server/src/media/media-probe.service.ts
+++ b/apps/server/src/media/media-probe.service.ts
@@ -1,0 +1,175 @@
+import { Injectable } from '@nestjs/common'
+import type { ProbedMediaFile } from '@lnkpi/shared'
+
+const PROBE_TIMEOUT_MS = 10_000
+const IMAGE_PROBE_BYTES = 64 * 1024
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+
+function isImageMimeType(mimeType?: string): boolean {
+  return mimeType?.startsWith('image/') ?? false
+}
+
+export function parsePngDimensions(buf: Buffer): { width: number; height: number } | null {
+  if (buf.length < 24 || !buf.subarray(0, 8).equals(PNG_SIGNATURE)) {
+    return null
+  }
+  if (buf.subarray(12, 16).toString('ascii') !== 'IHDR') {
+    return null
+  }
+  const width = buf.readUInt32BE(16)
+  const height = buf.readUInt32BE(20)
+  if (width <= 0 || height <= 0) {
+    return null
+  }
+  return { width, height }
+}
+
+function isJpegSofMarker(marker: number): boolean {
+  return (
+    (marker >= 0xc0 && marker <= 0xc3) ||
+    (marker >= 0xc5 && marker <= 0xc7) ||
+    (marker >= 0xc9 && marker <= 0xcb) ||
+    (marker >= 0xcd && marker <= 0xcf)
+  )
+}
+
+export function parseJpegDimensions(buf: Buffer): { width: number; height: number } | null {
+  if (buf.length < 4 || buf[0] !== 0xff || buf[1] !== 0xd8) {
+    return null
+  }
+
+  let i = 2
+  while (i < buf.length - 1) {
+    if (buf[i] !== 0xff) {
+      i++
+      continue
+    }
+
+    const marker = buf[i + 1]
+    if (marker === 0xff) {
+      i++
+      continue
+    }
+
+    if (isJpegSofMarker(marker)) {
+      if (i + 9 >= buf.length) {
+        return null
+      }
+      const height = buf.readUInt16BE(i + 5)
+      const width = buf.readUInt16BE(i + 7)
+      if (width <= 0 || height <= 0) {
+        return null
+      }
+      return { width, height }
+    }
+
+    if (marker === 0xd8 || marker === 0xd9) {
+      i += 2
+      continue
+    }
+
+    if (i + 3 >= buf.length) {
+      return null
+    }
+    const segmentLength = buf.readUInt16BE(i + 2)
+    if (segmentLength < 2) {
+      return null
+    }
+    i += 2 + segmentLength
+  }
+
+  return null
+}
+
+function parseImageDimensions(buf: Buffer, mimeType?: string): { width: number; height: number } | null {
+  if (mimeType === 'image/png' || buf.subarray(0, 8).equals(PNG_SIGNATURE)) {
+    return parsePngDimensions(buf)
+  }
+  if (mimeType === 'image/jpeg' || mimeType === 'image/jpg' || (buf[0] === 0xff && buf[1] === 0xd8)) {
+    return parseJpegDimensions(buf)
+  }
+  return parsePngDimensions(buf) ?? parseJpegDimensions(buf)
+}
+
+function parseContentLength(header: string | null): number | undefined {
+  if (!header) {
+    return undefined
+  }
+  const parsed = Number.parseInt(header, 10)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined
+}
+
+@Injectable()
+export class MediaProbeService {
+  async probeUrl(url: string): Promise<ProbedMediaFile> {
+    const base: ProbedMediaFile = { url, probeStatus: 'pending' }
+
+    try {
+      const signal = AbortSignal.timeout(PROBE_TIMEOUT_MS)
+      const headResponse = await fetch(url, { method: 'HEAD', signal, redirect: 'follow' })
+
+      if (!headResponse.ok) {
+        return {
+          ...base,
+          probeStatus: 'failed',
+          probeError: `HEAD ${headResponse.status} ${headResponse.statusText}`,
+        }
+      }
+
+      const mimeType = headResponse.headers.get('content-type')?.split(';')[0]?.trim() || undefined
+      const bytes = parseContentLength(headResponse.headers.get('content-length'))
+
+      let width: number | undefined
+      let height: number | undefined
+
+      if (isImageMimeType(mimeType)) {
+        const getResponse = await fetch(url, {
+          method: 'GET',
+          signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+          redirect: 'follow',
+          headers: { Range: `bytes=0-${IMAGE_PROBE_BYTES - 1}` },
+        })
+
+        if (!getResponse.ok && getResponse.status !== 206) {
+          return {
+            ...base,
+            mimeType,
+            bytes,
+            probeStatus: 'failed',
+            probeError: `GET ${getResponse.status} ${getResponse.statusText}`,
+          }
+        }
+
+        const body = Buffer.from(await getResponse.arrayBuffer())
+        const dimensions = parseImageDimensions(body, mimeType)
+        if (!dimensions) {
+          return {
+            ...base,
+            mimeType,
+            bytes,
+            probeStatus: 'failed',
+            probeError: 'Unable to parse image dimensions',
+          }
+        }
+        width = dimensions.width
+        height = dimensions.height
+      }
+
+      return {
+        url,
+        probeStatus: 'ok',
+        mimeType,
+        bytes,
+        width,
+        height,
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      return {
+        ...base,
+        probeStatus: 'failed',
+        probeError: message,
+      }
+    }
+  }
+}

--- a/apps/server/src/studio/media-probe-rate-limit.ts
+++ b/apps/server/src/studio/media-probe-rate-limit.ts
@@ -1,0 +1,20 @@
+import { HttpException, HttpStatus } from '@nestjs/common'
+
+const RATE_WINDOW_MS = 60_000
+const RATE_LIMIT = 30
+
+const probeTimestamps = new Map<string, number[]>()
+
+export function checkMediaProbeRateLimit(userId: string): void {
+  const now = Date.now()
+  const recent = (probeTimestamps.get(userId) ?? []).filter((t) => now - t < RATE_WINDOW_MS)
+  if (recent.length >= RATE_LIMIT) {
+    throw new HttpException('media probe rate limit exceeded', HttpStatus.TOO_MANY_REQUESTS)
+  }
+  recent.push(now)
+  probeTimestamps.set(userId, recent)
+}
+
+export function resetMediaProbeRateLimitForTests(): void {
+  probeTimestamps.clear()
+}

--- a/apps/server/src/studio/media-probe-url.util.ts
+++ b/apps/server/src/studio/media-probe-url.util.ts
@@ -1,0 +1,26 @@
+const ALLOWED_HOSTS = new Set([
+  'platform-outputs.agnes-ai.space',
+  '119.29.173.89',
+  'localhost',
+  '127.0.0.1',
+])
+
+export function isAllowedMediaProbeUrl(raw: string): boolean {
+  let parsed: URL
+  try {
+    parsed = new URL(raw.trim())
+  } catch {
+    return false
+  }
+
+  const protocol = parsed.protocol.toLowerCase()
+  if (protocol !== 'http:' && protocol !== 'https:') {
+    return false
+  }
+
+  if (ALLOWED_HOSTS.has(parsed.hostname.toLowerCase())) {
+    return true
+  }
+
+  return parsed.pathname.includes('/api/uploads/')
+}

--- a/apps/server/src/studio/studio.controller.ts
+++ b/apps/server/src/studio/studio.controller.ts
@@ -1,9 +1,12 @@
-import { Body, Controller, ForbiddenException, Get, Inject, NotFoundException, Param, Post, Query, Req, UseGuards } from '@nestjs/common'
+import { BadRequestException, Body, Controller, ForbiddenException, Get, Inject, NotFoundException, Param, Post, Query, Req, UseGuards } from '@nestjs/common'
 import { Type } from 'class-transformer'
 import { IsArray, IsBoolean, IsIn, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator'
 import { AuthGuard } from '../auth/auth.guard'
+import { MediaProbeService } from '../media/media-probe.service'
 import { createCancelFlag } from '../points/charge-session'
 import { PrismaService } from '../prisma/prisma.service'
+import { checkMediaProbeRateLimit } from './media-probe-rate-limit'
+import { isAllowedMediaProbeUrl } from './media-probe-url.util'
 import { StudioService } from './studio.service'
 import { VideoGenerationOrchestrator } from './video-generation.orchestrator'
 import { resolveVideoStartRequest, type VideoStartBody } from './video-generation-request.util'
@@ -227,6 +230,7 @@ export class StudioController {
     @Inject(StudioService) private readonly studioService: StudioService,
     @Inject(VideoGenerationOrchestrator) private readonly videoOrchestrator: VideoGenerationOrchestrator,
     @Inject(PrismaService) private readonly prisma: PrismaService,
+    @Inject(MediaProbeService) private readonly mediaProbeService: MediaProbeService,
   ) {}
 
   private parseCanvas(raw: string | null | undefined): CanvasData {
@@ -316,6 +320,21 @@ export class StudioController {
   @UseGuards(AuthGuard)
   async getGeneration(@Req() req: { user: { sub: string } }, @Param('id') id: string) {
     const data = await this.studioService.getGeneration(req.user.sub, id)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Get('media-probe')
+  @UseGuards(AuthGuard)
+  async mediaProbe(@Req() req: { user: { sub: string } }, @Query('url') url?: string) {
+    const trimmed = url?.trim()
+    if (!trimmed) {
+      throw new BadRequestException('缺少 url')
+    }
+    if (!isAllowedMediaProbeUrl(trimmed)) {
+      throw new BadRequestException('URL 不在允许范围内')
+    }
+    checkMediaProbeRateLimit(req.user.sub)
+    const data = await this.mediaProbeService.probeUrl(trimmed)
     return { code: 0, message: 'ok', data }
   }
 

--- a/apps/server/src/studio/studio.diagnostic.test.ts
+++ b/apps/server/src/studio/studio.diagnostic.test.ts
@@ -5,6 +5,7 @@ import { NotFoundException } from '@nestjs/common'
 import { PointsService } from '../points/points.service'
 import { PrismaService } from '../prisma/prisma.service'
 import { ProviderResolverService } from '../provider/provider-resolver.service'
+import { MediaProbeService } from '../media/media-probe.service'
 import { StudioService } from './studio.service'
 
 describe('StudioService.getGenerationDiagnostic', () => {
@@ -37,6 +38,10 @@ describe('StudioService.getGenerationDiagnostic', () => {
         {
           provide: ProviderResolverService,
           useValue: { resolveForGeneration: vi.fn() },
+        },
+        {
+          provide: MediaProbeService,
+          useValue: { probeUrl: vi.fn(async (url: string) => ({ url, probeStatus: 'ok' as const })) },
         },
       ],
     }).compile()

--- a/apps/server/src/studio/studio.fallback.test.ts
+++ b/apps/server/src/studio/studio.fallback.test.ts
@@ -15,6 +15,7 @@ import { createCancelFlag } from '../points/charge-session'
 import { PointsService } from '../points/points.service'
 import { PrismaService } from '../prisma/prisma.service'
 import { ProviderResolverService } from '../provider/provider-resolver.service'
+import { MediaProbeService } from '../media/media-probe.service'
 import { StudioService } from './studio.service'
 
 const imageGenerate = vi.fn()
@@ -119,6 +120,10 @@ describe('StudioService BYOK fallback_pending', () => {
         {
           provide: ProviderResolverService,
           useValue: { resolveForGeneration },
+        },
+        {
+          provide: MediaProbeService,
+          useValue: { probeUrl: vi.fn(async (url: string) => ({ url, probeStatus: 'ok' as const })) },
         },
       ],
     }).compile()

--- a/apps/server/src/studio/studio.media-info.test.ts
+++ b/apps/server/src/studio/studio.media-info.test.ts
@@ -1,0 +1,135 @@
+import 'reflect-metadata'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Test } from '@nestjs/testing'
+import { createImageProvider } from '@lnkpi/agent'
+import { MediaProbeService } from '../media/media-probe.service'
+import { PointsService } from '../points/points.service'
+import { PrismaService } from '../prisma/prisma.service'
+import { ProviderResolverService } from '../provider/provider-resolver.service'
+import { createMediaProbeMock, createPrismaMock, defaultPlatformResolve } from './studio.test-utils'
+import { StudioService } from './studio.service'
+
+const imageGenerate = vi.fn(async () => ({
+  url: 'https://example.com/output.png',
+  urls: ['https://example.com/output.png'],
+}))
+
+vi.mock('@lnkpi/agent', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@lnkpi/agent')>()
+  return {
+    ...actual,
+    createImageProvider: vi.fn(() => ({ generate: imageGenerate })),
+  }
+})
+
+describe('StudioService mediaInfo on generation complete', () => {
+  let svc: StudioService
+  let probeUrl: ReturnType<typeof vi.fn>
+  let stored: Record<string, unknown>
+  let generationUpdate: ReturnType<typeof vi.fn>
+  let generationFindFirst: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    stored = {
+      id: 'g1',
+      status: 'generating',
+      metadata: JSON.stringify({
+        referenceImages: ['https://example.com/ref.png'],
+      }),
+    }
+    probeUrl = vi.fn(async (url: string) => ({
+      url,
+      width: url.includes('output') ? 1920 : 1024,
+      height: url.includes('output') ? 1080 : 768,
+      bytes: 900_000,
+      mimeType: 'image/png',
+      probeStatus: 'ok' as const,
+    }))
+    generationUpdate = vi.fn(async (args: { where: { id: string }; data: Record<string, unknown> }) => {
+      stored = { ...stored, ...args.data, id: args.where.id }
+      return stored
+    })
+    generationFindFirst = vi.fn(async () => stored)
+
+    const prisma = createPrismaMock()
+    prisma.generationRecord.create = vi.fn(async (args: { data: Record<string, unknown> }) => {
+      stored = { id: 'g1', createdAt: new Date(), ...args.data }
+      return stored
+    })
+    prisma.generationRecord.update = generationUpdate
+    prisma.generationRecord.updateMany = vi.fn(async () => {
+      stored = {
+        ...stored,
+        url: 'https://example.com/output.png',
+        status: 'completed',
+        metadata: JSON.stringify({
+          ...JSON.parse(String(stored.metadata ?? '{}')),
+          urls: ['https://example.com/output.png'],
+        }),
+      }
+      return { count: 1 }
+    })
+    prisma.generationRecord.findFirst = generationFindFirst
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        StudioService,
+        PointsService,
+        { provide: PrismaService, useValue: prisma },
+        {
+          provide: ProviderResolverService,
+          useValue: {
+            resolveForGeneration: vi.fn(async (_userId: string, model?: string) =>
+              defaultPlatformResolve(model ?? 'gpt-image-1'),
+            ),
+          },
+        },
+        {
+          provide: MediaProbeService,
+          useValue: { probeUrl },
+        },
+      ],
+    }).compile()
+
+    svc = moduleRef.get(StudioService)
+  })
+
+  it('persists mediaInfo.output.width after image generation completes', async () => {
+    await svc.generateImage(
+      'u1',
+      'a prompt',
+      'gpt-image-1',
+      '16:9',
+      [{ refKey: 'I1', mediaType: 'image', url: 'https://example.com/ref.png' }],
+    )
+
+    await vi.waitFor(() => expect(probeUrl).toHaveBeenCalled())
+
+    const meta = JSON.parse(String(stored.metadata))
+    expect(meta.mediaInfo?.output?.width).toBe(1920)
+    expect(meta.mediaInfo?.references?.[0]?.width).toBe(1024)
+    expect(meta.mediaInfo?.probedAt).toBeTruthy()
+  })
+
+  it('getGeneration returns parsed mediaInfo from metadata', async () => {
+    const mediaInfo = {
+      output: {
+        url: 'https://example.com/output.png',
+        width: 1920,
+        height: 1080,
+        probeStatus: 'ok' as const,
+      },
+      probedAt: '2026-08-15T12:00:00.000Z',
+    }
+    stored = {
+      id: 'g1',
+      userId: 'u1',
+      status: 'completed',
+      metadata: JSON.stringify({ mediaInfo }),
+    }
+
+    const record = await svc.getGeneration('u1', 'g1')
+    expect(record.mediaInfo).toEqual(mediaInfo)
+  })
+})

--- a/apps/server/src/studio/studio.media-probe.test.ts
+++ b/apps/server/src/studio/studio.media-probe.test.ts
@@ -1,0 +1,123 @@
+import 'reflect-metadata'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BadRequestException, HttpException, HttpStatus } from '@nestjs/common'
+import { StudioController } from './studio.controller'
+import { isAllowedMediaProbeUrl } from './media-probe-url.util'
+import { checkMediaProbeRateLimit, resetMediaProbeRateLimitForTests } from './media-probe-rate-limit'
+
+describe('isAllowedMediaProbeUrl', () => {
+  it('allows platform-outputs hostname', () => {
+    expect(isAllowedMediaProbeUrl('https://platform-outputs.agnes-ai.space/out.png')).toBe(true)
+  })
+
+  it('allows 119.29.173.89', () => {
+    expect(isAllowedMediaProbeUrl('https://119.29.173.89/media/test.png')).toBe(true)
+  })
+
+  it('allows localhost and 127.0.0.1', () => {
+    expect(isAllowedMediaProbeUrl('http://localhost:3000/api/uploads/u1/a.png')).toBe(true)
+    expect(isAllowedMediaProbeUrl('http://127.0.0.1:3000/file.png')).toBe(true)
+  })
+
+  it('allows /api/uploads/ path on any host', () => {
+    expect(isAllowedMediaProbeUrl('https://example.com/api/uploads/user/file.png')).toBe(true)
+  })
+
+  it('rejects non-http(s) schemes', () => {
+    expect(isAllowedMediaProbeUrl('file:///tmp/a.png')).toBe(false)
+    expect(isAllowedMediaProbeUrl('ftp://example.com/a.png')).toBe(false)
+  })
+
+  it('rejects disallowed host without uploads path', () => {
+    expect(isAllowedMediaProbeUrl('https://evil.example.com/secret.png')).toBe(false)
+  })
+})
+
+describe('StudioController GET media-probe', () => {
+  const probeUrl = vi.fn(async (url: string) => ({
+    url,
+    width: 1024,
+    height: 768,
+    bytes: 500_000,
+    mimeType: 'image/png',
+    probeStatus: 'ok' as const,
+  }))
+
+  let controller: StudioController
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetMediaProbeRateLimitForTests()
+    controller = new StudioController(
+      {} as never,
+      {} as never,
+      {} as never,
+      { probeUrl } as never,
+    )
+  })
+
+  it('returns ProbedMediaFile for allowlisted URL', async () => {
+    const url = 'https://platform-outputs.agnes-ai.space/out.png'
+    const result = await controller.mediaProbe({ user: { sub: 'u1' } }, url)
+
+    expect(probeUrl).toHaveBeenCalledWith(url)
+    expect(result).toEqual({
+      code: 0,
+      message: 'ok',
+      data: {
+        url,
+        width: 1024,
+        height: 768,
+        bytes: 500_000,
+        mimeType: 'image/png',
+        probeStatus: 'ok',
+      },
+    })
+  })
+
+  it('rejects missing url with 400', async () => {
+    await expect(controller.mediaProbe({ user: { sub: 'u1' } }, undefined)).rejects.toBeInstanceOf(
+      BadRequestException,
+    )
+    expect(probeUrl).not.toHaveBeenCalled()
+  })
+
+  it('rejects disallowed URL with 400', async () => {
+    await expect(
+      controller.mediaProbe({ user: { sub: 'u1' } }, 'https://evil.example.com/x.png'),
+    ).rejects.toBeInstanceOf(BadRequestException)
+    expect(probeUrl).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-http(s) URL with 400', async () => {
+    await expect(controller.mediaProbe({ user: { sub: 'u1' } }, 'file:///tmp/a.png')).rejects.toBeInstanceOf(
+      BadRequestException,
+    )
+    expect(probeUrl).not.toHaveBeenCalled()
+  })
+
+  it('enforces 30/min rate limit per user', async () => {
+    const url = 'https://platform-outputs.agnes-ai.space/out.png'
+    for (let i = 0; i < 30; i++) {
+      await controller.mediaProbe({ user: { sub: 'u-rate' } }, url)
+    }
+    await expect(controller.mediaProbe({ user: { sub: 'u-rate' } }, url)).rejects.toMatchObject({
+      status: HttpStatus.TOO_MANY_REQUESTS,
+    })
+    expect(probeUrl).toHaveBeenCalledTimes(30)
+  })
+})
+
+describe('checkMediaProbeRateLimit', () => {
+  beforeEach(() => {
+    resetMediaProbeRateLimitForTests()
+  })
+
+  it('tracks limits independently per user', () => {
+    for (let i = 0; i < 30; i++) {
+      checkMediaProbeRateLimit('user-a')
+    }
+    expect(() => checkMediaProbeRateLimit('user-a')).toThrow(HttpException)
+    expect(() => checkMediaProbeRateLimit('user-b')).not.toThrow()
+  })
+})

--- a/apps/server/src/studio/studio.module.ts
+++ b/apps/server/src/studio/studio.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common'
+import { MediaProbeModule } from '../media/media-probe.module'
 import { PointsModule } from '../points/points.module'
 import { PrismaModule } from '../prisma/prisma.module'
 import { ProviderModule } from '../provider/provider.module'
@@ -7,7 +8,7 @@ import { StudioService } from './studio.service'
 import { VideoGenerationOrchestrator } from './video-generation.orchestrator'
 
 @Module({
-  imports: [PointsModule, ProviderModule, PrismaModule],
+  imports: [MediaProbeModule, PointsModule, ProviderModule, PrismaModule],
   controllers: [StudioController],
   providers: [StudioService, VideoGenerationOrchestrator],
   exports: [StudioService, VideoGenerationOrchestrator],

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -23,6 +23,7 @@ import {
 } from '@lnkpi/agent'
 import {
   BYOK_FALLBACK_CONFIRM_MESSAGE,
+  evaluateMediaRefPreflight,
   mapMessageToErrorCode,
   redactProviderSnippet,
   resolveImageSize,
@@ -35,6 +36,7 @@ import {
   type ImageRefWire,
   type ImageResolutionTier,
   type MediaInfo,
+  type MediaRefPreflight,
   type StudioModality,
 } from '@lnkpi/shared'
 import {
@@ -627,9 +629,11 @@ export class StudioService {
     }
     const meta = parseMeta(record.metadata)
     const mediaInfo = meta.mediaInfo as MediaInfo | undefined
+    const refPreflight = meta.refPreflight as MediaRefPreflight | undefined
     return {
       ...record,
       ...(mediaInfo ? { mediaInfo } : {}),
+      ...(refPreflight ? { refPreflight } : {}),
     }
   }
 
@@ -1072,6 +1076,22 @@ export class StudioService {
       providerOptions.model = resolved.modelName
     }
     const effectiveBundle = built.effectiveReferenceBundle
+    let refPreflight: MediaRefPreflight | undefined
+    if (effectiveBundle.images.length > 0) {
+      const probedRefs = await Promise.all(
+        effectiveBundle.images.map(async (ref) => ({
+          ...(await this.mediaProbe.probeUrl(ref.url)),
+          refKey: ref.refKey,
+        })),
+      )
+      refPreflight = evaluateMediaRefPreflight(probedRefs, {
+        blockWire: built.meta.refWire === 'agnes_keyframes' ? 'agnes_keyframes' : undefined,
+      })
+      if (refPreflight.level === 'error' && built.meta.refWire === 'agnes_keyframes') {
+        await this.points.refund(userId, durationCredits, `${chargeReason}-预检拒绝退款`)
+        throw new BadRequestException(refPreflight.message)
+      }
+    }
     const record = await this.prisma.generationRecord.create({
       data: {
         userId,
@@ -1095,6 +1115,7 @@ export class StudioService {
               channelId: resolved.channelId,
               originalModel: model,
               providerSource: resolved.source,
+              ...(refPreflight && refPreflight.level === 'warn' ? { refPreflight } : {}),
             },
             durationCredits,
           ),

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -34,6 +34,7 @@ import {
   type GenerationDiagnostic,
   type ImageRefWire,
   type ImageResolutionTier,
+  type MediaInfo,
   type StudioModality,
 } from '@lnkpi/shared'
 import {
@@ -53,6 +54,7 @@ import {
   ProviderResolverService,
   type ResolvedGenerationProvider,
 } from '../provider/provider-resolver.service'
+import { MediaProbeService } from '../media/media-probe.service'
 import { inlineUpstreamReferenceImages } from '../media/upstream-ref-inline'
 
 const AUDIO_PLACEHOLDER = 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3'
@@ -233,6 +235,7 @@ export class StudioService {
     @Inject(PrismaService) private readonly prisma: PrismaService,
     @Inject(PointsService) private readonly points: PointsService,
     @Inject(ProviderResolverService) private readonly resolver: ProviderResolverService,
+    @Inject(MediaProbeService) private readonly mediaProbe: MediaProbeService,
   ) {}
 
   async listGenerations(userId: string, type?: string, sessionId?: string) {
@@ -622,7 +625,39 @@ export class StudioService {
     if (!record) {
       throw new BadRequestException('生成记录不存在')
     }
-    return record
+    const meta = parseMeta(record.metadata)
+    const mediaInfo = meta.mediaInfo as MediaInfo | undefined
+    return {
+      ...record,
+      ...(mediaInfo ? { mediaInfo } : {}),
+    }
+  }
+
+  private async attachMediaInfoToRecord(
+    recordId: string,
+    outputUrl: string | null,
+    referenceUrls: string[],
+  ): Promise<void> {
+    const output = outputUrl ? await this.mediaProbe.probeUrl(outputUrl) : undefined
+    const references = await Promise.all(
+      referenceUrls
+        .filter((url) => typeof url === 'string' && url.trim())
+        .map(async (url) => this.mediaProbe.probeUrl(url.trim())),
+    )
+    const mediaInfo: MediaInfo = {
+      ...(output ? { output } : {}),
+      ...(references.length ? { references } : {}),
+      probedAt: new Date().toISOString(),
+    }
+    const existing = await this.prisma.generationRecord.findFirst({ where: { id: recordId } })
+    if (!existing) return
+    const meta = parseMeta(existing.metadata)
+    await this.prisma.generationRecord.update({
+      where: { id: recordId },
+      data: {
+        metadata: JSON.stringify({ ...meta, mediaInfo }),
+      },
+    })
   }
 
   async getGenerationDiagnostic(userId: string, id: string): Promise<GenerationDiagnostic> {
@@ -814,6 +849,10 @@ export class StudioService {
         },
       })
       if (updated.count === 0) return null
+      const referenceUrls = Array.isArray(meta.referenceImages)
+        ? (meta.referenceImages as string[]).filter((url) => typeof url === 'string' && url.trim())
+        : []
+      await this.attachMediaInfoToRecord(id, imageUrls[0] ?? null, referenceUrls)
       return this.prisma.generationRecord.findFirst({ where: { id } })
     } catch (err) {
       console.error('Image generation failed:', err)
@@ -1567,6 +1606,12 @@ export class StudioService {
         },
       })
       if (updated.count === 0) return
+      const referenceUrls = [
+        ...(Array.isArray(meta.referenceImages) ? (meta.referenceImages as string[]) : []),
+        ...(Array.isArray(meta.referenceVideos) ? (meta.referenceVideos as string[]) : []),
+        ...(Array.isArray(meta.referenceAudios) ? (meta.referenceAudios as string[]) : []),
+      ].filter((u): u is string => typeof u === 'string' && u.trim())
+      await this.attachMediaInfoToRecord(id, url, referenceUrls)
     } catch (err) {
       console.error('Video generation failed:', err)
       const existing = await this.prisma.generationRecord.findFirst({ where: { id } })

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -1631,7 +1631,7 @@ export class StudioService {
         ...(Array.isArray(meta.referenceImages) ? (meta.referenceImages as string[]) : []),
         ...(Array.isArray(meta.referenceVideos) ? (meta.referenceVideos as string[]) : []),
         ...(Array.isArray(meta.referenceAudios) ? (meta.referenceAudios as string[]) : []),
-      ].filter((u): u is string => typeof u === 'string' && u.trim())
+      ].filter((u): u is string => typeof u === 'string' && u.trim().length > 0)
       await this.attachMediaInfoToRecord(id, url, referenceUrls)
     } catch (err) {
       console.error('Video generation failed:', err)

--- a/apps/server/src/studio/studio.test-utils.ts
+++ b/apps/server/src/studio/studio.test-utils.ts
@@ -1,9 +1,21 @@
 import { Test } from '@nestjs/testing'
 import { vi } from 'vitest'
+import { MediaProbeService } from '../media/media-probe.service'
 import { PointsService } from '../points/points.service'
 import { ProviderResolverService } from '../provider/provider-resolver.service'
 import { StudioService } from './studio.service'
 import { PrismaService } from '../prisma/prisma.service'
+
+export function createMediaProbeMock(probeUrl = vi.fn(async (url: string) => ({
+  url,
+  width: 1024,
+  height: 1024,
+  bytes: 900_000,
+  mimeType: 'image/png',
+  probeStatus: 'ok' as const,
+}))) {
+  return { probeUrl }
+}
 
 export function defaultPlatformResolve(model?: string) {
   const modelName = model?.includes('::') ? model.split('::')[1]! : (model ?? '')
@@ -74,6 +86,10 @@ export async function createStudioService() {
             defaultPlatformResolve(model),
           ),
         },
+      },
+      {
+        provide: MediaProbeService,
+        useValue: createMediaProbeMock(),
       },
     ],
   }).compile()

--- a/apps/server/src/studio/studio.video-preflight.test.ts
+++ b/apps/server/src/studio/studio.video-preflight.test.ts
@@ -1,0 +1,133 @@
+import 'reflect-metadata'
+import { BadRequestException } from '@nestjs/common'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Test } from '@nestjs/testing'
+import { createVideoProvider, mergeRefsToPrompt } from '@lnkpi/agent'
+import { MediaProbeService } from '../media/media-probe.service'
+import { PointsService } from '../points/points.service'
+import { PrismaService } from '../prisma/prisma.service'
+import { ProviderResolverService } from '../provider/provider-resolver.service'
+import { createPrismaMock, defaultPlatformResolve } from './studio.test-utils'
+import { StudioService } from './studio.service'
+
+const videoGenerate = vi.fn(async () => ({ url: 'https://example.com/v.mp4' }))
+
+vi.mock('@lnkpi/agent', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@lnkpi/agent')>()
+  return {
+    ...actual,
+    mergeRefsToPrompt: vi.fn(async (input: { localPrompt?: string }) => ({
+      mergedText: input.localPrompt ?? '',
+      skippedMerge: true,
+    })),
+    createVideoProvider: vi.fn(() => ({ generate: videoGenerate })),
+  }
+})
+
+describe('StudioService video reference preflight', () => {
+  let svc: StudioService
+  let probeUrl: ReturnType<typeof vi.fn>
+  let pointsRefund: ReturnType<typeof vi.fn>
+  let generationCreate: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    pointsRefund = vi.fn(async () => {})
+    generationCreate = vi.fn(async (args: { data: Record<string, unknown> }) => ({
+      id: 'g1',
+      createdAt: new Date(),
+      ...args.data,
+    }))
+    probeUrl = vi.fn(async (url: string) => {
+      if (url.includes('ref3')) {
+        return {
+          url,
+          width: 3072,
+          height: 4096,
+          bytes: 13 * 1024 * 1024,
+          mimeType: 'image/png',
+          probeStatus: 'ok' as const,
+        }
+      }
+      return {
+        url,
+        width: 1024,
+        height: 1024,
+        bytes: 900_000,
+        mimeType: 'image/png',
+        probeStatus: 'ok' as const,
+      }
+    })
+
+    const prisma = createPrismaMock()
+    prisma.generationRecord.create = generationCreate
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        StudioService,
+        {
+          provide: PointsService,
+          useValue: {
+            consume: vi.fn(async () => {}),
+            refund: pointsRefund,
+          },
+        },
+        { provide: PrismaService, useValue: prisma },
+        {
+          provide: ProviderResolverService,
+          useValue: {
+            resolveForGeneration: vi.fn(async (_userId: string, model?: string) =>
+              defaultPlatformResolve(model ?? 'agnes-video-v2.0'),
+            ),
+          },
+        },
+        {
+          provide: MediaProbeService,
+          useValue: { probeUrl },
+        },
+      ],
+    }).compile()
+
+    svc = moduleRef.get(StudioService)
+    vi.mocked(mergeRefsToPrompt).mockImplementation(async (input) => ({
+      mergedText: input.localPrompt ?? '',
+      skippedMerge: true,
+    }))
+  })
+
+  it('blocks agnes_keyframes when ref exceeds error threshold', async () => {
+    await expect(
+      svc.generateVideo(
+        'u1',
+        'a prompt',
+        'agnes-video-v2.0',
+        5,
+        '16:9',
+        [
+          { refKey: 'I1', mediaType: 'image', url: 'https://example.com/ref1.png' },
+          { refKey: 'I2', mediaType: 'image', url: 'https://example.com/ref2.png' },
+          { refKey: 'I3', mediaType: 'image', url: 'https://example.com/ref3.png' },
+        ],
+      ),
+    ).rejects.toThrow(/I3|过大/)
+
+    await expect(
+      svc.generateVideo(
+        'u1',
+        'a prompt',
+        'agnes-video-v2.0',
+        5,
+        '16:9',
+        [
+          { refKey: 'I1', mediaType: 'image', url: 'https://example.com/ref1.png' },
+          { refKey: 'I2', mediaType: 'image', url: 'https://example.com/ref2.png' },
+          { refKey: 'I3', mediaType: 'image', url: 'https://example.com/ref3.png' },
+        ],
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException)
+
+    expect(videoGenerate).not.toHaveBeenCalled()
+    expect(generationCreate).not.toHaveBeenCalled()
+    expect(pointsRefund).toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/components/canvas/CanvasNodeImage.vue
+++ b/apps/web/src/components/canvas/CanvasNodeImage.vue
@@ -1,13 +1,17 @@
 <script setup lang="ts">
 import NeoBaseNode from '@/components/canvas/NeoBaseNode.vue'
 import NodeTaskCornerActions from '@/components/canvas/NodeTaskCornerActions.vue'
+import MediaInfoSummary from '@/components/media/MediaInfoSummary.vue'
 import { useCanvasEditorStore } from '@/stores/canvasEditor'
 import { resolveMediaUrl } from '@/services/api-base'
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useNodeMediaUpload } from '@/composables/useNodeMediaUpload'
+import { useMediaInspector } from '@/composables/useMediaInspector'
 import { downloadMediaFile, isUpstreamMediaUrl, mediaDownloadName, UPSTREAM_MEDIA_DOWNLOAD_HINT } from '@/composables/useCanvasMedia'
 import { saveAssetToLibrary } from '@/composables/useAssetLibrary'
+import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
+import type { MediaRefWarningLevel } from '@lnkpi/shared'
 
 const props = defineProps<{
   id: string
@@ -23,11 +27,19 @@ const props = defineProps<{
     generationStartedAt?: string
     generationRecordId?: string
     materialId?: string
+    mediaInfo?: {
+      width?: number
+      height?: number
+      bytes?: number
+      model?: string
+      refWarning?: MediaRefWarningLevel
+    }
   }
 }>()
 
 const editor = useCanvasEditorStore()
 const route = useRoute()
+const { openInspector } = useMediaInspector()
 const sessionId = computed(() => route.params.sessionId as string | undefined)
 const taskId = computed(
   () =>
@@ -48,6 +60,11 @@ const downloadTitle = computed(() =>
     ? UPSTREAM_MEDIA_DOWNLOAD_HINT
     : '下载图片',
 )
+const showMediaSummary = computed(
+  () => props.data.status === NODE_GENERATION_STATUS.completed && Boolean(props.data.mediaInfo),
+)
+const showInspectorBtn = computed(() => Boolean(props.data.generationRecordId))
+const isCompleted = computed(() => props.data.status === NODE_GENERATION_STATUS.completed)
 const {
   accept,
   dragOver,
@@ -95,6 +112,20 @@ function saveToLibrary() {
     url,
     label: props.data.label ?? props.data.prompt ?? '',
     sourceNodeId: props.id,
+  })
+}
+
+function openMediaInspector(e: Event) {
+  e.stopPropagation()
+  e.preventDefault()
+  const recordId = props.data.generationRecordId
+  if (!recordId) return
+  void openInspector({
+    generationRecordId: recordId,
+    nodeId: props.id,
+    nodeLabel: props.data.label ?? props.data.prompt,
+    url: props.data.url,
+    kind: 'image',
   })
 }
 </script>
@@ -179,6 +210,24 @@ function saveToLibrary() {
           @click.stop="openEdit"
         >
           编辑
+        </button>
+        <MediaInfoSummary
+          v-if="showMediaSummary && data.mediaInfo"
+          v-bind="data.mediaInfo"
+          class="neo-media-info-summary--overlay"
+        />
+        <button
+          v-if="showInspectorBtn"
+          type="button"
+          class="neo-media-inspector-btn nodrag"
+          :class="{ 'is-completed': isCompleted }"
+          aria-label="媒体属性"
+          title="媒体属性"
+          @pointerdown.stop
+          @mousedown.stop
+          @click.stop="openMediaInspector"
+        >
+          ⓘ
         </button>
       </div>
       <div

--- a/apps/web/src/components/canvas/CanvasNodeVideo.vue
+++ b/apps/web/src/components/canvas/CanvasNodeVideo.vue
@@ -1,12 +1,16 @@
 <script setup lang="ts">
 import NeoBaseNode from '@/components/canvas/NeoBaseNode.vue'
 import NodeTaskCornerActions from '@/components/canvas/NodeTaskCornerActions.vue'
+import MediaInfoSummary from '@/components/media/MediaInfoSummary.vue'
 import { computed, onUnmounted, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { resolveMediaUrl } from '@/services/api-base'
 import { useNodeMediaUpload } from '@/composables/useNodeMediaUpload'
+import { useMediaInspector } from '@/composables/useMediaInspector'
 import { downloadMediaFile, isUpstreamMediaUrl, mediaDownloadName, UPSTREAM_MEDIA_DOWNLOAD_HINT } from '@/composables/useCanvasMedia'
 import { saveAssetToLibrary } from '@/composables/useAssetLibrary'
+import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
+import type { MediaRefWarningLevel } from '@lnkpi/shared'
 
 const props = defineProps<{
   id: string
@@ -22,10 +26,18 @@ const props = defineProps<{
     generationStartedAt?: string
     generationRecordId?: string
     materialId?: string
+    mediaInfo?: {
+      width?: number
+      height?: number
+      bytes?: number
+      model?: string
+      refWarning?: MediaRefWarningLevel
+    }
   }
 }>()
 
 const route = useRoute()
+const { openInspector } = useMediaInspector()
 const sessionId = computed(() => route.params.sessionId as string | undefined)
 const taskId = computed(
   () =>
@@ -46,6 +58,11 @@ const downloadTitle = computed(() =>
     ? UPSTREAM_MEDIA_DOWNLOAD_HINT
     : '下载视频',
 )
+const showMediaSummary = computed(
+  () => props.data.status === NODE_GENERATION_STATUS.completed && Boolean(props.data.mediaInfo),
+)
+const showInspectorBtn = computed(() => Boolean(props.data.generationRecordId))
+const isCompleted = computed(() => props.data.status === NODE_GENERATION_STATUS.completed)
 const {
   accept,
   dragOver,
@@ -71,6 +88,20 @@ function saveToLibrary() {
   const url = String(props.data.url ?? '').trim()
   if (!url) return
   void saveAssetToLibrary({ kind: 'video', url, label: props.data.label ?? '', sourceNodeId: props.id })
+}
+
+function openMediaInspector(e: Event) {
+  e.stopPropagation()
+  e.preventDefault()
+  const recordId = props.data.generationRecordId
+  if (!recordId) return
+  void openInspector({
+    generationRecordId: recordId,
+    nodeId: props.id,
+    nodeLabel: props.data.label,
+    url: props.data.url,
+    kind: 'video',
+  })
 }
 
 const mode = ref<'drag' | 'play'>('drag')
@@ -196,6 +227,24 @@ onUnmounted(() => {
           <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2">
             <path d="M19 21l-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
           </svg>
+        </button>
+        <MediaInfoSummary
+          v-if="showMediaSummary && data.mediaInfo"
+          v-bind="data.mediaInfo"
+          class="neo-media-info-summary--overlay"
+        />
+        <button
+          v-if="showInspectorBtn"
+          type="button"
+          class="neo-media-inspector-btn nodrag"
+          :class="{ 'is-completed': isCompleted }"
+          aria-label="媒体属性"
+          title="媒体属性"
+          @pointerdown.stop
+          @mousedown.stop
+          @click.stop="openMediaInspector"
+        >
+          ⓘ
         </button>
       </div>
       <div

--- a/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
+++ b/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
-import type { ErrorCode, GenerationDiagnostic } from '@lnkpi/shared'
+import type { ErrorCode, GenerationDiagnostic, MediaInfo } from '@lnkpi/shared'
 import { modelOptionName } from '@lnkpi/shared'
 import { studioApi, type GenerationRecord } from '@/services/studio-api'
 import DockTypeIcon from '@/components/canvas/dock-studio/shared/DockTypeIcon.vue'
 import NodeDiagnosticPopover from '@/components/canvas/NodeDiagnosticPopover.vue'
 import CanvasLocateButton from '@/components/shared/CanvasLocateButton.vue'
 import CanvasLocatePinIcon from '@/components/shared/CanvasLocatePinIcon.vue'
+import MediaInfoSummary from '@/components/media/MediaInfoSummary.vue'
+import MediaRefList from '@/components/media/MediaRefList.vue'
 import { useCanvasEditorStore } from '@/stores/canvasEditor'
 import { useProviderBootstrap } from '@/composables/useProviderBootstrap'
 import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
@@ -137,6 +139,41 @@ function parseRecordMeta(record: GenerationRecord): RecordMeta {
   } catch {
     return {}
   }
+}
+
+function recordMediaInfo(record: GenerationRecord): MediaInfo | undefined {
+  if (record.mediaInfo?.output || record.mediaInfo?.references?.length) {
+    return record.mediaInfo
+  }
+  try {
+    const meta = JSON.parse(record.metadata ?? '{}') as { mediaInfo?: MediaInfo }
+    if (meta.mediaInfo?.output || meta.mediaInfo?.references?.length) return meta.mediaInfo
+  } catch {
+    // ignore
+  }
+  return undefined
+}
+
+function recordMediaSummaryProps(record: GenerationRecord) {
+  const info = recordMediaInfo(record)
+  const output = info?.output
+  return {
+    width: output?.width,
+    height: output?.height,
+    bytes: output?.bytes,
+    model: record.model ?? undefined,
+  }
+}
+
+function recordMediaRefItems(record: GenerationRecord) {
+  const info = recordMediaInfo(record)
+  if (info?.references?.length) return info.references
+  return record.refPreflight?.refs ?? []
+}
+
+function hasRecordMediaInfo(record: GenerationRecord): boolean {
+  const info = recordMediaInfo(record)
+  return Boolean(info?.output || info?.references?.length || record.refPreflight?.refs?.length)
 }
 
 function recordModelName(record: GenerationRecord): string {
@@ -658,6 +695,18 @@ onUnmounted(stopPolling)
                     <p class="text-[var(--neo-text-secondary)]">{{ row.value }}</p>
                   </div>
                 </div>
+              </div>
+
+              <div v-if="hasRecordMediaInfo(attempt)">
+                <p class="mb-1 text-[10px] uppercase tracking-wider text-[var(--neo-text-muted)]">媒体属性</p>
+                <MediaInfoSummary
+                  v-bind="recordMediaSummaryProps(attempt)"
+                  class="mb-2"
+                />
+                <MediaRefList
+                  v-if="recordMediaRefItems(attempt).length"
+                  :refs="recordMediaRefItems(attempt)"
+                />
               </div>
 
               <div v-if="recordFailureMessage(attempt)">

--- a/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
@@ -258,10 +258,11 @@ watch(
     if (!pendingPreflightToast.value) return
     if (status !== NODE_GENERATION_STATUS.error || !msg) return
     pendingPreflightToast.value = false
+    const message = typeof msg === 'string' ? msg : String(msg)
     const isPreflight =
       code === 'invalid_input' ||
-      (msg.includes('参考图') && (msg.includes('过大') || msg.includes('偏大')))
-    if (isPreflight) ElMessage.error(msg)
+      (message.includes('参考图') && (message.includes('过大') || message.includes('偏大')))
+    if (isPreflight) ElMessage.error(message)
   },
 )
 

--- a/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
-import { ElMessage } from 'element-plus'
+import { ElAlert, ElMessage } from 'element-plus'
+import {
+  evaluateMediaRefPreflight,
+  type MediaRefPreflight,
+  type ProbedMediaFile,
+} from '@lnkpi/shared'
 import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import {
   resolveVideoMode,
@@ -22,7 +27,7 @@ import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
 import { useModelProviderSettings } from '@/composables/useModelProviderSettings'
 import { catalogModelKeyFromValue, resolveGenerationModel } from '@/constants/studioModels'
 import { DEFAULT_VIDEO_SETTINGS, type VideoSettings } from '@lnkpi/shared'
-import { isNodeGenerating } from '@/constants/dockStudio'
+import { isNodeGenerating, NODE_GENERATION_STATUS } from '@/constants/dockStudio'
 import { estimateVideoCredits } from '@/constants/credits'
 import { persistMediaUrl } from '@/composables/useMediaUpload'
 import { useVideoModelCapabilities } from '@/composables/useVideoModelCapabilities'
@@ -30,7 +35,9 @@ import VideoCapabilityBadges from '@/components/canvas/dock-studio/shared/VideoC
 import {
   countValidImageRefs,
   hasUnsupportedMediaRefs,
+  isValidImageRef,
 } from '@/components/canvas/dock-studio/shared/dockRefRoleLabels'
+import { studioApi } from '@/services/studio-api'
 
 const { getConfig } = useModelProviderSettings()
 
@@ -61,6 +68,10 @@ const refInput = ref<HTMLInputElement | null>(null)
 const refUploading = ref(false)
 const refUploadProgress = ref(0)
 const refUploadError = ref('')
+const refPreflight = ref<MediaRefPreflight | null>(null)
+const refPreflightLoading = ref(false)
+const pendingPreflightToast = ref(false)
+let preflightSeq = 0
 
 const speech = useSpeechRecognition()
 const promptSectionRef = ref<InstanceType<typeof DockPromptSection> | null>(null)
@@ -109,6 +120,87 @@ const effectiveRefUrl = computed(() => {
   return props.upstream.referenceImageUrl.trim()
 })
 
+function isProbeableUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url.trim())
+}
+
+const imageRefSources = computed(() => {
+  const items: Array<{ url: string; refKey?: string }> = []
+  const seen = new Set<string>()
+  for (const ref of props.refs ?? []) {
+    if (!isValidImageRef(ref)) continue
+    const url = ref.payload.url?.trim()
+    if (!url || seen.has(url)) continue
+    seen.add(url)
+    items.push({ url, refKey: ref.refKey })
+  }
+  const localUrl = effectiveRefUrl.value.trim()
+  if (localUrl && !seen.has(localUrl)) {
+    items.push({ url: localUrl })
+  }
+  return items
+})
+
+const probeableRefSources = computed(() =>
+  imageRefSources.value.filter((src) => isProbeableUrl(src.url)),
+)
+
+const showRefPreflightAlert = computed(
+  () => refPreflight.value != null && refPreflight.value.level !== 'none',
+)
+
+async function loadCachedRefPreflight(): Promise<MediaRefPreflight | null> {
+  const recordId = props.node.data?.generationRecordId
+  if (typeof recordId !== 'string' || !recordId.trim()) return null
+  try {
+    const { data: res } = await studioApi.getGeneration(recordId.trim())
+    const pf = res.data.refPreflight
+    if (pf && pf.level !== 'none') return pf
+  } catch {
+    // ignore — fall back to client-side probe
+  }
+  return null
+}
+
+async function refreshRefPreflight() {
+  const seq = ++preflightSeq
+  if (!imageRefSources.value.length) {
+    refPreflight.value = null
+    return
+  }
+
+  const cached = await loadCachedRefPreflight()
+  if (seq !== preflightSeq) return
+  if (cached) refPreflight.value = cached
+
+  if (!probeableRefSources.value.length) {
+    if (!cached) refPreflight.value = null
+    return
+  }
+
+  refPreflightLoading.value = true
+  try {
+    const probed: Array<ProbedMediaFile & { refKey?: string }> = []
+    for (const src of probeableRefSources.value) {
+      if (seq !== preflightSeq) return
+      try {
+        const file = await studioApi.probeMedia(src.url)
+        probed.push({ ...file, refKey: src.refKey })
+      } catch {
+        probed.push({
+          url: src.url,
+          refKey: src.refKey,
+          probeStatus: 'failed',
+        })
+      }
+    }
+    if (seq !== preflightSeq) return
+    refPreflight.value = evaluateMediaRefPreflight(probed)
+  } finally {
+    if (seq === preflightSeq) refPreflightLoading.value = false
+  }
+}
+
 function syncFromNode() {
   const data = props.node.data ?? {}
   prompt.value = String(data.prompt ?? data.content ?? '')
@@ -134,6 +226,43 @@ watch(
     }
   },
   { immediate: true, deep: true },
+)
+
+watch(
+  () =>
+    [props.node.id, imageRefSources.value.map((src) => `${src.refKey ?? ''}:${src.url}`).join('|')] as const,
+  () => {
+    void refreshRefPreflight()
+  },
+  { immediate: true },
+)
+
+watch(
+  () => [props.node.data?.status, props.generating] as const,
+  ([status, generating]) => {
+    if (generating) return
+    if (status === NODE_GENERATION_STATUS.completed) {
+      pendingPreflightToast.value = false
+    }
+  },
+)
+
+watch(
+  () =>
+    [
+      props.node.data?.status,
+      props.node.data?.errorMessage,
+      props.node.data?.errorCode,
+    ] as const,
+  ([status, msg, code]) => {
+    if (!pendingPreflightToast.value) return
+    if (status !== NODE_GENERATION_STATUS.error || !msg) return
+    pendingPreflightToast.value = false
+    const isPreflight =
+      code === 'invalid_input' ||
+      (msg.includes('参考图') && (msg.includes('过大') || msg.includes('偏大')))
+    if (isPreflight) ElMessage.error(msg)
+  },
 )
 
 watch(
@@ -180,6 +309,7 @@ function onSeedInput(raw: string) {
 }
 
 function onGenerate() {
+  pendingPreflightToast.value = true
   emit('patch', {
     prompt: prompt.value,
     videoModel: videoModel.value,
@@ -462,6 +592,15 @@ function onRefMention(refKey: string) {
         </div>
       </template>
 
+      <ElAlert
+        v-if="showRefPreflightAlert"
+        :type="refPreflight!.level === 'error' ? 'error' : 'warning'"
+        :closable="false"
+        show-icon
+        class="dock-ref-preflight-alert w-full basis-full"
+        :title="refPreflightLoading ? `${refPreflight!.message}（检测中…）` : refPreflight!.message"
+      />
+
       <div class="ml-auto flex items-center gap-2">
         <DockMicButton
           :listening="speech.listening.value"
@@ -481,6 +620,15 @@ function onRefMention(refKey: string) {
 </template>
 
 <style scoped>
+.dock-ref-preflight-alert {
+  margin: 0 2px 4px;
+}
+
+.dock-ref-preflight-alert :deep(.el-alert__title) {
+  font-size: 10px;
+  line-height: 1.4;
+}
+
 .dock-ref-warning {
   margin: 0 2px 4px;
   padding: 4px 8px;

--- a/apps/web/src/components/media/MediaInfoSummary.vue
+++ b/apps/web/src/components/media/MediaInfoSummary.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { MediaRefWarningLevel } from '@lnkpi/shared'
+import { formatMediaBytes, formatMediaDimensions } from '@/utils/mediaInfoFormat'
+
+const props = defineProps<{
+  width?: number
+  height?: number
+  bytes?: number
+  model?: string
+  refWarning?: MediaRefWarningLevel
+}>()
+
+const parts = computed(() => {
+  const line: string[] = []
+  const dims = formatMediaDimensions(props.width, props.height)
+  if (dims) line.push(dims)
+  const size = formatMediaBytes(props.bytes)
+  if (size) line.push(size)
+  if (props.model?.trim()) line.push(props.model.trim())
+  return line
+})
+
+const refWarningLabel = computed(() => {
+  if (props.refWarning === 'error') return 'ref 过大'
+  if (props.refWarning === 'warn') return 'ref 偏大'
+  return null
+})
+</script>
+
+<template>
+  <div v-if="parts.length || refWarningLabel" class="neo-media-info-summary nodrag">
+    <span v-if="parts.length" class="neo-media-info-summary-text">{{ parts.join(' · ') }}</span>
+    <span
+      v-if="refWarningLabel"
+      class="neo-media-info-summary-warn"
+      :class="refWarning === 'error' ? 'is-error' : 'is-warn'"
+      :title="refWarningLabel"
+    >
+      ⚠ {{ refWarningLabel }}
+    </span>
+  </div>
+</template>

--- a/apps/web/src/components/media/MediaInspectorDrawer.vue
+++ b/apps/web/src/components/media/MediaInspectorDrawer.vue
@@ -1,0 +1,476 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import { modelOptionName } from '@lnkpi/shared'
+import type { MediaInfo, ProbedMediaFile } from '@lnkpi/shared'
+import MediaRefList from '@/components/media/MediaRefList.vue'
+import { useMediaInspector } from '@/composables/useMediaInspector'
+import {
+  downloadMediaFile,
+  mediaDownloadName,
+} from '@/composables/useCanvasMedia'
+import { resolveMediaUrl } from '@/services/api-base'
+import { copyTextToClipboard } from '@/utils/copyToClipboard'
+import {
+  formatMediaBytes,
+  formatMediaDimensions,
+  truncateUrl,
+} from '@/utils/mediaInfoFormat'
+
+const route = useRoute()
+const sessionId = computed(() => route.params.sessionId as string | undefined)
+
+const {
+  open,
+  loading,
+  error,
+  target,
+  record,
+  closeInspector,
+  probeMedia,
+} = useMediaInspector()
+
+const lazyOutput = ref<ProbedMediaFile | undefined>()
+const lazyLoading = ref(false)
+
+watch(
+  () => [open.value, record.value?.id, record.value?.mediaInfo?.output] as const,
+  async ([isOpen, , output]) => {
+    lazyOutput.value = undefined
+    if (!isOpen || !record.value) return
+    if (output?.probeStatus === 'ok') {
+      lazyOutput.value = output
+      return
+    }
+    const url = record.value.url || target.value?.url
+    if (!url) return
+    lazyLoading.value = true
+    try {
+      lazyOutput.value = await probeMedia(url)
+    } catch {
+      lazyOutput.value = {
+        url,
+        probeStatus: 'failed',
+        probeError: '未能读取文件属性',
+      }
+    } finally {
+      lazyLoading.value = false
+    }
+  },
+  { immediate: true },
+)
+
+const parsedMeta = computed(() => {
+  const raw = record.value?.metadata
+  if (!raw) return {} as Record<string, unknown>
+  try {
+    return JSON.parse(raw) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+})
+
+const mediaInfo = computed<MediaInfo | undefined>(() => {
+  const fromRecord = record.value?.mediaInfo
+  if (fromRecord?.output || fromRecord?.references?.length) return fromRecord
+  if (lazyOutput.value) {
+    return { output: lazyOutput.value, probedAt: new Date().toISOString() }
+  }
+  return fromRecord
+})
+
+const previewUrl = computed(() => {
+  const url = record.value?.url || target.value?.url || mediaInfo.value?.output?.url
+  return url ? resolveMediaUrl(url) : ''
+})
+
+const previewKind = computed(() => {
+  if (target.value?.kind) return target.value.kind
+  return record.value?.type === 'video' ? 'video' : 'image'
+})
+
+const title = computed(() => {
+  if (target.value?.nodeLabel?.trim()) return target.value.nodeLabel.trim()
+  if (record.value?.prompt?.trim()) return record.value.prompt.trim()
+  return target.value?.nodeId ? `节点 ${target.value.nodeId}` : '媒体属性'
+})
+
+const createdAtText = computed(() => {
+  const ts = record.value?.createdAt
+  if (!ts) return null
+  const d = new Date(ts)
+  if (Number.isNaN(d.getTime())) return null
+  return d.toLocaleString()
+})
+
+const outputFile = computed(() => mediaInfo.value?.output ?? lazyOutput.value)
+
+const refPreflight = computed(() => record.value?.refPreflight)
+
+const modelLabel = computed(() => {
+  const model = record.value?.model || String(parsedMeta.value.originalModel ?? '')
+  if (!model) return null
+  return modelOptionName(model) || model
+})
+
+const channelLabel = computed(() => {
+  const source = parsedMeta.value.providerSource
+  if (source === 'user') return 'BYOK'
+  if (source === 'platform') return '平台'
+  return null
+})
+
+const generationParams = computed(() => {
+  const rows: Array<{ label: string; value: string }> = []
+  if (modelLabel.value) rows.push({ label: '模型', value: modelLabel.value })
+  if (channelLabel.value) rows.push({ label: '渠道', value: channelLabel.value })
+  const aspectRatio = parsedMeta.value.aspectRatio
+  if (typeof aspectRatio === 'string' && aspectRatio) {
+    rows.push({ label: '比例', value: aspectRatio })
+  }
+  const resolution = parsedMeta.value.resolution
+  if (typeof resolution === 'string' && resolution) {
+    rows.push({ label: '分辨率', value: resolution })
+  }
+  const duration = parsedMeta.value.duration
+  if (typeof duration === 'number' && Number.isFinite(duration)) {
+    rows.push({ label: '时长', value: `${duration}s` })
+  }
+  const videoMode = parsedMeta.value.videoMode
+  if (typeof videoMode === 'string' && videoMode) {
+    rows.push({ label: '视频模式', value: videoMode })
+  }
+  const points = parsedMeta.value.pointsCharged ?? parsedMeta.value.cost
+  if (typeof points === 'number' && Number.isFinite(points)) {
+    rows.push({ label: '积分', value: String(points) })
+  }
+  return rows
+})
+
+const fileInfoRows = computed(() => {
+  const file = outputFile.value
+  if (!file) return []
+  const rows: Array<{ label: string; value: string; copy?: string }> = []
+  const dims = formatMediaDimensions(file.width, file.height)
+  if (dims) rows.push({ label: '尺寸', value: dims })
+  const size = formatMediaBytes(file.bytes)
+  if (size) rows.push({ label: '体积', value: size })
+  if (file.mimeType) rows.push({ label: '格式', value: file.mimeType })
+  if (file.durationSec != null) rows.push({ label: '时长', value: `${file.durationSec}s` })
+  if (file.url) {
+    rows.push({
+      label: 'URL',
+      value: truncateUrl(file.url),
+      copy: file.url,
+    })
+  }
+  return rows
+})
+
+const referenceItems = computed(() => {
+  const refs = mediaInfo.value?.references
+  if (refs?.length) return refs
+  if (refPreflight.value?.refs?.length) return refPreflight.value.refs
+  return []
+})
+
+const taskIdCopyLabel = ref('复制任务 ID')
+
+async function copyTaskId() {
+  const id = record.value?.id || target.value?.generationRecordId
+  if (!id) return
+  try {
+    await copyTextToClipboard(id)
+    taskIdCopyLabel.value = '已复制'
+    setTimeout(() => {
+      taskIdCopyLabel.value = '复制任务 ID'
+    }, 1500)
+  } catch {
+    taskIdCopyLabel.value = '复制失败'
+  }
+}
+
+async function downloadOutput() {
+  const url = record.value?.url || target.value?.url || outputFile.value?.url
+  if (!url) return
+  const kind = previewKind.value === 'video' ? 'video' : 'image'
+  await downloadMediaFile(
+    resolveMediaUrl(url),
+    mediaDownloadName(url, kind, title.value),
+    { sessionId: sessionId.value },
+  )
+}
+
+async function copyValue(text: string) {
+  try {
+    await copyTextToClipboard(text)
+  } catch {
+    // ignore
+  }
+}
+</script>
+
+<template>
+  <ElDrawer
+    :model-value="open"
+    direction="rtl"
+    size="320px"
+    :with-header="false"
+    append-to-body
+    class="media-inspector-drawer"
+    @update:model-value="(v: boolean) => { if (!v) closeInspector() }"
+  >
+    <div class="media-inspector">
+      <header class="media-inspector-header">
+        <div class="media-inspector-heading">
+          <h3 class="media-inspector-title">{{ title }}</h3>
+          <p v-if="createdAtText" class="media-inspector-subtitle">{{ createdAtText }}</p>
+        </div>
+        <button type="button" class="media-inspector-close" aria-label="关闭" @click="closeInspector">
+          ×
+        </button>
+      </header>
+
+      <div v-if="loading" class="media-inspector-loading">加载中…</div>
+      <div v-else-if="error" class="media-inspector-error">{{ error }}</div>
+      <div v-else class="media-inspector-body">
+        <section v-if="previewUrl" class="media-inspector-section">
+          <div class="media-inspector-preview">
+            <img v-if="previewKind === 'image'" :src="previewUrl" alt="" class="media-inspector-media">
+            <video
+              v-else
+              :src="previewUrl"
+              controls
+              playsinline
+              preload="metadata"
+              class="media-inspector-media"
+            />
+          </div>
+        </section>
+
+        <ElAlert
+          v-if="refPreflight && refPreflight.level !== 'none'"
+          :type="refPreflight.level === 'error' ? 'error' : 'warning'"
+          :closable="false"
+          show-icon
+          class="media-inspector-alert"
+          :title="refPreflight.message"
+        />
+
+        <section class="media-inspector-section">
+          <h4 class="media-inspector-section-title">文件信息</h4>
+          <p v-if="lazyLoading" class="media-inspector-muted">正在读取文件属性…</p>
+          <p
+            v-else-if="outputFile?.probeStatus === 'failed'"
+            class="media-inspector-muted"
+          >
+            未能读取文件属性
+          </p>
+          <dl v-else-if="fileInfoRows.length" class="media-inspector-dl">
+            <template v-for="row in fileInfoRows" :key="row.label">
+              <dt>{{ row.label }}</dt>
+              <dd>
+                <span>{{ row.value }}</span>
+                <button
+                  v-if="row.copy"
+                  type="button"
+                  class="media-inspector-copy-inline"
+                  @click="copyValue(row.copy)"
+                >
+                  复制
+                </button>
+              </dd>
+            </template>
+          </dl>
+          <p v-else class="media-inspector-muted">暂无文件属性</p>
+        </section>
+
+        <section v-if="generationParams.length" class="media-inspector-section">
+          <h4 class="media-inspector-section-title">生成参数</h4>
+          <dl class="media-inspector-dl">
+            <template v-for="row in generationParams" :key="row.label">
+              <dt>{{ row.label }}</dt>
+              <dd>{{ row.value }}</dd>
+            </template>
+          </dl>
+        </section>
+
+        <section v-if="referenceItems.length" class="media-inspector-section">
+          <h4 class="media-inspector-section-title">参考媒体</h4>
+          <MediaRefList :refs="referenceItems" />
+        </section>
+
+        <section class="media-inspector-section media-inspector-actions">
+          <button type="button" class="media-inspector-action" @click="copyTaskId">
+            {{ taskIdCopyLabel }}
+          </button>
+          <button
+            v-if="previewUrl"
+            type="button"
+            class="media-inspector-action"
+            @click="downloadOutput"
+          >
+            下载
+          </button>
+        </section>
+      </div>
+    </div>
+  </ElDrawer>
+</template>
+
+<style scoped>
+.media-inspector {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  color: var(--neo-text-primary);
+}
+
+.media-inspector-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 16px 16px 12px;
+  border-bottom: 1px solid var(--neo-border);
+}
+
+.media-inspector-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.media-inspector-subtitle {
+  margin: 4px 0 0;
+  font-size: 11px;
+  color: var(--neo-text-secondary);
+}
+
+.media-inspector-close {
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--neo-text-secondary);
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.media-inspector-close:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--neo-text-primary);
+}
+
+.media-inspector-loading,
+.media-inspector-error {
+  padding: 16px;
+  font-size: 13px;
+}
+
+.media-inspector-error {
+  color: #fca5a5;
+}
+
+.media-inspector-body {
+  flex: 1;
+  overflow: auto;
+  padding: 0 16px 16px;
+}
+
+.media-inspector-section {
+  padding-top: 14px;
+}
+
+.media-inspector-section-title {
+  margin: 0 0 8px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--neo-text-secondary);
+}
+
+.media-inspector-preview {
+  overflow: hidden;
+  border-radius: 12px;
+  border: 1px solid var(--neo-border);
+  background: rgba(0, 0, 0, 0.25);
+}
+
+.media-inspector-media {
+  display: block;
+  width: 100%;
+  max-height: 180px;
+  object-fit: contain;
+  background: #000;
+}
+
+.media-inspector-alert {
+  margin-top: 12px;
+}
+
+.media-inspector-dl {
+  display: grid;
+  grid-template-columns: 72px 1fr;
+  gap: 6px 8px;
+  margin: 0;
+}
+
+.media-inspector-dl dt {
+  margin: 0;
+  font-size: 11px;
+  color: var(--neo-text-secondary);
+}
+
+.media-inspector-dl dd {
+  margin: 0;
+  font-size: 12px;
+  word-break: break-all;
+}
+
+.media-inspector-copy-inline {
+  margin-left: 6px;
+  border: none;
+  background: none;
+  color: #a78bfa;
+  font-size: 11px;
+  cursor: pointer;
+  padding: 0;
+}
+
+.media-inspector-muted {
+  margin: 0;
+  font-size: 12px;
+  color: var(--neo-text-secondary);
+}
+
+.media-inspector-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.media-inspector-action {
+  width: 100%;
+  border: 1px solid var(--neo-border);
+  border-radius: 10px;
+  padding: 9px 12px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--neo-text-primary);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.media-inspector-action:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+</style>
+
+<style>
+.media-inspector-drawer .el-drawer__body {
+  padding: 0;
+  background: var(--neo-popover-bg, #14141a);
+}
+</style>

--- a/apps/web/src/components/media/MediaRefList.vue
+++ b/apps/web/src/components/media/MediaRefList.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { MediaRefPreflight, ProbedMediaFile } from '@lnkpi/shared'
+import { resolveMediaUrl } from '@/services/api-base'
+import { formatMediaBytes, formatMediaDimensions } from '@/utils/mediaInfoFormat'
+
+type RefItem =
+  | (ProbedMediaFile & { refKey?: string; role?: string })
+  | MediaRefPreflight['refs'][number]
+
+const props = defineProps<{
+  refs: RefItem[]
+}>()
+
+const items = computed(() =>
+  props.refs.map((ref) => {
+    const dims = formatMediaDimensions(ref.width, ref.height)
+    const size = formatMediaBytes(ref.bytes)
+    const detail = [dims, size].filter(Boolean).join(' · ')
+    const level = 'level' in ref ? ref.level : undefined
+    return {
+      key: ref.refKey ?? ref.url,
+      refKey: ref.refKey,
+      url: ref.url,
+      thumbUrl: resolveMediaUrl(ref.url),
+      detail,
+      level,
+      probeFailed: 'probeStatus' in ref && ref.probeStatus === 'failed',
+    }
+  }),
+)
+</script>
+
+<template>
+  <ul v-if="items.length" class="media-ref-list">
+    <li v-for="item in items" :key="item.key" class="media-ref-item">
+      <img
+        v-if="item.thumbUrl"
+        :src="item.thumbUrl"
+        alt=""
+        class="media-ref-thumb"
+        loading="lazy"
+      >
+      <div class="media-ref-body">
+        <div class="media-ref-title">
+          <span class="media-ref-key">{{ item.refKey || '参考图' }}</span>
+          <span v-if="item.level === 'warn'" class="media-ref-badge is-warn">偏大</span>
+          <span v-else-if="item.level === 'error'" class="media-ref-badge is-error">过大</span>
+          <span v-else-if="item.probeFailed" class="media-ref-badge is-error">读取失败</span>
+        </div>
+        <p v-if="item.detail" class="media-ref-detail">{{ item.detail }}</p>
+      </div>
+    </li>
+  </ul>
+  <p v-else class="media-ref-empty">无参考媒体</p>
+</template>
+
+<style scoped>
+.media-ref-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.media-ref-item {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.media-ref-thumb {
+  width: 44px;
+  height: 44px;
+  flex-shrink: 0;
+  border-radius: 8px;
+  object-fit: cover;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.media-ref-body {
+  min-width: 0;
+  flex: 1;
+}
+
+.media-ref-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.media-ref-key {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--neo-text-primary);
+}
+
+.media-ref-badge {
+  display: inline-flex;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.media-ref-badge.is-warn {
+  background: rgba(234, 179, 8, 0.15);
+  color: #facc15;
+}
+
+.media-ref-badge.is-error {
+  background: rgba(239, 68, 68, 0.15);
+  color: #fca5a5;
+}
+
+.media-ref-detail {
+  margin: 2px 0 0;
+  font-size: 11px;
+  color: var(--neo-text-secondary);
+}
+
+.media-ref-empty {
+  margin: 0;
+  font-size: 12px;
+  color: var(--neo-text-secondary);
+}
+</style>

--- a/apps/web/src/composables/useMediaInspector.ts
+++ b/apps/web/src/composables/useMediaInspector.ts
@@ -1,0 +1,102 @@
+import { ref } from 'vue'
+import type { ProbedMediaFile } from '@lnkpi/shared'
+import { studioApi, type GenerationRecord } from '@/services/studio-api'
+
+export interface NodeMediaInfoSummary {
+  width?: number
+  height?: number
+  bytes?: number
+  model?: string
+  refWarning?: 'warn' | 'error'
+}
+
+export interface MediaInspectorTarget {
+  generationRecordId: string
+  nodeId?: string
+  nodeLabel?: string
+  url?: string
+  kind?: 'image' | 'video'
+}
+
+interface CachedRecord {
+  record: GenerationRecord
+  fetchedAt: number
+}
+
+const recordCache = new Map<string, CachedRecord>()
+const probeCache = new Map<string, ProbedMediaFile>()
+
+const open = ref(false)
+const loading = ref(false)
+const error = ref<string | null>(null)
+const target = ref<MediaInspectorTarget | null>(null)
+const record = ref<GenerationRecord | null>(null)
+
+export function buildNodeMediaInfoSummary(rec: GenerationRecord): NodeMediaInfoSummary | undefined {
+  const output = rec.mediaInfo?.output
+  const summary: NodeMediaInfoSummary = {}
+
+  if (output?.width != null) summary.width = output.width
+  if (output?.height != null) summary.height = output.height
+  if (output?.bytes != null) summary.bytes = output.bytes
+  if (rec.model) summary.model = rec.model
+
+  const refLevel = rec.refPreflight?.level
+  if (refLevel === 'warn' || refLevel === 'error') {
+    summary.refWarning = refLevel
+  }
+
+  return Object.keys(summary).length ? summary : undefined
+}
+
+export function useMediaInspector() {
+  async function openInspector(next: MediaInspectorTarget) {
+    target.value = next
+    open.value = true
+    error.value = null
+    loading.value = true
+    try {
+      const cached = recordCache.get(next.generationRecordId)
+      if (cached) {
+        record.value = cached.record
+      } else {
+        const { data: res } = await studioApi.getGeneration(next.generationRecordId)
+        recordCache.set(next.generationRecordId, { record: res.data, fetchedAt: Date.now() })
+        record.value = res.data
+      }
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : '加载媒体属性失败'
+      record.value = null
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function closeInspector() {
+    open.value = false
+  }
+
+  async function probeMedia(url: string): Promise<ProbedMediaFile> {
+    const cached = probeCache.get(url)
+    if (cached) return cached
+    const probed = await studioApi.probeMedia(url)
+    probeCache.set(url, probed)
+    return probed
+  }
+
+  function invalidateRecordCache(generationRecordId: string) {
+    recordCache.delete(generationRecordId)
+  }
+
+  return {
+    open,
+    loading,
+    error,
+    target,
+    record,
+    openInspector,
+    closeInspector,
+    probeMedia,
+    invalidateRecordCache,
+  }
+}

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -20,6 +20,7 @@ import {
 } from '@/composables/useGenerationPolling'
 import { parseRefMentions } from '@/composables/useRefMentions'
 import { notifyGenerationSaveLocalHint } from '@/composables/useCanvasMedia'
+import { buildNodeMediaInfoSummary } from '@/composables/useMediaInspector'
 import { canvasApi } from '@/services/canvas-api'
 import { studioApi, type CanvasGenerationScope, type GenerationRecord, type StudioRefPayload } from '@/services/studio-api'
 import {
@@ -469,6 +470,8 @@ async function cancelRemoteGeneration(nodeId: string) {
           if (lastFrameUrl) patch.lastFrameUrl = lastFrameUrl
         }
       }
+      const mediaSummary = buildNodeMediaInfoSummary(record)
+      if (mediaSummary) patch.mediaInfo = mediaSummary
       deps.patchNodeData(nodeId, patch)
       if (
         wasGenerating &&

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -112,6 +112,7 @@ import { useAgentMobileLayout } from '@/composables/useAgentMobileLayout'
 import type { CanvasAssetItem } from '@/components/canvas/CanvasAssetPanel.vue'
 import AIImageEditor from '@/components/canvas/AIImageEditor.vue'
 import MediaPreviewOverlay from '@/components/canvas/MediaPreviewOverlay.vue'
+import MediaInspectorDrawer from '@/components/media/MediaInspectorDrawer.vue'
 import CanvasContextMenu from '@/components/canvas/CanvasContextMenu.vue'
 import StoryboardDialog, { type StoryboardShot } from '@/components/canvas/StoryboardDialog.vue'
 import PublishNeoTVDialog from '@/components/works/PublishNeoTVDialog.vue'
@@ -3076,6 +3077,7 @@ onUnmounted(() => {
     />
     <AIImageEditor @apply="handleImageEditorApply" />
     <MediaPreviewOverlay />
+    <MediaInspectorDrawer />
     <CanvasContextMenu
       v-if="contextMenu"
       :x="contextMenu.x"

--- a/apps/web/src/services/studio-api.ts
+++ b/apps/web/src/services/studio-api.ts
@@ -1,5 +1,11 @@
 import { api } from './api'
-import type { GenerationDiagnostic, GenerationRefPayload } from '@lnkpi/shared'
+import type {
+  GenerationDiagnostic,
+  GenerationRefPayload,
+  MediaInfo,
+  MediaRefPreflight,
+  ProbedMediaFile,
+} from '@lnkpi/shared'
 
 export type StudioRefPayload = GenerationRefPayload
 
@@ -19,6 +25,8 @@ export interface GenerationRecord {
   sessionId?: string | null
   nodeId?: string | null
   createdAt: string
+  mediaInfo?: MediaInfo
+  refPreflight?: MediaRefPreflight
 }
 
 export interface AudioGenerateOptions {
@@ -203,4 +211,10 @@ export const studioApi = {
     api
       .get<{ data: GenerationDiagnostic }>(`/studio/generations/${id}/diagnostic`)
       .then((r) => r.data.data),
+  probeMedia: async (url: string): Promise<ProbedMediaFile> => {
+    const { data: res } = await api.get<{ data: ProbedMediaFile }>('/studio/media-probe', {
+      params: { url },
+    })
+    return res.data
+  },
 }

--- a/apps/web/src/styles/neo-node.css
+++ b/apps/web/src/styles/neo-node.css
@@ -450,6 +450,77 @@
   object-fit: cover;
 }
 
+.neo-media-info-summary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  padding: 4px 8px;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.62);
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 10px;
+  line-height: 1.25;
+  backdrop-filter: blur(6px);
+}
+
+.neo-media-info-summary--overlay {
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  bottom: 8px;
+  z-index: 2;
+}
+
+.neo-media-info-summary-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.neo-media-info-summary-warn {
+  flex-shrink: 0;
+  font-weight: 600;
+}
+
+.neo-media-info-summary-warn.is-warn {
+  color: #fde047;
+}
+
+.neo-media-info-summary-warn.is-error {
+  color: #fca5a5;
+}
+
+.neo-media-inspector-btn {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 4;
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.55);
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+
+.neo-media-inspector-btn.is-completed {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.neo-media-inspector-btn:hover {
+  color: #c4b5fd;
+  background: rgba(0, 0, 0, 0.72);
+}
+
 .neo-gen-video-poster {
   pointer-events: none;
 }

--- a/apps/web/src/utils/mediaInfoFormat.ts
+++ b/apps/web/src/utils/mediaInfoFormat.ts
@@ -1,0 +1,18 @@
+export function formatMediaBytes(bytes?: number): string | null {
+  if (bytes == null) return null
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)}MB`
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)}KB`
+  return `${bytes}B`
+}
+
+export function formatMediaDimensions(width?: number, height?: number): string | null {
+  if (width == null || height == null) return null
+  return `${width}×${height}`
+}
+
+export function truncateUrl(url: string, max = 48): string {
+  if (url.length <= max) return url
+  const head = Math.ceil((max - 1) / 2)
+  const tail = Math.floor((max - 1) / 2)
+  return `${url.slice(0, head)}…${url.slice(-tail)}`
+}

--- a/deploy/prod-media-inspector-verify.py
+++ b/deploy/prod-media-inspector-verify.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Production verify for Media Inspector P0 (mediaInfo + media-probe).
+
+Usage:
+  python3 deploy/prod-media-inspector-verify.py
+  BASE_URL=http://119.29.173.89:8888 PHONE=17279698608 CODE=123456 python3 deploy/prod-media-inspector-verify.py
+  PROBE_URL=https://platform-outputs.agnes-ai.space/.../out.png python3 deploy/prod-media-inspector-verify.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+BASE = os.environ.get("BASE_URL", "http://119.29.173.89:8888").rstrip("/")
+API = f"{BASE}/api"
+PHONE = os.environ.get("PHONE", "17279698608")
+CODE = os.environ.get("CODE", "123456")
+PROBE_URL = os.environ.get("PROBE_URL", "").strip()
+LIST_LIMIT = int(os.environ.get("LIST_LIMIT", "10"))
+
+PASS = FAIL = WARN = 0
+
+
+def record(case: str, ok: bool, detail: str = "", *, warn: bool = False) -> None:
+    global PASS, FAIL, WARN
+    if warn:
+        WARN += 1
+        icon = "⚠️"
+    elif ok:
+        PASS += 1
+        icon = "✅"
+    else:
+        FAIL += 1
+        icon = "❌"
+    line = f"{icon} {case}"
+    if detail:
+        line += f" — {detail[:240]}"
+    print(line)
+
+
+def http_json(method: str, path: str, body: dict | None = None, token: str | None = None) -> Any:
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = Request(
+        f"{API}{path}",
+        data=None if body is None else json.dumps(body).encode(),
+        headers=headers,
+        method=method,
+    )
+    with urlopen(req, timeout=120) as resp:
+        return json.loads(resp.read())
+
+
+def pick_completed_record(rows: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for row in rows:
+        if str(row.get("status") or "") != "completed":
+            continue
+        if str(row.get("type") or "") in ("image", "video"):
+            return row
+    return None
+
+
+def pick_probe_url(record: dict[str, Any], explicit: str) -> str | None:
+    if explicit:
+        return explicit
+    url = str(record.get("url") or "").strip()
+    if url.startswith("http"):
+        return url
+    try:
+        meta = json.loads(str(record.get("metadata") or "{}"))
+    except json.JSONDecodeError:
+        meta = {}
+    media_info = meta.get("mediaInfo") if isinstance(meta, dict) else None
+    if isinstance(media_info, dict):
+        output = media_info.get("output")
+        if isinstance(output, dict):
+            out_url = str(output.get("url") or "").strip()
+            if out_url.startswith("http"):
+                return out_url
+    return None
+
+
+def main() -> int:
+    print("=== Media Inspector P0 production verify ===")
+    print(f"BASE={BASE}\n")
+
+    try:
+        http_json("POST", "/auth/send-code", {"phone": PHONE})
+    except Exception:
+        pass
+
+    try:
+        token = http_json("POST", "/auth/login", {"phone": PHONE, "code": CODE})["data"]["token"]
+        record("Login", True)
+    except Exception as exc:  # noqa: BLE001
+        record("Login", False, str(exc))
+        print(f"\nRESULT: PASS={PASS} FAIL={FAIL} WARN={WARN}")
+        return 1
+
+    try:
+        list_res = http_json(
+            "GET",
+            f"/studio/generations?{urlencode({'limit': LIST_LIMIT})}",
+            token=token,
+        )
+        rows = list_res.get("data") or []
+        record("List recent generations", isinstance(rows, list), f"count={len(rows)}")
+    except Exception as exc:  # noqa: BLE001
+        record("List recent generations", False, str(exc))
+        print(f"\nRESULT: PASS={PASS} FAIL={FAIL} WARN={WARN}")
+        return 1
+
+    target = pick_completed_record(rows)
+    if not target:
+        record("Find completed image/video record", False, "none in recent list")
+        print(f"\nRESULT: PASS={PASS} FAIL={FAIL} WARN={WARN}")
+        return 1
+
+    record_id = str(target.get("id") or "")
+    record(
+        "Find completed image/video record",
+        True,
+        f"id={record_id} type={target.get('type')}",
+    )
+
+    try:
+        detail = http_json("GET", f"/studio/generations/{record_id}", token=token).get("data") or {}
+    except Exception as exc:  # noqa: BLE001
+        record("GET generation detail", False, str(exc))
+        print(f"\nRESULT: PASS={PASS} FAIL={FAIL} WARN={WARN}")
+        return 1
+
+    has_media_info_key = "mediaInfo" in detail
+    record("Generation response has mediaInfo key", has_media_info_key, record_id)
+    if not has_media_info_key:
+        print(f"\nRESULT: PASS={PASS} FAIL={FAIL} WARN={WARN}")
+        return 1
+
+    media_info = detail.get("mediaInfo")
+    if media_info:
+        output = media_info.get("output") if isinstance(media_info, dict) else None
+        dims = None
+        if isinstance(output, dict):
+            dims = f"{output.get('width')}x{output.get('height')}"
+        record("mediaInfo populated", True, dims or "has output/references")
+    else:
+        record(
+            "mediaInfo populated",
+            True,
+            "empty on legacy record — deploy mediaInfo backfill may be pending",
+            warn=True,
+        )
+
+    probe_url = pick_probe_url(detail, PROBE_URL)
+    if not probe_url:
+        record("Resolve probe URL", False, "no http output url; set PROBE_URL")
+        print(f"\nRESULT: PASS={PASS} FAIL={FAIL} WARN={WARN}")
+        return 1
+
+    try:
+        probe_res = http_json(
+            "GET",
+            f"/studio/media-probe?{urlencode({'url': probe_url})}",
+            token=token,
+        ).get("data") or {}
+        width = probe_res.get("width")
+        height = probe_res.get("height")
+        ok = isinstance(width, int) and width > 0 and isinstance(height, int) and height > 0
+        record(
+            "GET media-probe width/height",
+            ok,
+            f"{width}x{height} status={probe_res.get('probeStatus')} url={probe_url[:120]}",
+        )
+    except Exception as exc:  # noqa: BLE001
+        record("GET media-probe width/height", False, str(exc))
+
+    print(f"\nRESULT: PASS={PASS} FAIL={FAIL} WARN={WARN}")
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/superpowers/plans/2026-08-15-media-inspector.md
+++ b/docs/superpowers/plans/2026-08-15-media-inspector.md
@@ -1,0 +1,433 @@
+# 媒体属性 Inspector + 视频参考图预检 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 实现画布/资产库统一的只读 **MediaInspector**（L0 摘要 + L1 属性 Drawer），服务端 **mediaInfo probe** 落库，并在视频 keyframes 生成前 **block 超大参考图**，防止 Agnes 400 类失败。
+
+**Architecture:** `@lnkpi/shared` 定义 `MediaInfo` 与预检阈值；Nest `MediaProbeService` 在生成完成与 video 发起前 probe；`studio.service` 写 metadata + preflight 拦截；Vue `MediaInspectorDrawer` 统一入口，节点/任务历史/VideoDock 集成。
+
+**Tech Stack:** NestJS、Prisma SQLite、Vue 3 + Element Plus、Vitest、Python prod verify
+
+**Spec:** `docs/superpowers/specs/2026-08-15-media-inspector-design.md`
+
+## Global Constraints
+
+- P0 范围：**不含** UserAsset.metadata 迁移（P1）、**不含** 自动 downscale inline（P1）
+- Inspector 与 Dock **职责分离**：Inspector 只读，Dock 可编辑
+- 成功态节点 ⓘ 打开 Inspector；失败态 diagnostic **复用**现有 `NodeDiagnosticPopover` / GET diagnostic
+- 视频 preflight：`level === 'error'` 且 `refWire === 'agnes_keyframes'` → **400 block**，不调用 upstream
+- 阈值（verbatim）：warn 5MB / 2048px；error 10MB / 4096px
+- probe 超时 10s；`/studio/media-probe` rate limit 30/min/user
+- TDD：先写失败测试再实现；提交前缀 `feat:` / `fix:` / `test:`
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `packages/shared/src/mediaInfo.ts` | `MediaInfo`, `ProbedMediaFile`, 阈值, `evaluateMediaRefPreflight()` |
+| `packages/shared/src/mediaInfo.test.ts` | 共享单测 |
+| `packages/shared/src/index.ts` | 导出 |
+| `apps/server/src/media/media-probe.service.ts` | URL probe（HEAD + 图片头解析） |
+| `apps/server/src/media/media-probe.service.test.ts` | probe 单测 |
+| `apps/server/src/media/media-probe.module.ts` | Nest module |
+| `apps/server/src/studio/studio.service.ts` | completed 写 mediaInfo；video preflight |
+| `apps/server/src/studio/studio.controller.ts` | `GET media-probe`；generation 响应扩展 |
+| `apps/server/src/studio/studio.video-preflight.test.ts` | 超大 ref block |
+| `apps/web/src/components/media/MediaInspectorDrawer.vue` | L1/L2 UI |
+| `apps/web/src/components/media/MediaInfoSummary.vue` | L0 摘要 |
+| `apps/web/src/components/media/MediaRefList.vue` | 参考图 + badge |
+| `apps/web/src/composables/useMediaInspector.ts` | 状态 + API |
+| `apps/web/src/services/studio-api.ts` | 类型 + probe client |
+| `apps/web/src/composables/useNodeGeneration.ts` | `applyStudioRecord` 写摘要 |
+| `apps/web/src/components/canvas/CanvasNodeImage.vue` | L0 + ⓘ |
+| `apps/web/src/components/canvas/CanvasNodeVideo.vue` | L0 + ⓘ |
+| `apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue` | preflight banner |
+| `apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue` | 嵌入 Inspector 区 |
+| `deploy/prod-media-inspector-verify.py` | 生产验收 |
+
+---
+
+### Task 0: 分支与基线
+
+**Files:** —
+
+- [ ] **Step 1:** `git checkout main && git pull origin main`
+- [ ] **Step 2:** `git checkout -b feature/media-inspector-p0`
+- [ ] **Step 3:** `pnpm build` 确认基线绿
+
+---
+
+### Task 1: Shared MediaInfo 类型与预检逻辑
+
+**Files:**
+- Create: `packages/shared/src/mediaInfo.ts`
+- Create: `packages/shared/src/mediaInfo.test.ts`
+- Modify: `packages/shared/src/index.ts`
+
+**Interfaces:**
+- Produces:
+  - `export interface ProbedMediaFile { url: string; width?: number; height?: number; bytes?: number; mimeType?: string; durationSec?: number; probeStatus: 'ok' | 'failed' | 'pending'; probeError?: string }`
+  - `export interface MediaInfo { output?: ProbedMediaFile; references?: Array<ProbedMediaFile & { refKey?: string; role?: string }>; probedAt?: string }`
+  - `export type MediaRefWarningLevel = 'none' | 'warn' | 'error'`
+  - `export interface MediaRefPreflight { level: MediaRefWarningLevel; code?: string; message: string; refs: Array<{ url: string; refKey?: string; width?: number; height?: number; bytes?: number; level: MediaRefWarningLevel }> }`
+  - `export const VIDEO_REF_WARN_BYTES`, `VIDEO_REF_ERROR_BYTES`, `VIDEO_REF_WARN_MAX_EDGE`, `VIDEO_REF_ERROR_MAX_EDGE`
+  - `export function maxEdge(width?: number, height?: number): number`
+  - `export function classifyRefSize(file: Pick<ProbedMediaFile, 'width' | 'height' | 'bytes'>): MediaRefWarningLevel`
+  - `export function evaluateMediaRefPreflight(refs: Array<ProbedMediaFile & { refKey?: string }>, opts?: { blockWire?: string }): MediaRefPreflight`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest'
+import {
+  classifyRefSize,
+  evaluateMediaRefPreflight,
+  VIDEO_REF_ERROR_BYTES,
+} from './mediaInfo'
+
+describe('classifyRefSize', () => {
+  it('errors on 3072x4096 13MB poster (prod case)', () => {
+    expect(classifyRefSize({ width: 3072, height: 4096, bytes: 13_367_984 })).toBe('error')
+  })
+  it('warns on 1024x1024 6MB', () => {
+    expect(classifyRefSize({ width: 1024, height: 1024, bytes: 6 * 1024 * 1024 })).toBe('warn')
+  })
+  it('none on 1024x1024 1MB', () => {
+    expect(classifyRefSize({ width: 1024, height: 1024, bytes: 1_000_000 })).toBe('none')
+  })
+})
+
+describe('evaluateMediaRefPreflight', () => {
+  it('returns error level when any ref exceeds error threshold', () => {
+    const r = evaluateMediaRefPreflight([
+      { url: 'a', refKey: 'I1', width: 1024, height: 1024, bytes: 900_000, probeStatus: 'ok' },
+      { url: 'b', refKey: 'I3', width: 3072, height: 4096, bytes: VIDEO_REF_ERROR_BYTES + 1, probeStatus: 'ok' },
+    ])
+    expect(r.level).toBe('error')
+    expect(r.message).toMatch(/I3/)
+  })
+})
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+Run: `pnpm --filter @lnkpi/shared exec vitest run src/mediaInfo.test.ts`  
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement `mediaInfo.ts` + export in `index.ts`**
+
+- [ ] **Step 4: Run test — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/mediaInfo.ts packages/shared/src/mediaInfo.test.ts packages/shared/src/index.ts
+git commit -m "feat(shared): MediaInfo types and video ref preflight thresholds"
+```
+
+---
+
+### Task 2: MediaProbeService（服务端 probe）
+
+**Files:**
+- Create: `apps/server/src/media/media-probe.service.ts`
+- Create: `apps/server/src/media/media-probe.service.test.ts`
+- Create: `apps/server/src/media/media-probe.module.ts`
+- Modify: `apps/server/src/studio/studio.module.ts`（import MediaProbeModule）
+
+**Interfaces:**
+- Produces:
+  - `@Injectable() class MediaProbeService { probeUrl(url: string): Promise<ProbedMediaFile> }`
+  - `parsePngDimensions(buf: Buffer): { width: number; height: number } | null`
+  - `parseJpegDimensions(buf: Buffer): { width: number; height: number } | null`
+
+- [ ] **Step 1: Write failing tests**（PNG IHDR 假 buffer + JPEG SOF 假 buffer；mock fetch HEAD）
+
+- [ ] **Step 2: Run — FAIL**
+
+Run: `pnpm --filter @lnkpi/server exec vitest run src/media/media-probe.service.test.ts`
+
+- [ ] **Step 3: Implement probe**（HEAD content-length；GET Range 0-65535 解析宽高）
+
+- [ ] **Step 4: Run — PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(server): MediaProbeService for URL dimension and size probe"
+```
+
+---
+
+### Task 3: 生成完成写 mediaInfo + GET 扩展
+
+**Files:**
+- Modify: `apps/server/src/studio/studio.service.ts`
+- Modify: `apps/server/src/studio/studio.controller.ts`
+- Create: `apps/server/src/studio/studio.media-info.test.ts`
+
+**Interfaces:**
+- Consumes: `MediaProbeService`, `MediaInfo` from shared
+- Produces:
+  - `private async attachMediaInfoToRecord(recordId: string, outputUrl: string | null, referenceUrls: string[]): Promise<void>`
+  - `GET /studio/generations/:id` 响应 JSON 增加 `mediaInfo?: MediaInfo`
+
+- [ ] **Step 1: Test** — mock probe；image completed 后 metadata 含 `mediaInfo.output.width`
+
+- [ ] **Step 2: Implement** — 在 `completeImage` / `completeVideo` success 分支调用 `attachMediaInfoToRecord`
+
+- [ ] **Step 3: Run tests + `pnpm build`**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(studio): persist mediaInfo on generation complete"
+```
+
+---
+
+### Task 4: Video 参考图 preflight（block 超大 ref）
+
+**Files:**
+- Modify: `apps/server/src/studio/studio.service.ts`（`generateVideo` / `completeVideo` 前）
+- Create: `apps/server/src/studio/studio.video-preflight.test.ts`
+
+**Interfaces:**
+- Consumes: `evaluateMediaRefPreflight`, `MediaProbeService`
+- Produces: 抛 `BadRequestException` message 含 refKey；metadata 写 `refPreflight`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+it('blocks agnes_keyframes when ref exceeds error threshold', async () => {
+  // mock probe returning 3072x4096 13MB for third ref
+  await expect(svc.generateVideo(/* ... 3 refs ... */)).rejects.toThrow(/I3|过大/)
+  expect(videoGenerate).not.toHaveBeenCalled()
+})
+```
+
+- [ ] **Step 2: Run — FAIL**
+
+- [ ] **Step 3: Implement preflight in generateVideo**（probe refs → evaluate → block）
+
+- [ ] **Step 4: Run — PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(studio): block oversized video keyframe references before upstream"
+```
+
+---
+
+### Task 5: GET /studio/media-probe
+
+**Files:**
+- Modify: `apps/server/src/studio/studio.controller.ts`
+- Modify: `apps/server/src/studio/studio.media-info.test.ts`
+
+- [ ] **Step 1: Test** — 鉴权用户 probe allowlist URL 返回 ProbedMediaFile
+
+- [ ] **Step 2: Implement** — query `url`；拒绝非 http(s) / 非 allowlist（`platform-outputs.agnes-ai.space`, 本机 uploads 等）
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat(studio): authenticated media-probe endpoint"
+```
+
+---
+
+### Task 6: 前端 API + useMediaInspector
+
+**Files:**
+- Modify: `apps/web/src/services/studio-api.ts`
+- Create: `apps/web/src/composables/useMediaInspector.ts`
+
+- [ ] **Step 1: Extend `GenerationRecord` type** with `mediaInfo?: MediaInfo`, `refPreflight?: MediaRefPreflight`
+
+- [ ] **Step 2: Add `studioApi.probeMedia(url)`**
+
+- [ ] **Step 3: `useMediaInspector`** — `open({ generationRecordId?, url?, nodeId? })`；lazy fetch；缓存 Map
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(web): media inspector composable and studio API types"
+```
+
+---
+
+### Task 7: MediaInspector UI 组件
+
+**Files:**
+- Create: `apps/web/src/components/media/MediaInspectorDrawer.vue`
+- Create: `apps/web/src/components/media/MediaInfoSummary.vue`
+- Create: `apps/web/src/components/media/MediaRefList.vue`
+
+- [ ] **Step 1: MediaInfoSummary** — props: `{ width?, height?, bytes?, model?, refWarning? }`
+
+- [ ] **Step 2: MediaRefList** — 列表 + warn/error badge
+
+- [ ] **Step 3: MediaInspectorDrawer** — 320px ElDrawer；区块：预览、文件、生成、参考、操作按钮
+
+- [ ] **Step 4: Manual smoke** — Storybook 或 Canvas 本地打开
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(web): MediaInspector drawer and summary components"
+```
+
+---
+
+### Task 8: 画布节点 + useNodeGeneration 集成
+
+**Files:**
+- Modify: `apps/web/src/components/canvas/CanvasNodeImage.vue`
+- Modify: `apps/web/src/components/canvas/CanvasNodeVideo.vue`
+- Modify: `apps/web/src/composables/useNodeGeneration.ts`
+
+- [ ] **Step 1: `applyStudioRecord`** — 从 `record.mediaInfo` 写 `node.data.mediaInfo` 摘要
+
+- [ ] **Step 2: completed 节点** — 底部 `MediaInfoSummary`；右上角 ⓘ `@click="inspector.open({ generationRecordId })"`
+
+- [ ] **Step 3: 失败节点** — ⓘ 仍走 diagnostic；可选双按钮（属性 | 诊断）
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(canvas): node media summary and inspector entry"
+```
+
+---
+
+### Task 9: VideoDock preflight banner
+
+**Files:**
+- Modify: `apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue`
+
+- [ ] **Step 1: 选中 video 节点且有 referenceImages 时** — 调 probe（或读最近 failed record 的 pattern：生成前 client-side classify 若已有 mediaInfo on upstream image nodes）
+
+- [ ] **Step 2: P0 简化** — 生成 POST 若 400 preflight，toast 展示 server message
+
+- [ ] **Step 3: warn/error ElAlert** above 生成按钮 when refs probed
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(web): video dock ref preflight warning banner"
+```
+
+---
+
+### Task 10: 任务历史复用 Inspector
+
+**Files:**
+- Modify: `apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue`
+
+- [ ] **Step 1: 详情展开区** — 替换/并列现有参数字段为 `<MediaInspectorDrawer inline :record="record" />` 或只读子集
+
+- [ ] **Step 2: 避免重复 fetch** — 用 record 已有 mediaInfo
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat(web): task history uses MediaInspector read-only section"
+```
+
+---
+
+### Task 11: 生产验收脚本
+
+**Files:**
+- Create: `deploy/prod-media-inspector-verify.py`
+
+- [ ] **Step 1: 脚本逻辑**
+
+```python
+# 1. login
+# 2. GET /studio/generations?limit=5&type=video — find recent with referenceImages
+# 3. GET /studio/generations/:id — assert "mediaInfo" in response (after deploy)
+# 4. GET /studio/media-probe?url=<known png> — assert width/height
+# 5. print PASS/FAIL
+```
+
+- [ ] **Step 2: 本地 dry-run** against prod（只读）
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat(deploy): prod media inspector verify script"
+```
+
+---
+
+### Task 12: CI + PR
+
+- [ ] **Step 1:** `pnpm build`
+- [ ] **Step 2:** `pnpm --filter @lnkpi/shared exec vitest run src/mediaInfo.test.ts`
+- [ ] **Step 3:** `pnpm --filter @lnkpi/server exec vitest run src/media/media-probe.service.test.ts src/studio/studio.video-preflight.test.ts src/studio/studio.media-info.test.ts`
+- [ ] **Step 4:** `gh pr create` → CI watch → merge
+
+---
+
+## Execution tracking（闭环）
+
+> 实施过程中在本节勾选；PR merge 后补 **生产验证** 行。
+
+| ID | Task | Owner | Status | Evidence |
+|----|------|-------|--------|----------|
+| T0 | 分支基线 | — | `[ ]` | |
+| T1 | shared mediaInfo | — | `[ ]` | vitest log |
+| T2 | MediaProbeService | — | `[ ]` | vitest log |
+| T3 | completed 写 mediaInfo | — | `[ ]` | studio.media-info.test |
+| T4 | video preflight block | — | `[ ]` | studio.video-preflight.test |
+| T5 | media-probe API | — | `[ ]` | curl / pytest |
+| T6 | web composable | — | `[ ]` | |
+| T7 | Inspector UI | — | `[ ]` | screenshot |
+| T8 | 画布节点集成 | — | `[ ]` | manual UAT |
+| T9 | VideoDock banner | — | `[ ]` | manual UAT |
+| T10 | 任务历史 | — | `[ ]` | manual UAT |
+| T11 | prod verify script | — | `[ ]` | `prod-media-inspector-verify.py` |
+| T12 | CI / PR / merge | — | `[ ]` | PR URL |
+
+### 生产验证（merge + deploy 后）
+
+- [ ] `python3 deploy/prod-media-inspector-verify.py` 全绿
+- [ ] 会话 `cmsocwe7o000yqf01lbgv77wm` 复现：3 refs 含 3072 海报 → 生成前 UI 告警 + API 400 block
+- [ ] 新 video 生成 completed → GET record 含 `mediaInfo.output`
+
+### UAT checklist（spec §Testing）
+
+- [ ] 画布 image completed → hover 尺寸；ⓘ Inspector
+- [ ] video 超大 ref → Dock 红 banner；无法发起生成
+- [ ] 任务历史与 Inspector 信息一致
+
+---
+
+## P1 extension（不在本 plan 执行，仅跟踪入口）
+
+| 项 | Spec 节 | 状态 |
+|----|---------|------|
+| UserAsset.metadata 迁移 | §Data model | `[ ]` |
+| 资产库 Inspector 入口 | §UX | `[ ]` |
+| 超大 ref 自动 downscale inline | §Server P1 | `[ ]` |
+
+---
+
+## Plan self-review
+
+- [x] Spec P0 每条需求可映射到 Task 1–12
+- [x] 无 TBD 步骤；测试命令具体
+- [x] 生产故障 case 覆盖 Task 1 + Task 4 + Task 11
+- [x] 类型名前后一致（`MediaInfo`, `MediaRefPreflight`, `ProbedMediaFile`）
+
+---
+
+**Plan complete.** 执行选项：
+
+1. **Subagent-Driven（推荐）** — 每 Task 独立 subagent + 任务间 review  
+2. **Inline Execution** — 本会话按 Task 0→12 连续实施 + checkpoint
+
+请告知选择；若 spec 需修改，先改 spec 再动代码。

--- a/docs/superpowers/specs/2026-08-15-media-inspector-design.md
+++ b/docs/superpowers/specs/2026-08-15-media-inspector-design.md
@@ -1,0 +1,320 @@
+# 媒体属性 Inspector + 参考图 Probe / 视频预检 Design
+
+**Date:** 2026-08-15  
+**Status:** Approved for planning (pending user review of this file)  
+**代号:** **MEDIA-INSPECTOR**  
+**Related:**
+- 生产故障：`cmsud22f6003gpf01oybnvosn`（Agnes keyframes 因 I3 参考图 3072×4096 / 12.75MB 被拒）
+- `2026-07-21-node-generation-failure-diagnostics-design.md`（失败 ⓘ；本规格扩展成功态只读属性）
+- `2026-08-08-seedance-agnes-video-adapter-design.md`（video refWire / keyframes）
+- `2026-08-15-i2v-upstream-capability-audit-design.md`（I2V 能力产品化）
+
+---
+
+## Goal
+
+让创作者在**画布节点**与**资产库**上，用**一次点击**快速查看图片/视频的文件属性与生成上下文；并在视频生成前对参考图做**体积/尺寸预检**，避免上游 `image URL could not be downloaded or did not return a valid supported image` 类失败。
+
+## Decisions (locked)
+
+| Topic | Choice |
+|-------|--------|
+| 信息分层 | **L0** hover/角标摘要；**L1** Inspector 默认 Tab；**L2** 高级（prompt/seed/nativeParams）；**L3** 失败诊断（复用现有 diagnostic） |
+| 入口统一 | 画布节点、资产库、任务历史、预览浮层 → **同一 `MediaInspector` 组件** |
+| Dock 职责 | Dock = **编辑/再生成**；Inspector = **只读属性**（Figma Design vs Inspect） |
+| 数据 SSOT | `GenerationRecord.metadata.mediaInfo` + `Material.metadata.mediaInfo`；节点 `data.mediaInfo` 为 L0 缓存 |
+| Probe 时机 | 生成 **completed** 时服务端 probe 一次；参考图列表 lazy probe（视频生成前必 probe） |
+| 资产库 | `UserAsset.metadata` JSON（可选 `generationRecordId`）；存库时快照 L1 |
+| 视频预检 | 调用上游前 probe 全部 referenceImages；超阈值 **warn**（UI）+ 可选 **block**（服务端，见阈值） |
+| 超大图处理（P1） | 超阈值自动 downscale 至 2048 长边后 inline data URI（复用 `upstream-ref-inline` 思路）；P0 仅 warn |
+| API | 扩展 `GET /studio/generations/:id` 返回解析后的 `mediaInfo`；新增 `GET /studio/media-probe?url=`（鉴权 + 限流） |
+| 失败/成功 ⓘ | 成功态节点右上角 **18px ⓘ** 打开 Inspector；失败态 ⓘ 仍优先 diagnostic（Inspector 内链到诊断 Tab） |
+
+## Non-goals (this iteration)
+
+- EXIF/IPTC 深度解析、色彩空间、DPI 打印参数
+- 批量导出 CSV / 管理员全局媒体审计后台
+- Material/shot 旁路全面重构（仅复用 Inspector 组件读取 Material metadata）
+- Playwright 全链路 E2E（用手动 + pytest 生产脚本验收）
+- 视频参考图自动压缩 **强制** inline（P0 仅 warn；P1 Task 可选开启 auto-downscale）
+
+---
+
+## Problem baseline
+
+| 层 | 现状 | 问题 |
+|----|------|------|
+| 服务端 | `GenerationRecord.metadata` 含 model/refWire/参考 URL 等 | 无 width/height/bytes；参考图无 probe |
+| 节点 | `node.data` 仅 url/prompt/模型参数 | 成功态无属性入口；与 DB metadata 不同步 |
+| 资产库 | `UserAsset` 仅 url/label/kind | 存库丢弃生成上下文 |
+| 任务历史 | 部分展示 model/参数 | 无文件尺寸；与节点/资产库三套 UI |
+| 视频 | keyframes 直传 URL | 13MB 大图导致 BYOK 400；用户无事前感知 |
+
+---
+
+## UX
+
+### L0 — 零点击摘要
+
+- **Image/Video 节点** completed：节点底部细条（或 hover tooltip）：`1024×1024 · 0.9MB · seedream`
+- **Video 节点** 参考图有风险：细条追加 `⚠ ref 偏大`
+- **资产库** grid hover：同样格式的一行摘要
+
+### L1 — MediaInspector（一次点击）
+
+触发：节点 ⓘ、资产库「详情」、任务历史「属性」、预览浮层「更多信息」。
+
+**默认展开区块：**
+
+1. **预览** + 标题（label / 节点 id / 生成时间）
+2. **文件信息**：尺寸、体积、格式、时长（video）、URL（可复制，截断）
+3. **生成参数**：模型、渠道（BYOK/平台）、比例、分辨率、duration、videoMode、积分
+4. **参考媒体**（若有）：缩略图列表，每项含 refKey、尺寸、体积、告警 badge
+5. **操作**：复制任务 ID、定位画布节点、下载
+
+**告警规则（P0）：**
+
+| 条件 | 展示 | 视频 keyframes 含义 |
+|------|------|---------------------|
+| 长边 > 2048 或体积 > 5MB | 黄色 `偏大` | 可能上游拒收 |
+| 长边 > 4096 或体积 > 10MB | 红色 `过大` | 高概率失败（如生产 I3） |
+
+### L2 — 高级（折叠）
+
+- prompt（只读，可复制）
+- seed / negativePrompt / generateAudio
+- refWire / gatewayModelId / scenario
+- mergedText（若有）
+- nativeParams（JSON 折叠，默认收起）
+
+### L3 — 诊断（仅失败/fallback）
+
+- 复用 `NodeDiagnosticPopover` 数据与复制格式
+- Inspector 内 Tab 切换，不另做一套
+
+### 与 Dock 关系
+
+```
+选中节点
+├── Dock（底部）→ 编辑 prompt / 模型 / 再生成
+└── ⓘ Inspector（右侧 Drawer 320px）→ 只读属性
+```
+
+Drawer 不遮挡画布中心；移动端可全屏 Sheet。
+
+---
+
+## Data model
+
+### `MediaInfo`（shared SSOT）
+
+```ts
+export interface ProbedMediaFile {
+  url: string
+  width?: number
+  height?: number
+  bytes?: number
+  mimeType?: string
+  durationSec?: number   // video only
+  probeStatus: 'ok' | 'failed' | 'pending'
+  probeError?: string
+}
+
+export interface MediaInfo {
+  output?: ProbedMediaFile
+  references?: Array<ProbedMediaFile & { refKey?: string; role?: string }>
+  probedAt?: string      // ISO
+}
+
+export type MediaRefWarningLevel = 'none' | 'warn' | 'error'
+
+export interface MediaRefPreflight {
+  level: MediaRefWarningLevel
+  code?: 'ref_too_large' | 'ref_dimension_exceeded' | 'ref_probe_failed'
+  message: string
+  refs: Array<{ url: string; refKey?: string; width?: number; height?: number; bytes?: number; level: MediaRefWarningLevel }>
+}
+```
+
+### 阈值常量（shared）
+
+```ts
+export const VIDEO_REF_WARN_BYTES = 5 * 1024 * 1024      // 5MB
+export const VIDEO_REF_ERROR_BYTES = 10 * 1024 * 1024    // 10MB
+export const VIDEO_REF_WARN_MAX_EDGE = 2048
+export const VIDEO_REF_ERROR_MAX_EDGE = 4096
+```
+
+### Persistence
+
+**GenerationRecord / Material metadata**（生成 completed 时写入）：
+
+```json
+{
+  "mediaInfo": {
+    "output": { "url": "...", "width": 1024, "height": 1024, "bytes": 952274, "mimeType": "image/png", "probeStatus": "ok" },
+    "references": [
+      { "url": "...", "refKey": "I1", "width": 1024, "height": 1024, "bytes": 952274, "probeStatus": "ok" }
+    ],
+    "probedAt": "2026-08-15T12:37:00.000Z"
+  }
+}
+```
+
+**node.data**（`applyStudioRecord` 写入摘要）：
+
+```ts
+mediaInfo?: {
+  width?: number
+  height?: number
+  bytes?: number
+  model?: string
+  refWarning?: MediaRefWarningLevel
+}
+```
+
+**UserAsset**（Prisma 迁移）：
+
+```prisma
+model UserAsset {
+  // ...existing
+  metadata       String?   // JSON: { mediaInfo, generationRecordId?, promptPreview? }
+}
+```
+
+存库 API 接受可选 `generationRecordId`；服务端从 record 复制 `mediaInfo` 快照。
+
+---
+
+## Server behavior
+
+### Probe service
+
+`apps/server/src/media/media-probe.service.ts`
+
+- `probeUrl(url: string): Promise<ProbedMediaFile>`
+  - HEAD 取 content-length / content-type
+  - 图片：读 PNG IHDR 或 JPEG SOF（仅前 64KB）取宽高，避免全量下载
+  - 视频：优先 content-type + content-length；可选 ffprobe（**P0 不做**，duration 来自 generation metadata）
+- 超时 10s；失败 `probeStatus: 'failed'`
+
+### 写入时机
+
+| 事件 | 动作 |
+|------|------|
+| image/video completed | probe output url + metadata.referenceImages → 写 `mediaInfo` |
+| video generate 开始前 | probe 全部 refs → 写 `preflight` 到 metadata；超 error 阈值抛 `BadRequestException`（带 refKey） |
+| GET generation by id | 返回 `mediaInfo` + 解析后的 `preflight` |
+
+### Video preflight（P0）
+
+在 `studio.service.ts` `generateVideo` → `completeVideo` 之前：
+
+1. probe 所有 referenceImages
+2. 计算 `MediaRefPreflight`
+3. 若任一 ref `level === 'error'` 且 `refWire === 'agnes_keyframes'`：**拒绝发起上游**（400，`invalid_input`，userMessage 指明 refKey 与尺寸）
+4. 若 `warn`：仍允许生成，metadata 记录 `refPreflight`
+
+**错误示例（对齐生产 case）：**
+
+> 参考图 I3 过大（3072×4096，12.8MB），Agnes 关键帧模式可能无法处理。请压缩后重试或移除该参考图。
+
+### API
+
+| Method | Path | 说明 |
+|--------|------|------|
+| GET | `/studio/generations/:id` | 响应增加 `mediaInfo`, `refPreflight?` |
+| GET | `/studio/media-probe?url=` | 登录用户；同源或 allowlist 域名；rate limit 30/min |
+| POST | `/assets` | body 可含 `generationRecordId`；服务端填充 metadata |
+
+---
+
+## Frontend components
+
+| 组件 | 路径 | 职责 |
+|------|------|------|
+| `MediaInspectorDrawer.vue` | `apps/web/src/components/media/` | L1/L2 主 UI |
+| `MediaInfoSummary.vue` | 同上 | L0 摘要条（节点/资产库复用） |
+| `MediaRefList.vue` | 同上 | 参考图列表 + 告警 badge |
+| `useMediaInspector.ts` | `apps/web/src/composables/` | 打开/关闭、拉 record、缓存 |
+| `mediaProbeApi` | `apps/web/src/services/studio-api.ts` | probe + generation 扩展 |
+
+**集成点：**
+
+- `CanvasNodeImage.vue` / `CanvasNodeVideo.vue`：L0 摘要 + ⓘ
+- `CanvasAssetPanel.vue`：详情按钮 → Inspector
+- `CanvasTaskHistoryPanel.vue`：详情页嵌入 `MediaInspector` 只读区（去重 UI）
+- `VideoDockPanel.vue`：生成按钮上方显示 `refPreflight` banner（warn/error）
+- `useNodeGeneration.applyStudioRecord`：写入 `mediaInfo` 摘要
+
+---
+
+## Error handling
+
+| 场景 | 行为 |
+|------|------|
+| probe 超时 | `probeStatus: failed`；Inspector 显示「未能读取文件属性」 |
+| 私有/不可达 URL | probe failed；视频 preflight error → 阻止生成 |
+| 旧记录无 mediaInfo | Inspector lazy 调 `/media-probe` |
+| 用户取消平台回退 | 不影响 Inspector；诊断 Tab 仍可用 |
+
+---
+
+## Testing & acceptance
+
+### 单元
+
+- `packages/shared/src/mediaInfo.test.ts`：阈值判定、`evaluateMediaRefPreflight()`
+- `apps/server/src/media/media-probe.service.test.ts`：PNG/JPEG 头解析
+- `apps/server/src/studio/studio.video-preflight.test.ts`：3 refs 含 3072×4096 → 400
+
+### 集成
+
+- video generate with oversized ref → 不调用 upstream；metadata 含 preflight
+
+### 生产验收脚本
+
+`deploy/prod-media-inspector-verify.py`：
+
+1. 登录生产
+2. 查 `cmsud22f6003gpf01oybnvosn` 同类 session 最近 video record
+3. 断言 GET generation 返回 `mediaInfo.references[].bytes`
+4. （可选）POST 模拟超大 ref 应 400
+
+### 人工 UAT
+
+- [ ] 画布 image 节点 completed → hover 见尺寸；ⓘ 打开 Inspector
+- [ ] 资产库存库后 Inspector 见生成模型
+- [ ] video 节点 3 refs 含大图 → Dock banner 红色；点生成被拦截（P0）
+- [ ] 任务历史详情与 Inspector 信息一致
+
+---
+
+## Phasing
+
+| 阶段 | 交付 | 验收 |
+|------|------|------|
+| **P0** | shared 类型 + probe service + video preflight block + Inspector L1 + 节点/历史入口 | 单测 + 生产脚本 + UAT §1–3 |
+| **P1** | UserAsset.metadata + 资产库 Inspector + 自动 downscale inline | 存库可追溯 + 视频重试成功 |
+| **P2** | L2 高级 Tab + 批量列表视图 + Material 路径 | power user |
+
+本 plan 文件 **仅覆盖 P0**；P1/P2 另开 plan 或在本 plan 末尾 Extension 节跟踪。
+
+---
+
+## Open questions (resolved in spec)
+
+| 问题 | 决议 |
+|------|------|
+| 预检 block 还是仅 warn？ | P0：**error 阈值 block**；warn 仅 UI |
+| Inspector 与 Dock 合并？ | **否**，职责分离 |
+| ffprobe 取视频时长？ | P0 用 metadata.duration；probe 不依赖 ffprobe |
+
+---
+
+## Spec self-review
+
+- [x] 无 TBD / 占位段落
+- [x] 与失败诊断规格不矛盾（成功 ⓘ / 失败 diagnostic Tab）
+- [x] P0 范围可在一个 plan 内完成
+- [x] 生产故障 case 有明确阈值与验收

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -21,6 +21,7 @@ export * from './sidebarAttachments'
 export * from './agentIntent'
 export * from './promptContent'
 export * from './journeyTrace'
+export * from './mediaInfo'
 export * from './videoGeneration/types'
 export { resolveCanonicalVideoRequest } from './videoGeneration/resolveCanonicalVideoRequest'
 

--- a/packages/shared/src/mediaInfo.test.ts
+++ b/packages/shared/src/mediaInfo.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest'
+import {
+  classifyRefSize,
+  evaluateMediaRefPreflight,
+  maxEdge,
+  VIDEO_REF_ERROR_BYTES,
+  VIDEO_REF_ERROR_MAX_EDGE,
+  VIDEO_REF_WARN_BYTES,
+  VIDEO_REF_WARN_MAX_EDGE,
+} from './mediaInfo'
+
+describe('maxEdge', () => {
+  it('returns the longer side', () => {
+    expect(maxEdge(3072, 4096)).toBe(4096)
+    expect(maxEdge(1024, 1024)).toBe(1024)
+  })
+
+  it('treats missing dimensions as zero', () => {
+    expect(maxEdge(undefined, 800)).toBe(800)
+    expect(maxEdge()).toBe(0)
+  })
+})
+
+describe('classifyRefSize', () => {
+  it('errors on 3072x4096 13MB poster (prod case)', () => {
+    expect(classifyRefSize({ width: 3072, height: 4096, bytes: 13_367_984 })).toBe('error')
+  })
+  it('warns on 1024x1024 6MB', () => {
+    expect(classifyRefSize({ width: 1024, height: 1024, bytes: 6 * 1024 * 1024 })).toBe('warn')
+  })
+  it('none on 1024x1024 1MB', () => {
+    expect(classifyRefSize({ width: 1024, height: 1024, bytes: 1_000_000 })).toBe('none')
+  })
+
+  it('errors when max edge exceeds error threshold', () => {
+    expect(
+      classifyRefSize({
+        width: VIDEO_REF_ERROR_MAX_EDGE + 1,
+        height: 1000,
+        bytes: 1_000_000,
+      }),
+    ).toBe('error')
+  })
+
+  it('warns when max edge exceeds warn threshold only', () => {
+    expect(
+      classifyRefSize({
+        width: VIDEO_REF_WARN_MAX_EDGE + 1,
+        height: 1000,
+        bytes: 1_000_000,
+      }),
+    ).toBe('warn')
+  })
+
+  it('errors when bytes exceed error threshold only', () => {
+    expect(
+      classifyRefSize({
+        width: 1024,
+        height: 1024,
+        bytes: VIDEO_REF_ERROR_BYTES + 1,
+      }),
+    ).toBe('error')
+  })
+
+  it('warns when bytes exceed warn threshold only', () => {
+    expect(
+      classifyRefSize({
+        width: 1024,
+        height: 1024,
+        bytes: VIDEO_REF_WARN_BYTES + 1,
+      }),
+    ).toBe('warn')
+  })
+
+  it('none at exact warn thresholds', () => {
+    expect(
+      classifyRefSize({
+        width: VIDEO_REF_WARN_MAX_EDGE,
+        height: 1000,
+        bytes: VIDEO_REF_WARN_BYTES,
+      }),
+    ).toBe('none')
+  })
+})
+
+describe('evaluateMediaRefPreflight', () => {
+  it('returns error level when any ref exceeds error threshold', () => {
+    const r = evaluateMediaRefPreflight([
+      { url: 'a', refKey: 'I1', width: 1024, height: 1024, bytes: 900_000, probeStatus: 'ok' },
+      {
+        url: 'b',
+        refKey: 'I3',
+        width: 3072,
+        height: 4096,
+        bytes: VIDEO_REF_ERROR_BYTES + 1,
+        probeStatus: 'ok',
+      },
+    ])
+    expect(r.level).toBe('error')
+    expect(r.message).toMatch(/I3/)
+  })
+
+  it('returns none when all refs are within limits', () => {
+    const r = evaluateMediaRefPreflight([
+      { url: 'a', refKey: 'I1', width: 1024, height: 1024, bytes: 900_000, probeStatus: 'ok' },
+    ])
+    expect(r.level).toBe('none')
+    expect(r.message).toBe('')
+    expect(r.refs).toHaveLength(1)
+    expect(r.refs[0].level).toBe('none')
+  })
+
+  it('returns warn when only warn thresholds are exceeded', () => {
+    const r = evaluateMediaRefPreflight([
+      {
+        url: 'a',
+        refKey: 'I2',
+        width: 1024,
+        height: 1024,
+        bytes: VIDEO_REF_WARN_BYTES + 1,
+        probeStatus: 'ok',
+      },
+    ])
+    expect(r.level).toBe('warn')
+    expect(r.message).toMatch(/I2/)
+  })
+
+  it('uses agnes_keyframes message when blockWire is set', () => {
+    const r = evaluateMediaRefPreflight(
+      [
+        {
+          url: 'b',
+          refKey: 'I3',
+          width: 3072,
+          height: 4096,
+          bytes: VIDEO_REF_ERROR_BYTES + 1,
+          probeStatus: 'ok',
+        },
+      ],
+      { blockWire: 'agnes_keyframes' },
+    )
+    expect(r.message).toMatch(/Agnes/)
+    expect(r.message).toMatch(/I3/)
+  })
+
+  it('marks probe failures as error', () => {
+    const r = evaluateMediaRefPreflight([
+      {
+        url: 'bad',
+        refKey: 'I4',
+        probeStatus: 'failed',
+        probeError: 'timeout',
+      },
+    ])
+    expect(r.level).toBe('error')
+    expect(r.code).toBe('ref_probe_failed')
+    expect(r.message).toMatch(/I4/)
+  })
+})

--- a/packages/shared/src/mediaInfo.ts
+++ b/packages/shared/src/mediaInfo.ts
@@ -1,0 +1,162 @@
+export interface ProbedMediaFile {
+  url: string
+  width?: number
+  height?: number
+  bytes?: number
+  mimeType?: string
+  durationSec?: number
+  probeStatus: 'ok' | 'failed' | 'pending'
+  probeError?: string
+}
+
+export interface MediaInfo {
+  output?: ProbedMediaFile
+  references?: Array<ProbedMediaFile & { refKey?: string; role?: string }>
+  probedAt?: string
+}
+
+export type MediaRefWarningLevel = 'none' | 'warn' | 'error'
+
+export interface MediaRefPreflight {
+  level: MediaRefWarningLevel
+  code?: 'ref_too_large' | 'ref_dimension_exceeded' | 'ref_probe_failed'
+  message: string
+  refs: Array<{
+    url: string
+    refKey?: string
+    width?: number
+    height?: number
+    bytes?: number
+    level: MediaRefWarningLevel
+  }>
+}
+
+export const VIDEO_REF_WARN_BYTES = 5 * 1024 * 1024
+export const VIDEO_REF_ERROR_BYTES = 10 * 1024 * 1024
+export const VIDEO_REF_WARN_MAX_EDGE = 2048
+export const VIDEO_REF_ERROR_MAX_EDGE = 4096
+
+const LEVEL_RANK: Record<MediaRefWarningLevel, number> = {
+  none: 0,
+  warn: 1,
+  error: 2,
+}
+
+function maxLevel(a: MediaRefWarningLevel, b: MediaRefWarningLevel): MediaRefWarningLevel {
+  return LEVEL_RANK[a] >= LEVEL_RANK[b] ? a : b
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)}MB`
+  }
+  if (bytes >= 1024) {
+    return `${(bytes / 1024).toFixed(1)}KB`
+  }
+  return `${bytes}B`
+}
+
+export function maxEdge(width?: number, height?: number): number {
+  return Math.max(width ?? 0, height ?? 0)
+}
+
+export function classifyRefSize(
+  file: Pick<ProbedMediaFile, 'width' | 'height' | 'bytes'>,
+): MediaRefWarningLevel {
+  const edge = maxEdge(file.width, file.height)
+  const bytes = file.bytes ?? 0
+
+  if (bytes > VIDEO_REF_ERROR_BYTES || edge > VIDEO_REF_ERROR_MAX_EDGE) {
+    return 'error'
+  }
+  if (bytes > VIDEO_REF_WARN_BYTES || edge > VIDEO_REF_WARN_MAX_EDGE) {
+    return 'warn'
+  }
+  return 'none'
+}
+
+function refPreflightCode(
+  ref: ProbedMediaFile & { refKey?: string },
+  level: MediaRefWarningLevel,
+): MediaRefPreflight['code'] {
+  if (level !== 'error') return undefined
+  if (ref.probeStatus === 'failed') return 'ref_probe_failed'
+  const bytes = ref.bytes ?? 0
+  const edge = maxEdge(ref.width, ref.height)
+  if (bytes > VIDEO_REF_ERROR_BYTES) return 'ref_too_large'
+  if (edge > VIDEO_REF_ERROR_MAX_EDGE) return 'ref_dimension_exceeded'
+  return 'ref_too_large'
+}
+
+function buildPreflightMessage(
+  worst: {
+    refKey?: string
+    width?: number
+    height?: number
+    bytes?: number
+    level: MediaRefWarningLevel
+  },
+  opts?: { blockWire?: string },
+): string {
+  const refLabel = worst.refKey ?? '参考图'
+  const sizePart =
+    worst.width != null && worst.height != null ? `${worst.width}×${worst.height}` : undefined
+  const bytesPart = worst.bytes != null ? formatBytes(worst.bytes) : undefined
+  const detail = [sizePart, bytesPart].filter(Boolean).join('，')
+
+  if (worst.level === 'warn') {
+    return detail
+      ? `参考图 ${refLabel} 偏大（${detail}），可能上游拒收。`
+      : `参考图 ${refLabel} 偏大，可能上游拒收。`
+  }
+
+  if (opts?.blockWire === 'agnes_keyframes') {
+    return detail
+      ? `参考图 ${refLabel} 过大（${detail}），Agnes 关键帧模式可能无法处理。请压缩后重试或移除该参考图。`
+      : `参考图 ${refLabel} 过大，Agnes 关键帧模式可能无法处理。请压缩后重试或移除该参考图。`
+  }
+
+  return detail
+    ? `参考图 ${refLabel} 过大（${detail}），可能无法被上游处理。请压缩后重试或移除该参考图。`
+    : `参考图 ${refLabel} 过大，可能无法被上游处理。请压缩后重试或移除该参考图。`
+}
+
+export function evaluateMediaRefPreflight(
+  refs: Array<ProbedMediaFile & { refKey?: string }>,
+  opts?: { blockWire?: string },
+): MediaRefPreflight {
+  const evaluated = refs.map((ref) => {
+    const level =
+      ref.probeStatus === 'failed' ? 'error' : classifyRefSize(ref)
+    return {
+      url: ref.url,
+      refKey: ref.refKey,
+      width: ref.width,
+      height: ref.height,
+      bytes: ref.bytes,
+      level,
+    }
+  })
+
+  let level: MediaRefWarningLevel = 'none'
+  for (const ref of evaluated) {
+    level = maxLevel(level, ref.level)
+  }
+
+  if (level === 'none') {
+    return { level, message: '', refs: evaluated }
+  }
+
+  const worst =
+    evaluated.find((ref) => ref.level === 'error') ??
+    evaluated.find((ref) => ref.level === 'warn')!
+
+  const sourceRef = refs.find((ref) => ref.url === worst.url && ref.refKey === worst.refKey) ?? refs[0]
+
+  return {
+    level,
+    code: refPreflightCode(sourceRef, worst.level),
+    message: buildPreflightMessage(worst, opts),
+    refs: evaluated,
+  }
+}


### PR DESCRIPTION
## Summary
- 统一 **MediaInspector**（L0 摘要 + Drawer）：画布 image/video 节点 ⓘ、任务历史媒体属性区块
- 服务端 **mediaInfo probe** 落库（生成完成时 probe 输出与参考图）
- **视频 keyframes 预检**：超大参考图（>10MB / >4096px）在 BYOK agnes_keyframes 路径 block，对齐生产 case
- `GET /studio/media-probe` 鉴权端点 + 生产验收脚本

## Spec / Plan
- `docs/superpowers/specs/2026-08-15-media-inspector-design.md`
- `docs/superpowers/plans/2026-08-15-media-inspector.md`

## Test plan
- [x] `pnpm build`
- [x] shared mediaInfo tests (15)
- [x] server probe + preflight tests (23)
- [ ] `python3 deploy/prod-media-inspector-verify.py`（部署后）
- [ ] 会话 cmsocwe7o000yqf01lbgv77wm 复测 3 refs 海报 block


Made with [Cursor](https://cursor.com)