### PR TITLE
feat(web): Cmd/Ctrl+D canvas duplicate shortcut

### DIFF
--- a/apps/web/src/composables/useCanvasKeyboard.test.ts
+++ b/apps/web/src/composables/useCanvasKeyboard.test.ts
@@ -1,0 +1,70 @@
+import { defineComponent, ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useCanvasKeyboard } from './useCanvasKeyboard'
+
+function mountKeyboardHarness(options?: { onDuplicate?: () => void }) {
+  let duplicateCalls = 0
+  const Harness = defineComponent({
+    setup() {
+      const enabled = ref(true)
+      useCanvasKeyboard({
+        enabled,
+        onZoomIn: () => {},
+        onZoomOut: () => {},
+        onPan: () => {},
+        onDelete: () => {},
+        onDuplicate: options?.onDuplicate ?? (() => {
+          duplicateCalls += 1
+        }),
+      })
+      return () => null
+    },
+  })
+  mount(Harness)
+  return {
+    get duplicateCalls() {
+      return duplicateCalls
+    },
+  }
+}
+
+function dispatchWindowKey(type: 'keydown' | 'keyup', init: KeyboardEventInit) {
+  window.dispatchEvent(new KeyboardEvent(type, { bubbles: true, ...init }))
+}
+
+afterEach(() => {
+  dispatchWindowKey('keyup', { key: 'd' })
+  dispatchWindowKey('keyup', { key: 'Meta' })
+  dispatchWindowKey('keyup', { key: 'Control' })
+})
+
+describe('useCanvasKeyboard duplicate shortcut', () => {
+  it('calls onDuplicate for Meta+D', () => {
+    const harness = mountKeyboardHarness()
+    dispatchWindowKey('keydown', { key: 'd', metaKey: true })
+    expect(harness.duplicateCalls).toBe(1)
+  })
+
+  it('calls onDuplicate for Ctrl+D', () => {
+    const harness = mountKeyboardHarness()
+    dispatchWindowKey('keydown', { key: 'd', ctrlKey: true })
+    expect(harness.duplicateCalls).toBe(1)
+  })
+
+  it('does not call onDuplicate when typing in an input', () => {
+    const harness = mountKeyboardHarness()
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'd', metaKey: true, bubbles: true }))
+    expect(harness.duplicateCalls).toBe(0)
+    input.remove()
+  })
+
+  it('does not treat plain D as duplicate (reserved for pan)', () => {
+    const onDuplicate = vi.fn()
+    mountKeyboardHarness({ onDuplicate })
+    dispatchWindowKey('keydown', { key: 'd' })
+    expect(onDuplicate).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/composables/useCanvasKeyboard.ts
+++ b/apps/web/src/composables/useCanvasKeyboard.ts
@@ -6,6 +6,7 @@ interface CanvasKeyboardOptions {
   onZoomOut: () => void
   onPan: (dx: number, dy: number) => void
   onDelete: () => void
+  onDuplicate?: () => void
   onUndo?: () => void
   onRedo?: () => void
 }
@@ -24,9 +25,16 @@ export function useCanvasKeyboard(options: CanvasKeyboardOptions) {
     if (!options.enabled.value || isTypingTarget(event.target)) return
 
     const key = event.key.toLowerCase()
+    const mod = event.metaKey || event.ctrlKey
+
+    if (mod && key === 'd') {
+      event.preventDefault()
+      options.onDuplicate?.()
+      return
+    }
+
     pressed.add(key)
 
-    const mod = event.metaKey || event.ctrlKey
     if (mod && key === 'z') {
       event.preventDefault()
       if (event.shiftKey) options.onRedo?.()

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -2142,6 +2142,15 @@ function handleKeyboardDelete() {
   }
 }
 
+function handleKeyboardDuplicate() {
+  const contextId =
+    multiSelectedIds.value.length > 0
+      ? multiSelectedIds.value[0]
+      : selectedNodeId.value ?? undefined
+  if (!contextId) return
+  handleDuplicateSelection(contextId, 'internal')
+}
+
 function panViewport(dx: number, dy: number) {
   const flow = vueFlowRef.value as {
     getViewport?: () => { x: number; y: number; zoom: number }
@@ -2168,6 +2177,7 @@ useCanvasKeyboard({
   onZoomOut: () => zoomViewport(1 / 1.12),
   onPan: panViewport,
   onDelete: handleKeyboardDelete,
+  onDuplicate: handleKeyboardDuplicate,
   onUndo: () => {
     if (canvasUndo.undo()) void saveCanvas()
   },


### PR DESCRIPTION
## Summary
- 新增 `Cmd/Ctrl+D` 快捷键，触发「新建副本」（internal 模式，与右键默认行为一致）
- 在 `useCanvasKeyboard` 中优先处理 modifier+D，避免与 WASD 平移中的 `D` 冲突
- 选中逻辑：有多选时用多选集，否则用当前单选节点

## Test plan
- [x] `pnpm build` 通过
- [x] `useCanvasKeyboard.test.ts` 4/4 通过
- [ ] 选中单节点 → `Cmd/Ctrl+D` 创建副本
- [ ] 多选子图 → `Cmd/Ctrl+D` 复制整段子图
- [ ] 无选中 → 快捷键无效果
- [ ] 输入框聚焦时 → 快捷键不触发


Made with [Cursor](https://cursor.com)