### PR TITLE
feat: SAM3 point-select with MediaPipe fallback

### DIFF
--- a/apps/server/src/studio/studio.segment.test.ts
+++ b/apps/server/src/studio/studio.segment.test.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Test } from '@nestjs/testing'
 import {
+  BadGatewayException,
   BadRequestException,
   HttpException,
   HttpStatus,
@@ -175,5 +176,13 @@ describe('StudioService.segmentImage', () => {
     expect(segment).toHaveBeenCalledWith(
       expect.objectContaining({ label: 0 }),
     )
+  })
+
+  it('maps provider failure to BadGatewayException', async () => {
+    segment.mockRejectedValueOnce(new Error('Segment API 403: TOP_UP'))
+
+    await expect(
+      svc.segmentImage('u1', { imageUrl: 'https://a.png', x: 1, y: 2 }),
+    ).rejects.toBeInstanceOf(BadGatewayException)
   })
 })

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadGatewayException,
   BadRequestException,
   HttpException,
   HttpStatus,
@@ -1219,12 +1220,23 @@ export class StudioService {
     const [inlinedUrl] = await inlineUpstreamReferenceImages([imageUrl])
     const publicUrl = inlinedUrl ?? imageUrl
 
-    return createSegmentProvider({ apiKey }).segment({
-      imageUrl: publicUrl,
-      x: input.x,
-      y: input.y,
-      label: input.label ?? 1,
-    })
+    try {
+      return await createSegmentProvider({ apiKey }).segment({
+        imageUrl: publicUrl,
+        x: input.x,
+        y: input.y,
+        label: input.label ?? 1,
+      })
+    } catch (err) {
+      if (
+        err instanceof BadRequestException
+        || err instanceof ServiceUnavailableException
+        || err instanceof HttpException
+      ) {
+        throw err
+      }
+      throw new BadGatewayException('云端点选失败')
+    }
   }
 
   async generateVideo(

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@lnkpi/shared": "workspace:*",
+    "@mediapipe/tasks-vision": "^1.0.1",
     "@tiptap/extension-placeholder": "^3.28.0",
     "@tiptap/extension-table": "^3.28.0",
     "@tiptap/extension-table-cell": "^3.28.0",

--- a/apps/web/src/components/canvas/refine/RefineSidePanel.vue
+++ b/apps/web/src/components/canvas/refine/RefineSidePanel.vue
@@ -19,6 +19,12 @@ import VersionStrip from './VersionStrip.vue'
 import { countMaskPixelsFromImageData, exportMaskPng } from './maskExport'
 import { loadMaskRgbaFromUrl, mergeMaskRgba, registerRefinePointSelectHandler } from './maskRemote'
 import { parseFillHex } from './maskWand'
+import { resetMediaPipeSegmentSession, segmentPointLocal } from './mediapipeSegment'
+import {
+  createPointSegmentSession,
+  resetPointSegmentSession,
+  resolvePointMaskRgba,
+} from './pointSegmentSession'
 
 const REFINE_MIN_W = 360
 const REFINE_MAX_W = 560
@@ -61,6 +67,20 @@ let abortController: AbortController | null = null
 let resizing = false
 let dragging = false
 let dragOffset = { x: 0, y: 0 }
+const pointSession = createPointSegmentSession()
+
+function resetPointFallbackState() {
+  resetPointSegmentSession(pointSession)
+  resetMediaPipeSegmentSession()
+}
+
+async function loadWorkImage(url: string): Promise<HTMLImageElement> {
+  const img = new Image()
+  img.crossOrigin = 'anonymous'
+  img.src = url
+  await img.decode()
+  return img
+}
 
 const credits = computed(() => estimateImageCredits(1))
 const coverageKind = computed(() => maskCoverageMessage(editor.refineCoverage))
@@ -112,6 +132,7 @@ watch(
     compareBeforeUrl.value = next.compareBeforeUrl
     afterUrl.value = next.afterUrl
     if (next.reset) lastRecordId.value = undefined
+    resetPointFallbackState()
   },
 )
 
