### PR TITLE
fix: backfill node mediaInfo on reload and shot path

### DIFF
--- a/apps/server/src/canvas/canvas.module.ts
+++ b/apps/server/src/canvas/canvas.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common'
 import { PointsModule } from '../points/points.module'
 import { ProviderModule } from '../provider/provider.module'
 import { UploadModule } from '../upload/upload.module'
+import { MediaProbeModule } from '../media/media-probe.module'
 import { CanvasController } from './canvas.controller'
 import { CanvasService } from './canvas.service'
 import { MaterialService } from './material.service'
@@ -10,7 +11,7 @@ import { ShotService } from './shot.service'
 import { VideoCompositionService } from './video-composition.service'
 
 @Module({
-  imports: [UploadModule, PointsModule, ProviderModule],
+  imports: [UploadModule, PointsModule, ProviderModule, MediaProbeModule],
   controllers: [CanvasController],
   providers: [
     CanvasService,

--- a/apps/server/src/canvas/material.diagnostic.test.ts
+++ b/apps/server/src/canvas/material.diagnostic.test.ts
@@ -5,6 +5,7 @@ import { NotFoundException } from '@nestjs/common'
 import { PointsService } from '../points/points.service'
 import { PrismaService } from '../prisma/prisma.service'
 import { ProviderResolverService } from '../provider/provider-resolver.service'
+import { MediaProbeService } from '../media/media-probe.service'
 import { MaterialService } from './material.service'
 
 describe('MaterialService.getMaterialDiagnostic', () => {
@@ -37,6 +38,15 @@ describe('MaterialService.getMaterialDiagnostic', () => {
         {
           provide: ProviderResolverService,
           useValue: { resolveForGeneration: vi.fn() },
+        },
+        {
+          provide: MediaProbeService,
+          useValue: {
+            probeUrl: vi.fn(async (url: string) => ({
+              url,
+              probeStatus: 'ok' as const,
+            })),
+          },
         },
       ],
     }).compile()

--- a/apps/server/src/canvas/material.fallback.test.ts
+++ b/apps/server/src/canvas/material.fallback.test.ts
@@ -9,6 +9,7 @@ import { MaterialService } from './material.service'
 import { PointsService } from '../points/points.service'
 import { PrismaService } from '../prisma/prisma.service'
 import { ProviderResolverService } from '../provider/provider-resolver.service'
+import { MediaProbeService } from '../media/media-probe.service'
 
 const imageGenerate = vi.fn()
 const videoGenerate = vi.fn()
@@ -106,6 +107,18 @@ describe('MaterialService BYOK fallback_pending', () => {
         {
           provide: ProviderResolverService,
           useValue: { resolveForGeneration },
+        },
+        {
+          provide: MediaProbeService,
+          useValue: {
+            probeUrl: vi.fn(async (url: string) => ({
+              url,
+              width: 1024,
+              height: 768,
+              bytes: 500_000,
+              probeStatus: 'ok' as const,
+            })),
+          },
         },
       ],
     }).compile()

--- a/apps/server/src/canvas/material.service.test.ts
+++ b/apps/server/src/canvas/material.service.test.ts
@@ -7,6 +7,18 @@ import { MaterialService } from './material.service'
 import { PointsService } from '../points/points.service'
 import { PrismaService } from '../prisma/prisma.service'
 import { ProviderResolverService } from '../provider/provider-resolver.service'
+import { MediaProbeService } from '../media/media-probe.service'
+
+const mediaProbeMock = {
+  probeUrl: vi.fn(async (url: string) => ({
+    url,
+    width: 1024,
+    height: 768,
+    bytes: 500_000,
+    mimeType: 'image/png',
+    probeStatus: 'ok' as const,
+  })),
+}
 
 function platformResolve(model?: string) {
   const modelName = model?.includes('::') ? model.split('::')[1]! : (model ?? '')
@@ -73,6 +85,10 @@ describe('MaterialService image', () => {
           useValue: {
             resolveForGeneration: vi.fn(async (_u: string, model?: string) => platformResolve(model)),
           },
+        },
+        {
+          provide: MediaProbeService,
+          useValue: mediaProbeMock,
         },
       ],
     }).compile()
@@ -202,6 +218,10 @@ describe('MaterialService video', () => {
           useValue: {
             resolveForGeneration: vi.fn(async (_u: string, model?: string) => platformResolve(model)),
           },
+        },
+        {
+          provide: MediaProbeService,
+          useValue: mediaProbeMock,
         },
       ],
     }).compile()

