### PR TITLE
feat: SAM click-to-select subject for canvas refine

### DIFF
--- a/apps/server/src/studio/studio.controller.ts
+++ b/apps/server/src/studio/studio.controller.ts
@@ -243,6 +243,21 @@ class ImageEditDto extends CanvasScopeFields {
   parentVersionId?: string
 }
 
+class ImageSegmentDto {
+  @IsString()
+  imageUrl!: string
+
+  @IsNumber()
+  x!: number
+
+  @IsNumber()
+  y!: number
+
+  @IsOptional()
+  @IsIn([0, 1])
+  label?: 0 | 1
+}
+
 @Controller('studio')
 export class StudioController {
   constructor(
@@ -348,6 +363,21 @@ export class StudioController {
       },
       cancel,
     )
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('image/segment')
+  @UseGuards(AuthGuard)
+  async segmentImage(
+    @Req() req: { user: { sub: string } },
+    @Body() dto: ImageSegmentDto,
+  ) {
+    const data = await this.studioService.segmentImage(req.user.sub, {
+      imageUrl: dto.imageUrl,
+      x: dto.x,
+      y: dto.y,
+      label: dto.label,
+    })
     return { code: 0, message: 'ok', data }
   }
 

--- a/apps/server/src/studio/studio.segment.test.ts
+++ b/apps/server/src/studio/studio.segment.test.ts
@@ -1,0 +1,179 @@
+import 'reflect-metadata'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Test } from '@nestjs/testing'
+import {
+  BadRequestException,
+  HttpException,
+  HttpStatus,
+  ServiceUnavailableException,
+} from '@nestjs/common'
+import { createSegmentProvider } from '@lnkpi/agent'
+import { PointsService } from '../points/points.service'
+import { PrismaService } from '../prisma/prisma.service'
+import { ProviderResolverService } from '../provider/provider-resolver.service'
+import { MediaProbeService } from '../media/media-probe.service'
+import { UploadService } from '../upload/upload.service'
+import { inlineUpstreamReferenceImages } from '../media/upstream-ref-inline'
+import {
+  StudioService,
+  allowSegmentRate,
+  resetSegmentRateLimitForTests,
+} from './studio.service'
+
+const segment = vi.fn()
+
+vi.mock('@lnkpi/agent', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@lnkpi/agent')>()
+  return {
+    ...actual,
+    createSegmentProvider: vi.fn(() => ({ segment })),
+  }
+})
+vi.mock('../media/upstream-ref-inline', () => ({
+  inlineUpstreamReferenceImages: vi.fn(async (urls: string[]) => urls),
+}))
+
+describe('allowSegmentRate', () => {
+  beforeEach(() => {
+    resetSegmentRateLimitForTests()
+  })
+
+  it('allows up to 20 requests per 60s window', () => {
+    const base = 1_000_000
+    for (let i = 0; i < 20; i++) {
+      expect(allowSegmentRate('u1', base + i)).toBe(true)
+    }
+    expect(allowSegmentRate('u1', base + 20)).toBe(false)
+  })
+
+  it('tracks limits independently per user', () => {
+    const base = 1_000_000
+    for (let i = 0; i < 20; i++) {
+      allowSegmentRate('user-a', base + i)
+    }
+    expect(allowSegmentRate('user-a', base + 20)).toBe(false)
+    expect(allowSegmentRate('user-b', base)).toBe(true)
+  })
+
+  it('expires timestamps outside window', () => {
+    const now = 1_000_000
+    for (let i = 0; i < 20; i++) {
+      allowSegmentRate('u1', now + i)
+    }
+    expect(allowSegmentRate('u1', now + 20)).toBe(false)
+    expect(allowSegmentRate('u1', now + 61_000)).toBe(true)
+  })
+})
+
+describe('StudioService.segmentImage', () => {
+  let svc: StudioService
+  let pointsConsume: ReturnType<typeof vi.fn>
+  const savedFalKey = process.env.FAL_KEY
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    resetSegmentRateLimitForTests()
+    process.env.FAL_KEY = 'fal-test-key'
+    pointsConsume = vi.fn(async () => {})
+    segment.mockResolvedValue({ maskUrl: 'https://m' })
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        StudioService,
+        {
+          provide: PointsService,
+          useValue: {
+            consume: pointsConsume,
+            refund: vi.fn(),
+          },
+        },
+        {
+          provide: PrismaService,
+          useValue: {},
+        },
+        {
+          provide: ProviderResolverService,
+          useValue: {},
+        },
+        {
+          provide: MediaProbeService,
+          useValue: {},
+        },
+        {
+          provide: UploadService,
+          useValue: {},
+        },
+      ],
+    }).compile()
+
+    svc = moduleRef.get(StudioService)
+  })
+
+  afterEach(() => {
+    if (savedFalKey === undefined) delete process.env.FAL_KEY
+    else process.env.FAL_KEY = savedFalKey
+  })
+
+  it('segmentImage returns maskUrl without charging points', async () => {
+    const out = await svc.segmentImage('u1', { imageUrl: 'https://a.png', x: 1, y: 2 })
+
+    expect(out).toEqual({ maskUrl: 'https://m' })
+    expect(pointsConsume).not.toHaveBeenCalled()
+    expect(createSegmentProvider).toHaveBeenCalledWith({ apiKey: 'fal-test-key' })
+    expect(inlineUpstreamReferenceImages).toHaveBeenCalledWith(['https://a.png'])
+    expect(segment).toHaveBeenCalledWith({
+      imageUrl: 'https://a.png',
+      x: 1,
+      y: 2,
+      label: 1,
+    })
+  })
+
+  it('throws ServiceUnavailable when FAL_KEY missing', async () => {
+    delete process.env.FAL_KEY
+
+    await expect(
+      svc.segmentImage('u1', { imageUrl: 'https://a.png', x: 1, y: 2 }),
+    ).rejects.toBeInstanceOf(ServiceUnavailableException)
+    expect(segment).not.toHaveBeenCalled()
+  })
+
+  it('rejects empty imageUrl', async () => {
+    await expect(svc.segmentImage('u1', { imageUrl: '', x: 1, y: 2 })).rejects.toBeInstanceOf(
+      BadRequestException,
+    )
+  })
+
+  it('rejects negative coordinates', async () => {
+    await expect(
+      svc.segmentImage('u1', { imageUrl: 'https://a.png', x: -1, y: 2 }),
+    ).rejects.toBeInstanceOf(BadRequestException)
+  })
+
+  it('rejects non-finite coordinates', async () => {
+    await expect(
+      svc.segmentImage('u1', { imageUrl: 'https://a.png', x: Number.NaN, y: 2 }),
+    ).rejects.toBeInstanceOf(BadRequestException)
+  })
+
+  it('throws 429 when rate limit exceeded', async () => {
+    for (let i = 0; i < 20; i++) {
+      await svc.segmentImage('u-rate', { imageUrl: 'https://a.png', x: 1, y: 2 })
+    }
+
+    await expect(
+      svc.segmentImage('u-rate', { imageUrl: 'https://a.png', x: 1, y: 2 }),
+    ).rejects.toMatchObject({
+      status: HttpStatus.TOO_MANY_REQUESTS,
+      response: '点选过于频繁，请稍后再试',
+    })
+  })
+
+  it('passes custom label to provider', async () => {
+    await svc.segmentImage('u1', { imageUrl: 'https://a.png', x: 1, y: 2, label: 0 })
+
+    expect(segment).toHaveBeenCalledWith(
+      expect.objectContaining({ label: 0 }),
+    )
+  })
+})

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -1,4 +1,12 @@
-import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common'
+import {
+  BadRequestException,
+  HttpException,
+  HttpStatus,
+  Inject,
+  Injectable,
+  NotFoundException,
+  ServiceUnavailableException,
+} from '@nestjs/common'
 import {
   buildAudioRequest,
   buildEffectiveImagePrompt,
@@ -12,6 +20,7 @@ import {
   createAudioProvider,
   createImageEditProvider,
   createImageProvider,
+  createSegmentProvider,
   createTextProvider,
   createVideoProvider,
   generatePromptFromUserInput,
@@ -79,6 +88,27 @@ const AUDIO_PLACEHOLDER = 'https://www.soundhelix.com/examples/mp3/SoundHelix-So
 // Grace window before returning the async `generating` record: fast image
 // providers usually finish within this, sparing the client a polling round.
 const IMAGE_FAST_PATH_MS = 3000
+
+const segmentTimestamps = new Map<string, number[]>()
+
+export function allowSegmentRate(
+  userId: string,
+  now = Date.now(),
+  windowMs = 60_000,
+  max = 20,
+): boolean {
+  const recent = (segmentTimestamps.get(userId) ?? []).filter((t) => now - t < windowMs)
+  if (recent.length >= max) {
+    return false
+  }
+  recent.push(now)
+  segmentTimestamps.set(userId, recent)
+  return true
+}
+
+export function resetSegmentRateLimitForTests(): void {
+  segmentTimestamps.clear()
+}
 
 export interface StudioRefInput {
   refKey: string
@@ -1161,6 +1191,40 @@ export class StudioService {
       }
       return refundAndFail(err)
     }
+  }
+
+  async segmentImage(
+    userId: string,
+    input: { imageUrl: string; x: number; y: number; label?: 0 | 1 },
+  ): Promise<{ maskUrl: string }> {
+    const imageUrl = input.imageUrl?.trim()
+    if (!imageUrl) {
+      throw new BadRequestException('imageUrl 不能为空')
+    }
+    if (!Number.isFinite(input.x) || input.x < 0) {
+      throw new BadRequestException('x 无效')
+    }
+    if (!Number.isFinite(input.y) || input.y < 0) {
+      throw new BadRequestException('y 无效')
+    }
+    if (!allowSegmentRate(userId)) {
+      throw new HttpException('点选过于频繁，请稍后再试', HttpStatus.TOO_MANY_REQUESTS)
+    }
+
+    const apiKey = process.env.FAL_KEY?.trim()
+    if (!apiKey) {
+      throw new ServiceUnavailableException('点选暂不可用')
+    }
+
+    const [inlinedUrl] = await inlineUpstreamReferenceImages([imageUrl])
+    const publicUrl = inlinedUrl ?? imageUrl
+
+    return createSegmentProvider({ apiKey }).segment({
+      imageUrl: publicUrl,
+      x: input.x,
+      y: input.y,
+      label: input.label ?? 1,
+    })
   }
 
   async generateVideo(

--- a/apps/web/src/components/canvas/refine/MaskEditor.vue
+++ b/apps/web/src/components/canvas/refine/MaskEditor.vue
@@ -6,7 +6,7 @@ import { countMaskPixelsFromImageData, exportMaskPng } from './maskExport'
 import { fillPolygonMask, isNearPolygonStart } from './maskPolygon'
 import { floodFillMask, invertMaskRgba, parseFillHex } from './maskWand'
 
-export type MaskTool = 'brush' | 'eraser' | 'rect' | 'wand' | 'polygon'
+export type MaskTool = 'brush' | 'eraser' | 'rect' | 'wand' | 'polygon' | 'point'
 export type MaskOp = 'add' | 'subtract'
 
 const props = withDefaults(
@@ -35,6 +35,7 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   coverage: [payload: { ratio: number; width: number; height: number }]
+  pointSelect: [payload: { x: number; y: number }]
 }>()
 
 const canvasRef = ref<HTMLCanvasElement | null>(null)
@@ -231,6 +232,10 @@ function onPointerDown(event: PointerEvent) {
   const ctx = canvas?.getContext('2d')
   if (!canvas || !ctx) return
   const pt = canvasPoint(event)
+  if (props.tool === 'point') {
+    emit('pointSelect', { x: Math.round(pt.x), y: Math.round(pt.y) })
+    return
+  }
   if (props.tool === 'wand') {
     if (!imageRgba) return
     const mask = ctx.getImageData(0, 0, canvas.width, canvas.height)
@@ -282,7 +287,7 @@ function onDblClick(event: MouseEvent) {
 }
 
 function onPointerMove(event: PointerEvent) {
-  if (props.tool === 'wand') return
+  if (props.tool === 'wand' || props.tool === 'point') return
   if (props.tool === 'polygon') {
     if (!drawReady.value) return
     const pt = canvasPoint(event)

--- a/apps/web/src/components/canvas/refine/RefineSidePanel.vue
+++ b/apps/web/src/components/canvas/refine/RefineSidePanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { ElMessage } from 'element-plus'
 import type { ImageVersionEntry } from '@lnkpi/shared'
 import DockCreditBadge from '@/components/canvas/dock-studio/shared/DockCreditBadge.vue'
 import DockTypeIcon from '@/components/canvas/dock-studio/shared/DockTypeIcon.vue'
@@ -15,7 +16,9 @@ import { syncRefineUrls } from './syncRefineUrls'
 import CompareLightbox from './CompareLightbox.vue'
 import CompareView from './CompareView.vue'
 import VersionStrip from './VersionStrip.vue'
-import { exportMaskPng } from './maskExport'
+import { countMaskPixelsFromImageData, exportMaskPng } from './maskExport'
+import { loadMaskRgbaFromUrl, mergeMaskRgba, registerRefinePointSelectHandler } from './maskRemote'
+import { parseFillHex } from './maskWand'
 
 const REFINE_MIN_W = 360
 const REFINE_MAX_W = 560
@@ -44,6 +47,7 @@ const editor = useCanvasEditorStore()
 const promptRef = ref<HTMLTextAreaElement | null>(null)
 const prompt = ref('')
 const busy = ref(false)
+const segmentBusy = ref(false)
 const afterUrl = ref(props.beforeUrl)
 const errorMessage = ref('')
 const compareBeforeUrl = ref(props.beforeUrl)
@@ -283,6 +287,43 @@ function onKeydown(event: KeyboardEvent) {
   if (!busy.value) emit('close')
 }
 
+async function onPointSelect({ x, y }: { x: number; y: number }) {
+  if (busy.value || segmentBusy.value) return
+  const mask = editor.getRefineMask()
+  const canvas = mask?.getCanvas()
+  if (!canvas) return
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return
+
+  segmentBusy.value = true
+  try {
+    const { data } = await studioApi.segmentImage({
+      imageUrl: props.beforeUrl,
+      x,
+      y,
+      label: 1,
+    })
+    const remoteRgba = await loadMaskRgbaFromUrl(data.data.maskUrl, canvas.width, canvas.height)
+    const base = ctx.getImageData(0, 0, canvas.width, canvas.height)
+    const merged = mergeMaskRgba({
+      width: canvas.width,
+      height: canvas.height,
+      baseMaskRgba: base.data,
+      remoteMaskRgba: remoteRgba,
+      fillRgb: parseFillHex(editor.refineBrushColor),
+      mode: editor.refineMaskOp === 'subtract' ? 'subtract' : 'add',
+    })
+    ctx.putImageData(new ImageData(new Uint8ClampedArray(merged), canvas.width, canvas.height), 0, 0)
+    const counted = countMaskPixelsFromImageData(ctx.getImageData(0, 0, canvas.width, canvas.height))
+    editor.refineCoverage = counted.ratio
+  } catch (err) {
+    const message = formatError(err, '点选失败，请重试')
+    if (message) ElMessage.error(message)
+  } finally {
+    segmentBusy.value = false
+  }
+}
+
 async function runRefine() {
   if (refineDisabled.value) return
   const mask = editor.getRefineMask()
@@ -335,12 +376,14 @@ async function runRefine() {
 }
 
 onMounted(() => {
+  registerRefinePointSelectHandler(onPointSelect)
   syncNarrow()
   window.addEventListener('resize', syncNarrow)
   window.addEventListener('keydown', onKeydown)
 })
 
 onBeforeUnmount(() => {
+  registerRefinePointSelectHandler(null)
   window.removeEventListener('resize', syncNarrow)
   window.removeEventListener('keydown', onKeydown)
   stopResize()
@@ -541,6 +584,19 @@ onBeforeUnmount(() => {
             >
               <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75">
                 <path stroke-linejoin="round" d="M12 4 20 9.5 17 19H7L4 9.5Z" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              class="refine-side__icon-btn"
+              :class="{ 'is-active': editor.refineTool === 'point' }"
+              :title="editor.refineMaskOp === 'subtract' ? '点选减选' : '点选主体'"
+              :disabled="busy || segmentBusy"
+              @click="editor.setRefineTool('point')"
+            >
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.75">
+                <circle cx="12" cy="12" r="3" />
+                <path stroke-linecap="round" d="M12 2v4M12 18v4M2 12h4M18 12h4" />
               </svg>
             </button>
             <template v-if="editor.refineTool === 'wand'">

--- a/apps/web/src/components/canvas/refine/RefineWorkViewport.vue
+++ b/apps/web/src/components/canvas/refine/RefineWorkViewport.vue
@@ -4,6 +4,7 @@ import { useCanvasEditorStore } from '@/stores/canvasEditor'
 import { panFromDrag, panZoomFromWheel } from './compareLightboxTransform'
 import MaskEditor from './MaskEditor.vue'
 import ImageLoupe from './ImageLoupe.vue'
+import { dispatchRefinePointSelect } from './maskRemote'
 import { containRect, refineWorkInsetRight } from './refineWorkLayout'
 
 const props = defineProps<{
@@ -216,6 +217,7 @@ onBeforeUnmount(() => {
               :mask-op="editor.refineMaskOp"
               :disabled="editor.refineBusy || spaceDown"
               @coverage="(p) => { editor.refineCoverage = p.ratio }"
+              @point-select="dispatchRefinePointSelect"
             />
           </ImageLoupe>
         </div>

--- a/apps/web/src/components/canvas/refine/maskRemote.test.ts
+++ b/apps/web/src/components/canvas/refine/maskRemote.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { mergeMaskRgba } from './maskRemote'
+
+function rgba(vals: number[]) {
+  return new Uint8ClampedArray(vals)
+}
+
+describe('mergeMaskRgba', () => {
+  it('add paints remote opaque pixels', () => {
+    const base = rgba([0, 0, 0, 0, 0, 0, 0, 0])
+    const remote = rgba([255, 255, 255, 255, 0, 0, 0, 0])
+    const out = mergeMaskRgba({
+      width: 2,
+      height: 1,
+      baseMaskRgba: base,
+      remoteMaskRgba: remote,
+      fillRgb: [9, 9, 9],
+      mode: 'add',
+    })
+    expect([...out.slice(0, 4)]).toEqual([9, 9, 9, 255])
+    expect([...out.slice(4, 8)]).toEqual([0, 0, 0, 0])
+  })
+
+  it('subtract clears remote opaque pixels', () => {
+    const base = rgba([9, 9, 9, 255, 9, 9, 9, 255])
+    const remote = rgba([255, 255, 255, 200, 0, 0, 0, 0])
+    const out = mergeMaskRgba({
+      width: 2,
+      height: 1,
+      baseMaskRgba: base,
+      remoteMaskRgba: remote,
+      fillRgb: [9, 9, 9],
+      mode: 'subtract',
+    })
+    expect([...out.slice(0, 4)]).toEqual([0, 0, 0, 0])
+    expect([...out.slice(4, 8)]).toEqual([9, 9, 9, 255])
+  })
+})

--- a/apps/web/src/components/canvas/refine/maskRemote.ts
+++ b/apps/web/src/components/canvas/refine/maskRemote.ts
@@ -25,3 +25,47 @@ export function mergeMaskRgba(opts: {
   }
   return out
 }
+
+/** Normalize SAM PNG alpha: use alpha when varied; if all ~255, use luminance as selection. */
+export function normalizeRemoteMaskRgba(rgba: Uint8ClampedArray): Uint8ClampedArray {
+  const out = new Uint8ClampedArray(rgba)
+  let allOpaque = out.length > 0
+  for (let i = 3; i < out.length; i += 4) {
+    if (out[i]! < 250) {
+      allOpaque = false
+      break
+    }
+  }
+  if (!allOpaque) return out
+  for (let i = 0; i < out.length; i += 4) {
+    const luma = (out[i]! + out[i + 1]! + out[i + 2]!) / 3
+    out[i + 3] = luma > 127 ? 255 : 0
+  }
+  return out
+}
+
+export async function loadMaskRgbaFromUrl(
+  url: string,
+  width: number,
+  height: number,
+): Promise<Uint8ClampedArray> {
+  const img = await createImageBitmap(await (await fetch(url)).blob())
+  const c = document.createElement('canvas')
+  c.width = width
+  c.height = height
+  const ctx = c.getContext('2d')!
+  ctx.drawImage(img, 0, 0, width, height)
+  return normalizeRemoteMaskRgba(ctx.getImageData(0, 0, width, height).data)
+}
+
+type PointSelectPayload = { x: number; y: number }
+
+let pointSelectHandler: ((pt: PointSelectPayload) => void) | null = null
+
+export function registerRefinePointSelectHandler(fn: ((pt: PointSelectPayload) => void) | null) {
+  pointSelectHandler = fn
+}
+
+export function dispatchRefinePointSelect(pt: PointSelectPayload) {
+  pointSelectHandler?.(pt)
+}

--- a/apps/web/src/components/canvas/refine/maskRemote.ts
+++ b/apps/web/src/components/canvas/refine/maskRemote.ts
@@ -1,0 +1,27 @@
+export function mergeMaskRgba(opts: {
+  width: number
+  height: number
+  baseMaskRgba: Uint8ClampedArray
+  remoteMaskRgba: Uint8ClampedArray
+  fillRgb: [number, number, number]
+  mode: 'add' | 'subtract'
+}): Uint8ClampedArray {
+  const n = opts.width * opts.height * 4
+  const out = new Uint8ClampedArray(opts.baseMaskRgba)
+  const [fr, fg, fb] = opts.fillRgb
+  for (let i = 0; i < n; i += 4) {
+    if (opts.remoteMaskRgba[i + 3]! <= 127) continue
+    if (opts.mode === 'subtract') {
+      out[i] = 0
+      out[i + 1] = 0
+      out[i + 2] = 0
+      out[i + 3] = 0
+    } else {
+      out[i] = fr
+      out[i + 1] = fg
+      out[i + 2] = fb
+      out[i + 3] = 255
+    }
+  }
+  return out
+}

--- a/apps/web/src/services/studio-api.ts
+++ b/apps/web/src/services/studio-api.ts
@@ -97,6 +97,8 @@ export const studioApi = {
       { ...body, ...scopeBody({ sessionId: body.sessionId, nodeId: body.nodeId }) },
       { timeout: 300_000, signal },
     ),
+  segmentImage: (body: { imageUrl: string; x: number; y: number; label?: 0 | 1 }) =>
+    api.post<{ data: { maskUrl: string } }>('/studio/image/segment', body),
   generateText: (
     prompt: string,
     model?: string,

--- a/apps/web/src/stores/canvasEditor.refine.test.ts
+++ b/apps/web/src/stores/canvasEditor.refine.test.ts
@@ -155,6 +155,16 @@ describe('canvasEditor refine target', () => {
     expect(editor.refineMaskOp).toBe('add')
   })
 
+  it('keeps refineMaskOp when switching to point', () => {
+    setActivePinia(createPinia())
+    const editor = useCanvasEditorStore()
+    editor.setRefineTool('eraser')
+    expect(editor.refineMaskOp).toBe('subtract')
+    editor.setRefineTool('point')
+    expect(editor.refineTool).toBe('point')
+    expect(editor.refineMaskOp).toBe('subtract')
+  })
+
   it('resets refineMaskOp and polygon tool on close', () => {
     setActivePinia(createPinia())
     const editor = useCanvasEditorStore()

--- a/apps/web/src/stores/canvasEditor.ts
+++ b/apps/web/src/stores/canvasEditor.ts
@@ -5,7 +5,7 @@ import type { RefineChromeMode } from '@/utils/refineChrome'
 import { clampLoupeZoom } from '@/components/canvas/refine/refineWorkLayout'
 import { clampWandTolerance } from '@/components/canvas/refine/maskWand'
 
-export type RefineMaskTool = 'brush' | 'eraser' | 'rect' | 'wand' | 'polygon'
+export type RefineMaskTool = 'brush' | 'eraser' | 'rect' | 'wand' | 'polygon' | 'point'
 export type RefineMaskOp = 'add' | 'subtract'
 export type RefineLoupeShape = 'circle' | 'rect'
 

--- a/docs/superpowers/plans/2026-08-31-cx-image-edit-sam-point-select.md
+++ b/docs/superpowers/plans/2026-08-31-cx-image-edit-sam-point-select.md
@@ -1,0 +1,482 @@
+# 精修 SAM 点击选主体 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 精修选区链增加「点选」：单击工作图 → `POST /studio/image/segment`（fal SAM3）→ 按 `refineMaskOp` 并入/挖除 mask；点选不扣分。
+
+**Architecture:** `packages/agent` 新增 `SegmentProvider`（fal HTTP）。`StudioService.segmentImage` 鉴权、inline 图 URL、限流、调 provider、返回 `maskUrl`。前端 `refineTool: 'point'` + MaskEditor 单击拉 mask PNG 栅格合并。密钥仅服务端 `FAL_KEY`。
+
+**Tech Stack:** NestJS、Vitest、Vue 3、现有 MaskEditor / canvasEditor、fal `fal-ai/sam-3/image`（`fetch`，不强制 `@fal-ai/client`）
+
+**Spec:** `docs/superpowers/specs/2026-08-31-cx-image-edit-sam-point-select-design.md`
+
+## Global Constraints
+
+- 远端分割：**fal.ai** `fal-ai/sam-3/image`；CVM **不**跑 SAM
+- 点选 **不扣分**、**不**创建 GenerationRecord
+- 点「点选」**只换工具不改** `refineMaskOp`；加选并入、减选挖除
+- **每次单击一次**请求；MVP 仅 `label: 1`
+- 密钥不出浏览器；禁止改 `ImageProvider.generate` / 抠图 / 文本指代 / P4
+- TDD；提交前缀 `feat:` / `fix:` / `test:` / `docs:`
+- 不 `git add -A`；勿提交 `.seedream-backup`、`deploy/`、`q.js`、`.superpowers/sdd/*`
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `packages/agent/src/tools/segment-provider.ts` | fal segment HTTP + `createSegmentProvider` |
+| `packages/agent/src/tools/segment-provider.test.ts` | 请求体映射 / 单 mask 选取 |
+| `packages/agent/src/index.ts` | 导出 |
+| `apps/server/src/studio/studio.controller.ts` | `POST image/segment` + DTO |
+| `apps/server/src/studio/studio.service.ts` | `segmentImage`：inline、限流、调 provider |
+| `apps/server/src/studio/studio.segment.test.ts` | 服务层单测 |
+| `apps/web/src/services/studio-api.ts` | `segmentImage` 客户端 |
+| `apps/web/src/stores/canvasEditor.ts` | `RefineMaskTool` 含 `'point'`；`setRefineTool` 不改 op |
+| `apps/web/src/stores/canvasEditor.refine.test.ts` | point 保持 op |
+| `apps/web/src/components/canvas/refine/maskRemote.ts` | PNG → RGBA 并入/挖除纯函数辅助（可测部分） |
+| `apps/web/src/components/canvas/refine/maskRemote.test.ts` | 合并逻辑 |
+| `apps/web/src/components/canvas/refine/MaskEditor.vue` | point 单击 → emit 请求坐标 |
+| `apps/web/src/components/canvas/refine/RefineWorkViewport.vue` | 透传 props/events |
+| `apps/web/src/components/canvas/refine/RefineSidePanel.vue` | 点选按钮 + 调 API + 写 mask |
+
+---
+
+### Task 0: Feature 分支
+
+- [ ] **Step 1:** 从含 SAM design 的 docs 分支切 feature 分支。
+
+```bash
+git fetch origin
+git checkout docs/cx-image-edit-sam-point-select
+git pull origin docs/cx-image-edit-sam-point-select 2>/dev/null || true
+git checkout -b feature/cx-image-edit-sam-point-select
+```
+
+若 docs 仅本地：`git checkout -b feature/cx-image-edit-sam-point-select docs/cx-image-edit-sam-point-select`
+
+- [ ] **Step 2: 基线**
+
+```bash
+pnpm --filter @lnkpi/web exec vitest run src/stores/canvasEditor.refine.test.ts
+pnpm --filter @lnkpi/agent exec vitest run src/studio/edit-adapter.test.ts
+```
+
+Expected: PASS
+
+---
+
+### Task 1: `mergeMaskRgba` 纯函数（远端 mask 并入/挖除）
+
+**Files:**
+- Create: `apps/web/src/components/canvas/refine/maskRemote.ts`
+- Create: `apps/web/src/components/canvas/refine/maskRemote.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `mergeMaskRgba(opts: { width; height; baseMaskRgba: Uint8ClampedArray; remoteMaskRgba: Uint8ClampedArray; fillRgb: [number, number, number]; mode: 'add' | 'subtract' }): Uint8ClampedArray`
+  - 规则：`remote` 像素 **alpha > 127** 视为选中。`add`：选中处写 `fillRgb` + A=255；`subtract`：选中处 RGB=0 A=0。其它像素保持 `base`。
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { mergeMaskRgba } from './maskRemote'
+
+function rgba(vals: number[]) {
+  return new Uint8ClampedArray(vals)
+}
+
+describe('mergeMaskRgba', () => {
+  it('add paints remote opaque pixels', () => {
+    const base = rgba([0, 0, 0, 0, 0, 0, 0, 0])
+    const remote = rgba([255, 255, 255, 255, 0, 0, 0, 0])
+    const out = mergeMaskRgba({
+      width: 2,
+      height: 1,
+      baseMaskRgba: base,
+      remoteMaskRgba: remote,
+      fillRgb: [9, 9, 9],
+      mode: 'add',
+    })
+    expect([...out.slice(0, 4)]).toEqual([9, 9, 9, 255])
+    expect([...out.slice(4, 8)]).toEqual([0, 0, 0, 0])
+  })
+
+  it('subtract clears remote opaque pixels', () => {
+    const base = rgba([9, 9, 9, 255, 9, 9, 9, 255])
+    const remote = rgba([255, 255, 255, 200, 0, 0, 0, 0])
+    const out = mergeMaskRgba({
+      width: 2,
+      height: 1,
+      baseMaskRgba: base,
+      remoteMaskRgba: remote,
+      fillRgb: [9, 9, 9],
+      mode: 'subtract',
+    })
+    expect([...out.slice(0, 4)]).toEqual([0, 0, 0, 0])
+    expect([...out.slice(4, 8)]).toEqual([9, 9, 9, 255])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm --filter @lnkpi/web exec vitest run src/components/canvas/refine/maskRemote.test.ts
+```
+
+Expected: FAIL（模块不存在）
+
+- [ ] **Step 3: Implement**
+
+```ts
+export function mergeMaskRgba(opts: {
+  width: number
+  height: number
+  baseMaskRgba: Uint8ClampedArray
+  remoteMaskRgba: Uint8ClampedArray
+  fillRgb: [number, number, number]
+  mode: 'add' | 'subtract'
+}): Uint8ClampedArray {
+  const n = opts.width * opts.height * 4
+  const out = new Uint8ClampedArray(opts.baseMaskRgba)
+  const [fr, fg, fb] = opts.fillRgb
+  for (let i = 0; i < n; i += 4) {
+    if (opts.remoteMaskRgba[i + 3]! <= 127) continue
+    if (opts.mode === 'subtract') {
+      out[i] = 0
+      out[i + 1] = 0
+      out[i + 2] = 0
+      out[i + 3] = 0
+    } else {
+      out[i] = fr
+      out[i + 1] = fg
+      out[i + 2] = fb
+      out[i + 3] = 255
+    }
+  }
+  return out
+}
+```
+
+- [ ] **Step 4: Run tests — PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/canvas/refine/maskRemote.ts apps/web/src/components/canvas/refine/maskRemote.test.ts
+git commit -m "feat(web): merge remote SAM mask into refine canvas"
+```
+
+---
+
+### Task 2: `SegmentProvider`（fal）
+
+**Files:**
+- Create: `packages/agent/src/tools/segment-provider.ts`
+- Create: `packages/agent/src/tools/segment-provider.test.ts`
+- Modify: `packages/agent/src/index.ts`
+
+**Interfaces:**
+- Produces:
+  - `SegmentPointInput = { imageUrl: string; x: number; y: number; label?: 0 | 1 }`
+  - `SegmentProvider = { segment(input: SegmentPointInput): Promise<{ maskUrl: string }> }`
+  - `createSegmentProvider(opts: { apiKey: string; falModel?: string }): SegmentProvider`
+  - 默认 model：`fal-ai/sam-3/image`
+  - HTTP：`POST https://fal.run/${model}`，Header `Authorization: Key ${apiKey}`，Body：
+    ```json
+    {
+      "image_url": "...",
+      "point_prompts": [{ "x": 10, "y": 20, "label": 1 }],
+      "return_multiple_masks": false,
+      "apply_mask": false,
+      "output_format": "png"
+    }
+    ```
+  - 从 JSON 取 `masks[0].url`（或 `image.url` 回退）；缺失则 throw
+
+- [ ] **Step 1: Failing test**（mock `global.fetch`）
+
+```ts
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { createSegmentProvider } from './segment-provider'
+
+describe('createSegmentProvider', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('posts point prompt to fal.run and returns masks[0].url', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        masks: [{ url: 'https://fal.media/mask.png' }],
+      }),
+    } as Response)
+    const provider = createSegmentProvider({ apiKey: 'fal-test' })
+    const out = await provider.segment({ imageUrl: 'https://cdn/a.png', x: 12, y: 34, label: 1 })
+    expect(out.maskUrl).toBe('https://fal.media/mask.png')
+    expect(fetch).toHaveBeenCalledWith(
+      'https://fal.run/fal-ai/sam-3/image',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Key fal-test' }),
+      }),
+    )
+    const body = JSON.parse(String((vi.mocked(fetch).mock.calls[0]?.[1] as RequestInit).body))
+    expect(body.point_prompts).toEqual([{ x: 12, y: 34, label: 1 }])
+    expect(body.image_url).toBe('https://cdn/a.png')
+  })
+})
+```
+
+- [ ] **Step 2: RED** → **Step 3: implement** → **Step 4: GREEN**
+
+```bash
+pnpm --filter @lnkpi/agent exec vitest run src/tools/segment-provider.test.ts
+```
+
+- [ ] **Step 5: Export from `index.ts`** + commit
+
+```bash
+git add packages/agent/src/tools/segment-provider.ts packages/agent/src/tools/segment-provider.test.ts packages/agent/src/index.ts
+git commit -m "feat(agent): fal SegmentProvider for point prompts"
+```
+
+---
+
+### Task 3: Studio `POST /studio/image/segment`
+
+**Files:**
+- Modify: `apps/server/src/studio/studio.controller.ts`（DTO + route，紧挨 `image/edit`）
+- Modify: `apps/server/src/studio/studio.service.ts`（`segmentImage`）
+- Create: `apps/server/src/studio/studio.segment.test.ts`
+
+**Interfaces:**
+- DTO：`imageUrl: string; x: number; y: number; label?: 0 | 1`
+- `StudioService.segmentImage(userId, input): Promise<{ maskUrl: string }>`
+  - 校验 `imageUrl` 非空；`x`/`y` 为有限数且 ≥ 0
+  - `inlineUpstreamReferenceImages([imageUrl])` 后取公网 URL
+  - 读：`process.env.FAL_KEY`；缺失 → `ServiceUnavailableException('点选暂不可用')`
+  - 简易限流：内存 `Map<userId, timestamps[]>`，窗口 60s 最多 **20** 次；超限 `HttpException` 429「点选过于频繁，请稍后再试」
+  - `createSegmentProvider({ apiKey }).segment(...)`；**不** `points.consume`
+  - label 默认 1
+
+- [ ] **Step 1: Failing service test**（照 `studio.edit-image.test.ts` 的 Nest testing 模式 mock prisma/points/resolver；本测可不依赖 prisma）
+
+最小测法：直接 `new StudioService(...)` 若构造过重，则测抽出的限流纯函数 + mock provider 注入。
+
+推荐：在 `studio.service.ts` 旁或同文件可测的
+
+```ts
+export function allowSegmentRate(userId: string, now = Date.now(), windowMs = 60_000, max = 20): boolean
+```
+
+单测限流；另测 `segmentImage` 在无 `FAL_KEY` 时抛 ServiceUnavailable（可用 env 临时删除）。
+
+更完整：mock `createSegmentProvider` via `vi.mock('@lnkpi/agent')` 与 edit 测试相同。
+
+```ts
+it('segmentImage returns maskUrl without charging points', async () => {
+  process.env.FAL_KEY = 'k'
+  // mock createSegmentProvider → { segment: async () => ({ maskUrl: 'https://m' }) }
+  // mock inlineUpstreamReferenceImages → identity
+  const points = { consume: vi.fn(), refund: vi.fn() }
+  const out = await svc.segmentImage('u1', { imageUrl: 'https://a.png', x: 1, y: 2 })
+  expect(out).toEqual({ maskUrl: 'https://m' })
+  expect(points.consume).not.toHaveBeenCalled()
+})
+```
+
+- [ ] **Step 2–4:** RED → 实现 controller + service → GREEN
+
+Controller 片段：
+
+```ts
+@Post('image/segment')
+@UseGuards(AuthGuard)
+async segmentImage(@Req() req: { user: { sub: string } }, @Body() dto: ImageSegmentDto) {
+  const data = await this.studioService.segmentImage(req.user.sub, {
+    imageUrl: dto.imageUrl,
+    x: dto.x,
+    y: dto.y,
+    label: dto.label,
+  })
+  return { code: 0, message: 'ok', data }
+}
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/studio/studio.controller.ts apps/server/src/studio/studio.service.ts apps/server/src/studio/studio.segment.test.ts
+git commit -m "feat(server): POST /studio/image/segment via fal"
+```
+
+---
+
+### Task 4: Store `point` 工具
+
+**Files:**
+- Modify: `apps/web/src/stores/canvasEditor.ts`
+- Modify: `apps/web/src/stores/canvasEditor.refine.test.ts`
+
+**Interfaces:**
+- `RefineMaskTool` 增加 `'point'`
+- `setRefineTool('point')`：**不**改 `refineMaskOp`（与 wand/polygon 相同分支）
+
+- [ ] **Step 1: Extend test**
+
+```ts
+  it('keeps refineMaskOp when switching to point', () => {
+    const editor = useCanvasEditorStore()
+    editor.setRefineTool('eraser')
+    expect(editor.refineMaskOp).toBe('subtract')
+    editor.setRefineTool('point')
+    expect(editor.refineTool).toBe('point')
+    expect(editor.refineMaskOp).toBe('subtract')
+  })
+```
+
+- [ ] **Step 2: RED**（若类型未含 point）→ **Step 3: 改类型与 setter** → GREEN
+
+```ts
+export type RefineMaskTool = 'brush' | 'eraser' | 'rect' | 'wand' | 'polygon' | 'point'
+// setRefineTool: point 落入「不改 op」分支（与 wand/polygon）
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/stores/canvasEditor.ts apps/web/src/stores/canvasEditor.refine.test.ts
+git commit -m "feat(web): refineTool point keeps mask op"
+```
+
+---
+
+### Task 5: MaskEditor + SidePanel + studioApi 接线
+
+**Files:**
+- Modify: `apps/web/src/services/studio-api.ts` — `segmentImage`
+- Modify: `apps/web/src/components/canvas/refine/MaskEditor.vue` — `tool: 'point'` 单击 `emit('pointSelect', { x, y })`；不涂抹
+- Modify: `apps/web/src/components/canvas/refine/RefineWorkViewport.vue` — 透传
+- Modify: `apps/web/src/components/canvas/refine/RefineSidePanel.vue` — 按钮；处理 pointSelect：调 API、拉 PNG、`mergeMaskRgba`、写 canvas
+
+**Interfaces:**
+- `studioApi.segmentImage(body): Promise<{ data: { maskUrl: string } }>` → `POST /studio/image/segment`
+- MaskEditor：`MaskTool` 含 `'point'`；`defineEmits` 增加 `pointSelect: [{ x: number; y: number }]`
+- SidePanel：`segmentBusy` ref；成功/失败 ElMessage；用现有 mask canvas ref / `export` 路径的反向：`getImageData` → merge → `putImageData`
+
+拉 PNG 栅格化辅助（可放 `maskRemote.ts`）：
+
+```ts
+export async function loadMaskRgbaFromUrl(
+  url: string,
+  width: number,
+  height: number,
+): Promise<Uint8ClampedArray> {
+  const img = await createImageBitmap(await (await fetch(url)).blob())
+  const c = document.createElement('canvas')
+  c.width = width
+  c.height = height
+  const ctx = c.getContext('2d')!
+  ctx.drawImage(img, 0, 0, width, height)
+  return ctx.getImageData(0, 0, width, height).data
+}
+```
+
+（若 jsdom 难测 `createImageBitmap`，该函数可不单测，只测 `mergeMaskRgba`。）
+
+SidePanel 点选按钮：
+
+```vue
+<button
+  type="button"
+  class="refine-side__icon-btn"
+  :class="{ 'is-active': editor.refineTool === 'point' }"
+  :title="editor.refineMaskOp === 'subtract' ? '点选减选' : '点选主体'"
+  :disabled="busy || segmentBusy"
+  @click="editor.setRefineTool('point')"
+>
+  <!-- 简单 crosshair / 鼠标图标 SVG -->
+</button>
+```
+
+- [ ] **Step 1:** 实现 studio-api + MaskEditor emit + SidePanel handler（可选手动测为主；可选 mount 测按钮 title）
+- [ ] **Step 2:**
+
+```bash
+pnpm --filter @lnkpi/web exec vitest run \
+  src/stores/canvasEditor.refine.test.ts \
+  src/components/canvas/refine/maskRemote.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/services/studio-api.ts \
+  apps/web/src/components/canvas/refine/MaskEditor.vue \
+  apps/web/src/components/canvas/refine/RefineWorkViewport.vue \
+  apps/web/src/components/canvas/refine/RefineSidePanel.vue \
+  apps/web/src/components/canvas/refine/maskRemote.ts
+git commit -m "feat(web): wire SAM point select into refine side panel"
+```
+
+---
+
+### Task 6: 验证 + 规格状态
+
+- [ ] **Step 1: 测试**
+
+```bash
+pnpm --filter @lnkpi/agent exec vitest run src/tools/segment-provider.test.ts
+pnpm --filter @lnkpi/server exec vitest run src/studio/studio.segment.test.ts
+pnpm --filter @lnkpi/web exec vitest run \
+  src/stores/canvasEditor.refine.test.ts \
+  src/components/canvas/refine/maskRemote.test.ts
+pnpm --filter @lnkpi/web exec vue-tsc --noEmit
+```
+
+Expected: PASS
+
+- [ ] **Step 2:** 更新 design Status → `Approved, plan in docs/superpowers/plans/2026-08-31-cx-image-edit-sam-point-select.md`
+
+- [ ] **Step 3: Commit docs**
+
+```bash
+git add docs/superpowers/specs/2026-08-31-cx-image-edit-sam-point-select-design.md \
+  docs/superpowers/plans/2026-08-31-cx-image-edit-sam-point-select.md
+git commit -m "docs: link SAM point-select implementation plan"
+```
+
+**手动 UAT（有 `FAL_KEY` 的环境）**
+1. 精修 → 点选 → 点主体 → mask 出现  
+2. 橡皮 → 点选 → 挖除  
+3. 积分仅在「精修」变化  
+4. 断网 toast，mask 不变  
+
+**部署注意：** 生产 / `.env` 配置 `FAL_KEY`；未配置时点选返回「点选暂不可用」。
+
+---
+
+## Spec coverage
+
+| Spec | Task |
+|------|------|
+| fal SegmentProvider | 2 |
+| POST /studio/image/segment，不扣分 | 3 |
+| 限流 | 3 |
+| inline 图 URL | 3 |
+| refineTool point + 不改 op | 4 |
+| 单击独立请求 + merge op | 1, 5 |
+| 侧栏 title 减选 | 5 |
+| 非目标未做 | Global Constraints |
+
+## Manual note for B later
+
+文本指代应复用 `SegmentProvider`，扩展 `prompt?: string` 调同一 fal 模型；本 plan 不实现。

--- a/docs/superpowers/specs/2026-08-31-cx-image-edit-sam-point-select-design.md
+++ b/docs/superpowers/specs/2026-08-31-cx-image-edit-sam-point-select-design.md
@@ -1,7 +1,7 @@
 # 画布精修选区：SAM 点击选主体 Design
 
 **Date:** 2026-08-31  
-**Status:** Approved, plan in `docs/superpowers/plans/2026-08-31-cx-image-edit-sam-point-select.md`  
+**Status:** Implemented on `feature/cx-image-edit-sam-point-select`; Approved, plan in `docs/superpowers/plans/2026-08-31-cx-image-edit-sam-point-select.md`  
 **代号:** **CX-IMAGE-EDIT-SAM-POINT**  
 **Related:**
 - `2026-08-18-cx-image-edit-design.md` — 精修作业、积分、EditProvider、版本链

--- a/docs/superpowers/specs/2026-08-31-cx-image-edit-sam-point-select-design.md
+++ b/docs/superpowers/specs/2026-08-31-cx-image-edit-sam-point-select-design.md
@@ -1,7 +1,7 @@
 # 画布精修选区：SAM 点击选主体 Design
 
 **Date:** 2026-08-31  
-**Status:** Approved for planning (pending user review of this file)  
+**Status:** Approved, plan in `docs/superpowers/plans/2026-08-31-cx-image-edit-sam-point-select.md`  
 **代号:** **CX-IMAGE-EDIT-SAM-POINT**  
 **Related:**
 - `2026-08-18-cx-image-edit-design.md` — 精修作业、积分、EditProvider、版本链

--- a/docs/superpowers/specs/2026-08-31-cx-image-edit-sam-point-select-design.md
+++ b/docs/superpowers/specs/2026-08-31-cx-image-edit-sam-point-select-design.md
@@ -1,0 +1,146 @@
+# 画布精修选区：SAM 点击选主体 Design
+
+**Date:** 2026-08-31  
+**Status:** Approved for planning (pending user review of this file)  
+**代号:** **CX-IMAGE-EDIT-SAM-POINT**  
+**Related:**
+- `2026-08-18-cx-image-edit-design.md` — 精修作业、积分、EditProvider、版本链
+- `2026-08-19-cx-image-edit-toolchain-design.md` — 三条链；选区不扣分
+- `2026-08-21-cx-image-edit-selection-tools-design.md` — 魔棒减选 / 多边形；本文件为「选区 3」
+- `2026-08-08-image-upstream-capability-design.md` §7.4 / P2 — 智能选区需分割服务
+
+**路线上下文（用户锁定顺序，本文件仅 A）：**  
+A SAM 点选 → B 文本指代 → C1 强度 → C3 文本/图参考 → C2 局部超分
+
+---
+
+## Goal
+
+在精修 **选区链** 增加 **点选主体**：用户在工作图上单击一次，经远端 SAM 得到主体 mask，再按当前 `refineMaskOp` 并入或挖除。不接抠图、不改精修扣分、不改 EditProvider 出图契约。
+
+## Decisions (locked)
+
+| Topic | Choice |
+|-------|--------|
+| 分割位置 | **远端 API**；CVM 只鉴权转发，不跑模型 |
+| 供应商 | **fal.ai** `fal-ai/sam-3/image`（平台 `FAL_KEY`）；APIMart/Agnes **无**点选分割接口 |
+| 积分 | **点选不扣分**；「精修」仍 10 分 |
+| 与 op | 点「点选」**只换工具不改** `refineMaskOp`；加选并入、减选挖除（同魔棒/多边形） |
+| 请求节奏 | **每次单击独立一次** segment 请求；不做累计多点会话、不多候选 |
+| MVP 点类型 | 仅 **前景** `label: 1`；负点击留给后续 |
+| 实现路径 | **SegmentProvider + `POST /studio/image/segment`**；密钥不出浏览器 |
+| 返回 | 推荐短时可拉 **`maskUrl`**（与底图同像素尺寸的 mask 图） |
+
+## Non-goals（本轮 A）
+
+- 文本指代选区（B）
+- P4 强度 / 局部超分 / 文本参考 / Agent 自动 apply
+- 真抠图 / CutoutProvider / `remove_bg`
+- 负点击、框选、多候选 mask UI、同会话多点一次请求
+- 浏览器直连 fal、BYOK 选 fal 供应商
+- 对照壳扩展；`run_icon_refine` 自动写回
+- 改 `ImageProvider.generate()` / 给 generate 加 mask
+
+---
+
+## Problem baseline
+
+| 层 | 现状 | 缺口 |
+|----|------|------|
+| 选区 | 画笔 / 橡皮 / 矩形 / 魔棒 / 多边形 | 复杂主体边缘仍需大量手绘 |
+| 上游 | Edit 已用 Image2 `mask_url` | 无「点 → mask」分割 |
+| 主机 | CVM 无 GPU、内存紧 | 不可常驻 SAM（与抠图同结论） |
+
+---
+
+## 1. 侧栏与点击行为
+
+- `RefineMaskTool` 增加 `'point'`；侧栏文案 **「点选」** / **「点选主体」**。
+- `setRefineTool('point')`：**不**改 `refineMaskOp`。
+- `op === 'subtract'` 时按钮 title 可为「点选减选」。
+- 工作图单击：
+  1. 坐标映射到工作图像素 `(x, y)`（与 mask 同空间）
+  2. `busy` / 无 URL / 尺寸未就绪 → 忽略
+  3. 进入 segment busy（可与 refine busy 区分或共用禁用点击）
+  4. `POST /studio/image/segment`，`label: 1`
+  5. 将返回 mask 栅格化后：`op === 'add'` 并入，`subtract` 挖除
+  6. `emitCoverage`；失败 toast，mask 不变
+
+关精修 / `resetRefineChromeState`：工具复位 `'brush'`，op 复位 `'add'`（与现有一致）。
+
+---
+
+## 2. 服务端契约与数据流
+
+### 2.1 HTTP
+
+```
+POST /studio/image/segment
+Auth: required
+Body: { imageUrl: string, x: number, y: number, label?: 0 | 1 }
+Success: { code: 0, data: { maskUrl: string } }
+```
+
+- `x`/`y`：非负整数，且应在图像宽高内（可知时校验）
+- MVP 客户端固定 `label: 1`
+- **不**创建 GenerationRecord、**不**走积分扣减
+
+### 2.2 SegmentProvider（fal）
+
+- 平台环境变量 `FAL_KEY`（缺失时接口明确 503/配置错误）
+- 调用 `fal-ai/sam-3/image`：
+  - `image_url`：公网可拉 URL（内网图先走现有 inline/公网化，与 edit 同源策略）
+  - `point_prompts: [{ x, y, label }]`
+  - 取 **单张** 最佳 mask（`return_multiple_masks: false` 或服务端选最高分）
+- 将上游 mask 落成可下载 `maskUrl`（复用现有临时/素材存储模式之一，实现时对齐 edit mask 上传习惯）
+- 按用户 **频率限流**（防连点刷 fal）；超限 429 + 文案
+
+### 2.3 前端
+
+- `studioApi.segmentImage(...)`
+- MaskEditor：`refineTool === 'point'` 时单击触发，非涂抹
+- 栅格并入逻辑复用现有 mask 合成方式（与魔棒结果写入同路径）
+
+---
+
+## 3. 错误与测试
+
+**错误**
+- fal/网络失败：toast「点选失败，请重试」；不改 mask
+- 限流：提示稍后再试
+- 配置缺失：服务端明确错误，前端可展示「点选暂不可用」
+
+**测试**
+- Provider：坐标/label → fal 请求映射；单 mask 选取
+- Controller/service：鉴权、非法坐标、成功 `maskUrl`
+- Store/UI：`point` 工具不改 op；busy 不连发
+- 回归：魔棒/多边形/精修 edit 行为不变
+
+**手动验收**
+1. 点选工具 → 点主体 → mask 贴合主体轮廓  
+2. 先橡皮再点选 → 挖除该主体  
+3. 多次点选（加选）并入多块  
+4. 积分不变直至点「精修」  
+5. 断网/错误时 toast，原 mask 保留  
+
+---
+
+## Success criteria
+
+1. 选区链有「点选」；单击经服务端 fal 写入 mask。  
+2. 跟随 `refineMaskOp` 加/减。  
+3. 点选零扣分；精修扣分不变。  
+4. 密钥仅服务端；无浏览器直连 fal。  
+5. 无文本指代、无抠图、无 P4。  
+
+---
+
+## Follow-ups（不进本文件实现）
+
+| 包 | 内容 |
+|----|------|
+| B | 文本指代；复用 SegmentProvider + text `prompt` |
+| C1 | 编辑强度滑杆 |
+| C3 | 精修附参考图 |
+| C2 | 局部超分 |
+| 后续 | 负点击、多候选、BYOK fal |

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,6 +1,7 @@
 export { applyCanvasActions } from './tools/executor'
 export { createImageProvider, PlaceholderImageProvider, OpenAIImageProvider } from './tools/image-provider'
 export { createImageEditProvider, ApimartImageEditProvider } from './tools/image-edit-provider'
+export { createSegmentProvider } from './tools/segment-provider'
 export {
   createTextProvider,
   PlaceholderTextProvider,
@@ -13,6 +14,7 @@ export { createVideoProvider, PlaceholderVideoProvider, AgnesVideoProvider, reso
 export { createAudioProvider, PlaceholderAudioProvider, OpenAITTSProvider, FallbackAudioProvider } from './tools/audio-provider'
 export type { ImageProvider, ProviderCredentialOpts, ImageGenerateOptions } from './tools/image-provider'
 export type { ImageEditProvider, ImageEditInput } from './tools/image-edit-provider'
+export type { SegmentProvider, SegmentPointInput } from './tools/segment-provider'
 export type { TextProvider, TextGenerateOptions, TextThinkingEffort } from './tools/text-provider'
 export type { VideoProvider } from './tools/video-provider'
 export type { AudioProvider, AudioGenerateOptions } from './tools/audio-provider'

--- a/packages/agent/src/tools/segment-provider.test.ts
+++ b/packages/agent/src/tools/segment-provider.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createSegmentProvider } from './segment-provider'
+
+describe('createSegmentProvider', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('posts point prompt to fal.run and returns masks[0].url', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        masks: [{ url: 'https://fal.media/mask.png' }],
+      }),
+    } as Response)
+    const provider = createSegmentProvider({ apiKey: 'fal-test' })
+    const out = await provider.segment({ imageUrl: 'https://cdn/a.png', x: 12, y: 34, label: 1 })
+    expect(out.maskUrl).toBe('https://fal.media/mask.png')
+    expect(fetch).toHaveBeenCalledWith(
+      'https://fal.run/fal-ai/sam-3/image',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Key fal-test' }),
+      }),
+    )
+    const body = JSON.parse(String((vi.mocked(fetch).mock.calls[0]?.[1] as RequestInit).body))
+    expect(body.point_prompts).toEqual([{ x: 12, y: 34, label: 1 }])
+    expect(body.image_url).toBe('https://cdn/a.png')
+    expect(body.return_multiple_masks).toBe(false)
+    expect(body.apply_mask).toBe(false)
+    expect(body.output_format).toBe('png')
+  })
+
+  it('falls back to image.url when masks is empty', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        image: { url: 'https://fal.media/fallback.png' },
+      }),
+    } as Response)
+    const provider = createSegmentProvider({ apiKey: 'fal-test' })
+    const out = await provider.segment({ imageUrl: 'https://cdn/a.png', x: 1, y: 2 })
+    expect(out.maskUrl).toBe('https://fal.media/fallback.png')
+  })
+
+  it('throws when response has no mask url', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as Response)
+    const provider = createSegmentProvider({ apiKey: 'fal-test' })
+    await expect(provider.segment({ imageUrl: 'https://cdn/a.png', x: 1, y: 2 })).rejects.toThrow(
+      /mask/i,
+    )
+  })
+
+  it('uses custom falModel when provided', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        masks: [{ url: 'https://fal.media/mask.png' }],
+      }),
+    } as Response)
+    const provider = createSegmentProvider({ apiKey: 'fal-test', falModel: 'custom/sam' })
+    await provider.segment({ imageUrl: 'https://cdn/a.png', x: 0, y: 0 })
+    expect(fetch).toHaveBeenCalledWith('https://fal.run/custom/sam', expect.any(Object))
+  })
+})

