### PR TITLE
feat(web): canvas node duplicate with internal edges

### DIFF
--- a/apps/web/src/components/canvas/CanvasContextMenu.vue
+++ b/apps/web/src/components/canvas/CanvasContextMenu.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
-const { x, y, nodeId, nodeType } = defineProps<{
+const { x, y, nodeId, nodeType, multiSelectedCount = 1 } = defineProps<{
   x: number
   y: number
   nodeId?: string
   nodeType?: string
+  multiSelectedCount?: number
 }>()
 
 const emit = defineEmits<{
@@ -14,6 +15,10 @@ const emit = defineEmits<{
 }>()
 
 const visible = ref(true)
+
+const showUpstreamDuplicate = computed(
+  () => multiSelectedCount <= 1 && nodeType !== 'group' && Boolean(nodeId),
+)
 
 function run(action: string, payload?: string) {
   emit('action', action, payload)
@@ -58,7 +63,14 @@ function run(action: string, payload?: string) {
       class="neo-popover-item block w-full px-4 py-2 text-left text-xs"
       @click="run('duplicate')"
     >
-      复制节点
+      新建副本
+    </button>
+    <button
+      v-if="showUpstreamDuplicate"
+      class="neo-popover-item block w-full px-4 py-2 text-left text-xs"
+      @click="run('duplicate-upstream')"
+    >
+      新建副本（含上游）
     </button>
     <button
       v-if="nodeId"

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -116,6 +116,11 @@ import AIImageEditor from '@/components/canvas/AIImageEditor.vue'
 import MediaPreviewOverlay from '@/components/canvas/MediaPreviewOverlay.vue'
 import MediaInspectorDrawer from '@/components/media/MediaInspectorDrawer.vue'
 import CanvasContextMenu from '@/components/canvas/CanvasContextMenu.vue'
+import {
+  duplicateSubgraph,
+  resolveDuplicateSourceIds,
+  type DuplicateEdgeMode,
+} from '@/utils/duplicateCanvasSubgraph'
 import StoryboardDialog, { type StoryboardShot } from '@/components/canvas/StoryboardDialog.vue'
 import PublishNeoTVDialog from '@/components/works/PublishNeoTVDialog.vue'
 import AgentSideRail from '@/components/agent/AgentSideRail.vue'
@@ -2345,6 +2350,51 @@ function handleCanvasRefPickToggle() {
   }
 }
 
+function selectMultipleNodes(ids: string[]) {
+  const idSet = new Set(ids)
+  nodes.value = nodes.value.map((node) => {
+    const selected = idSet.has(node.id)
+    return node.selected === selected ? node : { ...node, selected }
+  })
+  multiSelectedIds.value = ids
+  if (ids.length === 1) {
+    selectedNodeId.value = ids[0]
+  } else {
+    clearEditorSelection()
+  }
+}
+
+function handleDuplicateSelection(
+  contextNodeId: string,
+  edgeMode: DuplicateEdgeMode,
+) {
+  const sourceIds = resolveDuplicateSourceIds(
+    nodes.value as import('@/utils/duplicateCanvasSubgraph').DuplicateFlowNode[],
+    edges.value,
+    contextNodeId,
+    multiSelectedIds.value,
+    edgeMode,
+  )
+  if (!sourceIds.length) return
+
+  const result = duplicateSubgraph(
+    nodes.value as import('@/utils/duplicateCanvasSubgraph').DuplicateFlowNode[],
+    edges.value,
+    sourceIds,
+  )
+  if (!result.nodes.length) return
+
+  nodes.value.push(...(result.nodes as EditableFlowNode[]))
+  edges.value.push(...(result.edges as CanvasEdge[]))
+  selectMultipleNodes(result.newRootIds.length ? result.newRootIds : result.nodes.map((n) => n.id))
+  persistUserEdit()
+
+  const count = result.nodes.length
+  if (count > 1) {
+    ElMessage.success(`已创建 ${count} 个节点副本`)
+  }
+}
+
 function handleContextAction(action: string) {
   const menu = contextMenu.value
   contextMenu.value = null
@@ -2376,13 +2426,12 @@ function handleContextAction(action: string) {
   }
 
   if (action === 'duplicate' && menu.nodeId) {
-    const node = findNodeById(menu.nodeId)
-    if (node) {
-      addNode(String(node.type), { ...(node.data as Record<string, unknown>) }, {
-        position: { x: node.position.x + 40, y: node.position.y + 40 },
-      })
-      persistUserEdit()
-    }
+    handleDuplicateSelection(menu.nodeId, 'internal')
+    return
+  }
+
+  if (action === 'duplicate-upstream' && menu.nodeId) {
+    handleDuplicateSelection(menu.nodeId, 'upstream')
     return
   }
 
@@ -3121,6 +3170,13 @@ onUnmounted(() => {
       :y="contextMenu.y"
       :node-id="contextMenu.nodeId"
       :node-type="contextMenu.nodeType"
+      :multi-selected-count="
+        contextMenu.nodeId &&
+        multiSelectedIds.includes(contextMenu.nodeId) &&
+        multiSelectedIds.length > 1
+          ? multiSelectedIds.length
+          : 1
+      "
       @action="handleContextAction"
       @close="closeContextMenu"
     />

--- a/apps/web/src/utils/duplicateCanvasSubgraph.test.ts
+++ b/apps/web/src/utils/duplicateCanvasSubgraph.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import {
+  duplicateSubgraph,
+  resolveDuplicateSourceIds,
+  sanitizeNodeDataForDuplicate,
+} from './duplicateCanvasSubgraph'
+import type { DuplicateFlowNode } from './duplicateCanvasSubgraph'
+import type { FlowEdge } from '@/composables/useCanvasActions'
+
+const n = (
+  id: string,
+  type = 'image',
+  extra: Partial<DuplicateFlowNode> = {},
+): DuplicateFlowNode => ({
+  id,
+  type,
+  position: { x: 0, y: 0 },
+  data: {},
+  ...extra,
+})
+
+const e = (source: string, target: string): FlowEdge => ({
+  id: `e-${source}-${target}`,
+  source,
+  target,
+})
+
+describe('resolveDuplicateSourceIds upstream', () => {
+  it('adds only direct upstream nodes for single seed', () => {
+    const nodes = [n('ref'), n('img')]
+    const edges = [e('ref', 'img')]
+    const ids = resolveDuplicateSourceIds(nodes, edges, 'img', ['img'], 'upstream')
+    expect(ids.sort()).toEqual(['img', 'ref'])
+  })
+
+  it('does not recurse upstream chain', () => {
+    const nodes = [n('a', 'prompt'), n('b', 'prompt'), n('c', 'image')]
+    const edges = [e('a', 'b'), e('b', 'c')]
+    const ids = resolveDuplicateSourceIds(nodes, edges, 'c', ['c'], 'upstream')
+    expect(ids.sort()).toEqual(['b', 'c'])
+  })
+})
+
+describe('duplicateSubgraph', () => {
+  it('clears generationRecordId on copy', () => {
+    const nodes = [
+      n('a', 'image', {
+        data: { generationRecordId: 'g1', url: 'u', status: 'completed' },
+      }),
+    ]
+    const { nodes: out } = duplicateSubgraph(nodes, [], ['a'])
+    expect(out[0].data.generationRecordId).toBeUndefined()
+    expect(out[0].data.url).toBe('u')
+    expect(out[0].id).not.toBe('a')
+  })
+
+  it('copies internal edges for A->B->C selection', () => {
+    const nodes = [n('a', 'prompt'), n('b', 'image'), n('c', 'video')]
+    const edges = [e('a', 'b'), e('b', 'c'), e('a', 'c')]
+    const { nodes: outNodes, edges: outEdges } = duplicateSubgraph(nodes, edges, ['a', 'b', 'c'])
+    expect(outNodes).toHaveLength(3)
+    expect(outEdges).toHaveLength(3)
+    for (const edge of outEdges) {
+      expect(outNodes.some((x) => x.id === edge.source)).toBe(true)
+      expect(outNodes.some((x) => x.id === edge.target)).toBe(true)
+    }
+  })
+
+  it('upstream mode copies ref->img when only img selected', () => {
+    const nodes = [n('ref', 'image'), n('img', 'image')]
+    const edges = [e('ref', 'img')]
+    const sourceIds = resolveDuplicateSourceIds(nodes, edges, 'img', ['img'], 'upstream')
+    const { nodes: outNodes, edges: outEdges } = duplicateSubgraph(nodes, edges, sourceIds)
+    expect(outNodes).toHaveLength(2)
+    expect(outEdges).toHaveLength(1)
+  })
+
+  it('offsets duplicated positions', () => {
+    const nodes = [n('a', 'image', { position: { x: 100, y: 200 } })]
+    const { nodes: out } = duplicateSubgraph(nodes, [], ['a'], { offset: { x: 48, y: 48 } })
+    expect(out[0].position).toEqual({ x: 148, y: 248 })
+  })
+})
+
+describe('sanitizeNodeDataForDuplicate', () => {
+  it('resets generating status to idle when no url', () => {
+    const data = sanitizeNodeDataForDuplicate('image', { status: 'generating', prompt: 'p' })
+    expect(data.status).toBe('idle')
+    expect(data.prompt).toBe('p')
+  })
+
+  it('sets completed when media has url', () => {
+    const data = sanitizeNodeDataForDuplicate('image', {
+      status: 'generating',
+      url: 'https://x/a.png',
+    })
+    expect(data.status).toBe('completed')
+  })
+})

--- a/apps/web/src/utils/duplicateCanvasSubgraph.ts
+++ b/apps/web/src/utils/duplicateCanvasSubgraph.ts
@@ -1,0 +1,194 @@
+import type { FlowEdge, FlowNode } from '@/composables/useCanvasActions'
+import { getGroupChildIds, type FlowNode as GroupFlowNode } from '@/composables/useCanvasGrouping'
+
+export type DuplicateFlowNode = FlowNode & {
+  parentNode?: string
+  selected?: boolean
+}
+
+export type DuplicateEdgeMode = 'none' | 'internal' | 'upstream'
+
+export interface DuplicateSubgraphOptions {
+  offset?: { x: number; y: number }
+  edgeMode?: DuplicateEdgeMode
+}
+
+export interface DuplicateSubgraphResult {
+  nodes: DuplicateFlowNode[]
+  edges: FlowEdge[]
+  idMap: Map<string, string>
+  newRootIds: string[]
+}
+
+const DEFAULT_OFFSET = { x: 48, y: 48 }
+
+const STRIP_DATA_KEYS = [
+  'generationRecordId',
+  'materialId',
+  'errorMessage',
+  'errorCode',
+  'generationStartedAt',
+  'uploadProgress',
+] as const
+
+const ACTIVE_STATUSES = new Set([
+  'generating',
+  'pending',
+  'fallback_pending',
+  'processing',
+  'running',
+])
+
+let duplicateCounter = 0
+
+function nextDuplicateId(type: string): string {
+  duplicateCounter += 1
+  return `${type}-dup-${Date.now()}-${duplicateCounter}`
+}
+
+function expandGroupClosure(nodes: DuplicateFlowNode[], ids: string[]): string[] {
+  const set = new Set(ids)
+  for (const id of [...set]) {
+    const node = nodes.find((entry) => entry.id === id)
+    if (node?.type !== 'group') continue
+    for (const childId of getGroupChildIds(nodes as GroupFlowNode[], id)) {
+      set.add(childId)
+    }
+  }
+  return [...set]
+}
+
+export function resolveDuplicateSourceIds(
+  nodes: DuplicateFlowNode[],
+  edges: FlowEdge[],
+  contextNodeId: string,
+  multiSelectedIds: string[],
+  edgeMode: DuplicateEdgeMode = 'internal',
+): string[] {
+  let ids =
+    multiSelectedIds.includes(contextNodeId) && multiSelectedIds.length > 1
+      ? [...multiSelectedIds]
+      : [contextNodeId]
+
+  ids = expandGroupClosure(nodes, ids)
+
+  if (edgeMode === 'upstream' && ids.length === 1) {
+    const seed = ids[0]
+    const upstream = edges
+      .filter((edge) => edge.target === seed)
+      .map((edge) => edge.source)
+    ids = [...new Set([seed, ...upstream])]
+  }
+
+  return ids.filter((id) => nodes.some((node) => node.id === id))
+}
+
+export function sanitizeNodeDataForDuplicate(
+  type: string | undefined,
+  data: Record<string, unknown>,
+): Record<string, unknown> {
+  const next = structuredClone(data)
+  for (const key of STRIP_DATA_KEYS) {
+    delete next[key]
+  }
+  const mediaType = type === 'image' || type === 'video' || type === 'audio'
+  const hasUrl = typeof next.url === 'string' && next.url.trim().length > 0
+  if (ACTIVE_STATUSES.has(String(next.status ?? ''))) {
+    next.status = mediaType && hasUrl ? 'completed' : 'idle'
+  } else if (mediaType && hasUrl) {
+    next.status = 'completed'
+  }
+  next.createdAt = Date.now()
+  return next
+}
+
+function remapGroupChildIds(
+  data: Record<string, unknown>,
+  idMap: Map<string, string>,
+): Record<string, unknown> {
+  const childIds = data.childIds
+  if (!Array.isArray(childIds)) return data
+  return {
+    ...data,
+    childIds: childIds
+      .map((id) => (typeof id === 'string' ? idMap.get(id) ?? id : id))
+      .filter((id): id is string => typeof id === 'string'),
+  }
+}
+
+export function duplicateSubgraph(
+  nodes: DuplicateFlowNode[],
+  edges: FlowEdge[],
+  sourceIds: string[],
+  options?: DuplicateSubgraphOptions,
+): DuplicateSubgraphResult {
+  const offset = options?.offset ?? DEFAULT_OFFSET
+  const edgeMode = options?.edgeMode ?? 'internal'
+  const idSet = new Set(expandGroupClosure(nodes, sourceIds))
+  const idMap = new Map<string, string>()
+
+  for (const id of idSet) {
+    idMap.set(id, nextDuplicateId(String(nodes.find((n) => n.id === id)?.type ?? 'node')))
+  }
+
+  const newNodes: DuplicateFlowNode[] = []
+  for (const id of idSet) {
+    const node = nodes.find((entry) => entry.id === id)
+    if (!node) continue
+    const sanitized = sanitizeNodeDataForDuplicate(node.type, {
+      ...(node.data ?? {}),
+    } as Record<string, unknown>)
+    const remappedParent =
+      node.parentNode && idSet.has(node.parentNode)
+        ? idMap.get(node.parentNode)
+        : undefined
+    newNodes.push({
+      id: idMap.get(id)!,
+      type: node.type,
+      position: {
+        x: node.position.x + offset.x,
+        y: node.position.y + offset.y,
+      },
+      data:
+        node.type === 'group'
+          ? remapGroupChildIds(sanitized, idMap)
+          : sanitized,
+      ...(remappedParent ? { parentNode: remappedParent } : {}),
+      selected: false,
+    })
+  }
+
+  // Second pass: ensure group childIds only reference copied children
+  for (const node of newNodes) {
+    if (node.type !== 'group') continue
+    const data = node.data as { childIds?: string[] }
+    if (!Array.isArray(data.childIds)) continue
+    node.data = {
+      ...data,
+      childIds: data.childIds.filter((childId) =>
+        newNodes.some((copy) => copy.id === childId),
+      ),
+    }
+  }
+
+  const newEdges: FlowEdge[] = []
+  if (edgeMode !== 'none') {
+    for (const edge of edges) {
+      const newSource = idMap.get(edge.source)
+      const newTarget = idMap.get(edge.target)
+      if (!newSource || !newTarget) continue
+      newEdges.push({
+        ...edge,
+        id: `e-dup-${newSource}-${newTarget}`,
+        source: newSource,
+        target: newTarget,
+      })
+    }
+  }
+
+  const newRootIds = newNodes
+    .filter((node) => !node.parentNode || !idMap.has(node.parentNode))
+    .map((node) => node.id)
+
+  return { nodes: newNodes, edges: newEdges, idMap, newRootIds }
+}

--- a/docs/superpowers/plans/2026-08-17-canvas-node-duplicate.md
+++ b/docs/superpowers/plans/2026-08-17-canvas-node-duplicate.md
@@ -1,0 +1,218 @@
+# 画布节点「新建副本」Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 实现画布右键「新建副本」与「新建副本（含上游）」，支持多选子图 internal edge 复制，并清除副本上的 generation 任务绑定。
+
+**Architecture:** 纯函数 `duplicateSubgraph` 解析选区、扩展上游（仅直接一层）、remap id、卫生化 data、复制 internal edges；`CanvasPage` 与 `CanvasContextMenu` 接入；Vitest 覆盖核心拓扑与 data 卫生。
+
+**Tech Stack:** Vue 3 + Vue Flow、`useCanvasActions` FlowNode/FlowEdge 类型、Vitest
+
+**Spec:** `docs/superpowers/specs/2026-08-17-canvas-node-duplicate-design.md`
+
+## Global Constraints
+
+- 默认 edge 模式：**internal**（edge 两端均在复制集合内）
+- 含上游：**仅直接上游一层**，不递归
+- 多选时菜单**不显示**「含上游」
+- 副本 offset 默认 **`(+48, +48)`**
+- 清除 **`generationRecordId`**、**`materialId`**；生成中状态重置
+- 替换菜单文案「复制节点」→「新建副本」
+- TDD：先写失败测试再实现；提交前缀 `feat:`
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `apps/web/src/utils/duplicateCanvasSubgraph.ts` | 选区解析、拷贝、data 卫生、edge 过滤 |
+| `apps/web/src/utils/duplicateCanvasSubgraph.test.ts` | 单测 |
+| `apps/web/src/components/canvas/CanvasContextMenu.vue` | 菜单项 + 含上游条件 |
+| `apps/web/src/pages/CanvasPage.vue` | 右键 action 接入、选区解析、选中副本 |
+
+---
+
+### Task 0: 分支基线
+
+- [ ] **Step 1:** `git checkout main && git pull origin main`
+- [ ] **Step 2:** `git checkout -b feature/canvas-node-duplicate`
+- [ ] **Step 3:** `pnpm build` 确认基线绿
+
+---
+
+### Task 1: `duplicateCanvasSubgraph` 核心逻辑
+
+**Files:**
+- Create: `apps/web/src/utils/duplicateCanvasSubgraph.ts`
+- Create: `apps/web/src/utils/duplicateCanvasSubgraph.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `export type DuplicateEdgeMode = 'none' | 'internal' | 'upstream'`
+  - `export function resolveDuplicateSourceIds(nodes, edges, contextNodeId, multiSelectedIds, edgeMode): string[]`
+  - `export function sanitizeNodeDataForDuplicate(type, data): Record<string, unknown>`
+  - `export function duplicateSubgraph(nodes, edges, sourceIds, options?): DuplicateSubgraphResult`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+import { describe, expect, it } from 'vitest'
+import {
+  duplicateSubgraph,
+  resolveDuplicateSourceIds,
+  sanitizeNodeDataForDuplicate,
+} from './duplicateCanvasSubgraph'
+import type { FlowEdge, FlowNode } from '@/composables/useCanvasActions'
+
+const n = (id: string, type = 'image', extra: Partial<FlowNode> = {}): FlowNode => ({
+  id,
+  type,
+  position: { x: 0, y: 0 },
+  data: {},
+  ...extra,
+})
+const e = (source: string, target: string): FlowEdge => ({ id: `e-${source}-${target}`, source, target })
+
+describe('resolveDuplicateSourceIds upstream', () => {
+  it('adds only direct upstream nodes for single seed', () => {
+    const nodes = [n('ref'), n('img')]
+    const edges = [e('ref', 'img')]
+    const ids = resolveDuplicateSourceIds(nodes, edges, 'img', ['img'], 'upstream')
+    expect(ids.sort()).toEqual(['img', 'ref'])
+  })
+})
+
+describe('duplicateSubgraph', () => {
+  it('clears generationRecordId on copy', () => {
+    const nodes = [n('a', 'image', { data: { generationRecordId: 'g1', url: 'u', status: 'completed' } })]
+    const { nodes: out } = duplicateSubgraph(nodes, [], ['a'])
+    expect(out[0].data.generationRecordId).toBeUndefined()
+    expect(out[0].data.url).toBe('u')
+  })
+
+  it('copies internal edges for A->B->C selection', () => {
+    const nodes = [n('a', 'prompt'), n('b', 'image'), n('c', 'video')]
+    const edges = [e('a', 'b'), e('b', 'c'), e('a', 'c')]
+    const { nodes: outNodes, edges: outEdges } = duplicateSubgraph(nodes, edges, ['a', 'b', 'c'])
+    expect(outNodes).toHaveLength(3)
+    expect(outEdges).toHaveLength(3)
+    for (const edge of outEdges) {
+      expect(outNodes.some((x) => x.id === edge.source)).toBe(true)
+      expect(outNodes.some((x) => x.id === edge.target)).toBe(true)
+    }
+  })
+
+  it('upstream mode copies ref->img when only img selected', () => {
+    const nodes = [n('ref', 'image'), n('img', 'image')]
+    const edges = [e('ref', 'img')]
+    const { nodes: outNodes, edges: outEdges } = duplicateSubgraph(
+      nodes,
+      edges,
+      ['img'],
+      { edgeMode: 'upstream' },
+    )
+    expect(outNodes).toHaveLength(2)
+    expect(outEdges).toHaveLength(1)
+  })
+})
+
+describe('sanitizeNodeDataForDuplicate', () => {
+  it('resets generating status to idle', () => {
+    const data = sanitizeNodeDataForDuplicate('image', { status: 'generating', prompt: 'p' })
+    expect(data.status).toBe('idle')
+    expect(data.prompt).toBe('p')
+  })
+})
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `pnpm --filter @lnkpi/web exec vitest run src/utils/duplicateCanvasSubgraph.test.ts`
+
+- [ ] **Step 3: Implement `duplicateCanvasSubgraph.ts`**
+
+要点：
+- `resolveDuplicateSourceIds`：多选含 context → 用 multiSelectedIds；group 闭包；upstream 仅 `edges.filter(t=>t.target===seed).map(s=>s.source)`
+- 新 id：`${type}-dup-${counter}` 或 `${type}-${Date.now()}-${i}`
+- position：bbox min + offset
+- group `childIds` / `parentNode` remap
+- `sanitizeNodeDataForDuplicate` 字段表
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/utils/duplicateCanvasSubgraph.ts apps/web/src/utils/duplicateCanvasSubgraph.test.ts
+git commit -m "feat(web): duplicate canvas subgraph utility with upstream one-hop"
+```
+
+---
+
+### Task 2: 右键菜单
+
+**Files:**
+- Modify: `apps/web/src/components/canvas/CanvasContextMenu.vue`
+
+**Interfaces:**
+- Consumes: props `multiSelectedCount?: number`（或 `showUpstreamDuplicate?: boolean`）
+- Emits: `duplicate`, `duplicate-upstream`
+
+- [ ] **Step 1:** 将「复制节点」改为「新建副本」，`emit('duplicate')`
+- [ ] **Step 2:** 当 `multiSelectedCount <= 1` 且 `nodeType !== 'group'` 时显示「新建副本（含上游）」→ `emit('duplicate-upstream')`
+- [ ] **Step 3:** `CanvasPage` 传入 `multiSelectedIds.length`
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(web): context menu duplicate and duplicate-upstream entries"
+```
+
+---
+
+### Task 3: CanvasPage 接入
+
+**Files:**
+- Modify: `apps/web/src/pages/CanvasPage.vue`
+
+**Interfaces:**
+- Consumes: `duplicateSubgraph`, `resolveDuplicateSourceIds`
+
+- [ ] **Step 1:** 新增 `handleDuplicateSelection(edgeMode: 'internal' | 'upstream')`
+  - 从 `menu.nodeId` + `multiSelectedIds` 解析 sourceIds
+  - 调用 `duplicateSubgraph`，append nodes/edges
+  - `selectNodes(newRootIds)` + `persistUserEdit()`
+  - 可选 `ElMessage.success`
+- [ ] **Step 2:** 替换现有 `action === 'duplicate'` 浅拷贝逻辑
+- [ ] **Step 3:** 处理 `duplicate-upstream` action
+- [ ] **Step 4:** 手动冒烟：单节点、含上游、多选子图
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(web): wire canvas duplicate subgraph to context menu"
+```
+
+---
+
+### Task 4: CI + PR
+
+- [ ] **Step 1:** `pnpm build`
+- [ ] **Step 2:** `pnpm --filter @lnkpi/web exec vitest run src/utils/duplicateCanvasSubgraph.test.ts`
+- [ ] **Step 3:** `gh pr create` → CI watch → merge
+
+---
+
+## Execution tracking
+
+| ID | Task | Status |
+|----|------|--------|
+| T0 | 分支基线 | `[ ]` |
+| T1 | duplicateSubgraph util + tests | `[ ]` |
+| T2 | Context menu | `[ ]` |
+| T3 | CanvasPage 接入 | `[ ]` |
+| T4 | CI / PR | `[ ]` |
+
+## Plan self-review
+
+- [x] Spec 含上游仅一层已覆盖 Task 1 `resolveDuplicateSourceIds`
+- [x] 多选无含上游 → Task 2 条件
+- [x] generationRecordId 清除 → Task 1 test + sanitize
+- [x] 无 TBD 步骤

--- a/docs/superpowers/specs/2026-08-17-canvas-node-duplicate-design.md
+++ b/docs/superpowers/specs/2026-08-17-canvas-node-duplicate-design.md
@@ -1,0 +1,207 @@
+# 画布节点「新建副本」Design
+
+**Date:** 2026-08-17  
+**Status:** Approved for planning (user chose option C)  
+**代号:** **CANVAS-DUPLICATE**
+
+---
+
+## Goal
+
+用户在画布上通过右键（及后续快捷键）**新建节点副本**，支持单节点与多选子图复制；默认保留选区**内部连线**，单节点场景额外提供**含上游连线**选项。
+
+## Decisions (locked)
+
+| Topic | Choice |
+|-------|--------|
+| 默认连线 | **内部连线（internal）**：两端都在选区内的 edge 一并复制 |
+| 单节点扩展 | 右键子项 **「新建副本（含上游）」**：复制该节点 + 所有直接上游节点 + 对应 edge |
+| 多选 | 仅 **「新建副本」**（internal）；不提供含上游/下游子项（避免边界歧义） |
+| 文案 | 主项 **「新建副本」**；替换现有「复制节点」 |
+| 任务 ID | 副本清除 `generationRecordId` / `materialId`；生成态重置 |
+| 分组 | 选中 group 时自动纳入子节点；部分选中子节点时不复制 group 框 |
+| 落位 | 选区 bbox 整体 offset `(+48, +48)` |
+| 选中 | 副本创建后选中新节点并 `persistUserEdit` |
+
+## Non-goals (P0)
+
+- 含下游连线 / 双向扩展
+- 跨 session 粘贴、剪贴板
+- 副本自动触发再生成
+- 远程 media 文件深拷贝（仍引用同一 URL）
+- Agent `duplicate_nodes` action（P2）
+
+---
+
+## Problem baseline
+
+| 现状 | 问题 |
+|------|------|
+| 右键「复制节点」 | 仅单节点、无 edge、浅拷贝含 `generationRecordId` |
+| 多选 | 右键仍只复制右键目标 |
+| 工作流 | 用户复制 `[Prompt→Image→Video]` 子图需手动重连连线 |
+
+---
+
+## UX
+
+### 右键菜单（节点上）
+
+**单选（`multiSelectedIds.length === 1` 或仅右键节点）：**
+
+```
+新建副本
+新建副本（含上游）
+─────────────
+… 其他现有项 …
+```
+
+**多选（`multiSelectedIds.length > 1` 且含右键节点）：**
+
+```
+新建副本          ← internal edges only
+─────────────
+…
+```
+
+### 行为说明
+
+| 场景 | 新建副本 | 新建副本（含上游） |
+|------|----------|-------------------|
+| 单 Image 节点 | 1 个 Image 副本，无 edge | Image + 所有 `source→Image` 的上游节点 + 这些 edge |
+| Prompt→Image | 2 节点 + 1 edge（若全选） | 同左（上游已在内） |
+| Ref→Image，仅选 Image | 1 Image | Ref + Image + Ref→Image |
+| 多选 Prompt+Image+Video | 3 节点 + 内部 edges | **不显示**此菜单项 |
+| 选中 Group | Group + 全部 child + 内部 edges | 单选 group 时同「新建副本」；含上游对 group 无意义，**隐藏** |
+
+### 含上游定义（P0，已确认）
+
+- 从种子节点 `S` 出发，取所有 `edge.target === S` 的 **直接** source 节点（仅一层，**不递归**）
+- 复制集合 = `{S} ∪ upstreamDirect(S)`
+- 复制 edge = 集合内 internal edges（含 upstream→S）
+- ~~P1 递归上游链~~：**不在路线图中**（用户确认只要直接上游一层）
+
+### 反馈
+
+- Toast：`已创建 N 个节点副本`（N > 1 时）；单节点可省略或简短提示
+- 视口：可选 `focusNodeById` 第一个副本根节点
+
+---
+
+## Architecture
+
+### 核心纯函数
+
+路径：`apps/web/src/utils/duplicateCanvasSubgraph.ts`
+
+```ts
+export type DuplicateEdgeMode = 'none' | 'internal' | 'upstream'
+
+export interface DuplicateSubgraphOptions {
+  offset?: { x: number; y: number }  // default { x: 48, y: 48 }
+  edgeMode?: DuplicateEdgeMode         // default 'internal'
+  preserveGroups?: boolean           // default true
+}
+
+export interface DuplicateSubgraphResult {
+  nodes: FlowNode[]
+  edges: FlowEdge[]
+  idMap: Map<string, string>
+  newRootIds: string[]
+}
+
+export function duplicateSubgraph(
+  nodes: FlowNode[],
+  edges: FlowEdge[],
+  sourceIds: string[],
+  options?: DuplicateSubgraphOptions,
+): DuplicateSubgraphResult
+```
+
+### 选区解析 `resolveDuplicateSourceIds`
+
+1. 输入 `contextNodeId` + `multiSelectedIds`
+2. 若 `multiSelectedIds` 含 `contextNodeId` 且 length > 1 → 源 = 多选全集
+3. 否则 → 源 = `[contextNodeId]`
+4. **Group 闭包**：若源含 `type === 'group'` → union 其 `childIds` / `parentNode === groupId` 的子节点
+5. **含 upstream 扩展**（仅 `edgeMode === 'upstream'` 且源为单节点）：
+   - `sources = {node} ∪ { e.source | e.target === node }`
+
+### 数据卫生 `sanitizeNodeDataForDuplicate`
+
+| 字段 | 处理 |
+|------|------|
+| `generationRecordId`, `materialId` | `delete` |
+| `status` | `generating`/`pending`/`fallback_pending` → `idle`；有 `url` 的媒体节点 → `completed` |
+| `errorMessage`, `errorCode`, `generationStartedAt` | `delete` |
+| `uploadProgress` | `delete` |
+| `url`, `prompt`, `model`, `label`, `mediaInfo`, 模型参数 | **保留** |
+| `childIds`（group） | 在 idMap 建立后 remap |
+| `parentNode` | remap |
+| `createdAt` | `Date.now()` |
+
+实现：`structuredClone` + 字段表驱动，避免 mutate 原节点。
+
+### Edge 复制
+
+- 新 edge id：`e-dup-${newSource}-${newTarget}` 或 `e-${newSource}-${newTarget}`
+- 保留 `animated` / `style`（若有）
+- 过滤：`idMap.has(source) && idMap.has(target)`
+
+### 集成点
+
+| 文件 | 变更 |
+|------|------|
+| `duplicateCanvasSubgraph.ts` | 新建 + unit tests |
+| `CanvasContextMenu.vue` | 文案 + 条件显示「含上游」 |
+| `CanvasPage.vue` | `handleContextMenuAction('duplicate' \| 'duplicate-upstream')` 调用 util |
+| `useCanvasActions.ts` | 复用 `FlowNode` / `FlowEdge` 类型 |
+
+---
+
+## Error handling
+
+| 场景 | 行为 |
+|------|------|
+| 源节点不存在 | no-op |
+| 含上游但无上游 | 等价单节点副本 |
+| group 无子节点 | 仅复制空 group |
+| 副本后 id 冲突 | 新 id 用 counter + timestamp 后缀 |
+
+---
+
+## Testing
+
+### 单元（vitest）
+
+- 单节点 → 1 新节点，0 edge，`generationRecordId` 清除
+- A→B→C 全选 → 3 节点 2 internal edges
+- 仅选 B + upstream 模式 → A,B + A→B
+- group + 2 children → group 结构 + childIds remap
+- 多选不提供 upstream 模式（menu 层测试或 omit）
+
+### 人工 UAT
+
+- [ ] 单 Image 右键「新建副本」→ 偏移副本，无连线，无 generationRecordId
+- [ ] Ref→Image，仅选 Image，「含上游」→ Ref 副本 + 连线
+- [ ] 框选 Prompt→Image→Video，「新建副本」→ 结构完整
+- [ ] 副本后 Dock 再生成 → 新 record，不污染原节点
+
+---
+
+## Phasing
+
+| 阶段 | 交付 |
+|------|------|
+| **P0** | util + 右键双项 + 多选 internal + 数据卫生 + 单测 |
+| **P1** | `Cmd/Ctrl+D`；可选「含下游」子项 |
+| **P2** | Agent action |
+
+---
+
+## Spec self-review
+
+- [x] 无 TBD
+- [x] 与现有 group/delete 语义一致
+- [x] option C 已锁定：默认 internal + 单节点含上游
+- [x] P0 范围可一个 plan 完成


### PR DESCRIPTION
## Summary
- 将画布右键「复制节点」升级为「新建副本」，支持内部连线复制（默认 internal 模式）
- 单节点额外提供「新建副本（含上游）」——仅复制直接上游一层，不递归
- 多选时仅显示「新建副本」，自动复制选中子图及内部边
- 副本数据清洗：清除 `generationRecordId`/`materialId`，重置生成态；偏移 (+48,+48)
- 新增 `duplicateCanvasSubgraph` 工具函数及 8 个单元测试

## Test plan
- [x] `pnpm build` 通过
- [x] `pnpm --filter @lnkpi/web test -- duplicateCanvasSubgraph` 8/8 通过
- [ ] 单节点：右键 → 新建副本，验证偏移与数据清洗
- [ ] 单节点：新建副本（含上游），验证仅一层上游被复制
- [ ] 多选子图：验证内部边复制、无「含上游」选项


Made with [Cursor](https://cursor.com)