--- a/apps/server/src/canvas/material.service.ts
+++ b/apps/server/src/canvas/material.service.ts
@@ -44,6 +44,11 @@ import {
   rethrowWithRefundedPoints,
   throwCancelledException,
 } from '../points/charge-session'
+import { MediaProbeService } from '../media/media-probe.service'
+import {
+  buildMediaInfoPayload,
+  enrichVideoMediaInfoDimensions,
+} from '../media/build-media-info'
 import { PrismaService } from '../prisma/prisma.service'
 import { PointsService } from '../points/points.service'
 import { videoCredits } from '../points/video-credits'
@@ -246,6 +251,7 @@ export class MaterialService {
     @Inject(PrismaService) private readonly prisma: PrismaService,
     @Inject(PointsService) private readonly points: PointsService,
     @Inject(ProviderResolverService) private readonly resolver: ProviderResolverService,
+    @Inject(MediaProbeService) private readonly mediaProbe: MediaProbeService,
   ) {}
 
   async createFromAgent(data: {
@@ -878,6 +884,13 @@ export class MaterialService {
       if (!existing || existing.status !== 'generating') return
       const prev = parseMeta(existing.metadata)
       if (isCancelledMeta(prev) || alreadyRefunded(prev)) return
+      const mediaInfo = await buildMediaInfoPayload(
+        this.mediaProbe,
+        url,
+        Array.isArray(referenceImages)
+          ? referenceImages.filter((u): u is string => typeof u === 'string' && u.trim().length > 0)
+          : [],
+      )
       const updated = await this.prisma.material.updateMany({
         where: { id: materialId, status: 'generating' },
         data: {
@@ -901,6 +914,7 @@ export class MaterialService {
                 effectivePrompt,
                 responseMode: built.meta.responseMode,
                 refWire: built.meta.refWire,
+                mediaInfo,
               },
               skipCharge ? 0 : cost,
             ),
@@ -1058,6 +1072,16 @@ export class MaterialService {
       if (!existing || existing.status !== 'generating') return
       const prev = parseMeta(existing.metadata)
       if (isCancelledMeta(prev) || alreadyRefunded(prev)) return
+      const referenceUrls = [
+        ...effectiveBundle.images.map(({ url: refUrl }) => refUrl),
+        ...effectiveBundle.videos.map(({ url: refUrl }) => refUrl),
+        ...effectiveBundle.audios.map(({ url: refUrl }) => refUrl),
+      ].filter((u): u is string => typeof u === 'string' && u.trim().length > 0)
+      const mediaInfo = await enrichVideoMediaInfoDimensions(
+        this.mediaProbe,
+        await buildMediaInfoPayload(this.mediaProbe, url, referenceUrls),
+        lastFrameUrl,
+      )
       const updated = await this.prisma.material.updateMany({
         where: { id: materialId, status: 'generating' },
         data: {
@@ -1082,6 +1106,7 @@ export class MaterialService {
                 channelId: resolved.channelId,
                 effectivePrompt,
                 ...(lastFrameUrl ? { lastFrameUrl } : {}),
+                mediaInfo,
               },
               skipCharge ? 0 : cost,
             ),

--- a/apps/server/src/media/build-media-info.ts
+++ b/apps/server/src/media/build-media-info.ts
@@ -1,0 +1,46 @@
+import type { MediaInfo } from '@lnkpi/shared'
+import type { MediaProbeService } from './media-probe.service'
+
+export async function buildMediaInfoPayload(
+  mediaProbe: MediaProbeService,
+  outputUrl: string | null,
+  referenceUrls: string[],
+): Promise<MediaInfo> {
+  const output = outputUrl ? await mediaProbe.probeUrl(outputUrl) : undefined
+  const references = await Promise.all(
+    referenceUrls
+      .filter((url) => typeof url === 'string' && url.trim())
+      .map(async (url) => mediaProbe.probeUrl(url.trim())),
+  )
+  return {
+    ...(output ? { output } : {}),
+    ...(references.length ? { references } : {}),
+    probedAt: new Date().toISOString(),
+  }
+}
+
+export async function enrichVideoMediaInfoDimensions(
+  mediaProbe: MediaProbeService,
+  mediaInfo: MediaInfo,
+  lastFrameUrl?: string | null,
+): Promise<MediaInfo> {
+  if (mediaInfo.output?.width && mediaInfo.output?.height) {
+    return mediaInfo
+  }
+  const frameUrl = String(lastFrameUrl ?? '').trim()
+  if (!frameUrl) {
+    return mediaInfo
+  }
+  const lastFrame = await mediaProbe.probeUrl(frameUrl)
+  if (!lastFrame.width || !lastFrame.height) {
+    return mediaInfo
+  }
+  return {
+    ...mediaInfo,
+    output: {
+      ...(mediaInfo.output ?? { url: frameUrl, probeStatus: 'ok' as const }),
+      width: lastFrame.width,
+      height: lastFrame.height,
+    },
+  }
+}

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -57,6 +57,10 @@ import {
   type ResolvedGenerationProvider,
 } from '../provider/provider-resolver.service'
 import { MediaProbeService } from '../media/media-probe.service'
+import {
+  buildMediaInfoPayload,
+  enrichVideoMediaInfoDimensions,
+} from '../media/build-media-info'
 import { inlineUpstreamReferenceImages } from '../media/upstream-ref-inline'
 
 const AUDIO_PLACEHOLDER = 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3'
@@ -641,42 +645,14 @@ export class StudioService {
     outputUrl: string | null,
     referenceUrls: string[],
   ): Promise<MediaInfo> {
-    const output = outputUrl ? await this.mediaProbe.probeUrl(outputUrl) : undefined
-    const references = await Promise.all(
-      referenceUrls
-        .filter((url) => typeof url === 'string' && url.trim())
-        .map(async (url) => this.mediaProbe.probeUrl(url.trim())),
-    )
-    return {
-      ...(output ? { output } : {}),
-      ...(references.length ? { references } : {}),
-      probedAt: new Date().toISOString(),
-    }
+    return buildMediaInfoPayload(this.mediaProbe, outputUrl, referenceUrls)
   }
 
   private async enrichVideoMediaInfoDimensions(
     mediaInfo: MediaInfo,
     lastFrameUrl?: string | null,
   ): Promise<MediaInfo> {
-    if (mediaInfo.output?.width && mediaInfo.output?.height) {
-      return mediaInfo
-    }
-    const frameUrl = String(lastFrameUrl ?? '').trim()
-    if (!frameUrl) {
-      return mediaInfo
-    }
-    const lastFrame = await this.mediaProbe.probeUrl(frameUrl)
-    if (!lastFrame.width || !lastFrame.height) {
-      return mediaInfo
-    }
-    return {
-      ...mediaInfo,
-      output: {
-        ...(mediaInfo.output ?? { url: frameUrl, probeStatus: 'ok' as const }),
-        width: lastFrame.width,
-        height: lastFrame.height,
-      },
-    }
+    return enrichVideoMediaInfoDimensions(this.mediaProbe, mediaInfo, lastFrameUrl)
   }
 
   async getGenerationDiagnostic(userId: string, id: string): Promise<GenerationDiagnostic> {

--- a/apps/web/src/components/canvas/CanvasNodeImage.vue
+++ b/apps/web/src/components/canvas/CanvasNodeImage.vue
@@ -33,7 +33,6 @@ const props = defineProps<{
       height?: number
       bytes?: number
       aspectRatio?: string
-      duration?: number
       resolution?: string
       refWarning?: MediaRefWarningLevel
     }

--- a/apps/web/src/components/canvas/CanvasNodeVideo.vue
+++ b/apps/web/src/components/canvas/CanvasNodeVideo.vue
@@ -32,7 +32,6 @@ const props = defineProps<{
       height?: number
       bytes?: number
       aspectRatio?: string
-      duration?: number
       resolution?: string
       refWarning?: MediaRefWarningLevel
     }

--- a/apps/web/src/composables/useMediaInspector.test.ts
+++ b/apps/web/src/composables/useMediaInspector.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildNodeMediaInfoSummary } from './useMediaInspector'
+import { buildNodeMediaInfoSummary, buildMaterialMediaInfoSummary } from './useMediaInspector'
 import type { GenerationRecord } from '@/services/studio-api'
 
 function rec(partial: Partial<GenerationRecord> & Pick<GenerationRecord, 'id' | 'type' | 'status' | 'prompt' | 'createdAt'>): GenerationRecord {
@@ -78,5 +78,31 @@ describe('buildNodeMediaInfoSummary', () => {
       bytes: 12_000_000,
     })
     expect(summary?.width).toBeUndefined()
+  })
+
+  it('builds material summary from metadata.mediaInfo', () => {
+    const summary = buildMaterialMediaInfoSummary({
+      type: 'image',
+      metadata: JSON.stringify({
+        aspectRatio: '16:9',
+        mediaInfo: {
+          output: {
+            url: 'https://x/c.png',
+            width: 800,
+            height: 600,
+            bytes: 300_000,
+            probeStatus: 'ok',
+          },
+          probedAt: '2026-08-15T00:00:00.000Z',
+        },
+      }),
+    })
+    expect(summary).toMatchObject({
+      kind: 'image',
+      width: 800,
+      height: 600,
+      bytes: 300_000,
+      aspectRatio: '16:9',
+    })
   })
 })

--- a/apps/web/src/composables/useMediaInspector.ts
+++ b/apps/web/src/composables/useMediaInspector.ts
@@ -88,6 +88,56 @@ export function buildNodeMediaInfoSummary(rec: GenerationRecord): NodeMediaInfoS
   return hasPayload || summary.refWarning ? summary : undefined
 }
 
+function parseMaterialMeta(metadata?: string | null): Record<string, unknown> {
+  if (!metadata) return {}
+  try {
+    return JSON.parse(metadata) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+export interface MaterialMediaSource {
+  type?: string | null
+  metadata?: string | null
+}
+
+export function buildMaterialMediaInfoSummary(
+  material: MaterialMediaSource,
+): NodeMediaInfoSummary | undefined {
+  const kind: NodeMediaInfoSummary['kind'] = material.type === 'video' ? 'video' : 'image'
+  const meta = parseMaterialMeta(material.metadata)
+  const fromMeta = meta.mediaInfo
+  const mediaInfo =
+    fromMeta && typeof fromMeta === 'object' ? (fromMeta as MediaInfo) : undefined
+  const output = mediaInfo?.output
+  const summary: NodeMediaInfoSummary = { kind }
+
+  if (kind === 'video') {
+    const resolution = meta.resolution
+    if (typeof resolution === 'string' && resolution.trim()) {
+      summary.resolution = resolution.trim()
+    }
+    const aspectRatio = meta.aspectRatio
+    if (typeof aspectRatio === 'string' && aspectRatio.trim()) {
+      summary.aspectRatio = aspectRatio.trim()
+    }
+    if (output?.bytes != null) summary.bytes = output.bytes
+  } else {
+    if (output?.width != null) summary.width = output.width
+    if (output?.height != null) summary.height = output.height
+    if (output?.bytes != null) summary.bytes = output.bytes
+    const aspectRatio = meta.aspectRatio
+    if (typeof aspectRatio === 'string' && aspectRatio.trim()) {
+      summary.aspectRatio = aspectRatio.trim()
+    }
+  }
+
+  const { kind: _kind, ...rest } = summary
+  const hasPayload = Object.values(rest).some((v) => v != null && v !== '')
+  return hasPayload ? summary : undefined
+}
+
 export function useMediaInspector() {
   async function openInspector(next: MediaInspectorTarget) {
     target.value = next

--- a/apps/web/src/composables/useShotPolling.ts
+++ b/apps/web/src/composables/useShotPolling.ts
@@ -6,6 +6,8 @@ interface ShotMaterial {
   url?: string | null
   status: string
   prompt?: string | null
+  type?: string | null
+  metadata?: string | null
 }
 
 interface ShotStatus {

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -30,7 +30,8 @@ import { applyActionsToFlow, flowToCanvasData } from '@/composables/useCanvasAct
 import { annotateEdgesForSelection } from '@/utils/edgeHighlight'
 import { useShotPolling } from '@/composables/useShotPolling'
 import { useGenerationPolling, parseRecordPromptContent, parseRecordText, parseRecordUrl, parseRecordUrls, parseRecordLastFrameUrl, type GenerationPollTask } from '@/composables/useGenerationPolling'
-import { buildNodeMediaInfoSummary } from '@/composables/useMediaInspector'
+import { buildNodeMediaInfoSummary, buildMaterialMediaInfoSummary } from '@/composables/useMediaInspector'
+import type { GenerationRecord } from '@/services/studio-api'
 import { useNodeGeneration } from '@/composables/useNodeGeneration'
 import { createInitialSceneComposerNodeData } from '@/utils/sceneComposer'
 import { studioApi } from '@/services/studio-api'
@@ -551,6 +552,12 @@ const shotPolling = useShotPolling((shots) => {
           const lastFrameUrl = parseRecordLastFrameUrl(material as { metadata?: string | null })
           if (lastFrameUrl) nodePatch.lastFrameUrl = lastFrameUrl
         }
+        const mediaSummary = buildMaterialMediaInfoSummary({
+          type: n.type === 'video' ? 'video' : material.type ?? 'image',
+          metadata: (material as { metadata?: string | null }).metadata,
+        })
+        if (mediaSummary) nodePatch.mediaInfo = mediaSummary
+        nodePatch.materialId = material.id
         patchNodeData(n.id, nodePatch)
       }
     }
@@ -2636,29 +2643,36 @@ async function loadSession() {
 }
 
 /**
- * Walk media nodes (image/video/text/prompt/audio) that lack
- * `generationRecordId` and re-attach the matching Studio record by nodeId.
- * Tolerates empty / partial Studio responses.
+ * Reconcile studio generation records with canvas nodes:
+ * - attach missing generationRecordId by nodeId
+ * - backfill mediaInfo on completed image/video nodes
  */
 async function reconcileMissingGenerationRecords() {
   if (!sessionId.value) return
   const mediaTypes = new Set(['image', 'video', 'text', 'prompt', 'audio'])
-  const missing = nodes.value.filter((n) => {
+  const missingRecordId = nodes.value.filter((n) => {
     if (!mediaTypes.has(String(n.type))) return false
     const data = n.data as Record<string, unknown>
     return !data?.generationRecordId
   })
-  if (!missing.length) return
+  const missingMediaInfo = nodes.value.filter((n) => {
+    if (n.type !== 'image' && n.type !== 'video') return false
+    const data = n.data as Record<string, unknown>
+    return data?.status === NODE_GENERATION_STATUS.completed && !data?.mediaInfo
+  })
+  if (!missingRecordId.length && !missingMediaInfo.length) return
   try {
     const { data } = await studioApi.listGenerations({ sessionId: sessionId.value })
     const records = data.data ?? []
     if (!records.length) return
-    const byNodeId = new Map<string, typeof records[number]>()
+    const byNodeId = new Map<string, GenerationRecord>()
+    const byRecordId = new Map<string, GenerationRecord>()
     for (const r of records) {
       if (r.nodeId) byNodeId.set(r.nodeId, r)
+      byRecordId.set(r.id, r)
     }
     let patched = 0
-    for (const node of missing) {
+    for (const node of missingRecordId) {
       const rec = byNodeId.get(node.id)
       if (!rec) continue
       const patch = buildStudioRecordPatch(node, rec)
@@ -2666,8 +2680,17 @@ async function reconcileMissingGenerationRecords() {
       patchNodeData(node.id, patch)
       patched += 1
     }
+    for (const node of missingMediaInfo) {
+      const data = node.data as Record<string, unknown>
+      const recordId = typeof data.generationRecordId === 'string' ? data.generationRecordId : ''
+      const rec = (recordId && byRecordId.get(recordId)) || byNodeId.get(node.id)
+      if (!rec || rec.status !== 'completed') continue
+      const mediaSummary = buildNodeMediaInfoSummary(rec)
+      if (!mediaSummary) continue
+      patchNodeData(node.id, { mediaInfo: mediaSummary })
+      patched += 1
+    }
     if (patched > 0) {
-      // Persist the recovered state so a reload does not regress.
       void saveCanvas()
     }
   } catch {
@@ -2677,7 +2700,7 @@ async function reconcileMissingGenerationRecords() {
 
 function buildStudioRecordPatch(
   _node: EditableFlowNode,
-  record: { id: string; status: string; type: string; url?: string | null; metadata?: string | null; prompt: string },
+  record: GenerationRecord,
 ): Record<string, unknown> | null {
   // Skip non-terminal records — polling will catch them.
   if (record.status !== 'completed' && record.status !== 'failed' && record.status !== 'error') {
@@ -2696,19 +2719,27 @@ function buildStudioRecordPatch(
   }
   if (record.type === 'text' || record.type === 'prompt') {
     if (record.type === 'prompt') {
-      const parsed = parseRecordPromptContent(record as { metadata?: string | null; prompt: string })
+      const parsed = parseRecordPromptContent(record)
       patch.content = parsed.content
       patch.promptMode = parsed.mode
     } else {
-      patch.content = parseRecordText(record as { metadata?: string | null; prompt: string })
+      patch.content = parseRecordText(record)
     }
   } else {
-    const urls = parseRecordUrls(record as { url?: string | null; metadata?: string | null })
+    const urls = parseRecordUrls(record)
     if (urls.length) {
       patch.url = urls[0]
       patch.images = urls
     } else if (record.url) {
       patch.url = record.url
+    }
+    if (record.type === 'video') {
+      const lastFrameUrl = parseRecordLastFrameUrl(record)
+      if (lastFrameUrl) patch.lastFrameUrl = lastFrameUrl
+    }
+    if (status === NODE_GENERATION_STATUS.completed && (record.type === 'image' || record.type === 'video')) {
+      const mediaSummary = buildNodeMediaInfoSummary(record)
+      if (mediaSummary) patch.mediaInfo = mediaSummary
     }
   }
   return patch


### PR DESCRIPTION
## Summary
- Session load：completed 图片/视频节点缺 `mediaInfo` 时从 studio record 回填
- `buildStudioRecordPatch`：reconcile 时一并写入 mediaInfo
- Shot 路径：material 完成 probe 写 `metadata.mediaInfo`；轮询完成时 patch 节点 L0
- 抽取 `build-media-info.ts` 供 studio / material 复用

## Test plan
- [x] vitest + pnpm build
- [ ] 刷新画布：旧 completed 节点出现 L0 细条
- [ ] Shot 生成完成后 linked 节点出现 L0 细条


Made with [Cursor](https://cursor.com)