### PR TITLE
fix(web): canvas duplicate fails on reactive node data

### DIFF
--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -2394,8 +2394,8 @@ function handleDuplicateSelection(
   )
   if (!result.nodes.length) return
 
-  nodes.value.push(...(result.nodes as EditableFlowNode[]))
-  edges.value.push(...(result.edges as CanvasEdge[]))
+  nodes.value = [...nodes.value, ...(result.nodes as EditableFlowNode[])]
+  edges.value = [...edges.value, ...(result.edges as CanvasEdge[])]
   selectMultipleNodes(result.newRootIds.length ? result.newRootIds : result.nodes.map((n) => n.id))
   persistUserEdit()
 

--- a/apps/web/src/utils/duplicateCanvasSubgraph.reactive.test.ts
+++ b/apps/web/src/utils/duplicateCanvasSubgraph.reactive.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { reactive } from 'vue'
+import { duplicateSubgraph, resolveDuplicateSourceIds } from './duplicateCanvasSubgraph'
+
+describe('duplicate with reactive canvas nodes', () => {
+  it('does not throw on reactive nested data', () => {
+    const nodes = [
+      {
+        id: 'img-1',
+        type: 'image',
+        position: { x: 100, y: 100 },
+        data: reactive({
+          url: 'https://x/a.png',
+          prompt: 'test',
+          settings: reactive({ model: 'gpt' }),
+        }),
+      },
+    ]
+    expect(() => duplicateSubgraph(nodes as any, [], ['img-1'])).not.toThrow()
+    const result = duplicateSubgraph(nodes as any, [], ['img-1'])
+    expect(result.nodes).toHaveLength(1)
+    expect(result.nodes[0].position).toEqual({ x: 148, y: 148 })
+  })
+
+  it('upstream resolves with reactive edges array', () => {
+    const nodes = [
+      { id: 'ref', type: 'image', position: { x: 0, y: 0 }, data: reactive({}) },
+      { id: 'img', type: 'image', position: { x: 200, y: 0 }, data: reactive({ url: 'u' }) },
+    ]
+    const edges = [{ id: 'e-ref-img', source: 'ref', target: 'img' }]
+    const sourceIds = resolveDuplicateSourceIds(nodes as any, edges, 'img', ['img'], 'upstream')
+    expect(sourceIds.sort()).toEqual(['img', 'ref'])
+  })
+})

--- a/packages/shared/src/canvas/duplicateSubgraph.test.ts
+++ b/packages/shared/src/canvas/duplicateSubgraph.test.ts
@@ -93,6 +93,15 @@ describe('duplicateSubgraph', () => {
 })
 
 describe('sanitizeNodeDataForDuplicate', () => {
+  it('clones nested plain objects', () => {
+    const data = sanitizeNodeDataForDuplicate('image', {
+      prompt: 'p',
+      settings: { model: 'm' },
+    })
+    expect(data.prompt).toBe('p')
+    expect(data.settings).toEqual({ model: 'm' })
+  })
+
   it('resets generating status to idle when no url', () => {
     const data = sanitizeNodeDataForDuplicate('image', { status: 'generating', prompt: 'p' })
     expect(data.status).toBe('idle')

--- a/packages/shared/src/canvas/duplicateSubgraph.ts
+++ b/packages/shared/src/canvas/duplicateSubgraph.ts
@@ -95,11 +95,19 @@ export function resolveDuplicateSourceIds(
   return ids.filter((id) => nodes.some((node) => node.id === id))
 }
 
+function clonePlainRecord(data: Record<string, unknown>): Record<string, unknown> {
+  try {
+    return structuredClone(data)
+  } catch {
+    return JSON.parse(JSON.stringify(data)) as Record<string, unknown>
+  }
+}
+
 export function sanitizeNodeDataForDuplicate(
   type: string | undefined,
   data: Record<string, unknown>,
 ): Record<string, unknown> {
-  const next = structuredClone(data)
+  const next = clonePlainRecord(data)
   for (const key of STRIP_DATA_KEYS) {
     delete next[key]
   }


### PR DESCRIPTION
## Summary
- 修复「新建副本 / 含上游」无反应：Vue 响应式 `node.data` 嵌套字段导致 `structuredClone` 抛 `DataCloneError`，副本创建静默失败
- shared `sanitizeNodeDataForDuplicate` 增加 JSON fallback 克隆
- CanvasPage 改为 immutable 更新 nodes/edges 数组，确保 Vue Flow 受控模式刷新

## Test plan
- [x] shared duplicateSubgraph 10/10
- [x] web duplicate + reactive 10/10
- [x] pnpm build 通过
- [ ] 画布右键「新建副本」「含上游」出现偏移副本


Made with [Cursor](https://cursor.com)