### PR TITLE
feat(web): add duplicate actions to multi-select toolbar

### DIFF
--- a/apps/web/src/components/canvas/MultiSelectToolbar.vue
+++ b/apps/web/src/components/canvas/MultiSelectToolbar.vue
@@ -14,6 +14,8 @@ const emit = defineEmits<{
   generateVideo: []
   download: []
   addAgentRef: []
+  duplicate: []
+  duplicateUpstream: []
 }>()
 </script>
 
@@ -55,6 +57,22 @@ const emit = defineEmits<{
         @click="emit('group')"
       >
         打组
+      </button>
+      <button
+        v-if="selectedIds.length >= 2"
+        type="button"
+        class="toolbar-action"
+        @click="emit('duplicate')"
+      >
+        新建副本
+      </button>
+      <button
+        v-if="selectedIds.length >= 2"
+        type="button"
+        class="toolbar-action"
+        @click="emit('duplicateUpstream')"
+      >
+        新建副本（含上游）
       </button>
       <button
         v-if="selectedIds.length >= 2"

--- a/apps/web/src/components/canvas/MultiSelectToolbarOverlay.vue
+++ b/apps/web/src/components/canvas/MultiSelectToolbarOverlay.vue
@@ -18,6 +18,8 @@ const emit = defineEmits<{
   generateVideo: []
   download: []
   addAgentRef: []
+  duplicate: []
+  duplicateUpstream: []
 }>()
 
 const { viewport, nodes: flowNodes } = useVueFlow()
@@ -95,5 +97,7 @@ const visible = computed(() => props.selectedIds.length >= 2 || !!props.canUngro
     @generate-video="emit('generateVideo')"
     @download="emit('download')"
     @add-agent-ref="emit('addAgentRef')"
+    @duplicate="emit('duplicate')"
+    @duplicate-upstream="emit('duplicateUpstream')"
   />
 </template>

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -2151,6 +2151,12 @@ function handleKeyboardDuplicate() {
   handleDuplicateSelection(contextId, 'none')
 }
 
+function handleToolbarDuplicateUpstream() {
+  const contextId = multiSelectedIds.value[0]
+  if (!contextId) return
+  handleDuplicateSelection(contextId, 'upstream')
+}
+
 function panViewport(dx: number, dy: number) {
   const flow = vueFlowRef.value as {
     getViewport?: () => { x: number; y: number; zoom: number }
@@ -3006,6 +3012,8 @@ onUnmounted(() => {
             @generate-video="handleGenerateVideoFromSelection"
             @download="handlePackageDownload"
             @add-agent-ref="handleAddToAgentRefs()"
+            @duplicate="handleKeyboardDuplicate"
+            @duplicate-upstream="handleToolbarDuplicateUpstream"
           />
 
           <MultiSelectConnectOverlay


### PR DESCRIPTION
## Summary
- 框选多节点后，选区工具栏直接提供「新建副本」「新建副本（含上游）」
- 放在「打组」与「加入 Agent 引用」之间，避免框选后还要再开右键菜单
- 空白处右键仍打开节点创建菜单

## Test plan
- [x] 本地提交仅包含工具栏相关 3 个文件
- [ ] 框选 ≥2 节点后，选区底部出现两项复制入口
- [ ] 「新建副本」只复制节点、不含边
- [ ] 「新建副本（含上游）」复制选中节点并复用外部上游连入边
- [ ] 空白处右键仍打开创建节点菜单


Made with [Cursor](https://cursor.com)