--- a/packages/agent/src/tools/segment-provider.ts
+++ b/packages/agent/src/tools/segment-provider.ts
@@ -1,0 +1,62 @@
+export interface SegmentPointInput {
+  imageUrl: string
+  x: number
+  y: number
+  label?: 0 | 1
+}
+
+export interface SegmentProvider {
+  segment(input: SegmentPointInput): Promise<{ maskUrl: string }>
+}
+
+const DEFAULT_FAL_MODEL = 'fal-ai/sam-3/image'
+
+function extractMaskUrl(json: unknown): string | undefined {
+  if (!json || typeof json !== 'object') return undefined
+  const record = json as Record<string, unknown>
+  const masks = record.masks
+  if (Array.isArray(masks) && masks[0] && typeof masks[0] === 'object') {
+    const url = (masks[0] as Record<string, unknown>).url
+    if (typeof url === 'string' && url) return url
+  }
+  const image = record.image
+  if (image && typeof image === 'object') {
+    const url = (image as Record<string, unknown>).url
+    if (typeof url === 'string' && url) return url
+  }
+  return undefined
+}
+
+export function createSegmentProvider(opts: {
+  apiKey: string
+  falModel?: string
+}): SegmentProvider {
+  const apiKey = opts.apiKey
+  const model = opts.falModel ?? DEFAULT_FAL_MODEL
+
+  return {
+    async segment(input: SegmentPointInput): Promise<{ maskUrl: string }> {
+      const res = await fetch(`https://fal.run/${model}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Key ${apiKey}`,
+        },
+        body: JSON.stringify({
+          image_url: input.imageUrl,
+          point_prompts: [{ x: input.x, y: input.y, label: input.label ?? 1 }],
+          return_multiple_masks: false,
+          apply_mask: false,
+          output_format: 'png',
+        }),
+      })
+      if (!res.ok) throw new Error(`Segment API ${res.status}: ${await res.text()}`)
+      const json = await res.json()
+      const maskUrl = extractMaskUrl(json)
+      if (!maskUrl) {
+        throw new Error(`Segment API response missing mask url: ${JSON.stringify(json)}`)
+      }
+      return { maskUrl }
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- Add refine **点选** tool: one click on the work image calls fal SAM3 via `POST /studio/image/segment` and merges the mask with `refineMaskOp` (add/subtract), matching wand/polygon.
- New `SegmentProvider` (`fal-ai/sam-3/image`) in `@lnkpi/agent`; server proxies with platform `FAL_KEY`, rate limit, no points charge for segment.
- Spec/plan: `docs/superpowers/specs/2026-08-31-cx-image-edit-sam-point-select-design.md`, `docs/superpowers/plans/2026-08-31-cx-image-edit-sam-point-select.md`

## Deploy note
Production needs **`FAL_KEY`** set; without it, point-select returns「点选暂不可用」.

## Test plan
- [ ] With `FAL_KEY`: open refine → 点选 → click subject → mask appears
- [ ] Eraser then 点选 → subtract subject from mask
- [ ] Points balance unchanged until「精修」
- [ ] Offline / missing key: toast or「点选暂不可用」, mask unchanged
- [x] Local: segment-provider + studio.segment + refine tests; `pnpm build`; agent tests


Made with [Cursor](https://cursor.com)