### PR TITLE
feat(web): refine wand selection and disabled cutout slot

### DIFF
--- a/apps/web/src/components/canvas/refine/MaskEditor.vue
+++ b/apps/web/src/components/canvas/refine/MaskEditor.vue
@@ -3,8 +3,9 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { studioApi } from '@/services/studio-api'
 import { isMaskDrawReady, isRealBitmapSize } from './maskCanvasReady'
 import { countMaskPixelsFromImageData, exportMaskPng } from './maskExport'
+import { floodFillMask, invertMaskRgba, parseFillHex } from './maskWand'
 
-export type MaskTool = 'brush' | 'eraser' | 'rect'
+export type MaskTool = 'brush' | 'eraser' | 'rect' | 'wand'
 
 const props = withDefaults(
   defineProps<{
@@ -16,6 +17,7 @@ const props = withDefaults(
     disabled?: boolean
     surface?: 'panel' | 'node'
     color?: string
+    wandTolerance?: number
   }>(),
   {
     tool: 'brush',
@@ -23,6 +25,7 @@ const props = withDefaults(
     disabled: false,
     surface: 'panel',
     color: '#ffffff',
+    wandTolerance: 24,
   },
 )
 
@@ -42,6 +45,7 @@ let lastY = 0
 let rectStart: { x: number; y: number } | null = null
 let snapshot: ImageData | null = null
 let sizeToken = 0
+let imageRgba: Uint8ClampedArray | null = null
 
 function emitCoverage() {
   const canvas = canvasRef.value
@@ -70,6 +74,27 @@ function resizeCanvas(width: number, height: number) {
   canvas.height = nextHeight
   sizeReady.value = true
   emitCoverage()
+  loadImageRgba(nextWidth, nextHeight)
+}
+
+function loadImageRgba(width: number, height: number) {
+  imageRgba = null
+  const img = new Image()
+  img.crossOrigin = 'anonymous'
+  img.onload = () => {
+    const off = document.createElement('canvas')
+    off.width = width
+    off.height = height
+    const ctx = off.getContext('2d')
+    if (!ctx) return
+    ctx.drawImage(img, 0, 0, width, height)
+    try {
+      imageRgba = ctx.getImageData(0, 0, width, height).data
+    } catch {
+      imageRgba = null
+    }
+  }
+  img.src = props.url
 }
 
 async function resolveBitmapSize() {
@@ -103,6 +128,7 @@ watch(
   () => props.url,
   () => {
     sizeReady.value = false
+    imageRgba = null
     void resolveBitmapSize()
   },
 )
@@ -159,14 +185,41 @@ function applyToolStyle(ctx: CanvasRenderingContext2D) {
   }
 }
 
+function invertCanvas() {
+  const canvas = canvasRef.value
+  const ctx = canvas?.getContext('2d')
+  if (!canvas || !ctx) return
+  const mask = ctx.getImageData(0, 0, canvas.width, canvas.height)
+  const next = invertMaskRgba(mask.data)
+  ctx.putImageData(new ImageData(next, canvas.width, canvas.height), 0, 0)
+  emitCoverage()
+}
+
 function onPointerDown(event: PointerEvent) {
   if (!drawReady.value) return
   const canvas = canvasRef.value
   const ctx = canvas?.getContext('2d')
   if (!canvas || !ctx) return
+  const pt = canvasPoint(event)
+  if (props.tool === 'wand') {
+    if (!imageRgba) return
+    const mask = ctx.getImageData(0, 0, canvas.width, canvas.height)
+    const filled = floodFillMask({
+      width: canvas.width,
+      height: canvas.height,
+      imageRgba,
+      maskRgba: mask.data,
+      x: pt.x,
+      y: pt.y,
+      tolerance: props.wandTolerance,
+      fillRgb: parseFillHex(props.color),
+    })
+    ctx.putImageData(new ImageData(filled, canvas.width, canvas.height), 0, 0)
+    emitCoverage()
+    return
+  }
   canvas.setPointerCapture(event.pointerId)
   drawing = true
-  const pt = canvasPoint(event)
   lastX = pt.x
   lastY = pt.y
   applyToolStyle(ctx)
@@ -179,6 +232,7 @@ function onPointerDown(event: PointerEvent) {
 }
 
 function onPointerMove(event: PointerEvent) {
+  if (props.tool === 'wand') return
   if (!drawing || !drawReady.value) return
   const canvas = canvasRef.value
   const ctx = canvas?.getContext('2d')
@@ -227,6 +281,7 @@ defineExpose({
   getCanvas: () => canvasRef.value,
   exportPng,
   clear: clearCanvas,
+  invert: invertCanvas,
 })
 </script>
 

--- a/apps/web/src/components/canvas/refine/MaskEditor.vue
+++ b/apps/web/src/components/canvas/refine/MaskEditor.vue
@@ -185,13 +185,17 @@ function applyToolStyle(ctx: CanvasRenderingContext2D) {
   }
 }
 
+function putRgba(ctx: CanvasRenderingContext2D, rgba: Uint8ClampedArray, width: number, height: number) {
+  const data = new Uint8ClampedArray(rgba)
+  ctx.putImageData(new ImageData(data, width, height), 0, 0)
+}
+
 function invertCanvas() {
   const canvas = canvasRef.value
   const ctx = canvas?.getContext('2d')
   if (!canvas || !ctx) return
   const mask = ctx.getImageData(0, 0, canvas.width, canvas.height)
-  const next = invertMaskRgba(mask.data)
-  ctx.putImageData(new ImageData(next, canvas.width, canvas.height), 0, 0)
+  putRgba(ctx, invertMaskRgba(mask.data), canvas.width, canvas.height)
   emitCoverage()
 }
 
@@ -214,7 +218,7 @@ function onPointerDown(event: PointerEvent) {
       tolerance: props.wandTolerance,
       fillRgb: parseFillHex(props.color),
     })
-    ctx.putImageData(new ImageData(filled, canvas.width, canvas.height), 0, 0)
+    putRgba(ctx, filled, canvas.width, canvas.height)
     emitCoverage()
     return
   }

--- a/apps/web/src/components/canvas/refine/RefineSidePanel.vue
+++ b/apps/web/src/components/canvas/refine/RefineSidePanel.vue
@@ -151,6 +151,12 @@ function onBrushColorInput(event: Event) {
   editor.setRefineBrushColor(target.value)
 }
 
+function onWandToleranceInput(event: Event) {
+  const target = event.target
+  if (!(target instanceof HTMLInputElement)) return
+  editor.setRefineWandTolerance(Number(target.value))
+}
+
 function onSelectVersion(versionId: string) {
   if (busy.value) return
   const version = props.versions.find((item) => item.id === versionId)
@@ -511,6 +517,41 @@ onBeforeUnmount(() => {
               </button>
             </template>
           </div>
+          <div class="refine-side__icon-row">
+            <button
+              type="button"
+              class="refine-side__icon-btn"
+              :class="{ 'is-active': editor.refineTool === 'wand' }"
+              title="魔棒"
+              :disabled="busy"
+              @click="editor.refineTool = 'wand'"
+            >
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75">
+                <path stroke-linecap="round" d="M7 17 17 7" />
+                <path d="M15.5 5.5 18.5 8.5 9 18H6v-3Z" />
+              </svg>
+            </button>
+            <template v-if="editor.refineTool === 'wand'">
+              <label class="refine-side__slider" title="魔棒容差">
+                <input
+                  type="range"
+                  min="0"
+                  max="48"
+                  step="1"
+                  :value="editor.refineWandTolerance"
+                  :disabled="busy"
+                  @input="onWandToleranceInput"
+                >
+                <span>{{ editor.refineWandTolerance }}</span>
+              </label>
+              <button type="button" class="refine-side__icon-btn" title="反向选区" :disabled="busy" @click="editor.getRefineMask()?.invert()">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75">
+                  <circle cx="12" cy="12" r="7" />
+                  <path d="M12 5a7 7 0 0 1 0 14Z" fill="currentColor" stroke="none" />
+                </svg>
+              </button>
+            </template>
+          </div>
         </div>
 
         <div class="refine-dock__chips">
@@ -540,6 +581,7 @@ onBeforeUnmount(() => {
         <div class="bottom-toolbar-actions refine-dock__actions">
           <DockCreditBadge :credits="credits" />
           <button type="button" class="refine-dock__primary" :disabled="refineDisabled" @click="runRefine">精修</button>
+          <button type="button" class="refine-dock__apply" disabled title="抠图将走专用通道，尚未接入">抠图</button>
           <button v-if="canApply" type="button" class="refine-dock__apply" :disabled="busy" @click="onApply">应用到节点</button>
         </div>
 

--- a/apps/web/src/components/canvas/refine/RefineWorkViewport.vue
+++ b/apps/web/src/components/canvas/refine/RefineWorkViewport.vue
@@ -158,6 +158,7 @@ watch([maskRef], async () => {
     exportPng: () => maskRef.value!.exportPng(),
     clear: () => maskRef.value!.clear(),
     getCanvas: () => maskRef.value!.getCanvas(),
+    invert: () => maskRef.value?.invert(),
   })
 }, { immediate: true })
 
@@ -211,6 +212,7 @@ onBeforeUnmount(() => {
               :tool="editor.refineTool"
               :brush-size="editor.refineBrushSize"
               :color="editor.refineBrushColor"
+              :wand-tolerance="editor.refineWandTolerance"
               :disabled="editor.refineBusy || spaceDown"
               @coverage="(p) => { editor.refineCoverage = p.ratio }"
             />

--- a/apps/web/src/components/canvas/refine/maskWand.test.ts
+++ b/apps/web/src/components/canvas/refine/maskWand.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import { clampWandTolerance, floodFillMask, invertMaskRgba, parseFillHex } from './maskWand'
+
+function rgba(pixels: number[]): Uint8ClampedArray {
+  return new Uint8ClampedArray(pixels)
+}
+
+describe('clampWandTolerance', () => {
+  it('clamps to 0–48 and defaults non-finite to 24', () => {
+    expect(clampWandTolerance(-1)).toBe(0)
+    expect(clampWandTolerance(49)).toBe(48)
+    expect(clampWandTolerance(24.6)).toBe(25)
+    expect(clampWandTolerance(Number.NaN)).toBe(24)
+  })
+})
+
+describe('parseFillHex', () => {
+  it('parses #rrggbb and falls back to white', () => {
+    expect(parseFillHex('#22d3ee')).toEqual([34, 211, 238])
+    expect(parseFillHex('bad')).toEqual([255, 255, 255])
+  })
+})
+
+describe('floodFillMask', () => {
+  it('fills a 4-connected same-color run and leaves other pixels', () => {
+    const image = rgba([255, 0, 0, 255, 255, 0, 0, 255, 0, 0, 255, 255])
+    const mask = rgba(new Array(12).fill(0))
+    const next = floodFillMask({
+      width: 3,
+      height: 1,
+      imageRgba: image,
+      maskRgba: mask,
+      x: 0,
+      y: 0,
+      tolerance: 0,
+      fillRgb: [255, 255, 255],
+    })
+    expect([...next.slice(0, 8)]).toEqual([255, 255, 255, 255, 255, 255, 255, 255])
+    expect([...next.slice(8, 12)]).toEqual([0, 0, 0, 0])
+  })
+
+  it('does not fill diagonally and respects tolerance', () => {
+    const image = rgba([
+      255, 0, 0, 255, 0, 0, 255, 255,
+      0, 0, 255, 255, 255, 0, 0, 255,
+    ])
+    const mask = rgba(new Array(16).fill(0))
+    const next = floodFillMask({
+      width: 2,
+      height: 2,
+      imageRgba: image,
+      maskRgba: mask,
+      x: 0,
+      y: 0,
+      tolerance: 0,
+      fillRgb: [9, 9, 9],
+    })
+    expect([...next.slice(0, 4)]).toEqual([9, 9, 9, 255])
+    expect([...next.slice(4, 8)]).toEqual([0, 0, 0, 0])
+    expect([...next.slice(8, 12)]).toEqual([0, 0, 0, 0])
+    expect([...next.slice(12, 16)]).toEqual([0, 0, 0, 0])
+  })
+
+  it('returns the original mask buffer unchanged on invalid input', () => {
+    const mask = rgba([1, 2, 3, 4])
+    const out = floodFillMask({
+      width: 2,
+      height: 2,
+      imageRgba: rgba([0, 0, 0, 255]),
+      maskRgba: mask,
+      x: 0,
+      y: 0,
+      tolerance: 0,
+      fillRgb: [255, 255, 255],
+    })
+    expect(out).toBe(mask)
+  })
+
+  it('covers more pixels when tolerance increases on a gradient', () => {
+    const image = rgba([0, 0, 0, 255, 20, 0, 0, 255, 40, 0, 0, 255])
+    const empty = () => rgba(new Array(12).fill(0))
+    const tight = floodFillMask({
+      width: 3,
+      height: 1,
+      imageRgba: image,
+      maskRgba: empty(),
+      x: 0,
+      y: 0,
+      tolerance: 10,
+      fillRgb: [255, 255, 255],
+    })
+    const wide = floodFillMask({
+      width: 3,
+      height: 1,
+      imageRgba: image,
+      maskRgba: empty(),
+      x: 0,
+      y: 0,
+      tolerance: 40,
+      fillRgb: [255, 255, 255],
+    })
+    const count = (m: Uint8ClampedArray) => {
+      let n = 0
+      for (let i = 3; i < m.length; i += 4) if (m[i] > 127) n += 1
+      return n
+    }
+    expect(count(tight)).toBe(1)
+    expect(count(wide)).toBe(3)
+  })
+})
+
+describe('invertMaskRgba', () => {
+  it('swaps opaque edit pixels with empty keep pixels as white+A255', () => {
+    const mask = rgba([255, 255, 255, 255, 0, 0, 0, 0])
+    const next = invertMaskRgba(mask)
+    expect([...next]).toEqual([0, 0, 0, 0, 255, 255, 255, 255])
+  })
+})

--- a/apps/web/src/components/canvas/refine/maskWand.ts
+++ b/apps/web/src/components/canvas/refine/maskWand.ts
@@ -1,0 +1,99 @@
+export function clampWandTolerance(n: number): number {
+  if (!Number.isFinite(n)) return 24
+  return Math.min(48, Math.max(0, Math.round(n)))
+}
+
+export function parseFillHex(color: string): [number, number, number] {
+  const m = /^#([0-9a-fA-F]{6})$/.exec(color.trim())
+  if (!m) return [255, 255, 255]
+  const n = Number.parseInt(m[1], 16)
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255]
+}
+
+export function invertMaskRgba(maskRgba: Uint8ClampedArray): Uint8ClampedArray {
+  const next = new Uint8ClampedArray(maskRgba)
+  for (let i = 0; i < next.length; i += 4) {
+    if (next[i + 3] > 127) {
+      next[i] = 0
+      next[i + 1] = 0
+      next[i + 2] = 0
+      next[i + 3] = 0
+    } else {
+      next[i] = 255
+      next[i + 1] = 255
+      next[i + 2] = 255
+      next[i + 3] = 255
+    }
+  }
+  return next
+}
+
+export function floodFillMask(input: {
+  width: number
+  height: number
+  imageRgba: Uint8ClampedArray
+  maskRgba: Uint8ClampedArray
+  x: number
+  y: number
+  tolerance: number
+  fillRgb: [number, number, number]
+}): Uint8ClampedArray {
+  const { width, height, imageRgba, maskRgba, fillRgb } = input
+  const expected = width * height * 4
+  if (
+    width <= 0 ||
+    height <= 0 ||
+    imageRgba.length !== expected ||
+    maskRgba.length !== expected
+  ) {
+    return maskRgba
+  }
+  const x0 = Math.floor(input.x)
+  const y0 = Math.floor(input.y)
+  if (x0 < 0 || y0 < 0 || x0 >= width || y0 >= height) return maskRgba
+
+  const next = new Uint8ClampedArray(maskRgba)
+  const seed = (y0 * width + x0) * 4
+  const sr = imageRgba[seed]
+  const sg = imageRgba[seed + 1]
+  const sb = imageRgba[seed + 2]
+  const tol = clampWandTolerance(input.tolerance)
+  const seen = new Uint8Array(width * height)
+  const qx = [x0]
+  const qy = [y0]
+  seen[y0 * width + x0] = 1
+
+  const inTol = (ix: number, iy: number) => {
+    const o = (iy * width + ix) * 4
+    const dr = Math.abs(imageRgba[o] - sr)
+    const dg = Math.abs(imageRgba[o + 1] - sg)
+    const db = Math.abs(imageRgba[o + 2] - sb)
+    return Math.max(dr, dg, db) <= tol
+  }
+
+  while (qx.length) {
+    const x = qx.pop()!
+    const y = qy.pop()!
+    const o = (y * width + x) * 4
+    next[o] = fillRgb[0]
+    next[o + 1] = fillRgb[1]
+    next[o + 2] = fillRgb[2]
+    next[o + 3] = 255
+    const nbs = [
+      [x - 1, y],
+      [x + 1, y],
+      [x, y - 1],
+      [x, y + 1],
+    ]
+    for (const [nx, ny] of nbs) {
+      if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue
+      const idx = ny * width + nx
+      if (seen[idx]) continue
+      if (!inTol(nx, ny)) continue
+      seen[idx] = 1
+      qx.push(nx)
+      qy.push(ny)
+    }
+  }
+  return next
+}

--- a/apps/web/src/stores/canvasEditor.refine.test.ts
+++ b/apps/web/src/stores/canvasEditor.refine.test.ts
@@ -69,6 +69,7 @@ describe('canvasEditor refine target', () => {
       exportPng: async () => new Blob(),
       clear: () => {},
       getCanvas: () => null,
+      invert: () => {},
     }
     editor.registerRefineMask(handle)
     expect(editor.getRefineMask()).toBe(handle)
@@ -122,5 +123,16 @@ describe('canvasEditor refine target', () => {
     editor.openImageEditor({ nodeId: 'n1', url: 'https://cdn/a.png' })
     editor.closeImageEditor()
     expect(editor.refinePanelCollapsed).toBe(false)
+  })
+
+  it('resets wand tolerance when the session closes', () => {
+    setActivePinia(createPinia())
+    const editor = useCanvasEditorStore()
+    editor.refineTool = 'wand'
+    editor.setRefineWandTolerance(40)
+    editor.openImageEditor({ nodeId: 'n1', url: 'https://cdn/a.png' })
+    editor.closeImageEditor()
+    expect(editor.refineTool).toBe('brush')
+    expect(editor.refineWandTolerance).toBe(24)
   })
 })

--- a/apps/web/src/stores/canvasEditor.ts
+++ b/apps/web/src/stores/canvasEditor.ts
@@ -3,8 +3,9 @@ import { ref, shallowRef } from 'vue'
 import type { MediaInfo } from '@lnkpi/shared'
 import type { RefineChromeMode } from '@/utils/refineChrome'
 import { clampLoupeZoom } from '@/components/canvas/refine/refineWorkLayout'
+import { clampWandTolerance } from '@/components/canvas/refine/maskWand'
 
-export type RefineMaskTool = 'brush' | 'eraser' | 'rect'
+export type RefineMaskTool = 'brush' | 'eraser' | 'rect' | 'wand'
 export type RefineLoupeShape = 'circle' | 'rect'
 
 export interface ImageEditTarget {
@@ -26,6 +27,7 @@ export type RefineMaskHandle = {
   exportPng: () => Promise<Blob>
   clear: () => void
   getCanvas: () => HTMLCanvasElement | null
+  invert: () => void
 }
 
 export const useCanvasEditorStore = defineStore('canvasEditor', () => {
@@ -43,6 +45,7 @@ export const useCanvasEditorStore = defineStore('canvasEditor', () => {
   const refineLoupeZoom = ref(2.5)
   const refineBrushColor = ref('#22d3ee')
   const refineMaskMenuOpen = ref(false)
+  const refineWandTolerance = ref(24)
   const refinePanelWidth = ref(400)
   const refinePanelCollapsed = ref(false)
 
@@ -58,6 +61,7 @@ export const useCanvasEditorStore = defineStore('canvasEditor', () => {
     refineLoupeZoom.value = 2.5
     refineBrushColor.value = '#22d3ee'
     refineMaskMenuOpen.value = false
+    refineWandTolerance.value = 24
     refinePanelWidth.value = 400
     refinePanelCollapsed.value = false
   }
@@ -114,6 +118,10 @@ export const useCanvasEditorStore = defineStore('canvasEditor', () => {
     refineMaskMenuOpen.value = open
   }
 
+  function setRefineWandTolerance(n: number) {
+    refineWandTolerance.value = clampWandTolerance(n)
+  }
+
   function setRefinePanelWidth(width: number) {
     refinePanelWidth.value = width
   }
@@ -143,6 +151,7 @@ export const useCanvasEditorStore = defineStore('canvasEditor', () => {
     refineLoupeZoom,
     refineBrushColor,
     refineMaskMenuOpen,
+    refineWandTolerance,
     refinePanelWidth,
     refinePanelCollapsed,
     openImageEditor,
@@ -157,6 +166,7 @@ export const useCanvasEditorStore = defineStore('canvasEditor', () => {
     setRefineLoupeZoom,
     setRefineBrushColor,
     setRefineMaskMenuOpen,
+    setRefineWandTolerance,
     setRefinePanelWidth,
     setRefinePanelCollapsed,
     previewTarget,

--- a/docs/superpowers/plans/2026-08-19-cx-image-edit-toolchain.md
+++ b/docs/superpowers/plans/2026-08-19-cx-image-edit-toolchain.md
@@ -1,0 +1,551 @@
+# 画布精修工具链第一刀（魔棒 + 反向 + 抠图槽）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在精修选区链加入前端魔棒与反向选区；作业链露出禁用的「抠图」槽，不接上游、不声称 remove_bg。
+
+**Architecture:** 纯函数 `floodFillMask` / `invertMaskRgba` / `clampWandTolerance` 先单测。`MaskEditor` 在 `tool === 'wand'` 时对工作图位图单击一次 BFS 写入 mask。Store 增加 `wand` 工具与容差并在关精修时复位。侧栏选区行与作业行分离。后端、EditProvider、capabilities 不动。
+
+**Tech Stack:** Vue 3 + Pinia、Vitest、现有 MaskEditor canvas
+
+**Spec:** `docs/superpowers/specs/2026-08-19-cx-image-edit-toolchain-design.md`
+
+## Global Constraints
+
+- **禁止**改 `ImageProvider.generate()` / `buildImageProviderOptions()` / `run_icon_refine` / Prisma / `/image-studio`
+- **禁止**用 inpaint +「去背景」prompt 冒充抠图
+- **禁止**改 `get_image_edit_capabilities` 或把 `supportedModes` 加成 `remove_bg` / `crop` / `outpaint`
+- 魔棒 / 反向 / 清除 **不扣分**；「精修」仍 10 分、`chargeReason: '图像精修'`
+- 魔棒：4 连通；容差 `max(|ΔR|,|ΔG|,|ΔB|) ≤ n`；n ∈ [0, 48]，默认 24
+- 多次魔棒点击 **并入** mask，不先清空；不做魔棒减选
+- 对照不扩展（无上下擦除 / 溶解 / 闪光）
+- 无 SAM、无文本指代、无 CutoutProvider
+- TDD：先写失败测试再实现；提交前缀 `feat:`
+- 不 `git add -A`；勿提交 `.seedream-backup`、`deploy/`、`q.js`
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `apps/web/src/components/canvas/refine/maskWand.ts` | `clampWandTolerance`、`parseFillHex`、`floodFillMask`、`invertMaskRgba` |
+| `apps/web/src/components/canvas/refine/maskWand.test.ts` | 上述纯函数单测 |
+| `apps/web/src/stores/canvasEditor.ts` | `RefineMaskTool` 加 `'wand'`；`refineWandTolerance`；handle `invert` |
+| `apps/web/src/stores/canvasEditor.refine.test.ts` | wand 复位断言 |
+| `apps/web/src/components/canvas/refine/MaskEditor.vue` | wand 单击 fill；`invert()`；缓存底图 RGBA |
+| `apps/web/src/components/canvas/refine/RefineWorkViewport.vue` | 传入 `wand-tolerance` |
+| `apps/web/src/components/canvas/refine/RefineSidePanel.vue` | 魔棒 + 容差 + 反向；禁用「抠图」 |
+
+---
+
+### Task 0: 分支
+
+- [ ] **Step 1:** 当前应在已含 toolchain spec 的 `docs/cx-image-edit-toolchain`（commit 含 `2026-08-19-cx-image-edit-toolchain-design.md`）。
+
+```bash
+git checkout docs/cx-image-edit-toolchain
+git checkout -b feature/cx-image-edit-toolchain
+```
+
+- [ ] **Step 2:** 基线测试
+
+```bash
+pnpm --filter @lnkpi/web test -- src/stores/canvasEditor.refine.test.ts src/components/canvas/refine/maskExport.test.ts
+```
+
+Expected: PASS
+
+---
+
+### Task 1: 魔棒 / 反向纯函数
+
+**Files:**
+- Create: `apps/web/src/components/canvas/refine/maskWand.ts`
+- Create: `apps/web/src/components/canvas/refine/maskWand.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `export function clampWandTolerance(n: number): number`
+  - `export function parseFillHex(color: string): [number, number, number]`
+  - `export function floodFillMask(input: { width: number; height: number; imageRgba: Uint8ClampedArray; maskRgba: Uint8ClampedArray; x: number; y: number; tolerance: number; fillRgb: [number, number, number] }): Uint8ClampedArray`
+  - `export function invertMaskRgba(maskRgba: Uint8ClampedArray): Uint8ClampedArray`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/canvas/refine/maskWand.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { clampWandTolerance, floodFillMask, invertMaskRgba, parseFillHex } from './maskWand'
+
+function rgba(pixels: number[]): Uint8ClampedArray {
+  return new Uint8ClampedArray(pixels)
+}
+
+describe('clampWandTolerance', () => {
+  it('clamps to 0–48 and defaults non-finite to 24', () => {
+    expect(clampWandTolerance(-1)).toBe(0)
+    expect(clampWandTolerance(49)).toBe(48)
+    expect(clampWandTolerance(24.6)).toBe(25)
+    expect(clampWandTolerance(Number.NaN)).toBe(24)
+  })
+})
+
+describe('parseFillHex', () => {
+  it('parses #rrggbb and falls back to white', () => {
+    expect(parseFillHex('#22d3ee')).toEqual([34, 211, 238])
+    expect(parseFillHex('bad')).toEqual([255, 255, 255])
+  })
+})
+
+describe('floodFillMask', () => {
+  it('fills a 4-connected same-color run and leaves other pixels', () => {
+    // 3x1: red, red, blue
+    const image = rgba([255, 0, 0, 255, 255, 0, 0, 255, 0, 0, 255, 255])
+    const mask = rgba(new Array(12).fill(0))
+    const next = floodFillMask({
+      width: 3,
+      height: 1,
+      imageRgba: image,
+      maskRgba: mask,
+      x: 0,
+      y: 0,
+      tolerance: 0,
+      fillRgb: [255, 255, 255],
+    })
+    expect([...next.slice(0, 8)]).toEqual([255, 255, 255, 255, 255, 255, 255, 255])
+    expect([...next.slice(8, 12)]).toEqual([0, 0, 0, 0])
+  })
+
+  it('does not fill diagonally and respects tolerance', () => {
+    // 2x2: R B / B R  — click (0,0) tol 0 fills only one pixel
+    const image = rgba([
+      255, 0, 0, 255, 0, 0, 255, 255,
+      0, 0, 255, 255, 255, 0, 0, 255,
+    ])
+    const mask = rgba(new Array(16).fill(0))
+    const next = floodFillMask({
+      width: 2,
+      height: 2,
+      imageRgba: image,
+      maskRgba: mask,
+      x: 0,
+      y: 0,
+      tolerance: 0,
+      fillRgb: [9, 9, 9],
+    })
+    expect([...next.slice(0, 4)]).toEqual([9, 9, 9, 255])
+    expect([...next.slice(4, 8)]).toEqual([0, 0, 0, 0])
+    expect([...next.slice(8, 12)]).toEqual([0, 0, 0, 0])
+    expect([...next.slice(12, 16)]).toEqual([0, 0, 0, 0])
+  })
+
+  it('returns the original mask buffer unchanged on invalid input', () => {
+    const mask = rgba([1, 2, 3, 4])
+    const out = floodFillMask({
+      width: 2,
+      height: 2,
+      imageRgba: rgba([0, 0, 0, 255]),
+      maskRgba: mask,
+      x: 0,
+      y: 0,
+      tolerance: 0,
+      fillRgb: [255, 255, 255],
+    })
+    expect(out).toBe(mask)
+  })
+
+  it('covers more pixels when tolerance increases on a gradient', () => {
+    const image = rgba([0, 0, 0, 255, 20, 0, 0, 255, 40, 0, 0, 255])
+    const empty = () => rgba(new Array(12).fill(0))
+    const tight = floodFillMask({
+      width: 3,
+      height: 1,
+      imageRgba: image,
+      maskRgba: empty(),
+      x: 0,
+      y: 0,
+      tolerance: 10,
+      fillRgb: [255, 255, 255],
+    })
+    const wide = floodFillMask({
+      width: 3,
+      height: 1,
+      imageRgba: image,
+      maskRgba: empty(),
+      x: 0,
+      y: 0,
+      tolerance: 40,
+      fillRgb: [255, 255, 255],
+    })
+    const count = (m: Uint8ClampedArray) => {
+      let n = 0
+      for (let i = 3; i < m.length; i += 4) if (m[i] > 127) n += 1
+      return n
+    }
+    expect(count(tight)).toBe(1)
+    expect(count(wide)).toBe(3)
+  })
+})
+
+describe('invertMaskRgba', () => {
+  it('swaps opaque edit pixels with empty keep pixels as white+A255', () => {
+    const mask = rgba([255, 255, 255, 255, 0, 0, 0, 0])
+    const next = invertMaskRgba(mask)
+    expect([...next]).toEqual([0, 0, 0, 0, 255, 255, 255, 255])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm --filter @lnkpi/web test -- src/components/canvas/refine/maskWand.test.ts
+```
+
+Expected: FAIL (module not found)
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `apps/web/src/components/canvas/refine/maskWand.ts`:
+
+```ts
+export function clampWandTolerance(n: number): number {
+  if (!Number.isFinite(n)) return 24
+  return Math.min(48, Math.max(0, Math.round(n)))
+}
+
+export function parseFillHex(color: string): [number, number, number] {
+  const m = /^#([0-9a-fA-F]{6})$/.exec(color.trim())
+  if (!m) return [255, 255, 255]
+  const n = Number.parseInt(m[1], 16)
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255]
+}
+
+export function invertMaskRgba(maskRgba: Uint8ClampedArray): Uint8ClampedArray {
+  const next = new Uint8ClampedArray(maskRgba)
+  for (let i = 0; i < next.length; i += 4) {
+    if (next[i + 3] > 127) {
+      next[i] = 0
+      next[i + 1] = 0
+      next[i + 2] = 0
+      next[i + 3] = 0
+    } else {
+      next[i] = 255
+      next[i + 1] = 255
+      next[i + 2] = 255
+      next[i + 3] = 255
+    }
+  }
+  return next
+}
+
+export function floodFillMask(input: {
+  width: number
+  height: number
+  imageRgba: Uint8ClampedArray
+  maskRgba: Uint8ClampedArray
+  x: number
+  y: number
+  tolerance: number
+  fillRgb: [number, number, number]
+}): Uint8ClampedArray {
+  const { width, height, imageRgba, maskRgba, fillRgb } = input
+  const expected = width * height * 4
+  if (
+    width <= 0 ||
+    height <= 0 ||
+    imageRgba.length !== expected ||
+    maskRgba.length !== expected
+  ) {
+    return maskRgba
+  }
+  const x0 = Math.floor(input.x)
+  const y0 = Math.floor(input.y)
+  if (x0 < 0 || y0 < 0 || x0 >= width || y0 >= height) return maskRgba
+
+  const next = new Uint8ClampedArray(maskRgba)
+  const seed = (y0 * width + x0) * 4
+  const sr = imageRgba[seed]
+  const sg = imageRgba[seed + 1]
+  const sb = imageRgba[seed + 2]
+  const tol = clampWandTolerance(input.tolerance)
+  const seen = new Uint8Array(width * height)
+  const qx = [x0]
+  const qy = [y0]
+  seen[y0 * width + x0] = 1
+
+  const inTol = (ix: number, iy: number) => {
+    const o = (iy * width + ix) * 4
+    const dr = Math.abs(imageRgba[o] - sr)
+    const dg = Math.abs(imageRgba[o + 1] - sg)
+    const db = Math.abs(imageRgba[o + 2] - sb)
+    return Math.max(dr, dg, db) <= tol
+  }
+
+  while (qx.length) {
+    const x = qx.pop()!
+    const y = qy.pop()!
+    const o = (y * width + x) * 4
+    next[o] = fillRgb[0]
+    next[o + 1] = fillRgb[1]
+    next[o + 2] = fillRgb[2]
+    next[o + 3] = 255
+    const nbs = [
+      [x - 1, y],
+      [x + 1, y],
+      [x, y - 1],
+      [x, y + 1],
+    ]
+    for (const [nx, ny] of nbs) {
+      if (nx < 0 || ny < 0 || nx >= width || ny >= height) continue
+      const idx = ny * width + nx
+      if (seen[idx]) continue
+      if (!inTol(nx, ny)) continue
+      seen[idx] = 1
+      qx.push(nx)
+      qy.push(ny)
+    }
+  }
+  return next
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pnpm --filter @lnkpi/web test -- src/components/canvas/refine/maskWand.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/canvas/refine/maskWand.ts apps/web/src/components/canvas/refine/maskWand.test.ts
+git commit -m "feat(web): add mask wand flood-fill and invert helpers"
+```
+
+---
+
+### Task 2: Store 工具与容差
+
+**Files:**
+- Modify: `apps/web/src/stores/canvasEditor.ts`
+- Modify: `apps/web/src/stores/canvasEditor.refine.test.ts`
+
+**Interfaces:**
+- Consumes: `clampWandTolerance` from `maskWand.ts`
+- Produces: `RefineMaskTool` includes `'wand'`; `refineWandTolerance`; `RefineMaskHandle.invert?: () => void`（实现于 Task 3，本任务类型先加上）
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/web/src/stores/canvasEditor.refine.test.ts`:
+
+```ts
+  it('resets wand tolerance when the session closes', () => {
+    setActivePinia(createPinia())
+    const editor = useCanvasEditorStore()
+    editor.refineTool = 'wand'
+    editor.setRefineWandTolerance(40)
+    editor.openImageEditor({ nodeId: 'n1', url: 'https://cdn/a.png' })
+    editor.closeImageEditor()
+    expect(editor.refineTool).toBe('brush')
+    expect(editor.refineWandTolerance).toBe(24)
+  })
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm --filter @lnkpi/web test -- src/stores/canvasEditor.refine.test.ts
+```
+
+Expected: FAIL (`setRefineWandTolerance` / `refineWandTolerance` missing)
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `apps/web/src/stores/canvasEditor.ts`:
+
+- Change `export type RefineMaskTool = 'brush' | 'eraser' | 'rect' | 'wand'`
+- Add to `RefineMaskHandle`: `invert: () => void`
+- `import { clampWandTolerance } from '@/components/canvas/refine/maskWand'`
+- `const refineWandTolerance = ref(24)`
+- In `resetRefineChromeState`: `refineWandTolerance.value = 24`
+- `function setRefineWandTolerance(n: number) { refineWandTolerance.value = clampWandTolerance(n) }`
+- Export `refineWandTolerance` and `setRefineWandTolerance`
+
+Existing tests that stub `registerRefineMask({ exportPng, clear, getCanvas })` must add `invert: () => {}`.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+pnpm --filter @lnkpi/web test -- src/stores/canvasEditor.refine.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/stores/canvasEditor.ts apps/web/src/stores/canvasEditor.refine.test.ts
+git commit -m "feat(web): track refine wand tool and tolerance"
+```
+
+---
+
+### Task 3: MaskEditor 单击魔棒 + invert
+
+**Files:**
+- Modify: `apps/web/src/components/canvas/refine/MaskEditor.vue`
+- Modify: `apps/web/src/components/canvas/refine/RefineWorkViewport.vue`
+
+**Interfaces:**
+- Consumes: `floodFillMask`, `invertMaskRgba`, `parseFillHex`; props `tool?: MaskTool` 含 `'wand'`；`wandTolerance?: number`
+- Produces: `defineExpose.invert`；`RefineWorkViewport` 传入 `:wand-tolerance="editor.refineWandTolerance"`
+
+- [ ] **Step 1:** 扩展 `MaskTool`:
+
+```ts
+export type MaskTool = 'brush' | 'eraser' | 'rect' | 'wand'
+```
+
+`withDefaults` 增加 `wandTolerance: 24`。
+
+缓存底图：`let imageRgba: Uint8ClampedArray | null = null`。在 `resolveBitmapSize` 成功且 canvas 已定尺寸后，用 `new Image()` 画到离屏 canvas（`width/height` 与 mask 相同）`getImageData`。url 变化时清空缓存。
+
+- [ ] **Step 2:** `onPointerDown`：若 `props.tool === 'wand'`：
+
+```ts
+  if (props.tool === 'wand') {
+    if (!imageRgba) return
+    const mask = ctx.getImageData(0, 0, canvas.width, canvas.height)
+    const filled = floodFillMask({
+      width: canvas.width,
+      height: canvas.height,
+      imageRgba,
+      maskRgba: mask.data,
+      x: pt.x,
+      y: pt.y,
+      tolerance: props.wandTolerance ?? 24,
+      fillRgb: parseFillHex(props.color),
+    })
+    ctx.putImageData(new ImageData(filled, canvas.width, canvas.height), 0, 0)
+    emitCoverage()
+    drawing = false
+    return
+  }
+```
+
+不要 `setPointerCapture` 后进入涂抹。`onPointerMove` 开头：`if (props.tool === 'wand') return`。
+
+- [ ] **Step 3:** `function invertCanvas()`：读 mask `getImageData`，`invertMaskRgba`，`putImageData`，`emitCoverage`。`defineExpose({ ..., invert: invertCanvas })`。
+
+- [ ] **Step 4:** `RefineWorkViewport.vue` 的 `MaskEditor` 增加 `:wand-tolerance="editor.refineWandTolerance"`。
+
+- [ ] **Step 5:** 工作视口 `registerRefineMask` 处保证 handle 含 `invert: () => maskRef.value?.invert()`。
+
+当前 `RefineWorkViewport` 若直接 `registerRefineMask({ exportPng, clear, getCanvas })`，改为：
+
+```ts
+editor.registerRefineMask({
+  exportPng: () => maskRef.value!.exportPng(),
+  clear: () => maskRef.value!.clear(),
+  getCanvas: () => maskRef.value?.getCanvas() ?? null,
+  invert: () => maskRef.value?.invert(),
+})
+```
+
+（按文件里现有注册方式对齐，缺 invert 就补。）
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/canvas/refine/MaskEditor.vue apps/web/src/components/canvas/refine/RefineWorkViewport.vue
+git commit -m "feat(web): apply wand flood-fill and invert on the work mask"
+```
+
+---
+
+### Task 4: 侧栏选区行 + 禁用抠图
+
+**Files:**
+- Modify: `apps/web/src/components/canvas/refine/RefineSidePanel.vue`
+
+**Interfaces:**
+- Consumes: `editor.refineTool`、`setRefineWandTolerance`、`getRefineMask()?.invert`
+- Produces: 选区行魔棒 / 容差 / 反向；作业行「抠图」`disabled` + `title="抠图将走专用通道，尚未接入"`
+
+- [ ] **Step 1:** 在画笔组那一行 **之后**（同一 `refine-side__icon-row` 末尾或下一 `icon-row`，规格锁定魔棒行）增加：
+
+魔棒按钮：`title="魔棒"`，`is-active` 当 `refineTool === 'wand'`，`@click="editor.refineTool = 'wand'"`。
+
+`template v-if="editor.refineTool === 'wand'"`：
+
+- 容差 `input range` min=0 max=48 step=1，`@input` 调 `editor.setRefineWandTolerance(Number(...))`（用方法 `onWandToleranceInput`，不要在模板里 `as HTMLInputElement`）
+- 反向按钮 `title="反向选区"` `@click="editor.getRefineMask()?.invert()"`
+
+点魔棒不要关掉画笔组；点画笔父按钮现有逻辑可把 `refineTool` 设回 `brush`，容差行随之隐藏。
+
+- [ ] **Step 2:** 作业行「精修」按钮旁增加：
+
+```html
+<button type="button" class="refine-dock__apply" disabled title="抠图将走专用通道，尚未接入">抠图</button>
+```
+
+不要 `@click` 调 `runRefine` 或改 prompt。
+
+- [ ] **Step 3:** Commit
+
+```bash
+git add apps/web/src/components/canvas/refine/RefineSidePanel.vue
+git commit -m "feat(web): add wand controls and disabled cutout job slot"
+```
+
+---
+
+### Task 5: 验收
+
+- [ ] **Step 1:**
+
+```bash
+pnpm --filter @lnkpi/web test -- src/components/canvas/refine/maskWand.test.ts src/stores/canvasEditor.refine.test.ts src/components/canvas/refine/
+```
+
+Expected: PASS
+
+- [ ] **Step 2:** 手测
+
+1. 编辑图 → 魔棒单击色块出选区；容差变大覆盖变大  
+2. 反向后 coverage / 全图警告符合 P1  
+3. 画笔仍能改魔棒结果  
+4. 「抠图」灰、title 正确；「精修」仍走原 inpaint  
+5. 关精修再开，容差回到 24、工具回到画笔
+
+- [ ] **Step 3:** 不要改 agent capabilities 测试。若误改，必须保持 `supportedModes` 仅 `inpaint`。
+
+---
+
+## Deferred（本计划禁止实现）
+
+- SAM / 文本指代
+- CutoutProvider、透明底、`remove_bg` capability
+- 对照上下擦除 / 溶解 / 闪光
+- 魔棒减选、全图同色（非连通）
+
+## Spec coverage
+
+| Spec | Task |
+|------|------|
+| floodFill 4 连通 + 容差 + 并入 | 1, 3 |
+| invert 白=可编辑 | 1, 3 |
+| 容差 0–48 默认 24、reset | 1, 2 |
+| 侧栏魔棒下级容差 + 反向 | 4 |
+| 抠图禁用、不冒充 inpaint | 4 |
+| capabilities 仍 inpaint | 5（不改代码） |
+| 对照不扩展 | 全局约束 |
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-08-19-cx-image-edit-toolchain.md`.

--- a/docs/superpowers/specs/2026-08-18-cx-image-edit-design.md
+++ b/docs/superpowers/specs/2026-08-18-cx-image-edit-design.md
@@ -348,8 +348,8 @@ Material 表本轮不扩列。画布节点不依赖 `Material` 版本。
 | Phase | 本规格 | 内容 |
 |-------|--------|------|
 | **P1** | **本文件** | 手动画 mask + 指令 + 左右对照 + 同节点版本链 + EditProvider Image2 + 服务端合成 + 替换旧编辑弹窗 + 修正 capabilities |
-| P2 | 后续 spec | 智能选区；Wipe 滑杆；工作室「最近生成」上的精修入口；编辑模型可选 |
-| P3 | 后续 spec | 抠图 / 透明底工具槽 |
+| P2 | 后续 spec | 智能选区（第一刀见 toolchain：魔棒；SAM/文本指代更后）；工作室「最近生成」上的精修入口；编辑模型可选。Wipe 已在 chrome |
+| P3 | 后续 spec | 抠图 / 透明底（toolchain 本轮仅禁用槽，不接上游） |
 | P4 | 后续 spec | 强度、Agent 自动 apply、局部超分 |
 
 P1 实施可再拆任务（mask 编辑器、API、Dock 接入、版本链、合成、Agent 文案），但不拆成多个产品规格。

--- a/docs/superpowers/specs/2026-08-19-cx-image-edit-toolchain-design.md
+++ b/docs/superpowers/specs/2026-08-19-cx-image-edit-toolchain-design.md
@@ -1,0 +1,171 @@
+# 画布精修工具链（选区槽 + 作业槽）Design
+
+**Date:** 2026-08-19  
+**Status:** Draft pending user review  
+**代号:** **CX-IMAGE-EDIT-TOOLCHAIN**  
+**Related:**
+- `2026-08-18-cx-image-edit-design.md` — 作业 A+B（去污渍 / 替换局部）、EditProvider、合成、版本链、积分仍有效
+- `2026-08-19-cx-image-edit-sidepanel-design.md` — 右侧壳、工作图、对照；**对照扩展本轮不做**
+- `2026-08-08-image-upstream-capability-design.md` §13.2 P2/P3 — 智能选区与抠图的上游边界
+
+---
+
+## Goal
+
+把精修侧栏拆成 **三条互不混用的工具链**，并落地第一刀：**选区链补魔棒 + 反向**；**作业链只占抠图槽、不接假 remove_bg**。去污渍 / 替换局部仍走现有 inpaint。对照、放大镜不改。
+
+## Decisions (locked)
+
+| Topic | Choice |
+|-------|--------|
+| 三条链 | **壳**（对照/放大镜）· **选区**（产出 mask）· **作业**（消费 mask 或整图，才扣分） |
+| 本轮对照 | **不扩展**（不上上下擦除 / 溶解 / 闪光） |
+| 选区第一刀 | **魔棒**（工作图点击，4 连通、容差）+ **反向选区**。不接 SAM、不做文本指代 |
+| 魔棒后端 | **纯前端**，对工作图 RGB 做连通域填充，写入现有 mask canvas。无新 API |
+| 连通规则 | **4 连通**；仅连续区域，不做全图像素颜色选择 |
+| 容差 | 整数 **0–48**，默认 **24**；比较 `max(\|ΔR\|,\|ΔG\|,\|ΔB\|) ≤ 容差` |
+| 作业第一刀 | 侧栏出现 **抠图** 槽位，**禁用**；不调用 `POST /studio/image/edit` 冒充去背景 |
+| capabilities | 本轮仍仅 `['inpaint']`。**禁止**重新声称 `remove_bg` / `crop` / `outpaint` |
+| 写回 / 积分 | 魔棒、反向、清除 **不扣分**。点「精修」仍 10 分、`chargeReason: '图像精修'` |
+| 壳复用 | 抠图未来出 After 时复用现有对照；本轮抠图无 After |
+| 入口 | 不变：显式打开精修。选中节点不打开 |
+
+## Non-goals（本轮）
+
+- SAM / Grounding / 点击主体分割服务
+- 文本指代选区（「天空」「Logo」）
+- 真正抠图 API、透明底导出、白底主图模板、批量电商
+- CutoutProvider、新 `chargeReason`、新 Prisma 表
+- 扩图、裁切、局部超分、编辑强度滑杆、用户自选编辑模型
+- 对照：上下擦除、透明度溶解、自动闪光
+- 喷枪、多边形、磁性套索、全图同色选择（非连通）
+- 工作室 `/image-studio` 精修入口、Agent `run_icon_refine` 自动写回
+- 改 `ImageProvider.generate()` / 给 generate 加 `maskUrl`
+
+---
+
+## 1. 三条链（心智与侧栏）
+
+侧栏从上到下固定四块，**不要把作业图标塞进选区行，也不要把对照塞进作业行**。
+
+```text
+[壳]     左右 | 重叠 | 最大化 | 放大镜…
+[对照]   CompareView（迷你）
+[选区]   画笔组 | 魔棒 | （魔棒下级：容差）| 反向 | 清除已在画笔组内
+[作业]   污渍/替换芯片 · 指令框 · 「精修」|「抠图(禁用)」|「应用到节点」
+[版本]   版本条（不变）
+```
+
+| 链 | 改什么 | 扣分 |
+|----|--------|------|
+| 壳 | 只看 Before/After、放大 | 否 |
+| 选区 | 只改 mask | 否 |
+| 作业 | 出 After 或未来透明底 | 是（本轮仅「精修」） |
+
+画笔组交互保持现状：点画笔展开橡皮 / 矩形 / 颜色 / 粗细 / 清除。魔棒与画笔组 **并列**，点开后才出现容差滑杆（同放大镜下一级）。反向是选区链按钮，写在魔棒旁边（或画笔组展开区内，实现时二选一：**锁定为魔棒行：魔棒 + 容差 + 反向**，避免画笔组再膨胀）。
+
+---
+
+## 2. 选区链 — 魔棒
+
+### 2.1 行为
+
+1. 用户点「魔棒」，`refineTool = 'wand'`。工作图指针为点击，不是涂抹。
+2. 在工作图（Before 位图，与 mask 同像素尺寸）上 **单击**：以该像素 RGB 为种子，4 连通扩张所有「容差内」像素，把对应 mask 像素涂成当前选区色（与画笔相同，`refineBrushColor`），alpha=255。
+3. 多次点击 = **并入** 现有 mask，不先清空。
+4. 按住橡皮再点魔棒区域：本轮 **不做** 魔棒减选。减选用橡皮或反向后再手绘。
+5. busy 或尺寸未就绪：与画笔一样不可点。
+
+### 2.2 算法（可单测）
+
+纯函数，输入：`width, height, imageRgba: Uint8ClampedArray, maskRgba: Uint8ClampedArray, x, y, tolerance, fillRgba`。
+
+- 越界或 image/mask 长度不是 `width*height*4` → 原样返回 mask（no-op）。
+- 种子像素取 image 的 RGB。
+- 队列 BFS，4 邻接。访问标记长度为 `width*height`。
+- 像素纳入当且仅当 `max(|r-sr|,|g-sg|,|b-sb|) <= tolerance`。
+- 写入 mask：该像素 RGB = fill 的 RGB，A=255。不改未纳入像素。
+- **不**读取旧 mask 作为连通条件（魔棒看图，不看已有选区）。已有选区与新填充重叠则覆盖为 fill。
+
+默认 `tolerance = 24`。滑杆 0–48，步进 1。关精修时复位（与笔刷粗细同一 `resetRefineChromeState`）。
+
+### 2.3 反向选区
+
+纯函数 `invertMaskRgba(maskRgba)`：每个像素若 A>127 则清成 0；否则写成 RGB 白 + A=255（与导出约定：白=可编辑）。
+
+按钮「反向选区」对当前 mask canvas 执行一次并 `emitCoverage`。空 mask 反向 = 全图可编辑（覆盖率近 100%，沿用 P1 全图警告，仍允许点精修）。
+
+---
+
+## 3. 作业链 — 精修 vs 抠图槽
+
+### 3.1 精修（已有，不变）
+
+mask + 指令 → `POST /studio/image/edit` → After → 合成保真 → 应用到节点。芯片「去除污渍瑕疵」「替换选区内容」仍只改 prompt。
+
+### 3.2 抠图槽（本轮契约，不接上游）
+
+- 主按钮区增加「抠图」，`disabled`，`title="抠图将走专用通道，尚未接入"`。
+- **禁止**：用整图 mask +「去掉背景」prompt 走 inpaint 冒充抠图。
+- **禁止**：`get_image_edit_capabilities.supportedModes` 加入 `remove_bg`。
+- 下一独立规格再定：CutoutProvider、计费文案、透明 PNG 写回、是否要求先有选区。本文件只保证槽位存在且不撒谎。
+
+---
+
+## 4. 组件与数据
+
+| 单元 | 职责 |
+|------|------|
+| `maskWand.ts`（新） | `floodFillMask`、`invertMaskRgba`、夹取容差 `clampWandTolerance` |
+| `MaskEditor.vue` | `tool: 'wand'`：click 一次 flood；暴露 `invert()`；现有 `clear` 不变 |
+| `canvasEditor` | `refineTool` 增加 `'wand'`；`refineWandTolerance` 默认 24；reset 时恢复 |
+| `RefineSidePanel` | 选区行魔棒 + 容差 + 反向；作业行禁用抠图 |
+| `RefineWorkViewport` | 把 wand/tolerance 传给 MaskEditor；点击落在工作图像素坐标（与现有 brush 同一套 canvas 坐标） |
+| Agent capabilities | **不改**（仍仅 inpaint） |
+
+点击坐标：沿用 MaskEditor 现有 pointer → canvas 像素映射。魔棒 `pointerdown` 一次 fill，不拖动连续 fill。
+
+---
+
+## 5. 错误与边界
+
+| 情况 | 结果 |
+|------|------|
+| 图未就绪 | 魔棒 disabled（同画笔） |
+| 点击落在图外 | no-op |
+| 容差 0 | 仅种子像素（及 RGB 完全相同的 4 连通） |
+| 容差 48 + 平坦背景 | 可能近全图；覆盖率警告走 P1 |
+| 反向空选区 | 全选，P1 全图提示 |
+| 精修空选区 | 仍拦截 &lt; 0.3% |
+
+---
+
+## 6. 验收
+
+1. 打开精修 → 选区行能开魔棒；未点开时不出现容差滑杆。  
+2. 工作图单击平坦区域 → mask 出现连通块；再画笔/橡皮可改这块。  
+3. 容差变大，同样点击覆盖面积单调不减（单测用夹具图即可）。  
+4. 反向：有选区时选区与未选互换；coverage 更新。  
+5. 「抠图」可见且 disabled；点「精修」行为与 P1 相同。  
+6. capabilities 探测仍只有 `inpaint`。  
+7. 不改后端 edit DTO、不改 Prisma、不改 `ImageProvider.generate`。
+
+---
+
+## 7. 后续（不进本轮计划）
+
+| 刀 | 内容 |
+|----|------|
+| 选区 2 | SAM / 点击主体；再后文本指代 |
+| 作业 2 | CutoutProvider + 真透明底；capabilities 才加 `remove_bg` |
+| 壳 | 上下擦除 / 溶解 / 闪光 |
+
+---
+
+## 风险
+
+| 风险 | 缓解 |
+|------|------|
+| 魔棒在 JPEG 噪点上碎 | 容差默认 24；用户可调大 |
+| 大图 BFS 卡 UI | 单帧 fill；若 &gt;4K 仍同步（P1 工作图已按位图像素，与画笔同级） |
+| 产品把禁用抠图当 bug | title 写明尚未接入，不假装能点 |

--- a/docs/superpowers/specs/2026-08-19-cx-image-edit-toolchain-design.md
+++ b/docs/superpowers/specs/2026-08-19-cx-image-edit-toolchain-design.md
@@ -1,7 +1,7 @@
 # 画布精修工具链（选区槽 + 作业槽）Design
 
 **Date:** 2026-08-19  
-**Status:** Draft pending user review  
+**Status:** Approved, plan in `2026-08-19-cx-image-edit-toolchain.md`  
 **代号:** **CX-IMAGE-EDIT-TOOLCHAIN**  
 **Related:**
 - `2026-08-18-cx-image-edit-design.md` — 作业 A+B（去污渍 / 替换局部）、EditProvider、合成、版本链、积分仍有效


### PR DESCRIPTION
## Summary
- 精修工作画布增加纯前端魔棒（4 连通洪水填充、容差 0–48）和反向选区，不接 SAM、不扣分。
- 侧栏「抠图」作业槽禁用展示，禁止用 inpaint 冒充去背景，不扩展 `supportedModes`。
- 去污渍/替换仍走现有精修；对照扩展不在本 PR。

## Test plan
- [x] `pnpm --filter @lnkpi/web build`（含 vue-tsc）
- [x] `pnpm --filter @lnkpi/agent test`
- [ ] CI: Build monorepo / agent-runtime / API Docker 全绿
- [ ] 画布精修：魔棒单击填充、调容差、反向选区后精修仍 10 分
- [ ] 抠图槽禁用，不可当去背景提交


Made with [Cursor](https://cursor.com)