### PR TITLE
feat(web): finish Media Inspector P0 drawer UX

### DIFF
--- a/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
+++ b/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
-import type { ErrorCode, GenerationDiagnostic, MediaInfo } from '@lnkpi/shared'
+import type { GenerationDiagnostic, MediaInfo } from '@lnkpi/shared'
 import { modelOptionName } from '@lnkpi/shared'
 import { studioApi, type GenerationRecord } from '@/services/studio-api'
 import DockTypeIcon from '@/components/canvas/dock-studio/shared/DockTypeIcon.vue'
@@ -10,13 +10,15 @@ import CanvasLocateButton from '@/components/shared/CanvasLocateButton.vue'
 import CanvasLocatePinIcon from '@/components/shared/CanvasLocatePinIcon.vue'
 import MediaInfoSummary from '@/components/media/MediaInfoSummary.vue'
 import MediaRefList from '@/components/media/MediaRefList.vue'
-import { buildNodeMediaInfoSummary } from '@/composables/useMediaInspector'
+import { buildNodeMediaInfoSummary, useMediaInspector } from '@/composables/useMediaInspector'
 import { useCanvasEditorStore } from '@/stores/canvasEditor'
 import { useProviderBootstrap } from '@/composables/useProviderBootstrap'
 import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
 import {
   buildCopyForNode,
-  parseErrorCodeFromMetadata,
+  buildFallbackDiagnostic,
+  getRecordFailureMessage,
+  isFailedGenerationStatus,
   sharedDiagnosticCache,
 } from '@/utils/generationDiagnostic'
 import { copyTextToClipboard } from '@/utils/copyToClipboard'
