### PR TITLE
fix: node L0 media summary on generation complete

### DIFF
--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -654,6 +654,31 @@ export class StudioService {
     }
   }
 
+  private async enrichVideoMediaInfoDimensions(
+    mediaInfo: MediaInfo,
+    lastFrameUrl?: string | null,
+  ): Promise<MediaInfo> {
+    if (mediaInfo.output?.width && mediaInfo.output?.height) {
+      return mediaInfo
+    }
+    const frameUrl = String(lastFrameUrl ?? '').trim()
+    if (!frameUrl) {
+      return mediaInfo
+    }
+    const lastFrame = await this.mediaProbe.probeUrl(frameUrl)
+    if (!lastFrame.width || !lastFrame.height) {
+      return mediaInfo
+    }
+    return {
+      ...mediaInfo,
+      output: {
+        ...(mediaInfo.output ?? { url: frameUrl, probeStatus: 'ok' as const }),
+        width: lastFrame.width,
+        height: lastFrame.height,
+      },
+    }
+  }
+
   async getGenerationDiagnostic(userId: string, id: string): Promise<GenerationDiagnostic> {
     const record = await this.getGeneration(userId, id)
     if (
@@ -1611,7 +1636,10 @@ export class StudioService {
         ...(Array.isArray(meta.referenceVideos) ? (meta.referenceVideos as string[]) : []),
         ...(Array.isArray(meta.referenceAudios) ? (meta.referenceAudios as string[]) : []),
       ].filter((u): u is string => typeof u === 'string' && u.trim().length > 0)
-      const mediaInfo = await this.buildMediaInfo(url, referenceUrls)
+      const mediaInfo = await this.enrichVideoMediaInfoDimensions(
+        await this.buildMediaInfo(url, referenceUrls),
+        lastFrameUrl,
+      )
       const updated = await this.prisma.generationRecord.updateMany({
         where: { id, status: 'generating' },
         data: {

--- a/apps/web/src/components/canvas/CanvasNodeImage.vue
+++ b/apps/web/src/components/canvas/CanvasNodeImage.vue
@@ -28,10 +28,13 @@ const props = defineProps<{
     generationRecordId?: string
     materialId?: string
     mediaInfo?: {
+      kind?: 'image' | 'video'
       width?: number
       height?: number
       bytes?: number
-      model?: string
+      aspectRatio?: string
+      duration?: number
+      resolution?: string
       refWarning?: MediaRefWarningLevel
     }
   }

--- a/apps/web/src/components/canvas/CanvasNodeVideo.vue
+++ b/apps/web/src/components/canvas/CanvasNodeVideo.vue
@@ -27,10 +27,13 @@ const props = defineProps<{
     generationRecordId?: string
     materialId?: string
     mediaInfo?: {
+      kind?: 'image' | 'video'
       width?: number
       height?: number
       bytes?: number
-      model?: string
+      aspectRatio?: string
+      duration?: number
+      resolution?: string
       refWarning?: MediaRefWarningLevel
     }
   }

--- a/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
+++ b/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
@@ -10,6 +10,7 @@ import CanvasLocateButton from '@/components/shared/CanvasLocateButton.vue'
 import CanvasLocatePinIcon from '@/components/shared/CanvasLocatePinIcon.vue'
 import MediaInfoSummary from '@/components/media/MediaInfoSummary.vue'
 import MediaRefList from '@/components/media/MediaRefList.vue'
+import { buildNodeMediaInfoSummary } from '@/composables/useMediaInspector'
 import { useCanvasEditorStore } from '@/stores/canvasEditor'
 import { useProviderBootstrap } from '@/composables/useProviderBootstrap'
 import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
@@ -155,14 +156,7 @@ function recordMediaInfo(record: GenerationRecord): MediaInfo | undefined {
 }
 
 function recordMediaSummaryProps(record: GenerationRecord) {
-  const info = recordMediaInfo(record)
-  const output = info?.output
-  return {
-    width: output?.width,
-    height: output?.height,
-    bytes: output?.bytes,
-    model: record.model ?? undefined,
-  }
+  return buildNodeMediaInfoSummary(record) ?? {}
 }
 
 function recordMediaRefItems(record: GenerationRecord) {

--- a/apps/web/src/components/media/MediaInfoSummary.vue
+++ b/apps/web/src/components/media/MediaInfoSummary.vue
@@ -4,20 +4,33 @@ import type { MediaRefWarningLevel } from '@lnkpi/shared'
 import { formatMediaBytes, formatMediaDimensions } from '@/utils/mediaInfoFormat'
 
 const props = defineProps<{
+  kind?: 'image' | 'video'
   width?: number
   height?: number
   bytes?: number
-  model?: string
+  aspectRatio?: string
+  duration?: number
+  resolution?: string
   refWarning?: MediaRefWarningLevel
 }>()
 
 const parts = computed(() => {
   const line: string[] = []
+  if (props.kind === 'video') {
+    if (typeof props.duration === 'number' && props.duration > 0) {
+      line.push(`${props.duration}s`)
+    }
+    if (props.aspectRatio?.trim()) line.push(props.aspectRatio.trim())
+    if (props.resolution?.trim()) line.push(props.resolution.trim())
+    const size = formatMediaBytes(props.bytes)
+    if (size) line.push(size)
+    return line
+  }
   const dims = formatMediaDimensions(props.width, props.height)
   if (dims) line.push(dims)
   const size = formatMediaBytes(props.bytes)
   if (size) line.push(size)
-  if (props.model?.trim()) line.push(props.model.trim())
+  if (props.aspectRatio?.trim()) line.push(props.aspectRatio.trim())
   return line
 })
 

--- a/apps/web/src/components/media/MediaInfoSummary.vue
+++ b/apps/web/src/components/media/MediaInfoSummary.vue
@@ -9,28 +9,23 @@ const props = defineProps<{
   height?: number
   bytes?: number
   aspectRatio?: string
-  duration?: number
   resolution?: string
   refWarning?: MediaRefWarningLevel
 }>()
 
 const parts = computed(() => {
   const line: string[] = []
+  const size = formatMediaBytes(props.bytes)
   if (props.kind === 'video') {
-    if (typeof props.duration === 'number' && props.duration > 0) {
-      line.push(`${props.duration}s`)
-    }
-    if (props.aspectRatio?.trim()) line.push(props.aspectRatio.trim())
     if (props.resolution?.trim()) line.push(props.resolution.trim())
-    const size = formatMediaBytes(props.bytes)
+    if (props.aspectRatio?.trim()) line.push(props.aspectRatio.trim())
     if (size) line.push(size)
     return line
   }
   const dims = formatMediaDimensions(props.width, props.height)
   if (dims) line.push(dims)
-  const size = formatMediaBytes(props.bytes)
-  if (size) line.push(size)
   if (props.aspectRatio?.trim()) line.push(props.aspectRatio.trim())
+  if (size) line.push(size)
   return line
 })
 

--- a/apps/web/src/composables/useMediaInspector.test.ts
+++ b/apps/web/src/composables/useMediaInspector.test.ts
@@ -53,7 +53,7 @@ describe('buildNodeMediaInfoSummary', () => {
     expect(summary?.aspectRatio).toBe('16:9')
   })
 
-  it('builds video summary from duration, aspect ratio, and bytes', () => {
+  it('builds video summary from resolution, aspect ratio, and bytes', () => {
     const summary = buildNodeMediaInfoSummary(
       rec({
         id: 'g3',
@@ -62,7 +62,11 @@ describe('buildNodeMediaInfoSummary', () => {
         prompt: 'p',
         createdAt: '2026-08-15T00:00:00.000Z',
         mediaInfo: {
-          output: { url: 'https://x/v.mp4', bytes: 12_000_000, probeStatus: 'ok' },
+          output: {
+            url: 'https://x/v.mp4',
+            bytes: 12_000_000,
+            probeStatus: 'ok',
+          },
           probedAt: '2026-08-15T00:00:00.000Z',
         },
         metadata: JSON.stringify({ duration: 5, aspectRatio: '16:9', resolution: '720p' }),
@@ -70,9 +74,8 @@ describe('buildNodeMediaInfoSummary', () => {
     )
     expect(summary).toMatchObject({
       kind: 'video',
-      duration: 5,
-      aspectRatio: '16:9',
       resolution: '720p',
+      aspectRatio: '16:9',
       bytes: 12_000_000,
     })
     expect(summary?.width).toBeUndefined()

--- a/apps/web/src/composables/useMediaInspector.test.ts
+++ b/apps/web/src/composables/useMediaInspector.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { buildNodeMediaInfoSummary } from './useMediaInspector'
+import type { GenerationRecord } from '@/services/studio-api'
+
+function rec(partial: Partial<GenerationRecord> & Pick<GenerationRecord, 'id' | 'type' | 'status' | 'prompt' | 'createdAt'>): GenerationRecord {
+  return partial as GenerationRecord
+}
+
+describe('buildNodeMediaInfoSummary', () => {
+  it('builds image summary from top-level mediaInfo', () => {
+    const summary = buildNodeMediaInfoSummary(
+      rec({
+        id: 'g1',
+        type: 'image',
+        status: 'completed',
+        prompt: 'p',
+        createdAt: '2026-08-15T00:00:00.000Z',
+        mediaInfo: {
+          output: { url: 'https://x/a.png', width: 1024, height: 1024, bytes: 900_000, probeStatus: 'ok' },
+          probedAt: '2026-08-15T00:00:00.000Z',
+        },
+        metadata: JSON.stringify({ aspectRatio: '1:1' }),
+      }),
+    )
+    expect(summary).toMatchObject({
+      kind: 'image',
+      width: 1024,
+      height: 1024,
+      bytes: 900_000,
+      aspectRatio: '1:1',
+    })
+    expect(summary?.model).toBeUndefined()
+  })
+
+  it('falls back to metadata.mediaInfo when top-level field is missing', () => {
+    const summary = buildNodeMediaInfoSummary(
+      rec({
+        id: 'g2',
+        type: 'image',
+        status: 'completed',
+        prompt: 'p',
+        createdAt: '2026-08-15T00:00:00.000Z',
+        metadata: JSON.stringify({
+          aspectRatio: '16:9',
+          mediaInfo: {
+            output: { url: 'https://x/b.png', width: 1312, height: 736, bytes: 500_000, probeStatus: 'ok' },
+            probedAt: '2026-08-15T00:00:00.000Z',
+          },
+        }),
+      }),
+    )
+    expect(summary?.width).toBe(1312)
+    expect(summary?.aspectRatio).toBe('16:9')
+  })
+
+  it('builds video summary from duration, aspect ratio, and bytes', () => {
+    const summary = buildNodeMediaInfoSummary(
+      rec({
+        id: 'g3',
+        type: 'video',
+        status: 'completed',
+        prompt: 'p',
+        createdAt: '2026-08-15T00:00:00.000Z',
+        mediaInfo: {
+          output: { url: 'https://x/v.mp4', bytes: 12_000_000, probeStatus: 'ok' },
+          probedAt: '2026-08-15T00:00:00.000Z',
+        },
+        metadata: JSON.stringify({ duration: 5, aspectRatio: '16:9', resolution: '720p' }),
+      }),
+    )
+    expect(summary).toMatchObject({
+      kind: 'video',
+      duration: 5,
+      aspectRatio: '16:9',
+      resolution: '720p',
+      bytes: 12_000_000,
+    })
+    expect(summary?.width).toBeUndefined()
+  })
+})

--- a/apps/web/src/composables/useMediaInspector.test.ts
+++ b/apps/web/src/composables/useMediaInspector.test.ts
@@ -29,7 +29,6 @@ describe('buildNodeMediaInfoSummary', () => {
       bytes: 900_000,
       aspectRatio: '1:1',
     })
-    expect(summary?.model).toBeUndefined()
   })
 
   it('falls back to metadata.mediaInfo when top-level field is missing', () => {

--- a/apps/web/src/composables/useMediaInspector.ts
+++ b/apps/web/src/composables/useMediaInspector.ts
@@ -8,7 +8,6 @@ export interface NodeMediaInfoSummary {
   height?: number
   bytes?: number
   aspectRatio?: string
-  duration?: number
   resolution?: string
   refWarning?: 'warn' | 'error'
 }
@@ -60,17 +59,13 @@ export function buildNodeMediaInfoSummary(rec: GenerationRecord): NodeMediaInfoS
   const summary: NodeMediaInfoSummary = { kind }
 
   if (kind === 'video') {
-    const duration = meta.duration
-    if (typeof duration === 'number' && Number.isFinite(duration) && duration > 0) {
-      summary.duration = duration
+    const resolution = meta.resolution
+    if (typeof resolution === 'string' && resolution.trim()) {
+      summary.resolution = resolution.trim()
     }
     const aspectRatio = meta.aspectRatio
     if (typeof aspectRatio === 'string' && aspectRatio.trim()) {
       summary.aspectRatio = aspectRatio.trim()
-    }
-    const resolution = meta.resolution
-    if (typeof resolution === 'string' && resolution.trim()) {
-      summary.resolution = resolution.trim()
     }
     if (output?.bytes != null) summary.bytes = output.bytes
   } else {

--- a/apps/web/src/composables/useMediaInspector.ts
+++ b/apps/web/src/composables/useMediaInspector.ts
@@ -1,13 +1,34 @@
 import { ref } from 'vue'
-import type { ProbedMediaFile } from '@lnkpi/shared'
+import type { MediaInfo, ProbedMediaFile } from '@lnkpi/shared'
 import { studioApi, type GenerationRecord } from '@/services/studio-api'
 
 export interface NodeMediaInfoSummary {
+  kind?: 'image' | 'video'
   width?: number
   height?: number
   bytes?: number
-  model?: string
+  aspectRatio?: string
+  duration?: number
+  resolution?: string
   refWarning?: 'warn' | 'error'
+}
+
+function parseRecordMeta(rec: GenerationRecord): Record<string, unknown> {
+  if (!rec.metadata) return {}
+  try {
+    return JSON.parse(rec.metadata) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+export function resolveRecordMediaInfo(rec: GenerationRecord): MediaInfo | undefined {
+  if (rec.mediaInfo?.output || rec.mediaInfo?.references?.length) {
+    return rec.mediaInfo
+  }
+  const meta = parseRecordMeta(rec)
+  const fromMeta = meta.mediaInfo
+  return fromMeta && typeof fromMeta === 'object' ? (fromMeta as MediaInfo) : undefined
 }
 
 export interface MediaInspectorTarget {
@@ -33,20 +54,43 @@ const target = ref<MediaInspectorTarget | null>(null)
 const record = ref<GenerationRecord | null>(null)
 
 export function buildNodeMediaInfoSummary(rec: GenerationRecord): NodeMediaInfoSummary | undefined {
-  const output = rec.mediaInfo?.output
-  const summary: NodeMediaInfoSummary = {}
+  const output = resolveRecordMediaInfo(rec)?.output
+  const meta = parseRecordMeta(rec)
+  const kind: NodeMediaInfoSummary['kind'] = rec.type === 'video' ? 'video' : 'image'
+  const summary: NodeMediaInfoSummary = { kind }
 
-  if (output?.width != null) summary.width = output.width
-  if (output?.height != null) summary.height = output.height
-  if (output?.bytes != null) summary.bytes = output.bytes
-  if (rec.model) summary.model = rec.model
+  if (kind === 'video') {
+    const duration = meta.duration
+    if (typeof duration === 'number' && Number.isFinite(duration) && duration > 0) {
+      summary.duration = duration
+    }
+    const aspectRatio = meta.aspectRatio
+    if (typeof aspectRatio === 'string' && aspectRatio.trim()) {
+      summary.aspectRatio = aspectRatio.trim()
+    }
+    const resolution = meta.resolution
+    if (typeof resolution === 'string' && resolution.trim()) {
+      summary.resolution = resolution.trim()
+    }
+    if (output?.bytes != null) summary.bytes = output.bytes
+  } else {
+    if (output?.width != null) summary.width = output.width
+    if (output?.height != null) summary.height = output.height
+    if (output?.bytes != null) summary.bytes = output.bytes
+    const aspectRatio = meta.aspectRatio
+    if (typeof aspectRatio === 'string' && aspectRatio.trim()) {
+      summary.aspectRatio = aspectRatio.trim()
+    }
+  }
 
   const refLevel = rec.refPreflight?.level
   if (refLevel === 'warn' || refLevel === 'error') {
     summary.refWarning = refLevel
   }
 
-  return Object.keys(summary).length ? summary : undefined
+  const { kind: _kind, refWarning: _refWarning, ...rest } = summary
+  const hasPayload = Object.values(rest).some((v) => v != null && v !== '')
+  return hasPayload || summary.refWarning ? summary : undefined
 }
 
 export function useMediaInspector() {

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -30,6 +30,7 @@ import { applyActionsToFlow, flowToCanvasData } from '@/composables/useCanvasAct
 import { annotateEdgesForSelection } from '@/utils/edgeHighlight'
 import { useShotPolling } from '@/composables/useShotPolling'
 import { useGenerationPolling, parseRecordPromptContent, parseRecordText, parseRecordUrl, parseRecordUrls, parseRecordLastFrameUrl, type GenerationPollTask } from '@/composables/useGenerationPolling'
+import { buildNodeMediaInfoSummary } from '@/composables/useMediaInspector'
 import { useNodeGeneration } from '@/composables/useNodeGeneration'
 import { createInitialSceneComposerNodeData } from '@/utils/sceneComposer'
 import { studioApi } from '@/services/studio-api'
@@ -604,6 +605,8 @@ const generationPolling = useGenerationPolling((results) => {
         const lastFrameUrl = parseRecordLastFrameUrl(record)
         if (lastFrameUrl) patch.lastFrameUrl = lastFrameUrl
       }
+      const mediaSummary = buildNodeMediaInfoSummary(record)
+      if (mediaSummary) patch.mediaInfo = mediaSummary
       patchNodeData(task.nodeId, patch)
     } else if (record.status === NODE_GENERATION_STATUS.failed || record.status === NODE_GENERATION_STATUS.error) {
       patchNodeData(


### PR DESCRIPTION
## Summary
- 修复轮询完成路径未写入 `data.mediaInfo`，导致刚生成的图片/视频节点看不到底部常驻摘要
- 图片 L0：`尺寸 · 体积 · 比例`（去掉模型名）
- 视频 L0：`时长 · 比例 · 分辨率 · 体积`
- `buildNodeMediaInfoSummary` 支持从 `metadata.mediaInfo` 回退解析

## Test plan
- [x] `pnpm --filter @lnkpi/web exec vitest run src/composables/useMediaInspector.test.ts`
- [x] `pnpm build`
- [ ] 画布生成图片/视频完成后节点底部出现摘要条


Made with [Cursor](https://cursor.com)