### PR TITLE
fix(web): canvas duplicate semantics (nodes only / upstream edges)

### DIFF
--- a/apps/server/src/agent/agent-canvas-tools.service.test.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.test.ts
@@ -1330,7 +1330,7 @@ describe('AgentCanvasToolsService', () => {
       expect(layout.groups).toEqual([])
     })
 
-    it('duplicateNode copies internal subgraph with edges when duplicating p1 and i1', async () => {
+    it('duplicateNode copies selected nodes without edges by default', async () => {
       canvas = {
         nodes: [
           {
@@ -1354,49 +1354,82 @@ describe('AgentCanvasToolsService', () => {
         nodeIds: ['p1', 'i1'],
       })
       expect(result.nodeIds).toHaveLength(2)
-      expect(result.nodeId).toBe(result.nodeIds[0])
       expect(canvas.nodes).toHaveLength(4)
-      expect(canvas.edges).toHaveLength(2)
-      expect(result.actions.some((a) => a.type === 'add_edge')).toBe(true)
-      expect(result.canvasCommands[0]?.type).toBe('focus_node')
+      expect(canvas.edges).toHaveLength(1)
+      expect(result.actions.some((a) => a.type === 'add_edge')).toBe(false)
     })
 
-    it('duplicateNode includeUpstream copies only direct upstream nodes', async () => {
+    it('duplicateNode includeUpstream reuses upstream node via edge only', async () => {
       canvas = {
         nodes: [
           {
-            id: 'a',
-            type: 'prompt',
+            id: 'ref',
+            type: 'image',
             position: { x: 0, y: 0 },
-            data: { title: 'Root prompt' },
+            data: { title: 'Ref', url: 'https://cdn.example/ref.png', status: 'completed' },
           },
           {
-            id: 'b',
-            type: 'prompt',
-            position: { x: 100, y: 0 },
-            data: { title: 'Mid prompt' },
-          },
-          {
-            id: 'c',
+            id: 'img',
             type: 'image',
             position: { x: 200, y: 0 },
             data: { title: 'Image', url: 'https://cdn.example/img.png', status: 'completed' },
           },
         ],
+        edges: [{ id: 'e-ref-img', source: 'ref', target: 'img' }],
+      }
+      const result = await svc.duplicateNode({
+        sessionId: 's1',
+        userId: 'u1',
+        nodeId: 'img',
+        includeUpstream: true,
+      })
+      expect(result.nodeIds).toHaveLength(1)
+      expect(canvas.nodes).toHaveLength(3)
+      expect(canvas.edges).toHaveLength(2)
+      const copyId = result.nodeIds[0]
+      expect(canvas.edges.some((edge) => edge.source === 'ref' && edge.target === copyId)).toBe(true)
+    })
+
+    it('duplicateNode includeUpstream on multi-select skips internal edges', async () => {
+      canvas = {
+        nodes: [
+          {
+            id: 'ext',
+            type: 'prompt',
+            position: { x: 0, y: 0 },
+            data: { title: 'External' },
+          },
+          {
+            id: 'p1',
+            type: 'prompt',
+            position: { x: 100, y: 0 },
+            data: { title: 'Prompt' },
+          },
+          {
+            id: 'i1',
+            type: 'image',
+            position: { x: 300, y: 0 },
+            data: { title: 'Image', url: 'https://cdn.example/img.png', status: 'completed' },
+          },
+        ],
         edges: [
-          { id: 'e-a-b', source: 'a', target: 'b' },
-          { id: 'e-b-c', source: 'b', target: 'c' },
+          { id: 'e-ext-p1', source: 'ext', target: 'p1' },
+          { id: 'e-p1-i1', source: 'p1', target: 'i1' },
         ],
       }
       const result = await svc.duplicateNode({
         sessionId: 's1',
         userId: 'u1',
-        nodeId: 'c',
+        nodeIds: ['p1', 'i1'],
         includeUpstream: true,
       })
       expect(result.nodeIds).toHaveLength(2)
       expect(canvas.nodes).toHaveLength(5)
       expect(canvas.edges).toHaveLength(3)
+      const copyP = result.nodeIds.find((id) => canvas.nodes.find((n) => n.id === id)?.type === 'prompt')
+      expect(copyP).toBeTruthy()
+      expect(canvas.edges.some((edge) => edge.source === 'ext' && edge.target === copyP)).toBe(true)
+      expect(result.actions.filter((a) => a.type === 'add_edge')).toHaveLength(1)
     })
 
     it('duplicateNode clears generationRecordId on copy', async () => {

--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -1697,7 +1697,7 @@ export class AgentCanvasToolsService {
     const seeds = input.nodeIds?.length ? input.nodeIds : input.nodeId ? [input.nodeId] : []
     if (!seeds.length) throw new BadRequestException('nodeId or nodeIds required')
 
-    const edgeMode = input.includeUpstream && seeds.length === 1 ? 'upstream' : 'internal'
+    const edgeMode = input.includeUpstream ? 'upstream' : 'none'
     const nodes = canvas.nodes as DuplicateCanvasNode[]
     const edges = canvas.edges ?? []
     const sourceIds = resolveDuplicateSourceIds(
@@ -1705,10 +1705,10 @@ export class AgentCanvasToolsService {
       edges,
       seeds[0],
       seeds.length > 1 ? seeds : [seeds[0]],
-      edgeMode,
     )
     const result = duplicateSubgraph(nodes, edges, sourceIds, {
       offset: input.offset ?? { x: 48, y: 48 },
+      edgeMode,
       createNodeId: (type) => nextNodeId(type),
     })
     const updated: CanvasData = {

--- a/apps/web/src/components/canvas/CanvasContextMenu.vue
+++ b/apps/web/src/components/canvas/CanvasContextMenu.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 
-const { x, y, nodeId, nodeType, multiSelectedCount = 1 } = defineProps<{
+const { x, y, nodeId, nodeType } = defineProps<{
   x: number
   y: number
   nodeId?: string
@@ -17,7 +17,7 @@ const emit = defineEmits<{
 const visible = ref(true)
 
 const showUpstreamDuplicate = computed(
-  () => multiSelectedCount <= 1 && nodeType !== 'group' && Boolean(nodeId),
+  () => nodeType !== 'group' && Boolean(nodeId),
 )
 
 function run(action: string, payload?: string) {

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -2148,7 +2148,7 @@ function handleKeyboardDuplicate() {
       ? multiSelectedIds.value[0]
       : selectedNodeId.value ?? undefined
   if (!contextId) return
-  handleDuplicateSelection(contextId, 'internal')
+  handleDuplicateSelection(contextId, 'none')
 }
 
 function panViewport(dx: number, dy: number) {
@@ -2391,6 +2391,7 @@ function handleDuplicateSelection(
     nodes.value as import('@/utils/duplicateCanvasSubgraph').DuplicateFlowNode[],
     edges.value,
     sourceIds,
+    { edgeMode },
   )
   if (!result.nodes.length) return
 
@@ -2436,7 +2437,7 @@ function handleContextAction(action: string) {
   }
 
   if (action === 'duplicate' && menu.nodeId) {
-    handleDuplicateSelection(menu.nodeId, 'internal')
+    handleDuplicateSelection(menu.nodeId, 'none')
     return
   }
 

--- a/apps/web/src/utils/duplicateCanvasSubgraph.reactive.test.ts
+++ b/apps/web/src/utils/duplicateCanvasSubgraph.reactive.test.ts
@@ -22,13 +22,13 @@ describe('duplicate with reactive canvas nodes', () => {
     expect(result.nodes[0].position).toEqual({ x: 148, y: 148 })
   })
 
-  it('upstream resolves with reactive edges array', () => {
+  it('upstream resolve keeps only seed ids', () => {
     const nodes = [
       { id: 'ref', type: 'image', position: { x: 0, y: 0 }, data: reactive({}) },
       { id: 'img', type: 'image', position: { x: 200, y: 0 }, data: reactive({ url: 'u' }) },
     ]
     const edges = [{ id: 'e-ref-img', source: 'ref', target: 'img' }]
     const sourceIds = resolveDuplicateSourceIds(nodes as any, edges, 'img', ['img'], 'upstream')
-    expect(sourceIds.sort()).toEqual(['img', 'ref'])
+    expect(sourceIds).toEqual(['img'])
   })
 })

--- a/apps/web/src/utils/duplicateCanvasSubgraph.test.ts
+++ b/apps/web/src/utils/duplicateCanvasSubgraph.test.ts
@@ -25,19 +25,12 @@ const e = (source: string, target: string): FlowEdge => ({
   target,
 })
 
-describe('resolveDuplicateSourceIds upstream', () => {
-  it('adds only direct upstream nodes for single seed', () => {
+describe('resolveDuplicateSourceIds', () => {
+  it('keeps only selected seed for upstream mode', () => {
     const nodes = [n('ref'), n('img')]
     const edges = [e('ref', 'img')]
     const ids = resolveDuplicateSourceIds(nodes, edges, 'img', ['img'], 'upstream')
-    expect(ids.sort()).toEqual(['img', 'ref'])
-  })
-
-  it('does not recurse upstream chain', () => {
-    const nodes = [n('a', 'prompt'), n('b', 'prompt'), n('c', 'image')]
-    const edges = [e('a', 'b'), e('b', 'c')]
-    const ids = resolveDuplicateSourceIds(nodes, edges, 'c', ['c'], 'upstream')
-    expect(ids.sort()).toEqual(['b', 'c'])
+    expect(ids).toEqual(['img'])
   })
 })
 
@@ -54,25 +47,24 @@ describe('duplicateSubgraph', () => {
     expect(out[0].id).not.toBe('a')
   })
 
-  it('copies internal edges for A->B->C selection', () => {
+  it('copies nodes only by default', () => {
     const nodes = [n('a', 'prompt'), n('b', 'image'), n('c', 'video')]
-    const edges = [e('a', 'b'), e('b', 'c'), e('a', 'c')]
+    const edges = [e('a', 'b'), e('b', 'c')]
     const { nodes: outNodes, edges: outEdges } = duplicateSubgraph(nodes, edges, ['a', 'b', 'c'])
     expect(outNodes).toHaveLength(3)
-    expect(outEdges).toHaveLength(3)
-    for (const edge of outEdges) {
-      expect(outNodes.some((x) => x.id === edge.source)).toBe(true)
-      expect(outNodes.some((x) => x.id === edge.target)).toBe(true)
-    }
+    expect(outEdges).toHaveLength(0)
   })
 
-  it('upstream mode copies ref->img when only img selected', () => {
+  it('upstream mode links existing upstream to copy', () => {
     const nodes = [n('ref', 'image'), n('img', 'image')]
     const edges = [e('ref', 'img')]
-    const sourceIds = resolveDuplicateSourceIds(nodes, edges, 'img', ['img'], 'upstream')
-    const { nodes: outNodes, edges: outEdges } = duplicateSubgraph(nodes, edges, sourceIds)
-    expect(outNodes).toHaveLength(2)
+    const { nodes: outNodes, edges: outEdges } = duplicateSubgraph(nodes, edges, ['img'], {
+      edgeMode: 'upstream',
+    })
+    expect(outNodes).toHaveLength(1)
     expect(outEdges).toHaveLength(1)
+    expect(outEdges[0].source).toBe('ref')
+    expect(outEdges[0].target).toBe(outNodes[0].id)
   })
 
   it('offsets duplicated positions', () => {

--- a/packages/shared/src/canvas/duplicateSubgraph.test.ts
+++ b/packages/shared/src/canvas/duplicateSubgraph.test.ts
@@ -25,19 +25,18 @@ const e = (source: string, target: string): DuplicateCanvasEdge => ({
   target,
 })
 
-describe('resolveDuplicateSourceIds upstream', () => {
-  it('adds only direct upstream nodes for single seed', () => {
+describe('resolveDuplicateSourceIds', () => {
+  it('does not expand upstream nodes into copy set', () => {
     const nodes = [n('ref'), n('img')]
     const edges = [e('ref', 'img')]
     const ids = resolveDuplicateSourceIds(nodes, edges, 'img', ['img'], 'upstream')
-    expect(ids.sort()).toEqual(['img', 'ref'])
+    expect(ids).toEqual(['img'])
   })
 
-  it('does not recurse upstream chain', () => {
-    const nodes = [n('a', 'prompt'), n('b', 'prompt'), n('c', 'image')]
-    const edges = [e('a', 'b'), e('b', 'c')]
-    const ids = resolveDuplicateSourceIds(nodes, edges, 'c', ['c'], 'upstream')
-    expect(ids.sort()).toEqual(['b', 'c'])
+  it('uses multi-select when context is in selection', () => {
+    const nodes = [n('a', 'prompt'), n('b', 'image')]
+    const ids = resolveDuplicateSourceIds(nodes, [], 'b', ['a', 'b'], 'none')
+    expect(ids.sort()).toEqual(['a', 'b'])
   })
 })
 
@@ -48,31 +47,59 @@ describe('duplicateSubgraph', () => {
         data: { generationRecordId: 'g1', url: 'u', status: 'completed' },
       }),
     ]
-    const { nodes: out } = duplicateSubgraph(nodes, [], ['a'])
+    const { nodes: out, edges: outEdges } = duplicateSubgraph(nodes, [e('ref', 'a')], ['a'])
+    expect(out).toHaveLength(1)
     expect(out[0].data?.generationRecordId).toBeUndefined()
     expect(out[0].data?.url).toBe('u')
     expect(out[0].id).not.toBe('a')
+    expect(outEdges).toHaveLength(0)
   })
 
-  it('copies internal edges for A->B->C selection', () => {
-    const nodes = [n('a', 'prompt'), n('b', 'image'), n('c', 'video')]
-    const edges = [e('a', 'b'), e('b', 'c'), e('a', 'c')]
-    const { nodes: outNodes, edges: outEdges } = duplicateSubgraph(nodes, edges, ['a', 'b', 'c'])
-    expect(outNodes).toHaveLength(3)
-    expect(outEdges).toHaveLength(3)
-    for (const edge of outEdges) {
-      expect(outNodes.some((x) => x.id === edge.source)).toBe(true)
-      expect(outNodes.some((x) => x.id === edge.target)).toBe(true)
-    }
+  it('default mode copies nodes only without edges', () => {
+    const nodes = [n('a', 'prompt'), n('b', 'image')]
+    const edges = [e('a', 'b')]
+    const { nodes: outNodes, edges: outEdges } = duplicateSubgraph(nodes, edges, ['a', 'b'])
+    expect(outNodes).toHaveLength(2)
+    expect(outEdges).toHaveLength(0)
   })
 
-  it('upstream mode copies ref->img when only img selected', () => {
+  it('upstream mode reuses upstream node and links to copy', () => {
     const nodes = [n('ref', 'image'), n('img', 'image')]
     const edges = [e('ref', 'img')]
-    const sourceIds = resolveDuplicateSourceIds(nodes, edges, 'img', ['img'], 'upstream')
-    const { nodes: outNodes, edges: outEdges } = duplicateSubgraph(nodes, edges, sourceIds)
-    expect(outNodes).toHaveLength(2)
+    const { nodes: outNodes, edges: outEdges } = duplicateSubgraph(nodes, edges, ['img'], {
+      edgeMode: 'upstream',
+    })
+    expect(outNodes).toHaveLength(1)
+    expect(outNodes[0].id).not.toBe('img')
     expect(outEdges).toHaveLength(1)
+    expect(outEdges[0].source).toBe('ref')
+    expect(outEdges[0].target).toBe(outNodes[0].id)
+  })
+
+  it('upstream mode does not duplicate internal edges among selection', () => {
+    const nodes = [n('p', 'prompt'), n('i', 'image'), n('v', 'video')]
+    const edges = [e('p', 'i'), e('i', 'v'), e('ext', 'p')]
+    const { nodes: outNodes, edges: outEdges } = duplicateSubgraph(
+      nodes,
+      edges,
+      ['p', 'i', 'v'],
+      { edgeMode: 'upstream' },
+    )
+    expect(outNodes).toHaveLength(3)
+    expect(outEdges).toHaveLength(1)
+    expect(outEdges[0].source).toBe('ext')
+    const copyP = outNodes.find((node) => node.type === 'prompt')!
+    expect(outEdges[0].target).toBe(copyP.id)
+  })
+
+  it('internal mode copies edges fully inside selection', () => {
+    const nodes = [n('a', 'prompt'), n('b', 'image'), n('c', 'video')]
+    const edges = [e('a', 'b'), e('b', 'c'), e('a', 'c')]
+    const { nodes: outNodes, edges: outEdges } = duplicateSubgraph(nodes, edges, ['a', 'b', 'c'], {
+      edgeMode: 'internal',
+    })
+    expect(outNodes).toHaveLength(3)
+    expect(outEdges).toHaveLength(3)
   })
 
   it('offsets duplicated positions', () => {

--- a/packages/shared/src/canvas/duplicateSubgraph.ts
+++ b/packages/shared/src/canvas/duplicateSubgraph.ts
@@ -72,10 +72,10 @@ function expandGroupClosure(nodes: DuplicateCanvasNode[], ids: string[]): string
 
 export function resolveDuplicateSourceIds(
   nodes: DuplicateCanvasNode[],
-  edges: DuplicateCanvasEdge[],
+  _edges: DuplicateCanvasEdge[],
   contextNodeId: string,
   multiSelectedIds: string[],
-  edgeMode: DuplicateEdgeMode = 'internal',
+  _edgeMode: DuplicateEdgeMode = 'none',
 ): string[] {
   let ids =
     multiSelectedIds.includes(contextNodeId) && multiSelectedIds.length > 1
@@ -83,14 +83,6 @@ export function resolveDuplicateSourceIds(
       : [contextNodeId]
 
   ids = expandGroupClosure(nodes, ids)
-
-  if (edgeMode === 'upstream' && ids.length === 1) {
-    const seed = ids[0]
-    const upstream = edges
-      .filter((edge) => edge.target === seed)
-      .map((edge) => edge.source)
-    ids = [...new Set([seed, ...upstream])]
-  }
 
   return ids.filter((id) => nodes.some((node) => node.id === id))
 }
@@ -143,7 +135,7 @@ export function duplicateSubgraph(
   options?: DuplicateSubgraphOptions,
 ): DuplicateSubgraphResult {
   const offset = options?.offset ?? DEFAULT_OFFSET
-  const edgeMode = options?.edgeMode ?? 'internal'
+  const edgeMode = options?.edgeMode ?? 'none'
   const createNodeId = options?.createNodeId ?? defaultCreateNodeId
   const idSet = new Set(expandGroupClosure(nodes, sourceIds))
   const idMap = new Map<string, string>()
@@ -193,7 +185,7 @@ export function duplicateSubgraph(
   }
 
   const newEdges: DuplicateCanvasEdge[] = []
-  if (edgeMode !== 'none') {
+  if (edgeMode === 'internal') {
     for (const edge of edges) {
       const newSource = idMap.get(edge.source)
       const newTarget = idMap.get(edge.target)
@@ -202,6 +194,18 @@ export function duplicateSubgraph(
         ...edge,
         id: `e-dup-${newSource}-${newTarget}`,
         source: newSource,
+        target: newTarget,
+      })
+    }
+  } else if (edgeMode === 'upstream') {
+    for (const edge of edges) {
+      if (!idSet.has(edge.target) || idSet.has(edge.source)) continue
+      const newTarget = idMap.get(edge.target)
+      if (!newTarget) continue
+      newEdges.push({
+        ...edge,
+        id: `e-dup-${edge.source}-${newTarget}`,
+        source: edge.source,
         target: newTarget,
       })
     }

--- a/services/agent-runtime/app/tools/definitions.py
+++ b/services/agent-runtime/app/tools/definitions.py
@@ -611,9 +611,9 @@ def _all_tool_specs(client: NestCanvasClient) -> list[tuple[str, StructuredTool]
                 coroutine=duplicate_node,
                 name="duplicate_node",
                 description=(
-                    "Duplicate canvas node(s) with internal edges preserved. "
-                    "Use node_ids for a selected subgraph; use node_id alone for a single node. "
-                    "Set include_upstream=true only for a single node when the upstream prompt/ref chain must be copied (one hop)."
+                    "Duplicate canvas node(s). Default: copy nodes only, no edges. "
+                    "Use node_ids for multi-select. "
+                    "Set include_upstream=true to reuse existing upstream nodes and connect them to the copies via inbound edges (edges only, upstream nodes are not duplicated)."
                 ),
                 args_schema=DuplicateNodeInput,
             ),


### PR DESCRIPTION
## Summary
- **新建副本**：仅复制选中节点，不含任何边
- **新建副本（含上游）**：复制选中节点 + 外部上游连入边（上游节点复用，不复制）；选区内部边不复制
- 多选时也显示「含上游」
- Agent `duplicate_node` / server 对齐同一语义

## Test plan
- [x] shared 12/12, web 9/9, server 51/51, build 通过
- [ ] 单选 Image + 含上游：Ref→Image'，Ref 不复制
- [ ] 多选 Prompt+Image + 含上游：仅 ext→Prompt'，无 Prompt'→Image'
- [ ] 新建副本：仅有节点副本，无边


Made with [Cursor](https://cursor.com)