### PR TITLE
fix: write mediaInfo atomically on generation complete

### DIFF
--- a/apps/server/src/studio/studio.media-info.test.ts
+++ b/apps/server/src/studio/studio.media-info.test.ts
@@ -58,16 +58,8 @@ describe('StudioService mediaInfo on generation complete', () => {
       return stored
     })
     prisma.generationRecord.update = generationUpdate
-    prisma.generationRecord.updateMany = vi.fn(async () => {
-      stored = {
-        ...stored,
-        url: 'https://example.com/output.png',
-        status: 'completed',
-        metadata: JSON.stringify({
-          ...JSON.parse(String(stored.metadata ?? '{}')),
-          urls: ['https://example.com/output.png'],
-        }),
-      }
+    prisma.generationRecord.updateMany = vi.fn(async (args: { where: { id: string; status?: string }; data: Record<string, unknown> }) => {
+      stored = { ...stored, ...args.data, id: args.where.id }
       return { count: 1 }
     })
     prisma.generationRecord.findFirst = generationFindFirst
@@ -95,8 +87,8 @@ describe('StudioService mediaInfo on generation complete', () => {
     svc = moduleRef.get(StudioService)
   })
 
-  it('persists mediaInfo.output.width after image generation completes', async () => {
-    await svc.generateImage(
+  it('persists mediaInfo in the same write as status=completed', async () => {
+    const record = await svc.generateImage(
       'u1',
       'a prompt',
       'gpt-image-1',
@@ -104,12 +96,12 @@ describe('StudioService mediaInfo on generation complete', () => {
       [{ refKey: 'I1', mediaType: 'image', url: 'https://example.com/ref.png' }],
     )
 
-    await vi.waitFor(() => expect(probeUrl).toHaveBeenCalled())
-
+    expect(record?.status).toBe('completed')
     const meta = JSON.parse(String(stored.metadata))
     expect(meta.mediaInfo?.output?.width).toBe(1920)
     expect(meta.mediaInfo?.references?.[0]?.width).toBe(1024)
     expect(meta.mediaInfo?.probedAt).toBeTruthy()
+    expect(generationUpdate).not.toHaveBeenCalled()
   })
 
   it('getGeneration returns parsed mediaInfo from metadata', async () => {

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -637,31 +637,21 @@ export class StudioService {
     }
   }
 
-  private async attachMediaInfoToRecord(
-    recordId: string,
+  private async buildMediaInfo(
     outputUrl: string | null,
     referenceUrls: string[],
-  ): Promise<void> {
+  ): Promise<MediaInfo> {
     const output = outputUrl ? await this.mediaProbe.probeUrl(outputUrl) : undefined
     const references = await Promise.all(
       referenceUrls
         .filter((url) => typeof url === 'string' && url.trim())
         .map(async (url) => this.mediaProbe.probeUrl(url.trim())),
     )
-    const mediaInfo: MediaInfo = {
+    return {
       ...(output ? { output } : {}),
       ...(references.length ? { references } : {}),
       probedAt: new Date().toISOString(),
     }
-    const existing = await this.prisma.generationRecord.findFirst({ where: { id: recordId } })
-    if (!existing) return
-    const meta = parseMeta(existing.metadata)
-    await this.prisma.generationRecord.update({
-      where: { id: recordId },
-      data: {
-        metadata: JSON.stringify({ ...meta, mediaInfo }),
-      },
-    })
   }
 
   async getGenerationDiagnostic(userId: string, id: string): Promise<GenerationDiagnostic> {
@@ -844,19 +834,19 @@ export class StudioService {
       if (!existing || existing.status !== 'generating') return null
       const meta = parseMeta(existing.metadata)
       if (isCancelledMeta(meta) || alreadyRefunded(meta)) return null
+      const referenceUrls = Array.isArray(meta.referenceImages)
+        ? (meta.referenceImages as string[]).filter((url) => typeof url === 'string' && url.trim())
+        : []
+      const mediaInfo = await this.buildMediaInfo(imageUrls[0] ?? null, referenceUrls)
       const updated = await this.prisma.generationRecord.updateMany({
         where: { id, status: 'generating' },
         data: {
           url: imageUrls[0],
           status: 'completed',
-          metadata: JSON.stringify({ ...meta, urls: imageUrls }),
+          metadata: JSON.stringify({ ...meta, urls: imageUrls, mediaInfo }),
         },
       })
       if (updated.count === 0) return null
-      const referenceUrls = Array.isArray(meta.referenceImages)
-        ? (meta.referenceImages as string[]).filter((url) => typeof url === 'string' && url.trim())
-        : []
-      await this.attachMediaInfoToRecord(id, imageUrls[0] ?? null, referenceUrls)
       return this.prisma.generationRecord.findFirst({ where: { id } })
     } catch (err) {
       console.error('Image generation failed:', err)
@@ -1616,23 +1606,25 @@ export class StudioService {
       if (!existing || existing.status !== 'generating') return
       const meta = parseMeta(existing.metadata)
       if (isCancelledMeta(meta) || alreadyRefunded(meta)) return
-      const updated = await this.prisma.generationRecord.updateMany({
-        where: { id, status: 'generating' },
-        data: {
-          url,
-          status: 'completed',
-          ...(lastFrameUrl
-            ? { metadata: JSON.stringify({ ...meta, lastFrameUrl }) }
-            : {}),
-        },
-      })
-      if (updated.count === 0) return
       const referenceUrls = [
         ...(Array.isArray(meta.referenceImages) ? (meta.referenceImages as string[]) : []),
         ...(Array.isArray(meta.referenceVideos) ? (meta.referenceVideos as string[]) : []),
         ...(Array.isArray(meta.referenceAudios) ? (meta.referenceAudios as string[]) : []),
       ].filter((u): u is string => typeof u === 'string' && u.trim().length > 0)
-      await this.attachMediaInfoToRecord(id, url, referenceUrls)
+      const mediaInfo = await this.buildMediaInfo(url, referenceUrls)
+      const updated = await this.prisma.generationRecord.updateMany({
+        where: { id, status: 'generating' },
+        data: {
+          url,
+          status: 'completed',
+          metadata: JSON.stringify({
+            ...meta,
+            ...(lastFrameUrl ? { lastFrameUrl } : {}),
+            mediaInfo,
+          }),
+        },
+      })
+      if (updated.count === 0) return
     } catch (err) {
       console.error('Video generation failed:', err)
       const existing = await this.prisma.generationRecord.findFirst({ where: { id } })

--- a/deploy/prod-media-inspector-verify.py
+++ b/deploy/prod-media-inspector-verify.py
@@ -4,7 +4,8 @@
 Usage:
   python3 deploy/prod-media-inspector-verify.py
   BASE_URL=http://119.29.173.89:8888 PHONE=17279698608 CODE=123456 python3 deploy/prod-media-inspector-verify.py
-  PROBE_URL=https://platform-outputs.agnes-ai.space/.../out.png python3 deploy/prod-media-inspector-verify.py
+  RECORD_ID=<id> python3 deploy/prod-media-inspector-verify.py
+  VERIFY_VIDEO_PREFLIGHT=1 python3 deploy/prod-media-inspector-verify.py
 """
 
 from __future__ import annotations
@@ -13,6 +14,7 @@ import json
 import os
 import sys
 from typing import Any
+from urllib.error import HTTPError
 from urllib.parse import quote, urlencode
 from urllib.request import Request, urlopen
 
@@ -22,6 +24,16 @@ PHONE = os.environ.get("PHONE", "17279698608")
 CODE = os.environ.get("CODE", "123456")
 PROBE_URL = os.environ.get("PROBE_URL", "").strip()
 LIST_LIMIT = int(os.environ.get("LIST_LIMIT", "10"))
+RECORD_ID = os.environ.get("RECORD_ID", "").strip()
+VERIFY_VIDEO_PREFLIGHT = os.environ.get("VERIFY_VIDEO_PREFLIGHT", "").strip() in ("1", "true", "yes")
+OVERSIZED_REF_URL = os.environ.get(
+    "OVERSIZED_REF_URL",
+    "https://platform-outputs.agnes-ai.space/images/i2i/task_v8x4vgTKQhn5Hz0ga5VZy1f7APhYlVGj/output.png",
+).strip()
+SMALL_REF_URL = os.environ.get(
+    "SMALL_REF_URL",
+    "https://platform-outputs.agnes-ai.space/images/i2i/task_1LFSCNKkwPzlb1m2uJzjsOj7DJTYAkEv/output.png",
+).strip()
 
 PASS = FAIL = WARN = 0
 
@@ -57,13 +69,51 @@ def http_json(method: str, path: str, body: dict | None = None, token: str | Non
         return json.loads(resp.read())
 
 
+def http_json_status(
+    method: str, path: str, body: dict | None = None, token: str | None = None
+) -> tuple[Any, int]:
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = Request(
+        f"{API}{path}",
+        data=None if body is None else json.dumps(body).encode(),
+        headers=headers,
+        method=method,
+    )
+    try:
+        with urlopen(req, timeout=120) as resp:
+            return json.loads(resp.read()), resp.status
+    except HTTPError as exc:
+        raw = exc.read().decode()
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            payload = {"raw": raw[:500]}
+        return payload, exc.code
+
+
+def row_has_media_info(row: dict[str, Any]) -> bool:
+    if row.get("mediaInfo"):
+        return True
+    try:
+        meta = json.loads(str(row.get("metadata") or "{}"))
+    except json.JSONDecodeError:
+        return False
+    return isinstance(meta.get("mediaInfo"), dict) and bool(meta.get("mediaInfo"))
+
+
 def pick_completed_record(rows: list[dict[str, Any]]) -> dict[str, Any] | None:
-    for row in rows:
-        if str(row.get("status") or "") != "completed":
-            continue
-        if str(row.get("type") or "") in ("image", "video"):
-            return row
-    return None
+    candidates = [
+        row
+        for row in rows
+        if str(row.get("status") or "") == "completed"
+        and str(row.get("type") or "") in ("image", "video")
+    ]
+    if not candidates:
+        return None
+    with_media = [row for row in candidates if row_has_media_info(row)]
+    return with_media[0] if with_media else candidates[0]
 
 
 def pick_probe_url(record: dict[str, Any], explicit: str) -> str | None:
@@ -116,31 +166,49 @@ def main() -> int:
         print(f"\nRESULT: PASS={PASS} FAIL={FAIL} WARN={WARN}")
         return 1
 
-    target = pick_completed_record(rows)
-    if not target:
-        record("Find completed image/video record", False, "none in recent list")
-        print(f"\nRESULT: PASS={PASS} FAIL={FAIL} WARN={WARN}")
-        return 1
+    target = None
+    if RECORD_ID:
+        try:
+            target = http_json("GET", f"/studio/generations/{RECORD_ID}", token=token).get("data") or {}
+            record("Use explicit RECORD_ID", bool(target.get("id")), RECORD_ID)
+        except Exception as exc:  # noqa: BLE001
+            record("Use explicit RECORD_ID", False, str(exc))
+            print(f"\nRESULT: PASS={PASS} FAIL={FAIL} WARN={WARN}")
+            return 1
+    else:
+        target = pick_completed_record(rows)
+        if not target:
+            record("Find completed image/video record", False, "none in recent list")
+            print(f"\nRESULT: PASS={PASS} FAIL={FAIL} WARN={WARN}")
+            return 1
 
     record_id = str(target.get("id") or "")
+    has_media_info_in_list = row_has_media_info(target)
     record(
         "Find completed image/video record",
         True,
-        f"id={record_id} type={target.get('type')}",
+        f"id={record_id} type={target.get('type')} mediaInfo={'yes' if has_media_info_in_list else 'legacy'}",
     )
 
     try:
-        detail = http_json("GET", f"/studio/generations/{record_id}", token=token).get("data") or {}
+        detail = target if RECORD_ID else (
+            http_json("GET", f"/studio/generations/{record_id}", token=token).get("data") or {}
+        )
     except Exception as exc:  # noqa: BLE001
         record("GET generation detail", False, str(exc))
         print(f"\nRESULT: PASS={PASS} FAIL={FAIL} WARN={WARN}")
         return 1
 
     has_media_info_key = "mediaInfo" in detail
-    record("Generation response has mediaInfo key", has_media_info_key, record_id)
-    if not has_media_info_key:
-        print(f"\nRESULT: PASS={PASS} FAIL={FAIL} WARN={WARN}")
-        return 1
+    if has_media_info_key:
+        record("Generation response has mediaInfo key", True, record_id)
+    else:
+        record(
+            "Generation response has mediaInfo key",
+            True,
+            "legacy record without mediaInfo — continuing with media-probe only",
+            warn=True,
+        )
 
     media_info = detail.get("mediaInfo")
     if media_info:
@@ -179,6 +247,31 @@ def main() -> int:
         )
     except Exception as exc:  # noqa: BLE001
         record("GET media-probe width/height", False, str(exc))
+
+    if VERIFY_VIDEO_PREFLIGHT:
+        try:
+            body = {
+                "prompt": "media inspector preflight verify",
+                "model": "agnes-video-v2.0",
+                "duration": 5,
+                "aspectRatio": "16:9",
+                "resolution": "720p",
+                "refs": [
+                    {"refKey": "I1", "mediaType": "image", "url": SMALL_REF_URL},
+                    {"refKey": "I2", "mediaType": "image", "url": SMALL_REF_URL},
+                    {"refKey": "I3", "mediaType": "image", "url": OVERSIZED_REF_URL},
+                ],
+            }
+            res, status = http_json_status("POST", "/studio/video/generate", body, token=token)
+            msg = str(res.get("message") or res.get("error") or res)
+            blocked = status == 400 and ("过大" in msg or "参考图" in msg)
+            record(
+                "Video keyframes preflight block (oversized I3)",
+                blocked,
+                f"status={status} msg={msg[:160]}",
+            )
+        except Exception as exc:  # noqa: BLE001
+            record("Video keyframes preflight block (oversized I3)", False, str(exc))
 
     print(f"\nRESULT: PASS={PASS} FAIL={FAIL} WARN={WARN}")
     return 0 if FAIL == 0 else 1


### PR DESCRIPTION
## Summary
- 修复 `mediaInfo` 写入竞态：`completeImage` / `completeVideo` 在 probe 完成后**单次** `updateMany` 写入 `urls + mediaInfo + status=completed`，客户端轮询不再出现 completed 但无 mediaInfo 的窗口
- 删除已无调用的 `attachMediaInfoToRecord`
- 增强 `prod-media-inspector-verify.py`：优先选含 mediaInfo 的记录、旧记录 WARN 继续、支持 `RECORD_ID` / `VERIFY_VIDEO_PREFLIGHT=1`

## Test plan
- [x] `pnpm --filter @lnkpi/server exec vitest run src/studio/studio.media-info.test.ts src/studio/studio.video-preflight.test.ts`
- [x] `pnpm build`
- [ ] 部署后 `python3 deploy/prod-media-inspector-verify.py`
- [ ] 可选 `VERIFY_VIDEO_PREFLIGHT=1 python3 deploy/prod-media-inspector-verify.py`


Made with [Cursor](https://cursor.com)