### PR TITLE
feat: complete Media Inspector P1 and remaining polish

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -25,7 +25,8 @@
     "multer": "^2.2.0",
     "prisma": "^6.2.1",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "sharp": "^0.33.5"
   },
   "devDependencies": {
     "@nestjs/testing": "^10.4.22",

--- a/apps/server/prisma/migrations/20260816120000_user_asset_metadata/migration.sql
+++ b/apps/server/prisma/migrations/20260816120000_user_asset_metadata/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "UserAsset" ADD COLUMN "metadata" TEXT;

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -36,6 +36,7 @@ model UserAsset {
   url          String
   label        String   @default("")
   sourceNodeId String?
+  metadata     String?
   createdAt    DateTime @default(now())
 
   @@unique([userId, url])

--- a/apps/server/src/assets/assets.controller.ts
+++ b/apps/server/src/assets/assets.controller.ts
@@ -16,6 +16,10 @@ import { Request } from 'express'
 import { AuthGuard } from '../auth/auth.guard'
 import { PrismaService } from '../prisma/prisma.service'
 import { PUBLIC_ASSETS } from './public-assets.data'
+import {
+  buildUserAssetMetadataFromGeneration,
+  serializeUserAssetMetadata,
+} from './build-user-asset-metadata'
 
 type AuthedRequest = Request & { user: { sub: string; phone: string } }
 
@@ -46,6 +50,11 @@ class SaveUserAssetDto {
   @IsString()
   @MaxLength(64)
   sourceNodeId?: string
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  generationRecordId?: string
 }
 
 @Controller('assets')
@@ -79,7 +88,16 @@ export class AssetsController {
   @Post('mine')
   @UseGuards(AuthGuard)
   async saveMine(@Req() req: AuthedRequest, @Body() dto: SaveUserAssetDto) {
-    // 同一 URL 重复保存时更新标签，保持幂等
+    let metadata: string | undefined
+    if (dto.generationRecordId) {
+      const record = await this.prisma.generationRecord.findFirst({
+        where: { id: dto.generationRecordId, userId: req.user.sub },
+      })
+      if (record) {
+        metadata = serializeUserAssetMetadata(buildUserAssetMetadataFromGeneration(record))
+      }
+    }
+
     const item = await this.prisma.userAsset.upsert({
       where: { userId_url: { userId: req.user.sub, url: dto.url } },
       create: {
@@ -88,8 +106,13 @@ export class AssetsController {
         url: dto.url,
         label: dto.label ?? '',
         sourceNodeId: dto.sourceNodeId,
+        metadata,
       },
-      update: { label: dto.label ?? '', kind: dto.kind },
+      update: {
+        label: dto.label ?? '',
+        kind: dto.kind,
+        ...(metadata ? { metadata } : {}),
+      },
     })
     return { code: 0, message: 'ok', data: item }
   }
@@ -100,7 +123,9 @@ export class AssetsController {
     const existing = await this.prisma.userAsset.findFirst({
       where: { id, userId: req.user.sub },
     })
-    if (!existing) throw new NotFoundException('资产不存在')
+    if (!existing) {
+      throw new NotFoundException('资产不存在')
+    }
     await this.prisma.userAsset.delete({ where: { id } })
     return { code: 0, message: 'ok', data: { id } }
   }

--- a/apps/server/src/assets/build-user-asset-metadata.test.ts
+++ b/apps/server/src/assets/build-user-asset-metadata.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { buildUserAssetMetadataFromGeneration } from './build-user-asset-metadata'
+
+describe('buildUserAssetMetadataFromGeneration', () => {
+  it('copies mediaInfo snapshot from generation record metadata', () => {
+    const metadata = buildUserAssetMetadataFromGeneration({
+      id: 'gen-1',
+      prompt: 'a cute cat',
+      model: 'seedream',
+      metadata: JSON.stringify({
+        aspectRatio: '16:9',
+        resolution: '720p',
+        mediaInfo: {
+          output: {
+            url: 'https://x/a.png',
+            width: 1024,
+            height: 576,
+            bytes: 500_000,
+            probeStatus: 'ok',
+          },
+          probedAt: '2026-08-16T00:00:00.000Z',
+        },
+      }),
+    })
+    expect(metadata.generationRecordId).toBe('gen-1')
+    expect(metadata.promptPreview).toBe('a cute cat')
+    expect(metadata.aspectRatio).toBe('16:9')
+    expect(metadata.mediaInfo?.output?.width).toBe(1024)
+  })
+})

--- a/apps/server/src/assets/build-user-asset-metadata.ts
+++ b/apps/server/src/assets/build-user-asset-metadata.ts
@@ -1,0 +1,51 @@
+import type { MediaInfo } from '@lnkpi/shared'
+
+export interface UserAssetMetadata {
+  generationRecordId?: string
+  promptPreview?: string
+  model?: string | null
+  aspectRatio?: string
+  resolution?: string
+  mediaInfo?: MediaInfo
+}
+
+function parseGenerationMeta(raw?: string | null): Record<string, unknown> {
+  if (!raw) return {}
+  try {
+    return JSON.parse(raw) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+export function buildUserAssetMetadataFromGeneration(record: {
+  id: string
+  prompt: string
+  model?: string | null
+  metadata?: string | null
+}): UserAssetMetadata {
+  const meta = parseGenerationMeta(record.metadata)
+  const mediaInfo = meta.mediaInfo
+  return {
+    generationRecordId: record.id,
+    promptPreview: record.prompt?.slice(0, 240) || undefined,
+    model: record.model ?? null,
+    aspectRatio: typeof meta.aspectRatio === 'string' ? meta.aspectRatio : undefined,
+    resolution: typeof meta.resolution === 'string' ? meta.resolution : undefined,
+    mediaInfo:
+      mediaInfo && typeof mediaInfo === 'object' ? (mediaInfo as MediaInfo) : undefined,
+  }
+}
+
+export function serializeUserAssetMetadata(payload: UserAssetMetadata): string {
+  return JSON.stringify(payload)
+}
+
+export function parseUserAssetMetadata(raw?: string | null): UserAssetMetadata {
+  if (!raw) return {}
+  try {
+    return JSON.parse(raw) as UserAssetMetadata
+  } catch {
+    return {}
+  }
+}

--- a/apps/server/src/media/upstream-ref-downscale.ts
+++ b/apps/server/src/media/upstream-ref-downscale.ts
@@ -1,0 +1,156 @@
+import {
+  classifyRefSize,
+  maxEdge,
+  parseUploadRefPath,
+  VIDEO_REF_WARN_MAX_EDGE,
+  type ProbedMediaFile,
+} from '@lnkpi/shared'
+import sharp from 'sharp'
+import { readFile } from 'fs/promises'
+import { join } from 'path'
+
+const UPLOADS_ROOT = join(process.cwd(), 'uploads')
+
+function mimeFromBuffer(buffer: Buffer): string {
+  if (buffer.length >= 8 && buffer.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) {
+    return 'image/png'
+  }
+  if (buffer.length >= 2 && buffer[0] === 0xff && buffer[1] === 0xd8) {
+    return 'image/jpeg'
+  }
+  return 'image/jpeg'
+}
+
+function toDataUrl(buffer: Buffer, mimeType: string): string {
+  return `data:${mimeType};base64,${buffer.toString('base64')}`
+}
+
+async function readImageBuffer(url: string): Promise<Buffer> {
+  const upload = parseUploadRefPath(url)
+  if (upload) {
+    return readFile(join(UPLOADS_ROOT, upload.userId, upload.fileName))
+  }
+  const res = await fetch(url)
+  if (!res.ok) {
+    throw new Error(`参考图下载失败 (${res.status}): ${url}`)
+  }
+  return Buffer.from(await res.arrayBuffer())
+}
+
+export async function downscaleImageBuffer(
+  input: Buffer,
+  maxEdgePx = VIDEO_REF_WARN_MAX_EDGE,
+): Promise<{ buffer: Buffer; width: number; height: number; changed: boolean }> {
+  const meta = await sharp(input).metadata()
+  const width = meta.width ?? 0
+  const height = meta.height ?? 0
+  if (!width || !height || maxEdge(width, height) <= maxEdgePx) {
+    return { buffer: input, width, height, changed: false }
+  }
+  const output = await sharp(input)
+    .rotate()
+    .resize({
+      width: maxEdgePx,
+      height: maxEdgePx,
+      fit: 'inside',
+      withoutEnlargement: true,
+    })
+    .jpeg({ quality: 85, mozjpeg: true })
+    .toBuffer()
+  const outMeta = await sharp(output).metadata()
+  return {
+    buffer: output,
+    width: outMeta.width ?? width,
+    height: outMeta.height ?? height,
+    changed: true,
+  }
+}
+
+export interface DownscaleReferenceResult {
+  urls: string[]
+  changed: boolean
+  probed: Array<ProbedMediaFile & { refKey?: string }>
+}
+
+/** Downscale refs exceeding warn/error thresholds to max 2048 long edge, return data URLs when changed. */
+export async function downscaleOversizedReferenceImages(
+  refs: Array<{ url: string; refKey?: string }>,
+  maxEdgePx = VIDEO_REF_WARN_MAX_EDGE,
+): Promise<DownscaleReferenceResult> {
+  let changed = false
+  const urls: string[] = []
+  const probed: Array<ProbedMediaFile & { refKey?: string }> = []
+
+  for (const ref of refs) {
+    const url = ref.url.trim()
+    if (!url) {
+      urls.push(url)
+      probed.push({ url, refKey: ref.refKey, probeStatus: 'failed', probeError: 'empty url' })
+      continue
+    }
+    if (url.startsWith('data:')) {
+      urls.push(url)
+      probed.push({ url, refKey: ref.refKey, probeStatus: 'ok' })
+      continue
+    }
+
+    try {
+      const input = await readImageBuffer(url)
+      const meta = await sharp(input).metadata()
+      const width = meta.width
+      const height = meta.height
+      const bytes = input.length
+      const level = classifyRefSize({ width, height, bytes })
+      if (level === 'none') {
+        urls.push(url)
+        probed.push({
+          url,
+          refKey: ref.refKey,
+          width,
+          height,
+          bytes,
+          mimeType: meta.format ? `image/${meta.format}` : mimeFromBuffer(input),
+          probeStatus: 'ok',
+        })
+        continue
+      }
+
+      const downscaled = await downscaleImageBuffer(input, maxEdgePx)
+      if (!downscaled.changed) {
+        urls.push(url)
+        probed.push({
+          url,
+          refKey: ref.refKey,
+          width: downscaled.width,
+          height: downscaled.height,
+          bytes,
+          probeStatus: 'ok',
+        })
+        continue
+      }
+
+      changed = true
+      const dataUrl = toDataUrl(downscaled.buffer, 'image/jpeg')
+      urls.push(dataUrl)
+      probed.push({
+        url: dataUrl,
+        refKey: ref.refKey,
+        width: downscaled.width,
+        height: downscaled.height,
+        bytes: downscaled.buffer.length,
+        mimeType: 'image/jpeg',
+        probeStatus: 'ok',
+      })
+    } catch (err) {
+      urls.push(url)
+      probed.push({
+        url,
+        refKey: ref.refKey,
+        probeStatus: 'failed',
+        probeError: err instanceof Error ? err.message : 'downscale failed',
+      })
+    }
+  }
+
+  return { urls, changed, probed }
+}

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -62,6 +62,7 @@ import {
   enrichVideoMediaInfoDimensions,
 } from '../media/build-media-info'
 import { inlineUpstreamReferenceImages } from '../media/upstream-ref-inline'
+import { downscaleOversizedReferenceImages } from '../media/upstream-ref-downscale'
 
 const AUDIO_PLACEHOLDER = 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3'
 
@@ -1067,9 +1068,11 @@ export class StudioService {
       providerOptions.model = resolved.modelName
     }
     const effectiveBundle = built.effectiveReferenceBundle
+    let upstreamImageRefs = effectiveBundle.images
     let refPreflight: MediaRefPreflight | undefined
+    let refDownscaled = false
     if (effectiveBundle.images.length > 0) {
-      const probedRefs = await Promise.all(
+      let probedRefs = await Promise.all(
         effectiveBundle.images.map(async (ref) => ({
           ...(await this.mediaProbe.probeUrl(ref.url)),
           refKey: ref.refKey,
@@ -1078,6 +1081,23 @@ export class StudioService {
       refPreflight = evaluateMediaRefPreflight(probedRefs, {
         blockWire: built.meta.refWire === 'agnes_keyframes' ? 'agnes_keyframes' : undefined,
       })
+      if (refPreflight.level === 'error' && built.meta.refWire === 'agnes_keyframes') {
+        const downscaled = await downscaleOversizedReferenceImages(upstreamImageRefs)
+        if (downscaled.changed) {
+          upstreamImageRefs = upstreamImageRefs.map((ref, index) => ({
+            ...ref,
+            url: downscaled.urls[index] ?? ref.url,
+          }))
+          probedRefs = downscaled.probed.map((item, index) => ({
+            ...item,
+            refKey: upstreamImageRefs[index]?.refKey ?? item.refKey,
+          }))
+          refPreflight = evaluateMediaRefPreflight(probedRefs, {
+            blockWire: 'agnes_keyframes',
+          })
+          refDownscaled = true
+        }
+      }
       if (refPreflight.level === 'error' && built.meta.refWire === 'agnes_keyframes') {
         await this.points.refund(userId, durationCredits, `${chargeReason}-预检拒绝退款`)
         throw new BadRequestException(refPreflight.message)
@@ -1098,7 +1118,7 @@ export class StudioService {
               aspectRatio,
               resolution,
               crop,
-              referenceImages: effectiveBundle.images.map(({ url }) => url),
+              referenceImages: upstreamImageRefs.map(({ url }) => url),
               referenceVideos: effectiveBundle.videos.map(({ url }) => url),
               referenceAudios: effectiveBundle.audios.map(({ url }) => url),
               skippedMerge,
@@ -1106,6 +1126,7 @@ export class StudioService {
               channelId: resolved.channelId,
               originalModel: model,
               providerSource: resolved.source,
+              ...(refDownscaled ? { refDownscaled: true } : {}),
               ...(refPreflight && refPreflight.level === 'warn' ? { refPreflight } : {}),
             },
             durationCredits,

--- a/apps/web/src/components/canvas/CanvasAssetPanel.vue
+++ b/apps/web/src/components/canvas/CanvasAssetPanel.vue
@@ -7,6 +7,14 @@ import { fileToPersistedPayload } from '@/composables/useMediaUpload'
 import { resolveMediaUrl } from '@/services/api-base'
 import { useCanvasEditorStore } from '@/stores/canvasEditor'
 import CanvasRefTargetIcon from '@/components/shared/CanvasRefTargetIcon.vue'
+import MediaInfoSummary from '@/components/media/MediaInfoSummary.vue'
+import {
+  buildAssetMediaInfoSummary,
+  parseAssetMetadata,
+  useMediaInspector,
+  type NodeMediaInfoSummary,
+} from '@/composables/useMediaInspector'
+import type { MediaInfo } from '@lnkpi/shared'
 
 export interface CanvasAssetItem {
   id: string
@@ -18,6 +26,9 @@ export interface CanvasAssetItem {
   createdAt?: number
   /** user = 用户全局资产库；public = 平台发布的公共资产 */
   source?: 'user' | 'public'
+  metadata?: string | null
+  generationRecordId?: string
+  mediaSummary?: NodeMediaInfoSummary
 }
 
 const emit = defineEmits<{
@@ -26,6 +37,7 @@ const emit = defineEmits<{
 }>()
 
 const editor = useCanvasEditorStore()
+const { openInspector } = useMediaInspector()
 
 type AssetTab = 'user' | 'public'
 type AssetKindFilter = 'all' | 'image' | 'video' | 'audio'
@@ -60,15 +72,23 @@ async function loadUserAssets() {
   userLoading.value = true
   try {
     const res = await assetsApi.listMine()
-    userAssets.value = (res.data?.data?.items ?? []).map((item) => ({
-      id: item.id,
-      nodeId: item.sourceNodeId ?? '',
-      url: item.url,
-      label: item.label,
-      kind: item.kind,
-      createdAt: Date.parse(item.createdAt) || undefined,
-      source: 'user' as const,
-    }))
+    userAssets.value = (res.data?.data?.items ?? []).map((item) => {
+      const metadata = item.metadata ?? null
+      const parsed = parseAssetMetadata(metadata)
+      return {
+        id: item.id,
+        nodeId: item.sourceNodeId ?? '',
+        url: item.url,
+        label: item.label,
+        kind: item.kind,
+        createdAt: Date.parse(item.createdAt) || undefined,
+        source: 'user' as const,
+        metadata,
+        generationRecordId:
+          typeof parsed.generationRecordId === 'string' ? parsed.generationRecordId : undefined,
+        mediaSummary: buildAssetMediaInfoSummary({ kind: item.kind, metadata }),
+      }
+    })
   } catch {
     // 加载失败留空，切换 tab 或保存资产后会重试
   } finally {
@@ -174,14 +194,40 @@ function displayUrl(asset: CanvasAssetItem) {
   return resolveMediaUrl(asset.url)
 }
 
+function assetInspectorPayload(asset: CanvasAssetItem) {
+  const meta = parseAssetMetadata(asset.metadata)
+  const mediaInfo =
+    meta.mediaInfo && typeof meta.mediaInfo === 'object'
+      ? (meta.mediaInfo as MediaInfo)
+      : undefined
+  return {
+    generationRecordId: asset.generationRecordId,
+    nodeLabel: asset.label,
+    url: asset.url,
+    kind: (asset.kind === 'video' ? 'video' : 'image') as 'image' | 'video',
+    assetMediaInfo: mediaInfo,
+    assetMeta: meta,
+  }
+}
+
 /** 点击 = 预览 */
 function preview(asset: CanvasAssetItem) {
   if (asset.kind === 'other') return
+  const payload = assetInspectorPayload(asset)
   editor.openMediaPreview({
     url: displayUrl(asset),
     kind: asset.kind,
     label: asset.label,
+    generationRecordId: payload.generationRecordId,
+    assetMediaInfo: payload.assetMediaInfo,
+    assetMeta: payload.assetMeta,
   })
+}
+
+function openAssetInspector(asset: CanvasAssetItem, e?: Event) {
+  e?.stopPropagation()
+  if (asset.kind !== 'image' && asset.kind !== 'video') return
+  void openInspector(assetInspectorPayload(asset))
 }
 
 /** hover 操作：加载到当前画布（选中节点则作为引用，否则新建节点） */
@@ -400,10 +446,26 @@ function onDragStart(event: DragEvent, asset: CanvasAssetItem) {
               公共
             </span>
 
+            <MediaInfoSummary
+              v-if="asset.mediaSummary && (asset.kind === 'image' || asset.kind === 'video')"
+              v-bind="asset.mediaSummary"
+              class="absolute inset-x-0 bottom-0 z-[1] opacity-0 transition group-hover:opacity-100 neo-media-info-summary--overlay"
+            />
+
             <!-- hover 操作层 -->
             <div
               class="absolute inset-x-0 bottom-0 flex items-center justify-center gap-1.5 bg-gradient-to-t from-black/85 to-transparent px-1.5 pb-1.5 pt-5 opacity-0 transition group-hover:opacity-100"
             >
+              <button
+                v-if="asset.kind === 'image' || asset.kind === 'video'"
+                type="button"
+                class="asset-hover-btn"
+                title="媒体属性"
+                aria-label="媒体属性"
+                @click.stop="openAssetInspector(asset, $event)"
+              >
+                ⓘ
+              </button>
               <button
                 type="button"
                 class="asset-hover-btn"

--- a/apps/web/src/components/canvas/CanvasNodeImage.vue
+++ b/apps/web/src/components/canvas/CanvasNodeImage.vue
@@ -94,6 +94,7 @@ function openPreview() {
     url: displayUrl.value,
     kind: 'image',
     label: props.data.label ?? props.data.prompt,
+    generationRecordId: props.data.generationRecordId,
   })
 }
 
@@ -114,6 +115,7 @@ function saveToLibrary() {
     url,
     label: props.data.label ?? props.data.prompt ?? '',
     sourceNodeId: props.id,
+    generationRecordId: props.data.generationRecordId,
   })
 }
 
@@ -266,6 +268,18 @@ function openMediaInspector(e: Event) {
                   : '上传或等待生成'
             }}
           </span>
+          <button
+            v-if="showInspectorBtn"
+            type="button"
+            class="neo-media-inspector-btn neo-media-inspector-btn--placeholder nodrag"
+            aria-label="媒体属性"
+            title="媒体属性"
+            @pointerdown.stop
+            @mousedown.stop
+            @click.stop="openMediaInspector"
+          >
+            ⓘ
+          </button>
           <div v-if="data.status === 'uploading'" class="neo-upload-progress">
             <div class="neo-upload-progress-bar" :style="{ width: `${data.uploadProgress ?? 0}%` }" />
           </div>

--- a/apps/web/src/components/canvas/CanvasNodeVideo.vue
+++ b/apps/web/src/components/canvas/CanvasNodeVideo.vue
@@ -89,7 +89,13 @@ function download() {
 function saveToLibrary() {
   const url = String(props.data.url ?? '').trim()
   if (!url) return
-  void saveAssetToLibrary({ kind: 'video', url, label: props.data.label ?? '', sourceNodeId: props.id })
+  void saveAssetToLibrary({
+    kind: 'video',
+    url,
+    label: props.data.label ?? '',
+    sourceNodeId: props.id,
+    generationRecordId: props.data.generationRecordId,
+  })
 }
 
 function openMediaInspector(e: Event) {
@@ -283,6 +289,18 @@ onUnmounted(() => {
                   : '上传或等待生成'
             }}
           </span>
+          <button
+            v-if="showInspectorBtn"
+            type="button"
+            class="neo-media-inspector-btn neo-media-inspector-btn--placeholder nodrag"
+            aria-label="媒体属性"
+            title="媒体属性"
+            @pointerdown.stop
+            @mousedown.stop
+            @click.stop="openMediaInspector"
+          >
+            ⓘ
+          </button>
           <div v-if="data.status === 'uploading'" class="neo-upload-progress">
             <div class="neo-upload-progress-bar" :style="{ width: `${data.uploadProgress ?? 0}%` }" />
           </div>

--- a/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
+++ b/apps/web/src/components/canvas/CanvasTaskHistoryPanel.vue
@@ -12,7 +12,6 @@ import MediaInfoSummary from '@/components/media/MediaInfoSummary.vue'
 import MediaRefList from '@/components/media/MediaRefList.vue'
 import { buildNodeMediaInfoSummary, useMediaInspector } from '@/composables/useMediaInspector'
 import { useCanvasEditorStore } from '@/stores/canvasEditor'
-import { useProviderBootstrap } from '@/composables/useProviderBootstrap'
 import { NODE_GENERATION_STATUS } from '@/constants/dockStudio'
 import {
   buildCopyForNode,
@@ -39,7 +38,6 @@ const emit = defineEmits<{
 
 const route = useRoute()
 const editor = useCanvasEditorStore()
-const { allChannels } = useProviderBootstrap()
 const { openInspector } = useMediaInspector()
 
 const sessionId = computed(() => route.params.sessionId as string | undefined)
@@ -177,37 +175,6 @@ function recordModelName(record: GenerationRecord): string {
   const meta = parseRecordMeta(record)
   const raw = record.model ?? meta.originalModel ?? ''
   return raw ? modelOptionName(raw) : '—'
-}
-
-function recordChannelName(record: GenerationRecord): string {
-  const channelId = parseRecordMeta(record).channelId
-  if (!channelId) return '—'
-  const ch = allChannels.value.find((c) => c.id === channelId)
-  return ch?.name || channelId.slice(0, 8)
-}
-
-function recordParamRows(record: GenerationRecord): Array<{ label: string; value: string }> {
-  const meta = parseRecordMeta(record)
-  const rows: Array<{ label: string; value: string }> = []
-  const add = (label: string, v: unknown) => {
-    if (v === undefined || v === null || v === '') return
-    rows.push({ label, value: String(v) })
-  }
-  if (record.type === 'image') {
-    add('比例', meta.aspectRatio)
-    add('分辨率', meta.resolution)
-    add('尺寸', meta.size)
-    add('数量', meta.count)
-  } else if (record.type === 'video') {
-    add('时长', meta.duration != null ? `${meta.duration}s` : undefined)
-    add('分辨率', meta.resolution)
-    add('比例', meta.aspectRatio)
-    add('裁剪', meta.crop)
-  } else if (record.type === 'audio') {
-    add('音色', meta.voice)
-    add('语速', meta.speed)
-  }
-  return rows
 }
 
 function recordFailureMessage(record: GenerationRecord): string | null {
@@ -635,37 +602,12 @@ onUnmounted(stopPolling)
                 </p>
               </div>
 
-              <div class="grid grid-cols-2 gap-2">
-                <div>
-                  <p class="mb-0.5 text-[10px] text-[var(--neo-text-muted)]">类型</p>
-                  <p class="text-[var(--neo-text-secondary)]">{{ TYPE_LABELS[attempt.type] ?? attempt.type }}</p>
-                </div>
-                <div>
-                  <p class="mb-0.5 text-[10px] text-[var(--neo-text-muted)]">创建时间</p>
-                  <p class="tabular-nums text-[var(--neo-text-secondary)]">{{ formatFullTime(attempt.createdAt) }}</p>
-                </div>
-                <div class="col-span-2">
-                  <p class="mb-0.5 text-[10px] text-[var(--neo-text-muted)]">模型</p>
-                  <p class="truncate text-[var(--neo-text-secondary)]" :title="recordModelName(attempt)">
-                    {{ recordModelName(attempt) }}
-                  </p>
-                </div>
-                <div class="col-span-2">
-                  <p class="mb-0.5 text-[10px] text-[var(--neo-text-muted)]">渠道</p>
-                  <p class="truncate text-[var(--neo-text-secondary)]" :title="recordChannelName(attempt)">
-                    {{ recordChannelName(attempt) }}
-                  </p>
-                </div>
-              </div>
-
-              <div v-if="recordParamRows(attempt).length">
-                <p class="mb-1 text-[10px] uppercase tracking-wider text-[var(--neo-text-muted)]">参数</p>
-                <div class="grid grid-cols-2 gap-2 rounded-lg bg-[var(--neo-active-bg)] p-2">
-                  <div v-for="row in recordParamRows(attempt)" :key="row.label">
-                    <p class="text-[9px] text-[var(--neo-text-muted)]">{{ row.label }}</p>
-                    <p class="text-[var(--neo-text-secondary)]">{{ row.value }}</p>
-                  </div>
-                </div>
+              <div class="flex flex-wrap items-center gap-2 text-[10px] text-[var(--neo-text-muted)]">
+                <span>{{ TYPE_LABELS[attempt.type] ?? attempt.type }}</span>
+                <span>·</span>
+                <span class="tabular-nums">{{ formatFullTime(attempt.createdAt) }}</span>
+                <span>·</span>
+                <span class="truncate" :title="recordModelName(attempt)">{{ recordModelName(attempt) }}</span>
               </div>
 
               <div v-if="hasRecordMediaInfo(attempt)">

--- a/apps/web/src/components/canvas/MediaPreviewOverlay.vue
+++ b/apps/web/src/components/canvas/MediaPreviewOverlay.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, onUnmounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useCanvasEditorStore } from '@/stores/canvasEditor'
+import { useMediaInspector } from '@/composables/useMediaInspector'
 import {
   downloadMediaFile,
   isUpstreamMediaUrl,
@@ -10,9 +11,18 @@ import {
 } from '@/composables/useCanvasMedia'
 
 const editor = useCanvasEditorStore()
+const { openInspector } = useMediaInspector()
 const route = useRoute()
 const sessionId = computed(() => route.params.sessionId as string | undefined)
 const target = computed(() => editor.previewTarget)
+const canOpenInspector = computed(() => {
+  if (!target.value) return false
+  return Boolean(
+    target.value.generationRecordId ||
+    target.value.assetMediaInfo?.output ||
+    target.value.url,
+  )
+})
 const downloadTitle = computed(() => {
   if (!target.value) return '下载'
   return isUpstreamMediaUrl(target.value.url) ? UPSTREAM_MEDIA_DOWNLOAD_HINT : '下载'
@@ -38,6 +48,19 @@ async function download() {
   )
 }
 
+function openInspectorFromPreview() {
+  const t = target.value
+  if (!t) return
+  void openInspector({
+    generationRecordId: t.generationRecordId,
+    nodeLabel: t.label,
+    url: t.url,
+    kind: t.kind === 'video' ? 'video' : 'image',
+    assetMediaInfo: t.assetMediaInfo,
+    assetMeta: t.assetMeta,
+  })
+}
+
 onMounted(() => window.addEventListener('keydown', onKeydown, true))
 onUnmounted(() => window.removeEventListener('keydown', onKeydown, true))
 </script>
@@ -52,6 +75,15 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown, true))
       >
         <!-- 顶部操作栏 -->
         <div class="absolute right-4 top-4 z-10 flex items-center gap-2">
+          <button
+            v-if="canOpenInspector"
+            type="button"
+            class="preview-ctl preview-ctl-text"
+            title="更多信息"
+            @click.stop="openInspectorFromPreview"
+          >
+            更多信息
+          </button>
           <button
             type="button"
             class="preview-ctl"
@@ -150,6 +182,12 @@ onUnmounted(() => window.removeEventListener('keydown', onKeydown, true))
 .preview-ctl:hover {
   background: rgba(45, 45, 55, 0.9);
   color: #fff;
+}
+
+.preview-ctl-text {
+  width: auto;
+  padding: 0 12px;
+  font-size: 12px;
 }
 
 .preview-fade-enter-active,

--- a/apps/web/src/components/media/MediaInspectorDrawer.vue
+++ b/apps/web/src/components/media/MediaInspectorDrawer.vue
@@ -46,6 +46,9 @@ const activeTab = ref<'info' | 'diagnostic'>('info')
 const diagnostic = ref<GenerationDiagnostic | null>(null)
 const diagnosticLoading = ref(false)
 const diagnosticCopyLabel = ref('复制诊断')
+const drawerSize = computed(() =>
+  typeof window !== 'undefined' && window.innerWidth < 640 ? '100%' : '320px',
+)
 
 watch(
   () => open.value,
@@ -60,16 +63,27 @@ watch(
 )
 
 watch(
-  () => [open.value, record.value?.id, record.value?.mediaInfo?.output] as const,
-  async ([isOpen, , output]) => {
+  () =>
+    [
+      open.value,
+      record.value?.id,
+      record.value?.mediaInfo?.output,
+      target.value?.assetMediaInfo?.output,
+      target.value?.url,
+    ] as const,
+  async ([isOpen, , output, assetOutput]) => {
     lazyOutput.value = undefined
-    if (!isOpen || !record.value) return
+    if (!isOpen) return
     if (output?.probeStatus === 'ok') {
       lazyOutput.value = output
       return
     }
-    const url = record.value.url || target.value?.url
-    if (!url) return
+    if (assetOutput?.probeStatus === 'ok') {
+      lazyOutput.value = assetOutput
+      return
+    }
+    const url = record.value?.url || target.value?.url
+    if (!url || url.startsWith('data:')) return
     lazyLoading.value = true
     try {
       lazyOutput.value = await probeMedia(url)
@@ -88,21 +102,25 @@ watch(
 
 const parsedMeta = computed(() => {
   const raw = record.value?.metadata
-  if (!raw) return {} as Record<string, unknown>
-  try {
-    return JSON.parse(raw) as Record<string, unknown>
-  } catch {
-    return {}
+  if (raw) {
+    try {
+      return JSON.parse(raw) as Record<string, unknown>
+    } catch {
+      return {} as Record<string, unknown>
+    }
   }
+  return { ...(target.value?.assetMeta ?? {}) }
 })
 
 const mediaInfo = computed<MediaInfo | undefined>(() => {
   const fromRecord = record.value?.mediaInfo
   if (fromRecord?.output || fromRecord?.references?.length) return fromRecord
+  const fromAsset = target.value?.assetMediaInfo
+  if (fromAsset?.output || fromAsset?.references?.length) return fromAsset
   if (lazyOutput.value) {
     return { output: lazyOutput.value, probedAt: new Date().toISOString() }
   }
-  return fromRecord
+  return fromRecord ?? fromAsset
 })
 
 const previewUrl = computed(() => {
@@ -118,6 +136,8 @@ const previewKind = computed(() => {
 const title = computed(() => {
   if (target.value?.nodeLabel?.trim()) return target.value.nodeLabel.trim()
   if (record.value?.prompt?.trim()) return record.value.prompt.trim()
+  const promptPreview = parsedMeta.value.promptPreview
+  if (typeof promptPreview === 'string' && promptPreview.trim()) return promptPreview.trim()
   return target.value?.nodeId ? `节点 ${target.value.nodeId}` : '媒体属性'
 })
 
@@ -148,7 +168,9 @@ const diagnosticHint = computed(() => {
 })
 
 const modelLabel = computed(() => {
-  const model = record.value?.model || String(parsedMeta.value.originalModel ?? '')
+  const model =
+    record.value?.model ||
+    String(parsedMeta.value.originalModel ?? parsedMeta.value.model ?? '')
   if (!model) return null
   return modelOptionName(model) || model
 })
@@ -234,7 +256,7 @@ const l2Rows = computed(() => {
     const value = formatMetaValue(raw)
     if (value) rows.push({ label, value, multiline })
   }
-  add('Prompt', record.value?.prompt || meta.prompt, true)
+  add('Prompt', record.value?.prompt || parsedMeta.value.prompt || parsedMeta.value.promptPreview, true)
   add('Seed', meta.seed)
   add('Negative', meta.negativePrompt, true)
   add('Generate audio', meta.generateAudio)
@@ -351,7 +373,7 @@ async function copyValue(text: string) {
   <ElDrawer
     :model-value="open"
     direction="rtl"
-    size="320px"
+    :size="drawerSize"
     :with-header="false"
     append-to-body
     class="media-inspector-drawer"
@@ -476,7 +498,16 @@ async function copyValue(text: string) {
             <dl v-if="l2Rows.length" class="media-inspector-dl media-inspector-l2-dl">
               <template v-for="row in l2Rows" :key="row.label">
                 <dt>{{ row.label }}</dt>
-                <dd :class="{ 'is-multiline': row.multiline }">{{ row.value }}</dd>
+                <dd :class="{ 'is-multiline': row.multiline }">
+                  <span>{{ row.value }}</span>
+                  <button
+                    type="button"
+                    class="media-inspector-copy-inline"
+                    @click="copyValue(row.value)"
+                  >
+                    复制
+                  </button>
+                </dd>
               </template>
             </dl>
             <details v-if="nativeParamsJson" class="media-inspector-native">

--- a/apps/web/src/composables/useMediaInspector.test.ts
+++ b/apps/web/src/composables/useMediaInspector.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { buildNodeMediaInfoSummary, buildMaterialMediaInfoSummary } from './useMediaInspector'
+import {
+  buildAssetMediaInfoSummary,
+  buildMaterialMediaInfoSummary,
+  buildNodeMediaInfoSummary,
+} from './useMediaInspector'
 import type { GenerationRecord } from '@/services/studio-api'
 
 function rec(partial: Partial<GenerationRecord> & Pick<GenerationRecord, 'id' | 'type' | 'status' | 'prompt' | 'createdAt'>): GenerationRecord {
@@ -103,6 +107,32 @@ describe('buildNodeMediaInfoSummary', () => {
       height: 600,
       bytes: 300_000,
       aspectRatio: '16:9',
+    })
+  })
+
+  it('builds asset summary from UserAsset metadata snapshot', () => {
+    const summary = buildAssetMediaInfoSummary({
+      kind: 'image',
+      metadata: JSON.stringify({
+        generationRecordId: 'gen-1',
+        aspectRatio: '1:1',
+        mediaInfo: {
+          output: {
+            url: 'https://x/d.png',
+            width: 512,
+            height: 512,
+            bytes: 200_000,
+            probeStatus: 'ok',
+          },
+        },
+      }),
+    })
+    expect(summary).toMatchObject({
+      kind: 'image',
+      width: 512,
+      height: 512,
+      bytes: 200_000,
+      aspectRatio: '1:1',
     })
   })
 })

--- a/apps/web/src/composables/useMediaInspector.ts
+++ b/apps/web/src/composables/useMediaInspector.ts
@@ -31,11 +31,13 @@ export function resolveRecordMediaInfo(rec: GenerationRecord): MediaInfo | undef
 }
 
 export interface MediaInspectorTarget {
-  generationRecordId: string
+  generationRecordId?: string
   nodeId?: string
   nodeLabel?: string
   url?: string
   kind?: 'image' | 'video'
+  assetMediaInfo?: MediaInfo
+  assetMeta?: Record<string, unknown>
 }
 
 interface CachedRecord {
@@ -147,11 +149,65 @@ export function buildMaterialMediaInfoSummary(
   return hasPayload ? summary : undefined
 }
 
+export interface AssetMediaSource {
+  kind?: 'image' | 'video' | 'audio' | 'other'
+  metadata?: string | null
+}
+
+export function parseAssetMetadata(raw?: string | null): Record<string, unknown> {
+  if (!raw) return {}
+  try {
+    return JSON.parse(raw) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+export function buildAssetMediaInfoSummary(asset: AssetMediaSource): NodeMediaInfoSummary | undefined {
+  if (asset.kind !== 'image' && asset.kind !== 'video') return undefined
+  const meta = parseAssetMetadata(asset.metadata)
+  const fromMeta = meta.mediaInfo
+  const mediaInfo =
+    fromMeta && typeof fromMeta === 'object' ? (fromMeta as MediaInfo) : undefined
+  const output = mediaInfo?.output
+  const kind: NodeMediaInfoSummary['kind'] = asset.kind
+  const summary: NodeMediaInfoSummary = { kind }
+
+  if (kind === 'video') {
+    const resolution = meta.resolution
+    if (typeof resolution === 'string' && resolution.trim()) {
+      summary.resolution = resolution.trim()
+    }
+    const aspectRatio = meta.aspectRatio
+    if (typeof aspectRatio === 'string' && aspectRatio.trim()) {
+      summary.aspectRatio = aspectRatio.trim()
+    }
+    if (output?.bytes != null) summary.bytes = output.bytes
+  } else {
+    if (output?.width != null) summary.width = output.width
+    if (output?.height != null) summary.height = output.height
+    if (output?.bytes != null) summary.bytes = output.bytes
+    const aspectRatio = meta.aspectRatio
+    if (typeof aspectRatio === 'string' && aspectRatio.trim()) {
+      summary.aspectRatio = aspectRatio.trim()
+    }
+  }
+
+  const { kind: _kind, ...rest } = summary
+  const hasPayload = Object.values(rest).some((v) => v != null && v !== '')
+  return hasPayload ? summary : undefined
+}
+
 export function useMediaInspector() {
   async function openInspector(next: MediaInspectorTarget) {
     target.value = next
     open.value = true
     error.value = null
+    if (!next.generationRecordId) {
+      record.value = null
+      loading.value = false
+      return
+    }
     loading.value = true
     try {
       const cached = recordCache.get(next.generationRecordId)

--- a/apps/web/src/services/assets-api.ts
+++ b/apps/web/src/services/assets-api.ts
@@ -14,6 +14,7 @@ export interface UserAssetItem {
   label: string
   kind: 'image' | 'video' | 'audio'
   sourceNodeId?: string | null
+  metadata?: string | null
   createdAt: string
 }
 
@@ -22,6 +23,7 @@ export interface SaveUserAssetPayload {
   url: string
   label?: string
   sourceNodeId?: string
+  generationRecordId?: string
 }
 
 export const assetsApi = {

--- a/apps/web/src/stores/canvasEditor.ts
+++ b/apps/web/src/stores/canvasEditor.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
+import type { MediaInfo } from '@lnkpi/shared'
 
 export interface ImageEditTarget {
   nodeId: string
@@ -11,6 +12,9 @@ export interface MediaPreviewTarget {
   url: string
   kind: 'image' | 'video' | 'audio'
   label?: string
+  generationRecordId?: string
+  assetMediaInfo?: MediaInfo
+  assetMeta?: Record<string, unknown>
 }
 
 export const useCanvasEditorStore = defineStore('canvasEditor', () => {

--- a/docs/superpowers/plans/2026-08-15-media-inspector.md
+++ b/docs/superpowers/plans/2026-08-15-media-inspector.md
@@ -406,13 +406,24 @@ git commit -m "feat(deploy): prod media inspector verify script"
 
 ---
 
-## P1 extension（不在本 plan 执行，仅跟踪入口）
+## P1 extension（已完成 #256）
 
 | 项 | Spec 节 | 状态 |
 |----|---------|------|
-| UserAsset.metadata 迁移 | §Data model | `[ ]` |
-| 资产库 Inspector 入口 | §UX | `[ ]` |
-| 超大 ref 自动 downscale inline | §Server P1 | `[ ]` |
+| UserAsset.metadata 迁移 | §Data model | `[x]` |
+| 资产库 Inspector 入口 + L0 hover | §UX | `[x]` |
+| POST /assets generationRecordId | §API | `[x]` |
+| 超大 ref 自动 downscale inline | §Server P1 | `[x]` agnes_keyframes 预检前 downscale |
+
+## P0 polish（已完成 #256）
+
+| 项 | 状态 |
+|----|------|
+| 预览浮层「更多信息」 | `[x]` |
+| 失败占位节点 ⓘ | `[x]` |
+| L2 字段复制 | `[x]` |
+| 任务历史 UI 去重 | `[x]` |
+| 移动端 Drawer 全宽 | `[x]` |
 
 ---
 

--- a/docs/superpowers/specs/2026-08-15-media-inspector-design.md
+++ b/docs/superpowers/specs/2026-08-15-media-inspector-design.md
@@ -19,7 +19,7 @@
 
 | Topic | Choice |
 |-------|--------|
-| 信息分层 | **L0** hover/角标摘要；**L1** Inspector 默认 Tab；**L2** 高级（prompt/seed/nativeParams）；**L3** 失败诊断（复用现有 diagnostic） |
+| 信息分层 | **L0** 常驻摘要（completed + mediaInfo）；**L1** Inspector 默认 Tab；**L2** 高级（prompt/seed/nativeParams）；**L3** 失败诊断（复用现有 diagnostic） |
 | 入口统一 | 画布节点、资产库、任务历史、预览浮层 → **同一 `MediaInspector` 组件** |
 | Dock 职责 | Dock = **编辑/再生成**；Inspector = **只读属性**（Figma Design vs Inspect） |
 | 数据 SSOT | `GenerationRecord.metadata.mediaInfo` + `Material.metadata.mediaInfo`；节点 `data.mediaInfo` 为 L0 缓存 |
@@ -56,7 +56,7 @@
 
 ### L0 — 零点击摘要
 
-- **Image/Video 节点** completed：节点底部细条（或 hover tooltip）：`1024×1024 · 0.9MB · seedream`
+- **Image/Video 节点** completed：节点底部细条（常驻）：`1024×1024 · 16:9 · 0.9MB`
 - **Video 节点** 参考图有风险：细条追加 `⚠ ref 偏大`
 - **资产库** grid hover：同样格式的一行摘要
 
@@ -165,10 +165,12 @@ export const VIDEO_REF_ERROR_MAX_EDGE = 4096
 
 ```ts
 mediaInfo?: {
+  kind?: 'image' | 'video'
   width?: number
   height?: number
   bytes?: number
-  model?: string
+  aspectRatio?: string
+  resolution?: string
   refWarning?: MediaRefWarningLevel
 }
 ```
@@ -294,9 +296,9 @@ model UserAsset {
 
 | 阶段 | 交付 | 验收 |
 |------|------|------|
-| **P0** | shared 类型 + probe service + video preflight block + Inspector L1 + 节点/历史入口 | 单测 + 生产脚本 + UAT §1–3 |
-| **P1** | UserAsset.metadata + 资产库 Inspector + 自动 downscale inline | 存库可追溯 + 视频重试成功 |
-| **P2** | L2 高级 Tab + 批量列表视图 + Material 路径 | power user |
+| **P0** | shared 类型 + probe service + video preflight block + Inspector L1/L2/L3 + 节点/历史入口 | ✅ 已交付 (#250–#256) |
+| **P1** | UserAsset.metadata + 资产库 Inspector + 自动 downscale inline | ✅ 本 PR |
+| **P2** | 批量列表视图 + Material 路径深化 | 部分完成（#254 material mediaInfo） |
 
 本 plan 文件 **仅覆盖 P0**；P1/P2 另开 plan 或在本 plan 末尾 Extension 节跟踪。
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
+      sharp:
+        specifier: ^0.33.5
+        version: 0.33.5
     devDependencies:
       '@nestjs/testing':
         specifier: ^10.4.22
@@ -297,6 +300,9 @@ packages:
     resolution: {integrity: sha512-OzIuTaIfC8QXEPmJvB4Y4kw34rSXdCJzxcD1kFStBvr8bK6X1zQAYDo0CNMjojnfTqRQCJ0I7prlErcoRiET2A==}
     peerDependencies:
       vue: ^3.2.0
+
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -627,6 +633,123 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@img/sharp-darwin-arm64@0.33.5':
+    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.33.5':
+    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.33.5':
+    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.33.5':
+    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.33.5':
+    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.33.5':
+    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.33.5':
+    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-ia32@0.33.5':
+    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.33.5':
+    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -1621,6 +1744,13 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  color-string@1.9.1:
+    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+
+  color@4.2.3:
+    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
+    engines: {node: '>=12.5.0'}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -2076,6 +2206,9 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  is-arrayish@0.3.4:
+    resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -2688,6 +2821,10 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
+  sharp@0.33.5:
+    resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -2724,6 +2861,9 @@ packages:
 
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  simple-swizzle@0.2.4:
+    resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -3197,6 +3337,11 @@ snapshots:
     dependencies:
       vue: 3.5.39(typescript@5.9.3)
 
+  '@emnapi/runtime@1.11.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
@@ -3365,6 +3510,81 @@ snapshots:
       '@floating-ui/utils': 0.2.11
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@img/sharp-darwin-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.0.5
+    optional: true
+
+  '@img/sharp-linux-s390x@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-wasm32@0.33.5':
+    dependencies:
+      '@emnapi/runtime': 1.11.3
+    optional: true
+
+  '@img/sharp-win32-ia32@0.33.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.33.5':
+    optional: true
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -4389,6 +4609,16 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  color-string@1.9.1:
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.4
+
+  color@4.2.3:
+    dependencies:
+      color-convert: 2.0.1
+      color-string: 1.9.1
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -4524,8 +4754,7 @@ snapshots:
 
   destroy@1.2.0: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   didyoumean@1.2.2: {}
 
@@ -4902,6 +5131,8 @@ snapshots:
   ini@1.3.8: {}
 
   ipaddr.js@1.9.1: {}
+
+  is-arrayish@0.3.4: {}
 
   is-binary-path@2.1.0:
     dependencies:
@@ -5555,6 +5786,32 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
+  sharp@0.33.5:
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.33.5
+      '@img/sharp-darwin-x64': 0.33.5
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+      '@img/sharp-libvips-linux-arm': 1.0.5
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+      '@img/sharp-libvips-linux-x64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+      '@img/sharp-linux-arm': 0.33.5
+      '@img/sharp-linux-arm64': 0.33.5
+      '@img/sharp-linux-s390x': 0.33.5
+      '@img/sharp-linux-x64': 0.33.5
+      '@img/sharp-linuxmusl-arm64': 0.33.5
+      '@img/sharp-linuxmusl-x64': 0.33.5
+      '@img/sharp-wasm32': 0.33.5
+      '@img/sharp-win32-ia32': 0.33.5
+      '@img/sharp-win32-x64': 0.33.5
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -5602,6 +5859,10 @@ snapshots:
       once: 1.4.0
       simple-concat: 1.0.1
     optional: true
+
+  simple-swizzle@0.2.4:
+    dependencies:
+      is-arrayish: 0.3.4
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary
- P1: `UserAsset.metadata` 迁移 + `POST /assets/mine` 支持 `generationRecordId` 快照 mediaInfo
- P1: 资产库 hover L0 摘要 + ⓘ Inspector；存库时传递 generationRecordId
- P1: agnes_keyframes 超大 ref 预检前自动 downscale（sharp → 2048 长边 inline）
- P0 polish: 预览浮层「更多信息」、失败占位节点 ⓘ、L2 复制、任务历史去重、移动端全宽 Drawer
- 同步 spec/plan 文档

## Test plan
- [x] pnpm build
- [x] vitest useMediaInspector + build-user-asset-metadata + studio.video-preflight
- [ ] 资产库存库后 hover 见摘要、ⓘ 打开 Inspector
- [ ] 预览浮层「更多信息」
- [ ] 超大 keyframes ref 自动 downscale 后可生成


Made with [Cursor](https://cursor.com)