@@ -297,13 +318,33 @@ async function onPointSelect({ x, y }: { x: number; y: number }) {
 
   segmentBusy.value = true
   try {
-    const { data } = await studioApi.segmentImage({
-      imageUrl: props.beforeUrl,
-      x,
-      y,
-      label: 1,
+    const remoteRgba = await resolvePointMaskRgba({
+      session: pointSession,
+      remoteSegment: async () => {
+        const { data } = await studioApi.segmentImage({
+          imageUrl: props.beforeUrl,
+          x,
+          y,
+          label: 1,
+        })
+        return { maskUrl: data.data.maskUrl }
+      },
+      loadRemoteRgba: (maskUrl) => loadMaskRgbaFromUrl(maskUrl, canvas.width, canvas.height),
+      localSegment: async () => {
+        const img = await loadWorkImage(props.beforeUrl)
+        return segmentPointLocal({
+          image: img,
+          imageKey: props.beforeUrl,
+          x,
+          y,
+          width: canvas.width,
+          height: canvas.height,
+        })
+      },
+      onFallbackToast: () => {
+        ElMessage.warning('云端点选暂不可用，已用本地点选')
+      },
     })
-    const remoteRgba = await loadMaskRgbaFromUrl(data.data.maskUrl, canvas.width, canvas.height)
     const base = ctx.getImageData(0, 0, canvas.width, canvas.height)
     const merged = mergeMaskRgba({
       width: canvas.width,
@@ -384,6 +425,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   registerRefinePointSelectHandler(null)
+  resetPointFallbackState()
   window.removeEventListener('resize', syncNarrow)
   window.removeEventListener('keydown', onKeydown)
   stopResize()

--- a/apps/web/src/components/canvas/refine/mediapipeSegment.test.ts
+++ b/apps/web/src/components/canvas/refine/mediapipeSegment.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  confidenceMaskToRgba,
+  resetMediaPipeSegmentSession,
+  segmentPointLocal,
+} from './mediapipeSegment'
+
+describe('confidenceMaskToRgba', () => {
+  it('thresholds confidence into alpha mask', () => {
+    const out = confidenceMaskToRgba([0.1, 0.9], 2, 1, 0.5)
+    expect([...out.slice(0, 4)]).toEqual([0, 0, 0, 0])
+    expect([...out.slice(4, 8)]).toEqual([255, 255, 255, 255])
+  })
+})
+
+describe('segmentPointLocal', () => {
+  it('uses injected segmenter and caches setImage per imageKey', async () => {
+    resetMediaPipeSegmentSession()
+    const setImage = vi.fn()
+    const getAsFloat32Array = vi.fn(() => new Float32Array([0, 1, 0, 1]))
+    const segment = vi.fn(() => ({ confidenceMasks: [{ getAsFloat32Array }] }))
+    const loadSegmenter = vi.fn(async () => ({ setImage, segment }))
+
+    const canvas = document.createElement('canvas')
+    canvas.width = 2
+    canvas.height = 2
+
+    const a = await segmentPointLocal({
+      image: canvas,
+      imageKey: 'img-a',
+      x: 0,
+      y: 0,
+      width: 2,
+      height: 2,
+      deps: { loadSegmenter },
+    })
+    expect(loadSegmenter).toHaveBeenCalledTimes(1)
+    expect(setImage).toHaveBeenCalledTimes(1)
+    expect(a.length).toBe(16)
+
+    await segmentPointLocal({
+      image: canvas,
+      imageKey: 'img-a',
+      x: 1,
+      y: 1,
+      width: 2,
+      height: 2,
+      deps: { loadSegmenter },
+    })
+    expect(loadSegmenter).toHaveBeenCalledTimes(1)
+    expect(setImage).toHaveBeenCalledTimes(1)
+
+    await segmentPointLocal({
+      image: canvas,
+      imageKey: 'img-b',
+      x: 0,
+      y: 0,
+      width: 2,
+      height: 2,
+      deps: { loadSegmenter },
+    })
+    expect(setImage).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/web/src/components/canvas/refine/mediapipeSegment.test.ts
+++ b/apps/web/src/components/canvas/refine/mediapipeSegment.test.ts
@@ -15,10 +15,10 @@ describe('confidenceMaskToRgba', () => {
 
 describe('segmentPointLocal', () => {
   it('uses injected segmenter and caches setImage per imageKey', async () => {
-    resetMediaPipeSegmentSession()
+    await resetMediaPipeSegmentSession()
     const setImage = vi.fn()
     const getAsFloat32Array = vi.fn(() => new Float32Array([0, 1, 0, 1]))
-    const segment = vi.fn(() => ({ confidenceMasks: [{ getAsFloat32Array }] }))
+    const segment = vi.fn(() => ({ getAsFloat32Array }))
     const loadSegmenter = vi.fn(async () => ({ setImage, segment }))
 
     const canvas = document.createElement('canvas')
@@ -37,6 +37,9 @@ describe('segmentPointLocal', () => {
     expect(loadSegmenter).toHaveBeenCalledTimes(1)
     expect(setImage).toHaveBeenCalledTimes(1)
     expect(a.length).toBe(16)
+    expect(segment).toHaveBeenCalledWith([
+      expect.objectContaining({ brushMode: 1 }),
+    ])
 
     await segmentPointLocal({
       image: canvas,
@@ -60,5 +63,33 @@ describe('segmentPointLocal', () => {
       deps: { loadSegmenter },
     })
     expect(setImage).toHaveBeenCalledTimes(2)
+  })
+
+  it('closes the cached segmenter when resetting the session', async () => {
+    await resetMediaPipeSegmentSession()
+    const close = vi.fn()
+    const loadSegmenter = vi.fn(async () => ({
+      setImage: vi.fn(),
+      segment: vi.fn(() => ({
+        getAsFloat32Array: () => new Float32Array([1]),
+      })),
+      close,
+    }))
+    const canvas = document.createElement('canvas')
+    canvas.width = 1
+    canvas.height = 1
+
+    await segmentPointLocal({
+      image: canvas,
+      imageKey: 'img-close',
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 1,
+      deps: { loadSegmenter },
+    })
+    await resetMediaPipeSegmentSession()
+
+    expect(close).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/src/components/canvas/refine/mediapipeSegment.ts
+++ b/apps/web/src/components/canvas/refine/mediapipeSegment.ts
@@ -1,10 +1,17 @@
+type MediaPipeMaskLike = {
+  getAsFloat32Array(): Float32Array
+}
+
+type LegacyMediaPipeSegmentResult = {
+  confidenceMasks?: MediaPipeMaskLike[]
+}
+
 export type MediaPipeSegmenterLike = {
   setImage(image: CanvasImageSource): void
-  segment(strokes: unknown): {
-    confidenceMasks?: Array<{
-      getAsFloat32Array?: () => Float32Array
-    }>
-  } | void
+  segment(
+    strokes: unknown,
+  ): MediaPipeMaskLike | LegacyMediaPipeSegmentResult | void
+  close?: () => void
 }
 
 export type MediaPipeDeps = {
@@ -33,6 +40,7 @@ const PRIMARY_MODEL_URL =
   'https://storage.googleapis.com/mediapipe-models/interactive_segmenter/magic_touch/float16/latest/magic_touch.tflite'
 const FALLBACK_MODEL_URL =
   'https://storage.googleapis.com/mediapipe-models/interactive_segmenter_v2/magic_touch/int8/latest/interactive_segmentation.task'
+const BRUSH_POSITIVE = 1
 
 let segmenterPromise: Promise<MediaPipeSegmenterLike> | undefined
 let cachedImageKey: string | undefined
@@ -85,13 +93,35 @@ async function defaultLoadSegmenter(): Promise<MediaPipeSegmenterLike> {
   }
 }
 
-export function resetMediaPipeSegmentSession(): void {
-  segmenterPromise = undefined
-  cachedImageKey = undefined
+export async function resetMediaPipeSegmentSession(): Promise<void> {
+  const pendingSegmenter = segmenterPromise
+  if (pendingSegmenter) {
+    try {
+      const segmenter = await pendingSegmenter
+      segmenter.close?.()
+    } catch {
+      // Reset must remain best-effort when loading or closing MediaPipe fails.
+    }
+  }
+
+  if (segmenterPromise === pendingSegmenter) {
+    segmenterPromise = undefined
+    cachedImageKey = undefined
+  }
 }
 
 function clampNormalized(value: number): number {
   return Math.min(1, Math.max(0, value))
+}
+
+function extractConfidence(
+  result: MediaPipeMaskLike | LegacyMediaPipeSegmentResult | void,
+): Float32Array | undefined {
+  if (!result) return undefined
+  if ('getAsFloat32Array' in result) {
+    return result.getAsFloat32Array()
+  }
+  return result.confidenceMasks?.[0]?.getAsFloat32Array()
 }
 
 export async function segmentPointLocal(opts: {
@@ -116,11 +146,11 @@ export async function segmentPointLocal(opts: {
   const result = segmenter.segment([
     {
       isCompleted: true,
-      brushMode: 'ADD',
+      brushMode: BRUSH_POSITIVE,
       point: [{ x: nx, y: ny }],
     },
   ])
-  const confidence = result?.confidenceMasks?.[0]?.getAsFloat32Array?.()
+  const confidence = extractConfidence(result)
 
   if (!confidence || confidence.length !== opts.width * opts.height) {
     throw new Error('本地点选失败')

--- a/apps/web/src/components/canvas/refine/mediapipeSegment.ts
+++ b/apps/web/src/components/canvas/refine/mediapipeSegment.ts
@@ -1,0 +1,129 @@
+export type MediaPipeSegmenterLike = {
+  setImage(image: CanvasImageSource): void
+  segment(strokes: unknown): {
+    confidenceMasks?: Array<{
+      getAsFloat32Array?: () => Float32Array
+    }>
+  } | void
+}
+
+export type MediaPipeDeps = {
+  loadSegmenter: () => Promise<MediaPipeSegmenterLike>
+}
+
+type MediaPipeModuleLike = {
+  FilesetResolver: {
+    forVisionTasks(wasmRoot: string): Promise<unknown>
+  }
+  InteractiveSegmenter: {
+    createFromOptions(
+      fileset: unknown,
+      options: {
+        baseOptions: { modelAssetPath: string }
+        outputCategoryMask: boolean
+        outputConfidenceMasks: boolean
+      },
+    ): Promise<MediaPipeSegmenterLike>
+  }
+}
+
+const WASM_ROOT =
+  'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@1.0.1/wasm'
+const PRIMARY_MODEL_URL =
+  'https://storage.googleapis.com/mediapipe-models/interactive_segmenter/magic_touch/float16/latest/magic_touch.tflite'
+const FALLBACK_MODEL_URL =
+  'https://storage.googleapis.com/mediapipe-models/interactive_segmenter_v2/magic_touch/int8/latest/interactive_segmentation.task'
+
+let segmenterPromise: Promise<MediaPipeSegmenterLike> | undefined
+let cachedImageKey: string | undefined
+
+export function confidenceMaskToRgba(
+  confidence: Float32Array | number[],
+  width: number,
+  height: number,
+  threshold = 0.5,
+): Uint8ClampedArray {
+  if (confidence.length !== width * height) {
+    throw new Error('本地点选失败')
+  }
+
+  const rgba = new Uint8ClampedArray(width * height * 4)
+  for (let index = 0; index < confidence.length; index += 1) {
+    if (confidence[index] >= threshold) {
+      const offset = index * 4
+      rgba[offset] = 255
+      rgba[offset + 1] = 255
+      rgba[offset + 2] = 255
+      rgba[offset + 3] = 255
+    }
+  }
+  return rgba
+}
+
+async function createSegmenter(
+  vision: MediaPipeModuleLike,
+  fileset: unknown,
+  modelAssetPath: string,
+): Promise<MediaPipeSegmenterLike> {
+  return vision.InteractiveSegmenter.createFromOptions(fileset, {
+    baseOptions: { modelAssetPath },
+    outputCategoryMask: false,
+    outputConfidenceMasks: true,
+  })
+}
+
+async function defaultLoadSegmenter(): Promise<MediaPipeSegmenterLike> {
+  const vision = (await import(
+    '@mediapipe/tasks-vision'
+  )) as unknown as MediaPipeModuleLike
+  const fileset = await vision.FilesetResolver.forVisionTasks(WASM_ROOT)
+
+  try {
+    return await createSegmenter(vision, fileset, PRIMARY_MODEL_URL)
+  } catch {
+    return createSegmenter(vision, fileset, FALLBACK_MODEL_URL)
+  }
+}
+
+export function resetMediaPipeSegmentSession(): void {
+  segmenterPromise = undefined
+  cachedImageKey = undefined
+}
+
+function clampNormalized(value: number): number {
+  return Math.min(1, Math.max(0, value))
+}
+
+export async function segmentPointLocal(opts: {
+  image: CanvasImageSource
+  imageKey: string
+  x: number
+  y: number
+  width: number
+  height: number
+  deps?: MediaPipeDeps
+}): Promise<Uint8ClampedArray> {
+  segmenterPromise ??= (opts.deps?.loadSegmenter ?? defaultLoadSegmenter)()
+  const segmenter = await segmenterPromise
+
+  if (cachedImageKey !== opts.imageKey) {
+    segmenter.setImage(opts.image)
+    cachedImageKey = opts.imageKey
+  }
+
+  const nx = clampNormalized((opts.x + 0.5) / opts.width)
+  const ny = clampNormalized((opts.y + 0.5) / opts.height)
+  const result = segmenter.segment([
+    {
+      isCompleted: true,
+      brushMode: 'ADD',
+      point: [{ x: nx, y: ny }],
+    },
+  ])
+  const confidence = result?.confidenceMasks?.[0]?.getAsFloat32Array?.()
+
+  if (!confidence || confidence.length !== opts.width * opts.height) {
+    throw new Error('本地点选失败')
+  }
+  return confidenceMaskToRgba(confidence, opts.width, opts.height)
+}

--- a/apps/web/src/components/canvas/refine/pointSegmentSession.test.ts
+++ b/apps/web/src/components/canvas/refine/pointSegmentSession.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createPointSegmentSession,
+  resetPointSegmentSession,
+  resolvePointMaskRgba,
+} from './pointSegmentSession'
+
+const rgba = () => new Uint8ClampedArray([1, 2, 3, 255])
+
+describe('resolvePointMaskRgba', () => {
+  it('uses remote when healthy', async () => {
+    const session = createPointSegmentSession()
+    const remoteSegment = vi.fn(async () => ({ maskUrl: 'https://m' }))
+    const loadRemoteRgba = vi.fn(async () => rgba())
+    const localSegment = vi.fn(async () => rgba())
+    const out = await resolvePointMaskRgba({
+      session,
+      remoteSegment,
+      loadRemoteRgba,
+      localSegment,
+    })
+    expect([...out]).toEqual([1, 2, 3, 255])
+    expect(localSegment).not.toHaveBeenCalled()
+    expect(session.preferLocal).toBe(false)
+  })
+
+  it('falls back once and sticks to local', async () => {
+    const session = createPointSegmentSession()
+    const toast = vi.fn()
+    const remoteSegment = vi.fn(async () => {
+      throw { response: { status: 502 } }
+    })
+    const loadRemoteRgba = vi.fn()
+    const localSegment = vi.fn(async () => rgba())
+
+    await resolvePointMaskRgba({
+      session,
+      remoteSegment,
+      loadRemoteRgba,
+      localSegment,
+      onFallbackToast: toast,
+    })
+    expect(toast).toHaveBeenCalledTimes(1)
+    expect(session.preferLocal).toBe(true)
+
+    remoteSegment.mockClear()
+    localSegment.mockClear()
+    toast.mockClear()
+
+    await resolvePointMaskRgba({
+      session,
+      remoteSegment,
+      loadRemoteRgba,
+      localSegment,
+      onFallbackToast: toast,
+    })
+    expect(remoteSegment).not.toHaveBeenCalled()
+    expect(localSegment).toHaveBeenCalledTimes(1)
+    expect(toast).not.toHaveBeenCalled()
+  })
+
+  it('does not fallback on 429', async () => {
+    const session = createPointSegmentSession()
+    const localSegment = vi.fn(async () => rgba())
+    await expect(
+      resolvePointMaskRgba({
+        session,
+        remoteSegment: async () => {
+          throw { response: { status: 429, data: { message: '点选过于频繁，请稍后再试' } } }
+        },
+        loadRemoteRgba: async () => rgba(),
+        localSegment,
+      }),
+    ).rejects.toMatchObject({ response: { status: 429 } })
+    expect(localSegment).not.toHaveBeenCalled()
+  })
+
+  it('reset clears stickiness', () => {
+    const session = createPointSegmentSession()
+    session.preferLocal = true
+    session.fallbackToastShown = true
+    resetPointSegmentSession(session)
+    expect(session).toEqual({ preferLocal: false, fallbackToastShown: false })
+  })
+})

--- a/apps/web/src/components/canvas/refine/pointSegmentSession.ts
+++ b/apps/web/src/components/canvas/refine/pointSegmentSession.ts
@@ -1,0 +1,41 @@
+import { isSegmentUpstreamDegradable } from './segmentDegrade'
+
+export type PointSegmentSession = {
+  preferLocal: boolean
+  fallbackToastShown: boolean
+}
+
+export function createPointSegmentSession(): PointSegmentSession {
+  return { preferLocal: false, fallbackToastShown: false }
+}
+
+export function resetPointSegmentSession(session: PointSegmentSession): void {
+  session.preferLocal = false
+  session.fallbackToastShown = false
+}
+
+export async function resolvePointMaskRgba(opts: {
+  session: PointSegmentSession
+  remoteSegment: () => Promise<{ maskUrl: string }>
+  loadRemoteRgba: (maskUrl: string) => Promise<Uint8ClampedArray>
+  localSegment: () => Promise<Uint8ClampedArray>
+  onFallbackToast?: () => void
+}): Promise<Uint8ClampedArray> {
+  const { session } = opts
+  if (session.preferLocal) {
+    return opts.localSegment()
+  }
+  try {
+    const { maskUrl } = await opts.remoteSegment()
+    return await opts.loadRemoteRgba(maskUrl)
+  } catch (err) {
+    if (!isSegmentUpstreamDegradable(err)) throw err
+    const rgba = await opts.localSegment()
+    session.preferLocal = true
+    if (!session.fallbackToastShown) {
+      session.fallbackToastShown = true
+      opts.onFallbackToast?.()
+    }
+    return rgba
+  }
+}

--- a/apps/web/src/components/canvas/refine/segmentDegrade.test.ts
+++ b/apps/web/src/components/canvas/refine/segmentDegrade.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { isSegmentUpstreamDegradable } from './segmentDegrade'
+
+describe('isSegmentUpstreamDegradable', () => {
+  it('treats 502 and 503 as degradable', () => {
+    expect(isSegmentUpstreamDegradable({ response: { status: 502 } })).toBe(true)
+    expect(isSegmentUpstreamDegradable({ response: { status: 503 } })).toBe(true)
+  })
+
+  it('treats network errors without response as degradable', () => {
+    expect(isSegmentUpstreamDegradable({ message: 'Network Error' })).toBe(true)
+    expect(isSegmentUpstreamDegradable({ code: 'ECONNABORTED' })).toBe(true)
+  })
+
+  it('does not degrade 400 or platform 429', () => {
+    expect(isSegmentUpstreamDegradable({ response: { status: 400 } })).toBe(false)
+    expect(isSegmentUpstreamDegradable({ response: { status: 429 } })).toBe(false)
+  })
+
+  it('does not degrade unrelated 4xx', () => {
+    expect(isSegmentUpstreamDegradable({ response: { status: 401 } })).toBe(false)
+    expect(isSegmentUpstreamDegradable({ response: { status: 404 } })).toBe(false)
+  })
+})

--- a/apps/web/src/components/canvas/refine/segmentDegrade.ts
+++ b/apps/web/src/components/canvas/refine/segmentDegrade.ts
@@ -1,0 +1,7 @@
+export function isSegmentUpstreamDegradable(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const response = (err as { response?: { status?: number } }).response
+  if (!response) return true
+  const status = response.status
+  return status === 502 || status === 503
+}

--- a/docs/superpowers/plans/2026-08-31-cx-image-edit-sam-mediapipe-fallback.md
+++ b/docs/superpowers/plans/2026-08-31-cx-image-edit-sam-mediapipe-fallback.md
@@ -1,0 +1,742 @@
+# 精修点选 SAM3 + MediaPipe 降级 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 云端 fal SAM3 点选失败（502/503/网络）时，浏览器自动降级到 MediaPipe Interactive Segmenter；toast 一次、会话粘滞；不改积分与精修出图。
+
+**Architecture:** 服务端将 fal 失败映射为 `502`。前端抽可测编排 `resolvePointMaskRgba`（先 remote，可降级则本地 + 粘滞）。`mediapipeSegment.ts` 懒加载 `@mediapipe/tasks-vision`，把 confidence mask 转成与 `mergeMaskRgba` 兼容的 RGBA。`RefineSidePanel.onPointSelect` 接线；关精修/换图复位。
+
+**Tech Stack:** NestJS、Vitest、Vue 3、Element Plus `ElMessage`、`@mediapipe/tasks-vision`（Interactive Segmenter）
+
+**Spec:** `docs/superpowers/specs/2026-08-31-cx-image-edit-sam-mediapipe-fallback-design.md`
+
+## Global Constraints
+
+- 主路径仍为 fal **`fal-ai/sam-3/image`**；CVM **不**跑 MediaPipe / SAM
+- 仅故障自动降级；无手动「本地点选」；不预热精修面板
+- 首次降级成功 toast：**「云端点选暂不可用，已用本地点选」**（会话内一次）
+- 粘滞：本轮精修内后续点选只走本地；关精修 / 换工作图后复位再试 SAM3
+- 可降级：HTTP **502 / 503**，或无 `response` 的网络/超时；**不可**降级：400、本平台用户限流 429
+- 点选仍不扣分；不改 EditProvider / 抠图 / 文本指代
+- TDD；提交前缀 `feat:` / `fix:` / `test:` / `docs:`
+- 不 `git add -A`；勿提交 `.seedream-backup`、`deploy/`、`q.js`、`.superpowers/sdd/*`
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `apps/server/src/studio/studio.service.ts` | `segmentImage`：捕获 provider 错误 → `BadGatewayException` |
+| `apps/server/src/studio/studio.segment.test.ts` | 502 / 503 / 429 / 400 用例 |
+| `apps/web/src/components/canvas/refine/segmentDegrade.ts` | `isSegmentUpstreamDegradable` |
+| `apps/web/src/components/canvas/refine/segmentDegrade.test.ts` | 可降级判定单测 |
+| `apps/web/src/components/canvas/refine/pointSegmentSession.ts` | 会话状态 + `resolvePointMaskRgba` 编排 |
+| `apps/web/src/components/canvas/refine/pointSegmentSession.test.ts` | 粘滞 / toast / 跳过 API |
+| `apps/web/src/components/canvas/refine/mediapipeSegment.ts` | MediaPipe 懒加载 + 点选 → RGBA；可注入 factory 供测 |
+| `apps/web/src/components/canvas/refine/mediapipeSegment.test.ts` | `confidenceMaskToRgba` + mock segmenter |
+| `apps/web/src/components/canvas/refine/RefineSidePanel.vue` | `onPointSelect` 接线；换图/卸载复位 |
+| `apps/web/package.json` | 依赖 `@mediapipe/tasks-vision` |
+| Spec status | 实现后把 design Status 改为 Implemented |
+
+---
+
+### Task 0: 确认分支与基线
+
+**Files:** 无代码改动（当前应在 `feature/cx-sam-mediapipe-fallback`，已含 design commit）
+
+- [ ] **Step 1: 确认分支**
+
+```bash
+git branch --show-current
+git log -1 --oneline
+```
+
+Expected: `feature/cx-sam-mediapipe-fallback`；HEAD 含 mediapipe fallback design（或其后继提交）
+
+若在错误分支：
+
+```bash
+git fetch origin
+git checkout feature/cx-sam-mediapipe-fallback
+```
+
+- [ ] **Step 2: 基线测试**
+
+```bash
+pnpm --filter @lnkpi/server exec vitest run src/studio/studio.segment.test.ts
+pnpm --filter @lnkpi/web exec vitest run src/components/canvas/refine/maskRemote.test.ts
+```
+
+Expected: PASS
+
+---
+
+### Task 1: 服务端 fal 失败 → 502
+
+**Files:**
+- Modify: `apps/server/src/studio/studio.service.ts`（`segmentImage`）
+- Modify: `apps/server/src/studio/studio.segment.test.ts`
+
+**Interfaces:**
+- Consumes: 现有 `createSegmentProvider(...).segment(...)`
+- Produces: 无 key → 仍 `ServiceUnavailableException`（503）；provider throw → `BadGatewayException('云端点选失败')`（502）；限流/参数不变
+
+- [ ] **Step 1: Write the failing test**
+
+在 `studio.segment.test.ts` 的 `StudioService.segmentImage` describe 内追加（并在文件顶部 import 增加 `BadGatewayException`）：
+
+```ts
+it('maps provider failure to BadGatewayException', async () => {
+  segment.mockRejectedValueOnce(new Error('Segment API 403: TOP_UP'))
+
+  await expect(
+    svc.segmentImage('u1', { imageUrl: 'https://a.png', x: 1, y: 2 }),
+  ).rejects.toBeInstanceOf(BadGatewayException)
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm --filter @lnkpi/server exec vitest run src/studio/studio.segment.test.ts
+```
+
+Expected: FAIL — provider 错误未映射为 `BadGatewayException`（现为未捕获 Error / 500）
+
+- [ ] **Step 3: Write minimal implementation**
+
+在 `studio.service.ts` 的 Nest import 中增加 `BadGatewayException`。将 `segmentImage` 末尾：
+
+```ts
+return createSegmentProvider({ apiKey }).segment({
+  imageUrl: publicUrl,
+  x: input.x,
+  y: input.y,
+  label: input.label ?? 1,
+})
+```
+
+改为：
+
+```ts
+try {
+  return await createSegmentProvider({ apiKey }).segment({
+    imageUrl: publicUrl,
+    x: input.x,
+    y: input.y,
+    label: input.label ?? 1,
+  })
+} catch (err) {
+  if (
+    err instanceof BadRequestException
+    || err instanceof ServiceUnavailableException
+    || err instanceof HttpException
+  ) {
+    throw err
+  }
+  throw new BadGatewayException('云端点选失败')
+}
+```
+
+说明：限流/参数在 try 之前已抛出，不会进 catch。若未来 provider 抛 `HttpException`，原样透出。MVP 不强制业务码字段；前端以 status 为准。
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm --filter @lnkpi/server exec vitest run src/studio/studio.segment.test.ts
+```
+
+Expected: PASS（含原有 503/429/400 + 新 502）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/studio/studio.service.ts apps/server/src/studio/studio.segment.test.ts
+git commit -m "fix(server): map segment upstream failures to 502"
+```
+
+---
+
+### Task 2: `isSegmentUpstreamDegradable`
+
+**Files:**
+- Create: `apps/web/src/components/canvas/refine/segmentDegrade.ts`
+- Create: `apps/web/src/components/canvas/refine/segmentDegrade.test.ts`
+
+**Interfaces:**
+- Produces: `isSegmentUpstreamDegradable(err: unknown): boolean`
+  - `true`：`response.status` 为 502 或 503；或 **没有** `response`（网络/超时，axios 常见形态）
+  - `false`：400、429、其它 4xx（除无 response）、非对象、`undefined`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { isSegmentUpstreamDegradable } from './segmentDegrade'
+
+describe('isSegmentUpstreamDegradable', () => {
+  it('treats 502 and 503 as degradable', () => {
+    expect(isSegmentUpstreamDegradable({ response: { status: 502 } })).toBe(true)
+    expect(isSegmentUpstreamDegradable({ response: { status: 503 } })).toBe(true)
+  })
+
+  it('treats network errors without response as degradable', () => {
+    expect(isSegmentUpstreamDegradable({ message: 'Network Error' })).toBe(true)
+    expect(isSegmentUpstreamDegradable({ code: 'ECONNABORTED' })).toBe(true)
+  })
+
+  it('does not degrade 400 or platform 429', () => {
+    expect(isSegmentUpstreamDegradable({ response: { status: 400 } })).toBe(false)
+    expect(isSegmentUpstreamDegradable({ response: { status: 429 } })).toBe(false)
+  })
+
+  it('does not degrade unrelated 4xx', () => {
+    expect(isSegmentUpstreamDegradable({ response: { status: 401 } })).toBe(false)
+    expect(isSegmentUpstreamDegradable({ response: { status: 404 } })).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm --filter @lnkpi/web exec vitest run src/components/canvas/refine/segmentDegrade.test.ts
+```
+
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+export function isSegmentUpstreamDegradable(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const response = (err as { response?: { status?: number } }).response
+  if (!response) return true
+  const status = response.status
+  return status === 502 || status === 503
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm --filter @lnkpi/web exec vitest run src/components/canvas/refine/segmentDegrade.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/canvas/refine/segmentDegrade.ts apps/web/src/components/canvas/refine/segmentDegrade.test.ts
+git commit -m "feat(web): detect degradable segment upstream errors"
+```
+
+---
+
+### Task 3: 点选会话编排 `resolvePointMaskRgba`
+
+**Files:**
+- Create: `apps/web/src/components/canvas/refine/pointSegmentSession.ts`
+- Create: `apps/web/src/components/canvas/refine/pointSegmentSession.test.ts`
+
+**Interfaces:**
+- Consumes: `isSegmentUpstreamDegradable`
+- Produces:
+  - `type PointSegmentSession = { preferLocal: boolean; fallbackToastShown: boolean }`
+  - `createPointSegmentSession(): PointSegmentSession`
+  - `resetPointSegmentSession(session: PointSegmentSession): void` — 两字段归 `false`
+  - `resolvePointMaskRgba(opts): Promise<Uint8ClampedArray>`，opts：
+    - `session: PointSegmentSession`
+    - `remoteSegment: () => Promise<{ maskUrl: string }>`
+    - `loadRemoteRgba: (maskUrl: string) => Promise<Uint8ClampedArray>`
+    - `localSegment: () => Promise<Uint8ClampedArray>`
+    - `onFallbackToast?: () => void`
+  - 行为：
+    1. 若 `session.preferLocal`：只调 `localSegment`，不调 remote
+    2. 否则试 `remoteSegment` → `loadRemoteRgba`
+    3. remote 抛错且 `isSegmentUpstreamDegradable`：调 `localSegment`；成功则 `preferLocal=true`；若尚未 toast 则调 `onFallbackToast` 并 `fallbackToastShown=true`
+    4. remote 抛错且不可降级：原样 rethrow，不调 local
+    5. local 失败：原样 rethrow（调用方 toast 失败）
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createPointSegmentSession,
+  resetPointSegmentSession,
+  resolvePointMaskRgba,
+} from './pointSegmentSession'
+
+const rgba = () => new Uint8ClampedArray([1, 2, 3, 255])
+
+describe('resolvePointMaskRgba', () => {
+  it('uses remote when healthy', async () => {
+    const session = createPointSegmentSession()
+    const remoteSegment = vi.fn(async () => ({ maskUrl: 'https://m' }))
+    const loadRemoteRgba = vi.fn(async () => rgba())
+    const localSegment = vi.fn(async () => rgba())
+    const out = await resolvePointMaskRgba({
+      session,
+      remoteSegment,
+      loadRemoteRgba,
+      localSegment,
+    })
+    expect([...out]).toEqual([1, 2, 3, 255])
+    expect(localSegment).not.toHaveBeenCalled()
+    expect(session.preferLocal).toBe(false)
+  })
+
+  it('falls back once and sticks to local', async () => {
+    const session = createPointSegmentSession()
+    const toast = vi.fn()
+    const remoteSegment = vi.fn(async () => {
+      throw { response: { status: 502 } }
+    })
+    const loadRemoteRgba = vi.fn()
+    const localSegment = vi.fn(async () => rgba())
+
+    await resolvePointMaskRgba({
+      session,
+      remoteSegment,
+      loadRemoteRgba,
+      localSegment,
+      onFallbackToast: toast,
+    })
+    expect(toast).toHaveBeenCalledTimes(1)
+    expect(session.preferLocal).toBe(true)
+
+    remoteSegment.mockClear()
+    localSegment.mockClear()
+    toast.mockClear()
+
+    await resolvePointMaskRgba({
+      session,
+      remoteSegment,
+      loadRemoteRgba,
+      localSegment,
+      onFallbackToast: toast,
+    })
+    expect(remoteSegment).not.toHaveBeenCalled()
+    expect(localSegment).toHaveBeenCalledTimes(1)
+    expect(toast).not.toHaveBeenCalled()
+  })
+
+  it('does not fallback on 429', async () => {
+    const session = createPointSegmentSession()
+    const localSegment = vi.fn(async () => rgba())
+    await expect(
+      resolvePointMaskRgba({
+        session,
+        remoteSegment: async () => {
+          throw { response: { status: 429, data: { message: '点选过于频繁，请稍后再试' } } }
+        },
+        loadRemoteRgba: async () => rgba(),
+        localSegment,
+      }),
+    ).rejects.toMatchObject({ response: { status: 429 } })
+    expect(localSegment).not.toHaveBeenCalled()
+  })
+
+  it('reset clears stickiness', () => {
+    const session = createPointSegmentSession()
+    session.preferLocal = true
+    session.fallbackToastShown = true
+    resetPointSegmentSession(session)
+    expect(session).toEqual({ preferLocal: false, fallbackToastShown: false })
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm --filter @lnkpi/web exec vitest run src/components/canvas/refine/pointSegmentSession.test.ts
+```
+
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+import { isSegmentUpstreamDegradable } from './segmentDegrade'
+
+export type PointSegmentSession = {
+  preferLocal: boolean
+  fallbackToastShown: boolean
+}
+
+export function createPointSegmentSession(): PointSegmentSession {
+  return { preferLocal: false, fallbackToastShown: false }
+}
+
+export function resetPointSegmentSession(session: PointSegmentSession): void {
+  session.preferLocal = false
+  session.fallbackToastShown = false
+}
+
+export async function resolvePointMaskRgba(opts: {
+  session: PointSegmentSession
+  remoteSegment: () => Promise<{ maskUrl: string }>
+  loadRemoteRgba: (maskUrl: string) => Promise<Uint8ClampedArray>
+  localSegment: () => Promise<Uint8ClampedArray>
+  onFallbackToast?: () => void
+}): Promise<Uint8ClampedArray> {
+  const { session } = opts
+  if (session.preferLocal) {
+    return opts.localSegment()
+  }
+  try {
+    const { maskUrl } = await opts.remoteSegment()
+    return await opts.loadRemoteRgba(maskUrl)
+  } catch (err) {
+    if (!isSegmentUpstreamDegradable(err)) throw err
+    const rgba = await opts.localSegment()
+    session.preferLocal = true
+    if (!session.fallbackToastShown) {
+      session.fallbackToastShown = true
+      opts.onFallbackToast?.()
+    }
+    return rgba
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm --filter @lnkpi/web exec vitest run src/components/canvas/refine/pointSegmentSession.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/canvas/refine/pointSegmentSession.ts apps/web/src/components/canvas/refine/pointSegmentSession.test.ts
+git commit -m "feat(web): orchestrate SAM3 to MediaPipe point-segment fallback"
+```
+
+---
+
+### Task 4: MediaPipe 封装（可注入 + confidence→RGBA）
+
+**Files:**
+- Create: `apps/web/src/components/canvas/refine/mediapipeSegment.ts`
+- Create: `apps/web/src/components/canvas/refine/mediapipeSegment.test.ts`
+- Modify: `apps/web/package.json`（及锁文件：在 `apps/web` 目录执行 `pnpm add @mediapipe/tasks-vision`，从 monorepo 根目录）
+
+**Interfaces:**
+- Produces:
+  - `confidenceMaskToRgba(confidence: Float32Array | number[], width: number, height: number, threshold = 0.5): Uint8ClampedArray`  
+    — 长度须为 `width*height`；`value >= threshold` → RGB=255 A=255，否则 A=0（RGB=0）。供 `mergeMaskRgba` 使用（alpha>127 即选中）。
+  - `type MediaPipeSegmenterLike = { setImage(image: CanvasImageSource): void; segment(strokes: unknown): { confidenceMasks?: Array<{ getAsFloat32Array?: () => Float32Array }> } | void }`
+  - `type MediaPipeDeps = { loadSegmenter: () => Promise<MediaPipeSegmenterLike> }`
+  - `resetMediaPipeSegmentSession(): void` — 清缓存的 segmenter/imageKey
+  - `segmentPointLocal(opts: { image: CanvasImageSource; imageKey: string; x: number; y: number; width: number; height: number; deps?: MediaPipeDeps }): Promise<Uint8ClampedArray>`
+    - 像素点转归一化：`nx = (x + 0.5) / width`，`ny = (y + 0.5) / height`，夹到 `[0,1]`
+    - `imageKey` 变化时重新 `setImage`
+    - **默认** `deps.loadSegmenter`：动态 `import('@mediapipe/tasks-vision')`，`FilesetResolver.forVisionTasks` + `InteractiveSegmenter.createFromOptions`，模型：
+      `https://storage.googleapis.com/mediapipe-models/interactive_segmenter/magic_touch/float16/latest/magic_touch.tflite`  
+      若该 URL 404，改用官方文档当前推荐：  
+      `https://storage.googleapis.com/mediapipe-models/interactive_segmenter_v2/magic_touch/int8/latest/interactive_segmentation.task`  
+      与 wasm：`https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@<installed-version>/wasm`
+    - stroke 形态按已安装包的类型（优先 stateful：`setImage` + `segment` 带 `keypoint`/`point` 归一化坐标）。若 API 与文档不一致，以 `@mediapipe/tasks-vision` 类型定义为准，但 **对外仍返回同尺寸 RGBA**。
+    - 无 confidence mask 或长度不对 → `throw new Error('本地点选失败')`
+
+- [ ] **Step 1: Add dependency**
+
+```bash
+pnpm --filter @lnkpi/web add @mediapipe/tasks-vision
+```
+
+- [ ] **Step 2: Write the failing test（纯函数 + mock deps，不拉真实 WASM）**
+
+```ts
+import { describe, expect, it, vi } from 'vitest'
+import {
+  confidenceMaskToRgba,
+  resetMediaPipeSegmentSession,
+  segmentPointLocal,
+} from './mediapipeSegment'
+
+describe('confidenceMaskToRgba', () => {
+  it('thresholds confidence into alpha mask', () => {
+    const out = confidenceMaskToRgba([0.1, 0.9], 2, 1, 0.5)
+    expect([...out.slice(0, 4)]).toEqual([0, 0, 0, 0])
+    expect([...out.slice(4, 8)]).toEqual([255, 255, 255, 255])
+  })
+})
+
+describe('segmentPointLocal', () => {
+  it('uses injected segmenter and caches setImage per imageKey', async () => {
+    resetMediaPipeSegmentSession()
+    const setImage = vi.fn()
+    const getAsFloat32Array = vi.fn(() => new Float32Array([0, 1, 0, 1]))
+    const segment = vi.fn(() => ({ confidenceMasks: [{ getAsFloat32Array }] }))
+    const loadSegmenter = vi.fn(async () => ({ setImage, segment }))
+
+    const canvas = document.createElement('canvas')
+    canvas.width = 2
+    canvas.height = 2
+
+    const a = await segmentPointLocal({
+      image: canvas,
+      imageKey: 'img-a',
+      x: 0,
+      y: 0,
+      width: 2,
+      height: 2,
+      deps: { loadSegmenter },
+    })
+    expect(loadSegmenter).toHaveBeenCalledTimes(1)
+    expect(setImage).toHaveBeenCalledTimes(1)
+    expect(a.length).toBe(16)
+
+    await segmentPointLocal({
+      image: canvas,
+      imageKey: 'img-a',
+      x: 1,
+      y: 1,
+      width: 2,
+      height: 2,
+      deps: { loadSegmenter },
+    })
+    expect(loadSegmenter).toHaveBeenCalledTimes(1)
+    expect(setImage).toHaveBeenCalledTimes(1)
+
+    await segmentPointLocal({
+      image: canvas,
+      imageKey: 'img-b',
+      x: 0,
+      y: 0,
+      width: 2,
+      height: 2,
+      deps: { loadSegmenter },
+    })
+    expect(setImage).toHaveBeenCalledTimes(2)
+  })
+})
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+pnpm --filter @lnkpi/web exec vitest run src/components/canvas/refine/mediapipeSegment.test.ts
+```
+
+Expected: FAIL — module not found
+
+- [ ] **Step 4: Write minimal implementation**
+
+实现 `confidenceMaskToRgba`、模块级缓存（`segmenterPromise`、`cachedImageKey`）、`resetMediaPipeSegmentSession`、`segmentPointLocal`。  
+`segment` 调用参数：先按官方 web 示例传 strokes 数组；若编译类型报错，改为包内 `RegionOfInterest`/`keypoint` 形态，但测试里用 `vi.fn` 不校验具体 stroke 结构（可用 `expect(segment).toHaveBeenCalled()`）。
+
+默认 `loadSegmenter` 示例骨架：
+
+```ts
+async function defaultLoadSegmenter(): Promise<MediaPipeSegmenterLike> {
+  const vision = await import('@mediapipe/tasks-vision')
+  const fileset = await vision.FilesetResolver.forVisionTasks(
+    new URL('@mediapipe/tasks-vision/wasm', import.meta.url).href,
+  ).catch(async () =>
+    vision.FilesetResolver.forVisionTasks(
+      `https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision/wasm`,
+    ),
+  )
+  return vision.InteractiveSegmenter.createFromOptions(fileset, {
+    baseOptions: {
+      modelAssetPath:
+        'https://storage.googleapis.com/mediapipe-models/interactive_segmenter_v2/magic_touch/int8/latest/interactive_segmentation.task',
+    },
+    outputCategoryMask: false,
+    outputConfidenceMasks: true,
+  }) as unknown as MediaPipeSegmenterLike
+}
+```
+
+（若 `createFromOptions` 选项名与类型不符，删掉不存在的 output* 字段，仅保留 `baseOptions`。）
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+pnpm --filter @lnkpi/web exec vitest run src/components/canvas/refine/mediapipeSegment.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/package.json pnpm-lock.yaml \
+  apps/web/src/components/canvas/refine/mediapipeSegment.ts \
+  apps/web/src/components/canvas/refine/mediapipeSegment.test.ts
+git commit -m "feat(web): add MediaPipe local point segment helper"
+```
+
+---
+
+### Task 5: 接线 `RefineSidePanel`
+
+**Files:**
+- Modify: `apps/web/src/components/canvas/refine/RefineSidePanel.vue`
+
+**Interfaces:**
+- Consumes: `resolvePointMaskRgba`、`createPointSegmentSession`、`resetPointSegmentSession`、`segmentPointLocal`、`resetMediaPipeSegmentSession`、现有 `studioApi.segmentImage` / `loadMaskRgbaFromUrl` / `mergeMaskRgba`
+- Produces: 用户可见行为符合 spec（无新 UI 控件）
+
+- [ ] **Step 1: 在 script 增加 session 与辅助加载图**
+
+```ts
+import {
+  createPointSegmentSession,
+  resetPointSegmentSession,
+  resolvePointMaskRgba,
+} from './pointSegmentSession'
+import { resetMediaPipeSegmentSession, segmentPointLocal } from './mediapipeSegment'
+
+const pointSession = createPointSegmentSession()
+
+function resetPointFallbackState() {
+  resetPointSegmentSession(pointSession)
+  resetMediaPipeSegmentSession()
+}
+
+async function loadWorkImage(url: string): Promise<HTMLImageElement> {
+  const img = new Image()
+  img.crossOrigin = 'anonymous'
+  img.src = url
+  await img.decode()
+  return img
+}
+```
+
+- [ ] **Step 2: 替换 `onPointSelect` 主体**
+
+保持 `busy` / `segmentBusy` / canvas 校验不变；将 try 内 remote-only 换成：
+
+```ts
+const remoteRgba = await resolvePointMaskRgba({
+  session: pointSession,
+  remoteSegment: async () => {
+    const { data } = await studioApi.segmentImage({
+      imageUrl: props.beforeUrl,
+      x,
+      y,
+      label: 1,
+    })
+    return { maskUrl: data.data.maskUrl }
+  },
+  loadRemoteRgba: (maskUrl) => loadMaskRgbaFromUrl(maskUrl, canvas.width, canvas.height),
+  localSegment: async () => {
+    const img = await loadWorkImage(props.beforeUrl)
+    return segmentPointLocal({
+      image: img,
+      imageKey: props.beforeUrl,
+      x,
+      y,
+      width: canvas.width,
+      height: canvas.height,
+    })
+  },
+  onFallbackToast: () => {
+    ElMessage.warning('云端点选暂不可用，已用本地点选')
+  },
+})
+// 然后与现网相同：mergeMaskRgba + putImageData + refineCoverage
+```
+
+- [ ] **Step 3: 复位钩子**
+
+```ts
+watch(
+  () => props.beforeUrl,
+  () => {
+    resetPointFallbackState()
+  },
+)
+
+onBeforeUnmount(() => {
+  registerRefinePointSelectHandler(null)
+  resetPointFallbackState()
+  // ...现有 removeEventListener / stopResize / stopDrag
+})
+```
+
+（`onMounted` 注册 handler 保持不变。）
+
+- [ ] **Step 4: 手动类型检查**
+
+```bash
+pnpm --filter @lnkpi/web exec vue-tsc --noEmit
+```
+
+Expected: 无因本改动引入的错误
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/canvas/refine/RefineSidePanel.vue
+git commit -m "feat(web): wire MediaPipe fallback into refine point-select"
+```
+
+---
+
+### Task 6: 验证与文档状态
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-08-31-cx-image-edit-sam-mediapipe-fallback-design.md`（Status → Implemented）
+
+- [ ] **Step 1: 跑相关测试**
+
+```bash
+pnpm --filter @lnkpi/server exec vitest run src/studio/studio.segment.test.ts
+pnpm --filter @lnkpi/web exec vitest run \
+  src/components/canvas/refine/segmentDegrade.test.ts \
+  src/components/canvas/refine/pointSegmentSession.test.ts \
+  src/components/canvas/refine/mediapipeSegment.test.ts \
+  src/components/canvas/refine/maskRemote.test.ts
+pnpm --filter @lnkpi/web exec vue-tsc --noEmit
+```
+
+Expected: 全部 PASS
+
+- [ ] **Step 2: 更新 spec Status**
+
+将 design 文件头部改为：
+
+`**Status:** Implemented on \`feature/cx-sam-mediapipe-fallback\``
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-08-31-cx-image-edit-sam-mediapipe-fallback-design.md
+git commit -m "docs: mark MediaPipe segment fallback design implemented"
+```
+
+- [ ] **Step 4: 手工验收清单（PR 描述用）**
+
+- [ ] fal 正常：点选仍走云端，无 toast  
+- [ ] 模拟 502 / 无 `FAL_KEY`：toast 一次 + 出 mask；同会话再点不打 `/segment`  
+- [ ] 关精修再开：再试云端  
+- [ ] 本平台连点触发 429：不降级，错误提示  
+- [ ] 积分不变直至「精修」
+
+---
+
+## Spec coverage (self-review)
+
+| Spec 项 | Task |
+|---------|------|
+| 502 映射 fal 失败 | T1 |
+| 503 无 key 保持 | T1（既有 + 不改） |
+| 可降级判定 502/503/网络 | T2 |
+| 不降级 400/429 | T2 + T3 |
+| 编排 + 粘滞 + toast 一次 | T3 |
+| MediaPipe 懒加载封装 | T4 |
+| SidePanel 接线 / 换图复位 | T5 |
+| 成功标准 / 文档 | T6 |
+| 无手动开关 / 不预热 / CVM 不跑 | Global + T4/T5 未做相反事 |
+
+**Placeholder scan:** 无 TBD；MediaPipe 模型 URL 给了主选与文档备选。  
+**Type consistency:** `PointSegmentSession` / `resolvePointMaskRgba` / `segmentPointLocal` 命名在 T3–T5 一致。

--- a/docs/superpowers/plans/2026-09-01-points-stats-personal-center.md
+++ b/docs/superpowers/plans/2026-09-01-points-stats-personal-center.md
@@ -1,0 +1,779 @@
+# 个人中心积分统计 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 扩展积分账本结构化字段，提供按文本/图/音/视频的净消耗汇总与可筛选明细 API，并在个人中心用卡片式 UI 展示（含时间戳）。
+
+**Architecture:** 以 `PointTransaction` 为单一事实源；`PointsService.consume/refund` 与 membership grant 写入 `kind/category/status/model/generationId/balanceAfter`；`MembershipService` 按 `Asia/Shanghai` 窗口聚合汇总与分页明细；存量用 `reason` 映射回填；`ProfilePage` 卡片式汇总+明细。
+
+**Tech Stack:** NestJS、Prisma、Vue 3、Vitest、现有 `/membership/*` API
+
+**Spec:** `docs/superpowers/specs/2026-09-01-points-stats-personal-center-design.md`
+
+## Global Constraints
+
+- 汇总口径：四分类展示**净消耗**；另展示 `refundTotal` / `grantTotal`；grant 不进四分类净消耗
+- 时间范围：默认 `month`；可选 `7d` / `month` / `all`；日界 `Asia/Shanghai`；响应带回 `from`/`to`
+- 明细信息密度：本期 B（时间、kind、category、amount、reason、model、generationId、status）；演进 C 不实现
+- 存量：按 `reason` 回填；无法识别 → `category=other`
+- UI：卡片式汇总网格 + 卡片式明细列表
+- 分支建议：从最新主线拉 `feat/points-stats-personal-center`（勿堆在无关 feature 分支上）
+- 验证：相关 vitest 绿；`pnpm --filter @lnkpi/server exec vitest run` 与改动相关 web 测试通过
+- 不把 `.superpowers/`、`.seedream-backup/`、deploy 审计 JSON 等无关文件加入 commit
+
+---
+
+## File Structure Map
+
+| 路径 | 职责 |
+|------|------|
+| `apps/server/src/points/point-tx.types.ts` | `PointKind` / `PointCategory` / `PointTxStatus` / `PointTxMeta` |
+| `apps/server/src/points/reason-map.ts` | `reason` → 结构化字段映射（回填与可选兜底） |
+| `apps/server/src/points/reason-map.test.ts` | 映射表单测 |
+| `apps/server/src/points/points-range.ts` | `resolvePointsRange(range)` → `{ from, to }`（上海时区） |
+| `apps/server/src/points/points-range.test.ts` | 窗口边界单测 |
+| `apps/server/src/points/points.service.ts` | consume/refund 写结构化字段 + `balanceAfter` |
+| `apps/server/src/points/points.service.test.ts` | 更新断言含 meta |
+| `apps/server/prisma/schema.prisma` | `PointTransaction` 新列与索引 |
+| `apps/server/prisma/migrations/YYYYMMDDHHMMSS_point_tx_stats/migration.sql` | 迁移 |
+| `apps/server/scripts/backfill-point-transactions.ts` | 存量回填脚本 |
+| `apps/server/src/membership/membership.service.ts` | `listTransactions` 筛选分页 + `pointsSummary` |
+| `apps/server/src/membership/membership.service.test.ts` | 汇总口径与筛选单测 |
+| `apps/server/src/membership/membership.controller.ts` | query 参数 + `GET points-summary` |
+| `apps/server/src/studio/studio.service.ts` | 所有 consume/refund 传 category（及有则 model/generationId） |
+| `apps/server/src/canvas/material.service.ts` | 同上 |
+| `apps/server/src/canvas/scene-composer.service.ts` | 批量扣费 `category: other`（或多类型时 other） |
+| `apps/web/src/services/users-api.ts` | transactions 扩展 + `pointsSummary` |
+| `apps/web/src/pages/ProfilePage.vue` | 卡片式汇总与明细 |
+| `apps/web/src/pages/ProfilePage.test.ts`（可选） | 汇总/筛选渲染冒烟 |
+
+---
+
+### Task 1: 类型 + reason 映射纯函数（TDD）
+
+**Files:**
+- Create: `apps/server/src/points/point-tx.types.ts`
+- Create: `apps/server/src/points/reason-map.ts`
+- Create: `apps/server/src/points/reason-map.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `export type PointKind = 'consume' | 'refund' | 'grant'`
+  - `export type PointCategory = 'text' | 'image' | 'audio' | 'video' | 'other'`
+  - `export type PointTxStatus = 'success' | 'failed_refund' | 'cancelled_refund' | 'byok_refund'`
+  - `export interface PointTxMeta { kind: PointKind; category: PointCategory; status?: PointTxStatus | null; model?: string | null; generationId?: string | null }`
+  - `export function mapReasonToPointFields(reason: string, amount: number): { kind: PointKind; category: PointCategory; status: PointTxStatus | null }`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { mapReasonToPointFields } from './reason-map'
+
+describe('mapReasonToPointFields', () => {
+  it('maps 图像生成 to consume/image/success', () => {
+    expect(mapReasonToPointFields('图像生成', -10)).toEqual({
+      kind: 'consume',
+      category: 'image',
+      status: 'success',
+    })
+  })
+
+  it('maps 文本生成-失败退款', () => {
+    expect(mapReasonToPointFields('文本生成-失败退款', 5)).toEqual({
+      kind: 'refund',
+      category: 'text',
+      status: 'failed_refund',
+    })
+  })
+
+  it('maps 图像生成-取消退款', () => {
+    expect(mapReasonToPointFields('图像生成-取消退款', 10)).toEqual({
+      kind: 'refund',
+      category: 'image',
+      status: 'cancelled_refund',
+    })
+  })
+
+  it('maps BYOK 退款', () => {
+    expect(mapReasonToPointFields('视频生成-BYOK失败退款', 30)).toEqual({
+      kind: 'refund',
+      category: 'video',
+      status: 'byok_refund',
+    })
+  })
+
+  it('maps 每日签到 to grant/other', () => {
+    expect(mapReasonToPointFields('每日签到', 100)).toEqual({
+      kind: 'grant',
+      category: 'other',
+      status: null,
+    })
+  })
+
+  it('maps 升级 专业版 to grant/other', () => {
+    expect(mapReasonToPointFields('升级 专业版', 5000)).toEqual({
+      kind: 'grant',
+      category: 'other',
+      status: null,
+    })
+  })
+
+  it('unknown negative amount → consume/other/success', () => {
+    expect(mapReasonToPointFields('神秘扣费', -3)).toEqual({
+      kind: 'consume',
+      category: 'other',
+      status: 'success',
+    })
+  })
+
+  it('unknown positive amount → grant/other/null', () => {
+    expect(mapReasonToPointFields('神秘入账', 3)).toEqual({
+      kind: 'grant',
+      category: 'other',
+      status: null,
+    })
+  })
+
+  it('maps 平台回退生成 to consume/other', () => {
+    expect(mapReasonToPointFields('平台回退生成', -10)).toEqual({
+      kind: 'consume',
+      category: 'other',
+      status: 'success',
+    })
+  })
+
+  it('maps 导演台批量生成 prefix to consume/other', () => {
+    expect(mapReasonToPointFields('导演台批量生成 ×3', -40)).toEqual({
+      kind: 'consume',
+      category: 'other',
+      status: 'success',
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+Run: `pnpm --filter @lnkpi/server exec vitest run src/points/reason-map.test.ts`  
+Expected: FAIL（module not found）
+
+- [ ] **Step 3: Implement types + mapper**
+
+`point-tx.types.ts`：导出上文类型。
+
+`reason-map.ts` 逻辑要点：
+1. 若 `reason` 含 `-失败退款` / `-取消退款` / `-BYOK失败退款` / `失败退款` / `取消退款`（平台回退变体）→ `kind=refund`，解析 status，category 用前缀表。
+2. 前缀/全文表：`文本生成|提示词模式生成` → text；`图像生成|图像变体|图像精修` → image；`视频生成` → video；含 `音频` → audio。
+3. `每日签到` 或 `升级 ` 开头 → grant/other/null。
+4. `平台回退` / `导演台批量生成` → consume 或 refund（看后缀），category=`other`。
+5. 否则按 `amount` 符号兜底（见测试）。
+
+另导出小表供实现：
+
+```ts
+const CATEGORY_BY_LABEL: Array<{ match: RegExp; category: PointCategory }> = [
+  { match: /文本生成|提示词模式生成/, category: 'text' },
+  { match: /图像生成|图像变体|图像精修/, category: 'image' },
+  { match: /视频生成/, category: 'video' },
+  { match: /音频/, category: 'audio' },
+]
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `pnpm --filter @lnkpi/server exec vitest run src/points/reason-map.test.ts`  
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/points/point-tx.types.ts apps/server/src/points/reason-map.ts apps/server/src/points/reason-map.test.ts
+git commit -m "feat(points): add reason→ledger field mapper"
+```
+
+---
+
+### Task 2: 时间窗口 `resolvePointsRange`（TDD）
+
+**Files:**
+- Create: `apps/server/src/points/points-range.ts`
+- Create: `apps/server/src/points/points-range.test.ts`
+
+**Interfaces:**
+- Produces: `export type PointsRangeKey = '7d' | 'month' | 'all'`
+- Produces: `export function resolvePointsRange(range: PointsRangeKey, now?: Date): { from: Date | null; to: Date }`
+- Consumes: 无
+
+- [ ] **Step 1: Write failing tests**
+
+用固定 `now = new Date('2026-09-15T08:00:00+08:00')`：
+
+```ts
+it('month starts at Shanghai month start', () => {
+  const { from, to } = resolvePointsRange('month', now)
+  expect(from!.toISOString()).toBe(new Date('2026-09-01T00:00:00+08:00').toISOString())
+  expect(to.toISOString()).toBe(now.toISOString())
+})
+
+it('7d is now minus 7 days', () => {
+  const { from } = resolvePointsRange('7d', now)
+  expect(from!.toISOString()).toBe(new Date('2026-09-08T08:00:00+08:00').toISOString())
+})
+
+it('all has null from', () => {
+  expect(resolvePointsRange('all', now).from).toBeNull()
+})
+```
+
+实现时用显式 offset 计算上海墙钟（避免依赖运行环境 TZ）：例如用 `Temporal` 若项目已有，否则用手动 `+08:00` 字符串/`Date` 算术。推荐：
+
+```ts
+const SH_OFFSET_MS = 8 * 60 * 60 * 1000
+function shanghaiParts(d: Date) {
+  const shifted = new Date(d.getTime() + SH_OFFSET_MS)
+  return { y: shifted.getUTCFullYear(), m: shifted.getUTCMonth(), day: shifted.getUTCDate(), ... }
+}
+function shanghaiMidnight(y: number, m0: number, day: number) {
+  return new Date(Date.UTC(y, m0, day, 0, 0, 0) - SH_OFFSET_MS)
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+- [ ] **Step 3: Implement `points-range.ts`**
+- [ ] **Step 4: Run — expect PASS**
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/points/points-range.ts apps/server/src/points/points-range.test.ts
+git commit -m "feat(points): resolve Shanghai billing time ranges"
+```
+
+---
+
+### Task 3: Prisma 迁移扩展 `PointTransaction`
+
+**Files:**
+- Modify: `apps/server/prisma/schema.prisma`（`PointTransaction` 模型）
+- Create: `apps/server/prisma/migrations/<timestamp>_point_tx_stats/migration.sql`
+
+**Interfaces:**
+- Produces: DB 列 `kind`、`category`、`status`、`model`、`generationId`、`balanceAfter` + 索引
+
+- [ ] **Step 1: Update schema**
+
+```prisma
+model PointTransaction {
+  id           String   @id @default(cuid())
+  userId       String
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  amount       Int
+  reason       String
+  kind         String   @default("consume")
+  category     String   @default("other")
+  status       String?
+  model        String?
+  generationId String?
+  balanceAfter Int?
+  createdAt    DateTime @default(now())
+
+  @@index([userId, createdAt])
+  @@index([userId, kind, category, createdAt])
+}
+```
+
+- [ ] **Step 2: Add migration SQL**
+
+```sql
+-- AlterTable
+ALTER TABLE "PointTransaction" ADD COLUMN "kind" TEXT NOT NULL DEFAULT 'consume';
+ALTER TABLE "PointTransaction" ADD COLUMN "category" TEXT NOT NULL DEFAULT 'other';
+ALTER TABLE "PointTransaction" ADD COLUMN "status" TEXT;
+ALTER TABLE "PointTransaction" ADD COLUMN "model" TEXT;
+ALTER TABLE "PointTransaction" ADD COLUMN "generationId" TEXT;
+ALTER TABLE "PointTransaction" ADD COLUMN "balanceAfter" INTEGER;
+
+-- CreateIndex
+CREATE INDEX "PointTransaction_userId_createdAt_idx" ON "PointTransaction"("userId", "createdAt");
+CREATE INDEX "PointTransaction_userId_kind_category_createdAt_idx" ON "PointTransaction"("userId", "kind", "category", "createdAt");
+```
+
+（若表已有部分索引名冲突，按 Prisma 生成名为准。）
+
+- [ ] **Step 3: Apply locally**
+
+Run: `pnpm --filter @lnkpi/server exec prisma migrate deploy`（或项目惯用 `prisma migrate dev`）  
+Expected: 迁移成功
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/server/prisma/schema.prisma apps/server/prisma/migrations/
+git commit -m "feat(db): add structured fields on PointTransaction"
+```
+
+---
+
+### Task 4: `PointsService` 写入结构化字段 + balanceAfter
+
+**Files:**
+- Modify: `apps/server/src/points/points.service.ts`
+- Modify: `apps/server/src/points/points.service.test.ts`
+
+**Interfaces:**
+- Consumes: `PointTxMeta` from `point-tx.types.ts`
+- Produces:
+  - `consume(userId: string, cost: number, reason: string, meta: PointTxMeta): Promise<void>`
+  - `refund(userId: string, amount: number, reason: string, meta: PointTxMeta): Promise<void>`
+  - （可选）`grant(userId: string, amount: number, reason: string, meta: Omit<PointTxMeta,'kind'> & { kind?: 'grant' }): Promise<void>` — 或 membership 直接 create；推荐 PointsService 统一 `grant` 以便写 `balanceAfter`
+
+- [ ] **Step 1: Update failing tests** — `create` 期望含结构化字段与 `balanceAfter`
+
+在 consume 测试中 mock：`updateMany` 后 `findUnique` 返回 `{ points: 90 }`，断言：
+
+```ts
+expect(create).toHaveBeenCalledWith({
+  data: {
+    userId: 'u1',
+    amount: -10,
+    reason: '图像生成',
+    kind: 'consume',
+    category: 'image',
+    status: 'success',
+    model: 'seedream',
+    generationId: null,
+    balanceAfter: 90,
+  },
+})
+```
+
+调用改为：
+
+```ts
+await svc.consume('u1', 10, '图像生成', {
+  kind: 'consume',
+  category: 'image',
+  status: 'success',
+  model: 'seedream',
+})
+```
+
+refund 测试类似（`kind: 'refund'`, `status: 'failed_refund'`, `amount: 5`, `balanceAfter` 来自 findUnique）。
+
+- [ ] **Step 2: Run — expect FAIL**（签名/字段不匹配）
+
+- [ ] **Step 3: Implement**
+
+事务内：
+
+```ts
+const updated = await tx.user.updateMany({ where: { id: userId, points: { gte: cost } }, data: { points: { decrement: cost } } })
+if (updated.count === 0) throw new BadRequestException('积分不足')
+const user = await tx.user.findUnique({ where: { id: userId }, select: { points: true } })
+await tx.pointTransaction.create({
+  data: {
+    userId,
+    amount: -cost,
+    reason,
+    kind: meta.kind,
+    category: meta.category,
+    status: meta.status ?? 'success',
+    model: meta.model ?? null,
+    generationId: meta.generationId ?? null,
+    balanceAfter: user?.points ?? null,
+  },
+})
+```
+
+`refund` / `grant` 同理（increment）。
+
+- [ ] **Step 4: Run points.service.test.ts — PASS**
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(points): write structured ledger meta on consume/refund"
+```
+
+---
+
+### Task 5: 存量回填脚本
+
+**Files:**
+- Create: `apps/server/scripts/backfill-point-transactions.ts`
+
+**Interfaces:**
+- Consumes: `mapReasonToPointFields`
+- Produces: CLI 可重复执行；只更新仍为默认且未回填完成的行（建议条件：`category = 'other' AND model IS NULL AND generationId IS NULL AND status IS NULL` **且** `kind = 'consume'` 的默认行会误伤真实 other——改用：全表扫描按 reason 重算 kind/category/status，**幂等覆盖** kind/category/status，永不写 model/generationId/balanceAfter）
+
+- [ ] **Step 1: Implement script**
+
+```ts
+// 伪代码要点
+import { PrismaClient } from '@prisma/client'
+import { mapReasonToPointFields } from '../src/points/reason-map'
+
+const prisma = new PrismaClient()
+async function main() {
+  const batchSize = 200
+  let cursor: string | undefined
+  let updated = 0
+  for (;;) {
+    const rows = await prisma.pointTransaction.findMany({
+      take: batchSize,
+      ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+      orderBy: { id: 'asc' },
+    })
+    if (!rows.length) break
+    for (const row of rows) {
+      const mapped = mapReasonToPointFields(row.reason, row.amount)
+      await prisma.pointTransaction.update({
+        where: { id: row.id },
+        data: { kind: mapped.kind, category: mapped.category, status: mapped.status },
+      })
+      updated++
+    }
+    cursor = rows[rows.length - 1].id
+  }
+  console.log(`backfilled ${updated} rows`)
+}
+main().finally(() => prisma.$disconnect())
+```
+
+- [ ] **Step 2: Dry-run on local DB（若有数据）**
+
+Run: `pnpm --filter @lnkpi/server exec tsx scripts/backfill-point-transactions.ts`  
+Expected: 打印 backfilled N
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/server/scripts/backfill-point-transactions.ts
+git commit -m "chore(points): add PointTransaction backfill script"
+```
+
+---
+
+### Task 6: Membership 汇总 + 明细分页 API（TDD）
+
+**Files:**
+- Modify: `apps/server/src/membership/membership.service.ts`
+- Create: `apps/server/src/membership/membership.service.test.ts`
+- Modify: `apps/server/src/membership/membership.controller.ts`
+
+**Interfaces:**
+- Consumes: `resolvePointsRange`, Prisma
+- Produces:
+  - `listTransactions(userId, opts: { range: PointsRangeKey; kind?: PointKind; category?: PointCategory; cursor?: string; limit?: number }): Promise<{ items: PointTxDto[]; nextCursor: string | null; from: string | null; to: string }>`
+  - `pointsSummary(userId, range: PointsRangeKey): Promise<PointsSummaryDto>`
+
+`PointsSummaryDto`：
+
+```ts
+{
+  range: PointsRangeKey
+  from: string | null  // ISO
+  to: string
+  byCategory: {
+    text: number
+    image: number
+    audio: number
+    video: number
+  }  // netConsumed，展示用非负
+  otherNetConsumed: number
+  refundTotal: number
+  grantTotal: number
+}
+```
+
+净消耗：`net = (-sum(consume amounts)) - sum(refund amounts)`；若 `net < 0` 则 API 仍返回真实值，UI 按 spec 按 0 展示（或 clamp——**实现选 clamp≥0 与 spec「不为负时按 0 展示」一致，在 service 内 `Math.max(0, net)`**）。
+
+- [ ] **Step 1: Write membership.service.test.ts**
+
+用 mock prisma：给定一组 txs，断言 `pointsSummary('month')`：
+- image consume -10、-20 + refund +10 → net 20
+- grant 100 → grantTotal 100，不进 byCategory
+- text 无记录 → 0
+
+`listTransactions`：过滤 category=image 只返回 image 行；limit+cursor。
+
+- [ ] **Step 2: Run — FAIL**
+- [ ] **Step 3: Implement service methods**
+
+`pointsSummary` 可用 `groupBy` 或一次 `findMany` 在内存聚合（用户量级可接受）；优先：
+
+```ts
+const where = { userId, createdAt: from ? { gte: from, lte: to } : { lte: to } }
+const rows = await this.prisma.pointTransaction.findMany({ where, select: { amount: true, kind: true, category: true } })
+```
+
+然后 JS 聚合。
+
+`listTransactions`：
+
+```ts
+findMany({
+  where: { userId, ...(kind&&{kind}), ...(category&&{category}), createdAt: ... },
+  orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+  take: limit + 1,
+  ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+})
+```
+
+- [ ] **Step 4: Controller**
+
+```ts
+@Get('transactions')
+async transactions(@Req() req, @Query('range') range = 'month', @Query('kind') kind?, @Query('category') category?, @Query('cursor') cursor?, @Query('limit') limit?) {
+  const data = await this.membershipService.listTransactions(req.user.sub, {
+    range: parseRange(range),
+    kind,
+    category,
+    cursor,
+    limit: limit ? Number(limit) : 50,
+  })
+  return { code: 0, message: 'ok', data }
+}
+
+@Get('points-summary')
+async pointsSummary(@Req() req, @Query('range') range = 'month') {
+  const data = await this.membershipService.pointsSummary(req.user.sub, parseRange(range))
+  return { code: 0, message: 'ok', data }
+}
+```
+
+`parseRange`：非法值回退 `'month'`。
+
+- [ ] **Step 5: claimDaily / upgrade 写入 grant meta**
+
+```ts
+await this.prisma.pointTransaction.create({
+  data: {
+    userId,
+    amount: bonus,
+    reason: '每日签到',
+    kind: 'grant',
+    category: 'other',
+    status: null,
+    balanceAfter: user.points,
+  },
+})
+```
+
+（若改走 `points.grant`，同步改测试。）
+
+- [ ] **Step 6: Run membership + points tests — PASS**
+- [ ] **Step 7: Commit**
+
+```bash
+git commit -m "feat(membership): points summary and filtered transactions API"
+```
+
+---
+
+### Task 7: 生成路径补齐 `PointTxMeta`
+
+**Files:**
+- Modify: `apps/server/src/studio/studio.service.ts`
+- Modify: `apps/server/src/canvas/material.service.ts`
+- Modify: `apps/server/src/canvas/scene-composer.service.ts`
+- Modify: 受影响的 `*.test.ts`（mock consume/refund 现需第 4 参）
+
+**Interfaces:**
+- Consumes: `PointTxMeta`
+- Produces: 所有 `points.consume` / `points.refund` 调用带 meta
+
+**分类约定（写死在调用点）：**
+
+| chargeReason / 场景 | category |
+|---------------------|----------|
+| 文本生成、提示词模式生成 | text |
+| 图像生成、图像变体、图像精修 | image |
+| 视频生成 | video |
+| 音频生成（若有） | audio |
+| 平台回退*、导演台批量* | other（若 material.type 已知则用 image/video） |
+
+退款：`kind: 'refund'`，`category` 与对应 consume 相同，`status` 按后缀：`failed_refund` / `cancelled_refund` / `byok_refund`（预检拒绝用 `failed_refund`）。
+
+有 `generationId` / `model` 时传入；consume 时尚无 generationId 则 `null`。
+
+辅助（可放 `point-tx.types.ts` 旁）：
+
+```ts
+export function consumeMeta(category: PointCategory, extra?: Partial<PointTxMeta>): PointTxMeta {
+  return { kind: 'consume', category, status: 'success', ...extra }
+}
+export function refundMeta(category: PointCategory, status: PointTxStatus, extra?: Partial<PointTxMeta>): PointTxMeta {
+  return { kind: 'refund', category, status, ...extra }
+}
+```
+
+- [ ] **Step 1: 修编译 — 全局搜 `points.consume(` / `points.refund(`，补第 4 参**
+- [ ] **Step 2: 更新 studio/material fallback 单测里的 mock 与期望**
+- [ ] **Step 3: Run**
+
+```bash
+pnpm --filter @lnkpi/server exec vitest run src/points src/membership src/studio/studio.fallback.test.ts src/canvas/material.fallback.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(points): pass category meta from studio/canvas charge sites"
+```
+
+---
+
+### Task 8: Web API 客户端
+
+**Files:**
+- Modify: `apps/web/src/services/users-api.ts`
+
+**Interfaces:**
+- Produces:
+
+```ts
+export type PointsRangeKey = '7d' | 'month' | 'all'
+export type PointKind = 'consume' | 'refund' | 'grant'
+export type PointCategory = 'text' | 'image' | 'audio' | 'video' | 'other'
+
+export interface PointTransactionItem {
+  id: string
+  amount: number
+  reason: string
+  createdAt: string
+  kind: PointKind
+  category: PointCategory
+  status: string | null
+  model: string | null
+  generationId: string | null
+  balanceAfter: number | null
+}
+
+export interface PointsSummary {
+  range: PointsRangeKey
+  from: string | null
+  to: string
+  byCategory: Record<'text' | 'image' | 'audio' | 'video', number>
+  otherNetConsumed: number
+  refundTotal: number
+  grantTotal: number
+}
+
+// membershipApi:
+transactions: (params?: { range?: PointsRangeKey; kind?: PointKind; category?: PointCategory; cursor?: string; limit?: number }) =>
+  api.get<{ data: { items: PointTransactionItem[]; nextCursor: string | null; from: string | null; to: string } }>(...)
+
+pointsSummary: (range?: PointsRangeKey) =>
+  api.get<{ data: PointsSummary }>('/membership/points-summary', { params: { range } })
+```
+
+注意：后端若返回 `{ items, nextCursor }` 而不是裸数组，前端必须改；**Task 6 统一成对象包装**，打破旧 `data: Array`——仅 ProfilePage 使用，可接受。
+
+- [ ] **Step 1: 改 `users-api.ts`**
+- [ ] **Step 2: Commit**
+
+```bash
+git commit -m "feat(web): membership points summary and transaction query types"
+```
+
+---
+
+### Task 9: ProfilePage 卡片式 UI
+
+**Files:**
+- Modify: `apps/web/src/pages/ProfilePage.vue`
+- Create（推荐）: `apps/web/src/pages/ProfilePage.test.ts` — 用 shallow mount 或抽纯函数测格式化；若项目少页面测试，可只做手动验证清单
+
+**Interfaces:**
+- Consumes: `membershipApi.pointsSummary` / `transactions`
+
+- [ ] **Step 1: 状态与加载**
+
+```ts
+const range = ref<PointsRangeKey>('month')
+const summary = ref<PointsSummary | null>(null)
+const transactions = ref<PointTransactionItem[]>([])
+const filterCategory = ref<PointCategory | undefined>()
+const filterKind = ref<PointKind | undefined>()
+const nextCursor = ref<string | null>(null)
+
+async function reload() {
+  const [s, tx] = await Promise.all([
+    membershipApi.pointsSummary(range.value),
+    membershipApi.transactions({
+      range: range.value,
+      category: filterCategory.value,
+      kind: filterKind.value,
+    }),
+  ])
+  summary.value = s.data.data
+  transactions.value = tx.data.data.items
+  nextCursor.value = tx.data.data.nextCursor
+}
+watch([range, filterCategory, filterKind], () => { void reload() })
+```
+
+- [ ] **Step 2: 模板结构**
+
+1. 保留头像/余额/会员卡  
+2. **筛选卡**：三个按钮 `近 7 天` / `本月` / `全部`  
+3. **汇总网格**：四张分类卡显示 `summary.byCategory.*`；点击设 `filterCategory`；弱样式卡显示 `refundTotal`、`grantTotal`；`otherNetConsumed > 0` 显示其他卡  
+4. **明细卡列表**：每卡显示 reason、kind/category 徽章、金额、`createdAt` 格式化、`model`；有 `generationId` 时显示「查看生成」按钮（本期可 `console` 或禁用 + title「即将支持」——**实现选：仅当有 generationId 时渲染文字链接，href 暂指向 `/workflow` 或省略跳转只展示 ID 截断**，避免假路由）
+
+金额 class：`amount < 0` 红，`>= 0` 绿。
+
+空态：`暂无该时间范围的账单记录`
+
+- [ ] **Step 3: 手动验证清单**
+
+- 默认本月；切换 7d/全部会刷新  
+- 点「图片」卡后明细仅图片（或筛选生效）  
+- 每条有时间戳  
+- 退款与获得样式可区分  
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(web): card UI for points summary and ledger on profile"
+```
+
+---
+
+### Task 10: 端到端冒烟 + 文档勾选
+
+**Files:**
+- 无强制代码；可选在 spec 状态改为「实现中/已实现」
+
+- [ ] **Step 1: 跑全量相关测试**
+
+```bash
+pnpm --filter @lnkpi/server exec vitest run src/points src/membership
+pnpm --filter @lnkpi/web exec vitest run src/pages/ProfilePage.test.ts  # 若已添加
+```
+
+- [ ] **Step 2: 本地启动后** 登录 → 个人中心 → 确认汇总数字与扣费/退款后变化（若环境允许）
+- [ ] **Step 3: Final commit（若有收尾）**
+
+```bash
+git commit -m "docs: note points stats profile feature ready for QA"
+```
+
+---
+
+## Self-Review（对照 spec）
+
+| Spec 项 | Task |
+|---------|------|
+| 扩展 PointTransaction 字段/索引 | T3 |
+| kind/category/status/model/generationId/balanceAfter 写入 | T4、T7、T6 grant |
+| reason 回填 | T1 + T5 |
+| GET transactions 筛选/分页/range | T6 + T8 |
+| GET points-summary 净消耗+退款+获得 | T6 + T8 |
+| Asia/Shanghai 窗口 | T2 + T6 |
+| Profile 卡片 UI + 时间戳 | T9 |
+| 演进 C | **不在 plan 实现**（仅 spec §4） |
+| 测试要点 | T1/T2/T4/T6/T10 |
+
+无 TBD 占位；`generationId` 跳转路由明确为可选弱展示，避免假深链。

--- a/docs/superpowers/specs/2026-08-31-cx-image-edit-sam-mediapipe-fallback-design.md
+++ b/docs/superpowers/specs/2026-08-31-cx-image-edit-sam-mediapipe-fallback-design.md
@@ -1,7 +1,7 @@
 # 精修点选：主 SAM3 + MediaPipe 故障降级 Design
 
 **Date:** 2026-08-31  
-**Status:** Approved for planning (pending user review of this file)  
+**Status:** Approved; plan in `docs/superpowers/plans/2026-08-31-cx-image-edit-sam-mediapipe-fallback.md`  
 **代号:** **CX-IMAGE-EDIT-SAM-MEDIAPIPE-FALLBACK**  
 **Related:**
 - `2026-08-31-cx-image-edit-sam-point-select-design.md` — 点选主路径（fal SAM3）

--- a/docs/superpowers/specs/2026-08-31-cx-image-edit-sam-mediapipe-fallback-design.md
+++ b/docs/superpowers/specs/2026-08-31-cx-image-edit-sam-mediapipe-fallback-design.md
@@ -1,7 +1,7 @@
 # 精修点选：主 SAM3 + MediaPipe 故障降级 Design
 
 **Date:** 2026-08-31  
-**Status:** Approved; plan in `docs/superpowers/plans/2026-08-31-cx-image-edit-sam-mediapipe-fallback.md`  
+**Status:** Implemented on `feature/cx-sam-mediapipe-fallback`
 **代号:** **CX-IMAGE-EDIT-SAM-MEDIAPIPE-FALLBACK**  
 **Related:**
 - `2026-08-31-cx-image-edit-sam-point-select-design.md` — 点选主路径（fal SAM3）

--- a/docs/superpowers/specs/2026-08-31-cx-image-edit-sam-mediapipe-fallback-design.md
+++ b/docs/superpowers/specs/2026-08-31-cx-image-edit-sam-mediapipe-fallback-design.md
@@ -1,0 +1,122 @@
+# 精修点选：主 SAM3 + MediaPipe 故障降级 Design
+
+**Date:** 2026-08-31  
+**Status:** Approved for planning (pending user review of this file)  
+**代号:** **CX-IMAGE-EDIT-SAM-MEDIAPIPE-FALLBACK**  
+**Related:**
+- `2026-08-31-cx-image-edit-sam-point-select-design.md` — 点选主路径（fal SAM3）
+- `2026-08-21-cx-image-edit-selection-tools-design.md` — 选区工具链
+- `2026-08-19-cx-image-edit-toolchain-design.md` — 选区不扣分
+
+---
+
+## Goal
+
+在现有精修 **点选**（`POST /studio/image/segment` → fal `fal-ai/sam-3/image`）之上，当云端不可用时 **自动降级** 到浏览器端 **MediaPipe Interactive Segmenter**，保证点选仍能出 mask；不新增侧栏开关、不改积分与精修出图契约。
+
+## Decisions (locked)
+
+| Topic | Choice |
+|-------|--------|
+| 主路径 | 仍为 fal **SAM3**（服务端代理，`FAL_KEY`） |
+| 降级 | **MediaPipe Interactive Segmenter**，仅浏览器 |
+| 触发 | **仅故障自动降级**（无手动「本地点选」） |
+| 用户感知 | 首次降级成功时 **toast 一次**：「云端点选暂不可用，已用本地点选」 |
+| 粘滞 | **会话粘滞**：本轮精修内后续点选只走本地；关精修 / 换工作图后复位再试 SAM3 |
+| 实现路径 | **前端降级（路径 A）**：API 失败 → 懒加载 MediaPipe；CVM **不**跑分割 |
+| 加载时机 | **首次需要降级时** `import()`，不预热精修面板 |
+
+## Non-goals
+
+- 手动切换「本地点选」、双轨并行预热、竞速取快
+- 服务端 MediaPipe / ONNX / 自建 SAM
+- 文本指代（B）、负点击、多候选 mask
+- 改积分、GenerationRecord、EditProvider、真抠图
+- 静默永不提示（已定 toast 一次）
+
+---
+
+## 1. 触发条件与错误契约
+
+### 1.1 可降级 → MediaPipe + 置粘滞
+
+在尚未粘滞时，下列情况视为可降级：
+
+- `503` /「点选暂不可用」（无 `FAL_KEY`）
+- 上游 fal 失败：映射为 **`502`**（含原 401/403/`TOP_UP`、上游 429、5xx、超时、网络失败、响应无 maskUrl）
+- 前端可降级判定以 **HTTP `502` / `503`** 为准；若现有 API 信封支持业务码，502 时附带 `SEGMENT_UPSTREAM_UNAVAILABLE`（有则识别，无则仍仅靠 status）
+
+### 1.2 不可降级
+
+- `400` 参数无效
+- 本平台用户限流 `429`「点选过于频繁」
+- MediaPipe 自身失败（模型加载失败 / 无有效 mask）→ toast 失败，mask 不变
+
+### 1.3 服务端改动（配合识别）
+
+- 保持：无 key → `503`
+- **改：** fal/`SegmentProvider` 抛错不再变成未处理 500；捕获后 **`502 Bad Gateway`** + 可读文案（如「云端点选失败」）
+- 用户限流 / 参数校验语义不变
+
+---
+
+## 2. 前端数据流与懒加载
+
+### 2.1 模块
+
+建议新增 `apps/web/src/components/canvas/refine/mediapipeSegment.ts`：
+
+- 封装 MediaPipe Interactive Segmenter（stateful：`setImage` 一次 + 多次 `segment`）
+- 对外：`segmentPoint({ imageSource, x, y }) →` 与工作图同尺寸的 RGBA（或可喂入现有 `mergeMaskRgba` / `normalizeRemoteMaskRgba` 的等价数据）
+
+点选编排仍挂在现有 refine 点选 handler（`registerRefinePointSelectHandler` / SidePanel 侧），不改 `refineTool: 'point'` 与 `refineMaskOp` 语义。
+
+### 2.2 单次点击（未粘滞）
+
+1. `studioApi.segmentImage(...)` → SAM3  
+2. 成功：`loadMaskRgbaFromUrl` → 按 `refineMaskOp` 并入（现状）  
+3. 可降级失败：  
+   - 动态 `import()` MediaPipe（首次才拉 WASM/模型）  
+   - 对当前工作图 `setImage` + 点坐标 `segment`  
+   - 归一化 / 合并与远端 mask 相同路径  
+   - toast **一次**（会话内标志，避免重复吵）  
+   - `preferLocalSegment = true`
+
+### 2.3 粘滞后
+
+直接本地 `segmentPoint`，**不再**请求 `/studio/image/segment`。
+
+### 2.4 复位
+
+关精修 / `resetRefineChromeState` / 换工作图 URL 或尺寸源：
+
+- 清 `preferLocalSegment` 与「已 toast」标志  
+- 释放 MediaPipe 图会话缓存（下次降级再 `setImage`）  
+- 下一击重新先试 SAM3
+
+### 2.5 Busy
+
+SAM3 与 MediaPipe 共用现有点选 busy；WASM 首次加载期间不可连点。
+
+---
+
+## 3. 测试
+
+| 层 | 用例 |
+|----|------|
+| 服务端 | 无 key → 503；fal 403/5xx/无 mask → 502；限流 → 429；坏参 → 400 |
+| 前端编排 | 可降级 → 调本地；粘滞跳过 API；复位后恢复 SAM3；400/本平台 429 不调 MediaPipe |
+| MediaPipe | mock segmenter（CI 不强制真实 WASM）；手工：假 502 / 断 fal → toast 一次 + mask 出现 |
+
+---
+
+## 4. 成功标准
+
+- fal 正常：行为与现网点选一致（仍走 SAM3）  
+- fal 锁号 / 无 key / 502：点选仍能出 mask，首次 toast 一次，同会话后续本地且不刷 fal  
+- 关精修再开：再次优先 SAM3  
+- 点选仍不扣分；精修出图链路不变  
+
+## Open questions
+
+无（本轮已锁定）。实现阶段若 MediaPipe Web 包名/模型 URL 与文档有出入，以官方 Interactive Segmenter 推荐模型为准，记入 plan 任务即可。

--- a/docs/superpowers/specs/2026-09-01-points-stats-personal-center-design.md
+++ b/docs/superpowers/specs/2026-09-01-points-stats-personal-center-design.md
@@ -1,0 +1,219 @@
+# 个人中心积分统计（明细 + 分类汇总）
+
+**日期：** 2026-09-01  
+**状态：** 已确认设计，待实现  
+**范围：** 扩展积分账本、会员交易 API、个人中心卡片式汇总与明细；不含充值/支付改造
+
+## 背景
+
+- `PointTransaction` 仅有 `id / userId / amount / reason / createdAt`；扣费 `reason` 为中文自由文本（如「图像生成」「文本生成-失败退款」）。
+- 个人中心 `ProfilePage` 已拉取账单，但 UI 只展示 `reason` + `amount`，**未展示已有的 `createdAt`**，也无按文本/图片/音频/视频的消费汇总。
+- 用户需要：**可解释的消费明细（含时间戳等）** + **按媒体分类的积分汇总**，并支持时间范围切换。
+
+## 目标
+
+1. 账单明细可自查：时间、类型、分类、金额、说明，以及模型与生成记录追溯（本期 B 档）。
+2. 分类汇总：文本 / 图片 / 音频 / 视频的**净消耗**；同时展示期间退款合计、获得合计作对照。
+3. 时间范围：默认「本月」，可切换「近 7 天 / 本月 / 全部」。
+4. 存量流水回填结构化字段；新流水写入时强制带结构化 meta。
+5. UI 采用**卡片式**布局（汇总分类卡 + 明细流水卡）。
+
+## 非目标（本期）
+
+- 充值入口、支付渠道、会员套餐改版。
+- 消费趋势图、CSV 导出。
+- 运营级字段（节点 ID、计费规则版本、BYOK/平台路径、分辨率/时长等）——见 **演进 C**，本期不实现。
+- 独立分析库 / 双写事件表。
+
+## 已确认决策
+
+| 项 | 决策 |
+|----|------|
+| 目标 | A+B：明细透明 + 分类汇总 |
+| 实现路径 | 扩展 `PointTransaction` 单一账本（方案 1） |
+| 时间范围 | 默认 `month`；可选 `7d` / `month` / `all` |
+| 汇总口径 | 净消耗为主 + 退款合计对照；获得不进四分类净消耗 |
+| 明细信息密度 | 本期 B；演进计划写入 C |
+| 存量数据 | 按 `reason` 回填；无法识别 → `category=other` |
+| UI | 卡片式汇总网格 + 卡片式明细列表 |
+| 日界时区 | `Asia/Shanghai`；响应带回实际 `from` / `to` |
+
+---
+
+## §1 数据模型
+
+### 1.1 扩展 `PointTransaction`
+
+在现有字段上新增：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `kind` | `String` | `consume` \| `refund` \| `grant`；迁移默认 `consume`，随后回填脚本纠正 |
+| `category` | `String` | `text` \| `image` \| `audio` \| `video` \| `other`；迁移默认 `other`，随后回填纠正 |
+| `status` | `String?` | 消费成功：`success`；退款：`failed_refund` \| `cancelled_refund` \| `byok_refund`；grant 为 `null` |
+| `model` | `String?` | 计费时模型 ID |
+| `generationId` | `String?` | 关联 `GenerationRecord.id`（逻辑关联即可，本期不加 FK 约束） |
+| `balanceAfter` | `Int?` | 变动后余额；旧数据回填保持 `null` |
+
+保留 `reason` 作为面向用户的短文案；筛选与汇总只依赖结构化字段。
+
+### 1.2 索引
+
+- `(userId, createdAt)` — 明细分页  
+- `(userId, kind, category, createdAt)` — 汇总与筛选  
+
+### 1.3 写入约定
+
+- `PointsService.consume` / `refund` 与会员发放（签到、升级）统一写入结构化 meta（至少 `kind` + `category`）。
+- 消费：`amount < 0`，`kind=consume`，`status=success`（扣费成功落账时）。
+- 退款：`amount > 0`，`kind=refund`，`category` 与原消费一致；能关联则带同一 `generationId`。
+- 获得：`amount > 0`，`kind=grant`，`category=other`（签到、升级赠送等）。
+
+### 1.4 存量回填
+
+一次性脚本按 `reason` 启发式映射，例如：
+
+| reason 模式 | kind | category | status |
+|-------------|------|----------|--------|
+| 文本生成、提示词模式生成 | consume | text | success |
+| 图像生成、图像变体、图像精修 | consume | image | success |
+| 视频生成 | consume | video | success |
+| 音频相关（若有） | consume | audio | success |
+| `*-失败退款` | refund | 从前缀推断 | failed_refund |
+| `*-取消退款` | refund | 从前缀推断 | cancelled_refund |
+| `*-BYOK失败退款` | refund | 从前缀推断 | byok_refund |
+| 每日签到、升级 * | grant | other | null |
+| 平台回退生成、平台回退失败退款、导演台批量生成 * | 按后缀/符号 | other | 对应 success / *_refund |
+| 无法识别且 `amount < 0` | consume | other | success |
+| 无法识别且 `amount > 0` | grant | other | null |
+
+不臆造 `model` / `generationId` / `balanceAfter`。回填脚本幂等：仅更新仍为默认 `other`（或显式标记未回填）的行，可重复执行。
+
+---
+
+## §2 API 与汇总口径
+
+沿用 `/membership/*`，不新开积分域。
+
+### 2.1 `GET /membership/transactions`
+
+**Query**
+
+- `range`：`7d` \| `month` \| `all`（默认 `month`）
+- `kind?`、`category?`
+- `cursor?` / `limit?`（默认 50）
+
+**Item**
+
+```
+id, amount, reason, createdAt,
+kind, category, status, model, generationId, balanceAfter
+```
+
+另可返回本次查询的 `from` / `to`（与汇总一致）。
+
+### 2.2 `GET /membership/points-summary`
+
+**Query：** `range`（默认 `month`）
+
+**口径**
+
+- `byCategory.text|image|audio|video`（同 category）：  
+  `netConsumed = (-sum(amount where kind=consume)) - sum(amount where kind=refund)`  
+  即「消费绝对值之和 − 退款之和」；结果可为 0，不为负时按 0 展示（异常超退在明细可查）。
+- `refundTotal`：期间全部 `kind=refund` 的 `amount` 之和（正数）  
+- `grantTotal`：期间全部 `kind=grant` 的 `amount` 之和（正数）  
+- `otherNetConsumed`：对 `category=other` 用同一净消耗公式（仅当 > 0 时前端展示「其他」卡）  
+- `range`、`from`、`to`：实际窗口；`month` = 上海时区当月 00:00:00 至当前；`7d` = 当前往前 7×24h；`all` 无下界  
+
+**不**把 grant 计入四分类净消耗；**不**把毛消耗作为主数字。
+
+### 2.3 余额
+
+继续使用现有 `GET /membership/points` / profile 的 `points`。汇总接口可附带当前余额方便 UI，非必须。
+
+### 2.4 调用点改造
+
+Studio / canvas / scene-composer / membership 等所有 `consume`/`refund`/发放路径补齐 `category`（及有则 `model`、`generationId`）。
+
+---
+
+## §3 个人中心 UI（卡片式）
+
+改 `ProfilePage`（及 `membershipApi` 类型）：在余额/会员信息下方为 **汇总区 → 明细区**。
+
+### 3.1 时间范围
+
+顶部筛选卡片：`近 7 天` | `本月`（默认） | `全部`。切换同时刷新汇总与明细。
+
+### 3.2 汇总：分类卡片网格
+
+- 四张分类卡（文本 / 图片 / 音频 / 视频）：主数字为净消耗；点击 → 明细筛到该 `category`。
+- 对照卡：期间退款合计、期间获得合计（弱样式）。
+- `otherNetConsumed > 0` 时增加「其他」卡。
+
+### 3.3 明细：流水卡片列表
+
+每条一卡：
+
+- 主区：`reason`、分类徽章、类型（消费/退款/获得）、金额（消费负向强调；退款/获得正向）
+- 次要：`createdAt`（本地时区格式化）；有则 `model`；有 `generationId` 可提供「查看生成」（路由实现阶段确定）
+- 退款卡用徽章或左边色条区分
+
+轻量筛选：`kind`、`category`（与汇总同 `range`）。支持分页/加载更多。空态有文案。
+
+### 3.4 本期不做
+
+趋势图、导出、充值改版、演进 C 字段展示。
+
+---
+
+## §4 演进到 C（后续计划，本期不实现）
+
+在 B 稳定后，按需扩展账本（或关联 meta JSON）：
+
+| 方向 | 用途 |
+|------|------|
+| `nodeId` / `sessionId` | 画布节点与会话追溯 |
+| `billingRuleVersion` | 计价规则变更可解释 |
+| `chargePath` | `platform` / `byok` / `platform_fallback` |
+| `meter` | 计量快照：`durationSec`、`imageCount`、`resolution` 等 |
+| `relatedTxId` | 退款指向原消费流水 |
+
+UI：明细卡可展开「计量详情」；汇总可按 path / 规则版本切片。原则：只加列、旧行 null、不改 B 的净消耗口径。
+
+---
+
+## §5 边界与一致性
+
+- 汇总与明细必须使用同一 `range` 与同一 `from`/`to`。
+- 无 `generationId` 时不展示跳转。
+- 金额符号：消费 `amount < 0`；退款与获得 `amount > 0`。
+- 回填失败进 `other`，不阻塞上线。
+
+---
+
+## §6 测试要点
+
+- 回填映射表：覆盖常见 `reason` 与无法识别路径。
+- 汇总：同 category 消费 − 退款 = 净消耗；grant 不进四分类；`refundTotal` / `grantTotal` 正确。
+- API：默认 `month`；`7d` / `all`；`kind`/`category` 筛选；分页。
+- UI：卡片展示时间/分类/金额；点分类卡联动明细筛选；空态。
+
+---
+
+## §7 建议落地顺序
+
+1. Prisma 迁移 + `PointsService` / membership 写入结构化字段  
+2. 存量回填脚本  
+3. `transactions` 扩展 + 新 `points-summary`  
+4. `ProfilePage` 卡片式汇总与明细  
+5. 各生成路径补齐 category/model/generationId  
+6.（后续）演进 C 字段与 UI  
+
+## 参考
+
+- 现有模型：`apps/server/prisma/schema.prisma` → `PointTransaction`  
+- 现有服务：`apps/server/src/points/points.service.ts`、`apps/server/src/membership/membership.service.ts`  
+- 现有 UI：`apps/web/src/pages/ProfilePage.vue`  
+- 单价常量：`apps/web/src/constants/credits.ts`（text/image/video/audio）  

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@lnkpi/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@mediapipe/tasks-vision':
+        specifier: ^1.0.1
+        version: 1.0.1
       '@tiptap/extension-placeholder':
         specifier: ^3.28.0
         version: 3.28.0(@tiptap/extensions@3.28.0(@tiptap/core@3.28.0(@tiptap/pm@3.28.0))(@tiptap/pm@3.28.0))
@@ -774,6 +777,9 @@ packages:
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
+
+  '@mediapipe/tasks-vision@1.0.1':
+    resolution: {integrity: sha512-rvRE2FmAZ6ZxKSw7wq+e+jQDpN3t1B/tD2mJz9SmAzb1msoDkd4dMoE4wAh8Z30Um0PQwLiHr9QtomhmXk3aUQ==}
 
   '@nestjs/common@10.4.22':
     resolution: {integrity: sha512-fxJ4v85nDHaqT1PmfNCQ37b/jcv2OojtXTaK1P2uAXhzLf9qq6WNUOFvxBrV4fhQek1EQoT1o9oj5xAZmv3NRw==}
@@ -3615,6 +3621,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@lukeed/csprng@1.1.0': {}
+
+  '@mediapipe/tasks-vision@1.0.1': {}
 
   '@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:


### PR DESCRIPTION
## Summary
- Map fal segment upstream failures to HTTP **502** so the client can degrade cleanly (503 for missing `FAL_KEY` unchanged).
- Auto-fallback refine **点选** to browser **MediaPipe Interactive Segmenter** on 502/503/network errors, with one toast and session stickiness until refine closes / work image changes.
- Spec/plan: `docs/superpowers/specs/2026-08-31-cx-image-edit-sam-mediapipe-fallback-design.md`, `docs/superpowers/plans/2026-08-31-cx-image-edit-sam-mediapipe-fallback.md`

## Test plan
- [ ] fal healthy: point-select stays on cloud, no fallback toast
- [ ] 502 / no `FAL_KEY`: toast once「云端点选暂不可用，已用本地点选」+ mask appears; later clicks in session skip `/segment`
- [ ] Close refine and reopen: tries SAM3 again
- [ ] Platform rate-limit 429: no MediaPipe fallback, error shown
- [ ] Points unchanged until「精修」
- [ ] `pnpm --filter @lnkpi/server exec vitest run src/studio/studio.segment.test.ts`
- [ ] `pnpm --filter @lnkpi/web exec vitest run src/components/canvas/refine/{segmentDegrade,pointSegmentSession,mediapipeSegment,maskRemote}.test.ts`


Made with [Cursor](https://cursor.com)