@@ -38,6 +40,7 @@ const emit = defineEmits<{
 const route = useRoute()
 const editor = useCanvasEditorStore()
 const { allChannels } = useProviderBootstrap()
+const { openInspector } = useMediaInspector()
 
 const sessionId = computed(() => route.params.sessionId as string | undefined)
 
@@ -208,29 +211,22 @@ function recordParamRows(record: GenerationRecord): Array<{ label: string; value
 }
 
 function recordFailureMessage(record: GenerationRecord): string | null {
-  if (
-    record.status !== 'failed' &&
-    record.status !== 'error' &&
-    record.status !== NODE_GENERATION_STATUS.fallback_pending
-  ) {
-    return null
-  }
-  const meta = parseRecordMeta(record)
-  if (meta.userMessage) return meta.userMessage
-  const byok = meta.byokErrorRaw || meta.errorRaw
-  if (record.status === NODE_GENERATION_STATUS.fallback_pending) {
-    return byok ? `平台回退待确认：${byok.slice(0, 240)}` : '平台回退待确认'
-  }
-  if (byok) return byok.slice(0, 240)
-  return '生成失败'
+  return getRecordFailureMessage(record)
 }
 
 function isFailedStatus(status: string) {
-  return (
-    status === 'failed' ||
-    status === 'error' ||
-    status === NODE_GENERATION_STATUS.fallback_pending
-  )
+  return isFailedGenerationStatus(status)
+}
+
+function openFullInspector(record: GenerationRecord, e?: Event) {
+  e?.stopPropagation()
+  void openInspector({
+    generationRecordId: record.id,
+    nodeId: record.nodeId ?? undefined,
+    nodeLabel: record.prompt || undefined,
+    url: record.url ?? undefined,
+    kind: record.type === 'video' ? 'video' : 'image',
+  })
 }
 
 function recordTextSnippet(record: GenerationRecord): string {
@@ -389,25 +385,6 @@ function emitRetry(nodeId: string | null | undefined, e?: Event) {
   e?.stopPropagation()
   if (!nodeId) return
   emit('retry', nodeId)
-}
-
-function buildFallbackDiagnostic(record: GenerationRecord): GenerationDiagnostic {
-  const meta = parseRecordMeta(record)
-  const isFallback = record.status === NODE_GENERATION_STATUS.fallback_pending
-  const byok = meta.byokErrorRaw || meta.errorRaw || ''
-  return {
-    userMessage: meta.userMessage || recordFailureMessage(record) || '生成失败',
-    code: isFallback
-      ? 'fallback_pending'
-      : ((parseErrorCodeFromMetadata(record.metadata) as ErrorCode | undefined) || 'unknown'),
-    taskKind: 'generation',
-    taskId: record.id,
-    occurredAt: record.createdAt,
-    channelId: meta.channelId ?? null,
-    model: record.model ?? meta.originalModel ?? null,
-    providerSnippet: byok ? byok.slice(0, 2048) : null,
-    hint: isFallback ? '请确认是否使用平台回退继续，或取消本次生成。' : undefined,
-  }
 }
 
 function clampPopoverPosition(rect: DOMRect): Record<string, string> {
@@ -702,6 +679,14 @@ onUnmounted(stopPolling)
                   :refs="recordMediaRefItems(attempt)"
                 />
               </div>
+
+              <button
+                type="button"
+                class="mt-2 flex w-full items-center justify-center rounded-lg border border-[var(--neo-border)] py-1.5 text-[10px] text-[var(--neo-text-secondary)] transition hover:border-[var(--neo-border-strong)] hover:bg-[var(--neo-active-bg)] hover:text-[var(--neo-text-primary)]"
+                @click="openFullInspector(attempt, $event)"
+              >
+                查看完整属性
+              </button>
 
               <div v-if="recordFailureMessage(attempt)">
                 <p class="mb-1 text-[10px] uppercase tracking-wider text-[var(--neo-text-muted)]">失败原因</p>

--- a/apps/web/src/components/media/MediaInspectorDrawer.vue
+++ b/apps/web/src/components/media/MediaInspectorDrawer.vue
@@ -2,15 +2,23 @@
 import { computed, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { modelOptionName } from '@lnkpi/shared'
-import type { MediaInfo, ProbedMediaFile } from '@lnkpi/shared'
+import type { GenerationDiagnostic, MediaInfo, ProbedMediaFile } from '@lnkpi/shared'
 import MediaRefList from '@/components/media/MediaRefList.vue'
+import CanvasLocatePinIcon from '@/components/shared/CanvasLocatePinIcon.vue'
 import { useMediaInspector } from '@/composables/useMediaInspector'
 import {
   downloadMediaFile,
   mediaDownloadName,
 } from '@/composables/useCanvasMedia'
 import { resolveMediaUrl } from '@/services/api-base'
+import { studioApi } from '@/services/studio-api'
 import { copyTextToClipboard } from '@/utils/copyToClipboard'
+import {
+  buildCopyForNode,
+  buildFallbackDiagnostic,
+  isFailedGenerationStatus,
+  sharedDiagnosticCache,
+} from '@/utils/generationDiagnostic'
 import {
   formatMediaBytes,
   formatMediaDimensions,
@@ -26,12 +34,30 @@ const {
   error,
   target,
   record,
+  locateNodeHandler,
   closeInspector,
   probeMedia,
+  locateCanvasNode,
 } = useMediaInspector()
 
 const lazyOutput = ref<ProbedMediaFile | undefined>()
 const lazyLoading = ref(false)
+const activeTab = ref<'info' | 'diagnostic'>('info')
+const diagnostic = ref<GenerationDiagnostic | null>(null)
+const diagnosticLoading = ref(false)
+const diagnosticCopyLabel = ref('复制诊断')
+
+watch(
+  () => open.value,
+  (isOpen) => {
+    if (!isOpen) {
+      activeTab.value = 'info'
+      diagnostic.value = null
+      diagnosticLoading.value = false
+      diagnosticCopyLabel.value = '复制诊断'
+    }
+  },
+)
 
 watch(
   () => [open.value, record.value?.id, record.value?.mediaInfo?.output] as const,
@@ -107,6 +133,20 @@ const outputFile = computed(() => mediaInfo.value?.output ?? lazyOutput.value)
 
 const refPreflight = computed(() => record.value?.refPreflight)
 
+const showDiagnosticTab = computed(() =>
+  Boolean(record.value && isFailedGenerationStatus(record.value.status)),
+)
+
+const diagnosticMessage = computed(() => {
+  if (diagnosticLoading.value) return '加载中…'
+  return diagnostic.value?.userMessage || '暂无诊断信息'
+})
+
+const diagnosticHint = computed(() => {
+  if (diagnosticLoading.value) return undefined
+  return diagnostic.value?.hint
+})
+
 const modelLabel = computed(() => {
   const model = record.value?.model || String(parsedMeta.value.originalModel ?? '')
   if (!model) return null
@@ -174,7 +214,84 @@ const referenceItems = computed(() => {
   return []
 })
 
+function formatMetaValue(value: unknown): string | null {
+  if (value === undefined || value === null || value === '') return null
+  if (typeof value === 'boolean') return value ? '是' : '否'
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value, null, 2)
+    } catch {
+      return String(value)
+    }
+  }
+  return String(value)
+}
+
+const l2Rows = computed(() => {
+  const meta = parsedMeta.value
+  const rows: Array<{ label: string; value: string; multiline?: boolean }> = []
+  const add = (label: string, raw: unknown, multiline = false) => {
+    const value = formatMetaValue(raw)
+    if (value) rows.push({ label, value, multiline })
+  }
+  add('Prompt', record.value?.prompt || meta.prompt, true)
+  add('Seed', meta.seed)
+  add('Negative', meta.negativePrompt, true)
+  add('Generate audio', meta.generateAudio)
+  add('refWire', meta.refWire)
+  add('gatewayModelId', meta.gatewayModelId)
+  add('scenario', meta.scenario)
+  add('mergedText', meta.mergedText, true)
+  return rows
+})
+
+const nativeParamsJson = computed(() => {
+  const nativeParams = parsedMeta.value.nativeParams
+  if (nativeParams === undefined || nativeParams === null) return null
+  return formatMetaValue(nativeParams)
+})
+
+const hasL2 = computed(() => l2Rows.value.length > 0 || Boolean(nativeParamsJson.value))
+
+const canLocate = computed(() =>
+  Boolean(locateNodeHandler.value && (record.value?.id || target.value?.generationRecordId)),
+)
+
 const taskIdCopyLabel = ref('复制任务 ID')
+
+async function loadDiagnostic() {
+  const rec = record.value
+  if (!rec) return
+  diagnosticLoading.value = true
+  diagnosticCopyLabel.value = '复制诊断'
+  try {
+    diagnostic.value = await sharedDiagnosticCache.get('generation', rec.id, () =>
+      studioApi.getGenerationDiagnostic(rec.id),
+    )
+  } catch {
+    diagnostic.value = buildFallbackDiagnostic(rec)
+  } finally {
+    diagnosticLoading.value = false
+  }
+}
+
+async function switchToDiagnosticTab() {
+  activeTab.value = 'diagnostic'
+  if (!diagnostic.value && !diagnosticLoading.value) {
+    await loadDiagnostic()
+  }
+}
+
+watch(
+  () => [open.value, record.value?.id, record.value?.status] as const,
+  async ([isOpen, , status]) => {
+    diagnostic.value = null
+    if (!isOpen || !record.value || !status || !isFailedGenerationStatus(status)) return
+    if (activeTab.value === 'diagnostic') {
+      await loadDiagnostic()
+    }
+  },
+)
 
 async function copyTaskId() {
   const id = record.value?.id || target.value?.generationRecordId
@@ -187,6 +304,26 @@ async function copyTaskId() {
     }, 1500)
   } catch {
     taskIdCopyLabel.value = '复制失败'
+  }
+}
+
+async function copyDiagnostic() {
+  const rec = record.value
+  if (!rec) return
+  const payload = diagnostic.value || buildFallbackDiagnostic(rec)
+  const text = buildCopyForNode(payload, {
+    nodeId: target.value?.nodeId ?? rec.nodeId ?? undefined,
+    nodeLabel: target.value?.nodeLabel,
+    sessionId: sessionId.value,
+  })
+  try {
+    await copyTextToClipboard(text)
+    diagnosticCopyLabel.value = '已复制'
+    setTimeout(() => {
+      diagnosticCopyLabel.value = '复制诊断'
+    }, 1500)
+  } catch {
+    diagnosticCopyLabel.value = '复制失败'
   }
 }
 
@@ -231,8 +368,41 @@ async function copyValue(text: string) {
         </button>
       </header>
 
+      <div v-if="showDiagnosticTab" class="media-inspector-tabs">
+        <button
+          type="button"
+          class="media-inspector-tab"
+          :class="{ 'is-active': activeTab === 'info' }"
+          @click="activeTab = 'info'"
+        >
+          属性
+        </button>
+        <button
+          type="button"
+          class="media-inspector-tab"
+          :class="{ 'is-active': activeTab === 'diagnostic' }"
+          @click="switchToDiagnosticTab"
+        >
+          诊断
+        </button>
+      </div>
+
       <div v-if="loading" class="media-inspector-loading">加载中…</div>
       <div v-else-if="error" class="media-inspector-error">{{ error }}</div>
+      <div v-else-if="activeTab === 'diagnostic'" class="media-inspector-body">
+        <section class="media-inspector-section media-inspector-diagnostic">
+          <p class="media-inspector-diag-msg">{{ diagnosticMessage }}</p>
+          <p v-if="diagnosticHint" class="media-inspector-diag-hint">{{ diagnosticHint }}</p>
+          <button
+            type="button"
+            class="media-inspector-action"
+            :disabled="diagnosticLoading"
+            @click="copyDiagnostic"
+          >
+            {{ diagnosticCopyLabel }}
+          </button>
+        </section>
+      </div>
       <div v-else class="media-inspector-body">
         <section v-if="previewUrl" class="media-inspector-section">
           <div class="media-inspector-preview">
@@ -300,7 +470,32 @@ async function copyValue(text: string) {
           <MediaRefList :refs="referenceItems" />
         </section>
 
+        <section v-if="hasL2" class="media-inspector-section">
+          <details class="media-inspector-l2">
+            <summary class="media-inspector-section-title media-inspector-l2-summary">高级参数</summary>
+            <dl v-if="l2Rows.length" class="media-inspector-dl media-inspector-l2-dl">
+              <template v-for="row in l2Rows" :key="row.label">
+                <dt>{{ row.label }}</dt>
+                <dd :class="{ 'is-multiline': row.multiline }">{{ row.value }}</dd>
+              </template>
+            </dl>
+            <details v-if="nativeParamsJson" class="media-inspector-native">
+              <summary>nativeParams</summary>
+              <pre class="media-inspector-pre">{{ nativeParamsJson }}</pre>
+            </details>
+          </details>
+        </section>
+
         <section class="media-inspector-section media-inspector-actions">
+          <button
+            v-if="canLocate"
+            type="button"
+            class="media-inspector-action media-inspector-action-locate"
+            @click="locateCanvasNode"
+          >
+            <CanvasLocatePinIcon :size="14" />
+            定位画布节点
+          </button>
           <button type="button" class="media-inspector-action" @click="copyTaskId">
             {{ taskIdCopyLabel }}
           </button>
@@ -363,6 +558,29 @@ async function copyValue(text: string) {
 .media-inspector-close:hover {
   background: rgba(255, 255, 255, 0.06);
   color: var(--neo-text-primary);
+}
+
+.media-inspector-tabs {
+  display: flex;
+  gap: 6px;
+  padding: 10px 16px 0;
+}
+
+.media-inspector-tab {
+  flex: 1;
+  border: 1px solid var(--neo-border);
+  border-radius: 8px;
+  padding: 7px 10px;
+  background: transparent;
+  color: var(--neo-text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.media-inspector-tab.is-active {
+  background: rgba(167, 139, 250, 0.12);
+  border-color: rgba(167, 139, 250, 0.35);
+  color: #ddd6fe;
 }
 
 .media-inspector-loading,
@@ -430,6 +648,11 @@ async function copyValue(text: string) {
   word-break: break-all;
 }
 
+.media-inspector-dl dd.is-multiline {
+  white-space: pre-wrap;
+  line-height: 1.45;
+}
+
 .media-inspector-copy-inline {
   margin-left: 6px;
   border: none;
@@ -465,6 +688,82 @@ async function copyValue(text: string) {
 
 .media-inspector-action:hover {
   background: rgba(255, 255, 255, 0.06);
+}
+
+.media-inspector-action:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.media-inspector-action-locate {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.media-inspector-l2 {
+  border: 1px solid var(--neo-border);
+  border-radius: 10px;
+  padding: 8px 10px;
+}
+
+.media-inspector-l2-summary {
+  cursor: pointer;
+  list-style: none;
+  margin-bottom: 0;
+}
+
+.media-inspector-l2-summary::-webkit-details-marker {
+  display: none;
+}
+
+.media-inspector-l2-dl {
+  margin-top: 10px;
+}
+
+.media-inspector-native {
+  margin-top: 10px;
+}
+
+.media-inspector-native summary {
+  cursor: pointer;
+  font-size: 11px;
+  color: var(--neo-text-secondary);
+}
+
+.media-inspector-pre {
+  margin: 8px 0 0;
+  padding: 8px;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.25);
+  font-size: 10px;
+  line-height: 1.4;
+  overflow: auto;
+  max-height: 160px;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.media-inspector-diagnostic {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.media-inspector-diag-msg {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.media-inspector-diag-hint {
+  margin: 0;
+  font-size: 11px;
+  color: var(--neo-text-secondary);
+  line-height: 1.45;
 }
 </style>
 

--- a/apps/web/src/composables/useMediaInspector.ts
+++ b/apps/web/src/composables/useMediaInspector.ts
@@ -52,6 +52,15 @@ const error = ref<string | null>(null)
 const target = ref<MediaInspectorTarget | null>(null)
 const record = ref<GenerationRecord | null>(null)
 
+export interface LocateCanvasNodePayload {
+  recordId: string
+  nodeId?: string | null
+}
+
+type LocateCanvasNodeHandler = (payload: LocateCanvasNodePayload) => void | Promise<void>
+
+const locateNodeHandler = ref<LocateCanvasNodeHandler | null>(null)
+
 export function buildNodeMediaInfoSummary(rec: GenerationRecord): NodeMediaInfoSummary | undefined {
   const output = resolveRecordMediaInfo(rec)?.output
   const meta = parseRecordMeta(rec)
@@ -177,15 +186,30 @@ export function useMediaInspector() {
     recordCache.delete(generationRecordId)
   }
 
+  function registerLocateNodeHandler(handler: LocateCanvasNodeHandler | null) {
+    locateNodeHandler.value = handler
+  }
+
+  async function locateCanvasNode() {
+    const recordId = record.value?.id || target.value?.generationRecordId
+    if (!recordId || !locateNodeHandler.value) return
+    const nodeId = target.value?.nodeId ?? record.value?.nodeId
+    await locateNodeHandler.value({ recordId, nodeId })
+    closeInspector()
+  }
+
   return {
     open,
     loading,
     error,
     target,
     record,
+    locateNodeHandler,
     openInspector,
     closeInspector,
     probeMedia,
     invalidateRecordCache,
+    registerLocateNodeHandler,
+    locateCanvasNode,
   }
 }

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -30,7 +30,7 @@ import { applyActionsToFlow, flowToCanvasData } from '@/composables/useCanvasAct
 import { annotateEdgesForSelection } from '@/utils/edgeHighlight'
 import { useShotPolling } from '@/composables/useShotPolling'
 import { useGenerationPolling, parseRecordPromptContent, parseRecordText, parseRecordUrl, parseRecordUrls, parseRecordLastFrameUrl, type GenerationPollTask } from '@/composables/useGenerationPolling'
-import { buildNodeMediaInfoSummary, buildMaterialMediaInfoSummary } from '@/composables/useMediaInspector'
+import { buildNodeMediaInfoSummary, buildMaterialMediaInfoSummary, useMediaInspector } from '@/composables/useMediaInspector'
 import type { GenerationRecord } from '@/services/studio-api'
 import { useNodeGeneration } from '@/composables/useNodeGeneration'
 import { createInitialSceneComposerNodeData } from '@/utils/sceneComposer'
@@ -131,6 +131,7 @@ const route = useRoute()
 const router = useRouter()
 const auth = useAuthStore()
 const canvasEditor = useCanvasEditorStore()
+const { registerLocateNodeHandler } = useMediaInspector()
 const sessionId = computed(() => route.params.sessionId as string)
 
 interface CanvasEdge {
@@ -2781,6 +2782,7 @@ provide(CANVAS_REF_PICK_NODE_IDS_KEY, pickMode.pickedNodeIds)
 provide(CANVAS_REF_PICK_REJECT_KEY, pickRejectNodeId)
 
 onMounted(() => {
+  registerLocateNodeHandler(handleHistoryLocate)
   void loadProviderBootstrap().catch(() => {
     // Dock falls back to catalog defaults until bootstrap succeeds
   })
@@ -2852,6 +2854,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  registerLocateNodeHandler(null)
   if (pickModeKeydownHandler) {
     window.removeEventListener('keydown', pickModeKeydownHandler)
   }

--- a/apps/web/src/utils/generationDiagnostic.ts
+++ b/apps/web/src/utils/generationDiagnostic.ts
@@ -1,5 +1,6 @@
 import type { ErrorCode, GenerationDiagnostic, TaskKind } from '@lnkpi/shared'
 import { formatDiagnosticCopy } from '@lnkpi/shared'
+import type { GenerationRecord } from '@/services/studio-api'
 import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
 import {
   extractRefundedPointsFromError,
@@ -127,3 +128,59 @@ export function createDiagnosticCache(): DiagnosticCache {
 
 /** Session-scoped cache shared by node ⓘ popover and Dock failure chip. */
 export const sharedDiagnosticCache = createDiagnosticCache()
+
+export function parseGenerationRecordMeta(metadata?: string | null): Record<string, unknown> {
+  if (!metadata) return {}
+  try {
+    return JSON.parse(metadata) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+export function isFailedGenerationStatus(status: string): boolean {
+  return (
+    status === 'failed' ||
+    status === 'error' ||
+    status === NODE_GENERATION_STATUS.fallback_pending
+  )
+}
+
+export function getRecordFailureMessage(
+  record: Pick<GenerationRecord, 'status' | 'metadata'>,
+): string | null {
+  if (!isFailedGenerationStatus(record.status)) return null
+  const meta = parseGenerationRecordMeta(record.metadata)
+  if (typeof meta.userMessage === 'string' && meta.userMessage) return meta.userMessage
+  const byok =
+    (typeof meta.byokErrorRaw === 'string' && meta.byokErrorRaw) ||
+    (typeof meta.errorRaw === 'string' && meta.errorRaw) ||
+    ''
+  if (record.status === NODE_GENERATION_STATUS.fallback_pending) {
+    return byok ? `平台回退待确认：${byok.slice(0, 240)}` : '平台回退待确认'
+  }
+  if (byok) return byok.slice(0, 240)
+  return '生成失败'
+}
+
+export function buildFallbackDiagnostic(record: GenerationRecord): GenerationDiagnostic {
+  const meta = parseGenerationRecordMeta(record.metadata)
+  const isFallback = record.status === NODE_GENERATION_STATUS.fallback_pending
+  const byok =
+    (typeof meta.byokErrorRaw === 'string' && meta.byokErrorRaw) ||
+    (typeof meta.errorRaw === 'string' && meta.errorRaw) ||
+    ''
+  return {
+    userMessage: getRecordFailureMessage(record) || '生成失败',
+    code: isFallback
+      ? 'fallback_pending'
+      : ((parseErrorCodeFromMetadata(record.metadata) as ErrorCode | undefined) || 'unknown'),
+    taskKind: 'generation',
+    taskId: record.id,
+    occurredAt: record.createdAt,
+    channelId: typeof meta.channelId === 'string' ? meta.channelId : null,
+    model: record.model ?? (typeof meta.originalModel === 'string' ? meta.originalModel : null),
+    providerSnippet: byok ? byok.slice(0, 2048) : null,
+    hint: isFallback ? '请确认是否使用平台回退继续，或取消本次生成。' : undefined,
+  }
+}


### PR DESCRIPTION
## Summary
- Inspector Drawer 新增「定位画布节点」按钮，复用 CanvasPage 历史定位逻辑
- 新增 L2 高级参数折叠区（prompt/seed/refWire/nativeParams 等）
- 失败/待确认任务在 Drawer 内提供「属性 | 诊断」Tab，复用 diagnostic API 与复制格式
- 任务历史详情每条记录增加「查看完整属性」入口

## Test plan
- [x] pnpm build
- [x] vitest useMediaInspector.test.ts
- [ ] 画布节点 ⓘ 打开 Inspector → 定位按钮聚焦节点
- [ ] 失败任务 Inspector 诊断 Tab 可复制
- [ ] 任务历史详情 → 查看完整属性


Made with [Cursor](https://cursor.com)