### PR TITLE
feat: profile points insights and Neowow-style bill UX

### DIFF
--- a/apps/server/src/membership/membership.service.test.ts
+++ b/apps/server/src/membership/membership.service.test.ts
@@ -6,6 +6,7 @@ import { MembershipService } from './membership.service'
 
 describe('MembershipService', () => {
   const findMany = vi.fn()
+  const findFirst = vi.fn()
   const groupBy = vi.fn()
   const userUpdate = vi.fn()
   const transactionCreate = vi.fn()
@@ -25,7 +26,7 @@ describe('MembershipService', () => {
         {
           provide: PrismaService,
           useValue: {
-            pointTransaction: { findMany, groupBy },
+            pointTransaction: { findMany, groupBy, findFirst },
             $transaction,
           },
         },
@@ -34,36 +35,34 @@ describe('MembershipService', () => {
     service = moduleRef.get(MembershipService)
   })
 
-  it('aggregates non-negative net consumption and totals for the selected range', async () => {
+  it('aggregates non-negative net consumption and insights for the selected range', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-08-20T12:00:00.000Z'))
     groupBy.mockResolvedValue([
       { kind: 'consume', category: 'image', _sum: { amount: -30 } },
       { kind: 'refund', category: 'image', _sum: { amount: 10 } },
       { kind: 'grant', category: 'other', _sum: { amount: 100 } },
-      { kind: 'refund', category: 'audio', _sum: { amount: 7 } },
+    ])
+    findMany.mockResolvedValue([
+      { createdAt: new Date('2026-08-18T10:00:00.000Z'), amount: -20 },
+      { createdAt: new Date('2026-08-19T10:00:00.000Z'), amount: -10 },
     ])
 
-    await expect(service.pointsSummary('u1', 'month')).resolves.toEqual({
-      range: 'month',
-      from: '2026-07-31T16:00:00.000Z',
-      to: '2026-08-20T12:00:00.000Z',
-      byCategory: { text: 0, image: 20, audio: 0, video: 0 },
-      otherNetConsumed: 0,
-      refundTotal: 17,
-      grantTotal: 100,
+    const result = await service.pointsSummary('u1', 'month')
+    expect(result.byCategory.image).toBe(20)
+    expect(result.insights).toEqual({
+      netConsumedTotal: 20,
+      peakDayConsumed: 20,
+      avgDailyConsumed: expect.any(Number),
+      activeDays: 2,
+      longestStreakDays: 2,
     })
-    expect(groupBy).toHaveBeenCalledWith({
-      by: ['kind', 'category'],
-      where: {
-        userId: 'u1',
-        createdAt: {
-          gte: new Date('2026-07-31T16:00:00.000Z'),
-          lte: new Date('2026-08-20T12:00:00.000Z'),
-        },
-      },
-      _sum: { amount: true },
-    })
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ userId: 'u1', kind: 'consume' }),
+        select: { createdAt: true, amount: true },
+      }),
+    )
     vi.useRealTimers()
   })
 

--- a/apps/server/src/membership/membership.service.ts
+++ b/apps/server/src/membership/membership.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, BadRequestException } from '@nestjs/common'
 import { PrismaService } from '../prisma/prisma.service'
 import { PointsRangeKey, resolvePointsRange } from '../points/points-range'
+import { computePointsInsights, type PointsInsights } from '../points/points-insights'
 
 export type PointKind = 'consume' | 'refund' | 'grant'
 export type PointCategory = 'text' | 'image' | 'audio' | 'video' | 'other'
@@ -27,6 +28,7 @@ export interface PointsSummaryDto {
   otherNetConsumed: number
   refundTotal: number
   grantTotal: number
+  insights: PointsInsights
 }
 
 const PLANS = [
@@ -130,6 +132,29 @@ export class MembershipService {
     const netConsumed = (category: PointCategory) =>
       Math.max(0, -consumed[category] - refunded[category])
 
+    const netConsumedTotal =
+      netConsumed('text') +
+      netConsumed('image') +
+      netConsumed('audio') +
+      netConsumed('video') +
+      netConsumed('other')
+
+    const consumeRows = await this.prisma.pointTransaction.findMany({
+      where: {
+        userId,
+        kind: 'consume',
+        createdAt: from ? { gte: from, lte: to } : { lte: to },
+      },
+      select: { createdAt: true, amount: true },
+    })
+
+    const insights = computePointsInsights({
+      netConsumedTotal,
+      consumeRows,
+      from,
+      to,
+    })
+
     return {
       range,
       from: from?.toISOString() ?? null,
@@ -143,6 +168,7 @@ export class MembershipService {
       otherNetConsumed: netConsumed('other'),
       refundTotal,
       grantTotal,
+      insights,
     }
   }
 

--- a/apps/server/src/points/points-insights.test.ts
+++ b/apps/server/src/points/points-insights.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import {
+  calendarDaysInclusive,
+  computeLongestStreak,
+  computePointsInsights,
+  shanghaiDayKey,
+} from './points-insights'
+
+describe('shanghaiDayKey', () => {
+  it('uses Asia/Shanghai calendar day', () => {
+    // 2026-08-01 00:30 CST = 2026-07-31T16:30:00Z
+    expect(shanghaiDayKey(new Date('2026-07-31T16:30:00.000Z'))).toBe('2026-08-01')
+  })
+})
+
+describe('computeLongestStreak', () => {
+  it('returns 0 for empty', () => {
+    expect(computeLongestStreak([])).toBe(0)
+  })
+
+  it('counts consecutive calendar days', () => {
+    expect(computeLongestStreak(['2026-08-01', '2026-08-02', '2026-08-03', '2026-08-05'])).toBe(3)
+  })
+})
+
+describe('computePointsInsights', () => {
+  const to = new Date('2026-08-10T12:00:00.000Z')
+  const from = new Date('2026-08-01T00:00:00.000Z')
+
+  it('computes peak, active days, streak, and avg from consume rows', () => {
+    const insights = computePointsInsights({
+      netConsumedTotal: 45,
+      from,
+      to,
+      consumeRows: [
+        { createdAt: new Date('2026-08-02T10:00:00.000Z'), amount: -20 },
+        { createdAt: new Date('2026-08-02T08:00:00.000Z'), amount: -10 },
+        { createdAt: new Date('2026-08-03T10:00:00.000Z'), amount: -15 },
+      ],
+    })
+    expect(insights.netConsumedTotal).toBe(45)
+    expect(insights.peakDayConsumed).toBe(30)
+    expect(insights.activeDays).toBe(2)
+    expect(insights.longestStreakDays).toBe(2)
+    expect(insights.avgDailyConsumed).toBeCloseTo(45 / calendarDaysInclusive(from, to), 5)
+  })
+
+  it('returns zeros when no consume rows', () => {
+    const insights = computePointsInsights({
+      netConsumedTotal: 0,
+      from,
+      to,
+      consumeRows: [],
+    })
+    expect(insights).toEqual({
+      netConsumedTotal: 0,
+      peakDayConsumed: 0,
+      avgDailyConsumed: 0,
+      activeDays: 0,
+      longestStreakDays: 0,
+    })
+  })
+
+  it('uses from=null with earliest consume day for calendar span', () => {
+    const insights = computePointsInsights({
+      netConsumedTotal: 10,
+      from: null,
+      to: new Date('2026-08-09T15:00:00.000Z'),
+      consumeRows: [{ createdAt: new Date('2026-08-09T10:00:00.000Z'), amount: -10 }],
+    })
+    expect(insights.activeDays).toBe(1)
+    expect(insights.avgDailyConsumed).toBe(10)
+  })
+})

--- a/apps/server/src/points/points-insights.ts
+++ b/apps/server/src/points/points-insights.ts
@@ -1,0 +1,85 @@
+export interface PointsInsights {
+  netConsumedTotal: number
+  peakDayConsumed: number
+  avgDailyConsumed: number
+  activeDays: number
+  longestStreakDays: number
+}
+
+const SH_OFFSET_MS = 8 * 60 * 60 * 1000
+
+export function shanghaiDayKey(d: Date): string {
+  const shifted = new Date(d.getTime() + SH_OFFSET_MS)
+  const y = shifted.getUTCFullYear()
+  const m = String(shifted.getUTCMonth() + 1).padStart(2, '0')
+  const day = String(shifted.getUTCDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+function parseDayKey(key: string): Date {
+  const [y, m, d] = key.split('-').map(Number)
+  return new Date(Date.UTC(y, m - 1, d))
+}
+
+export function calendarDaysInclusive(from: Date, to: Date): number {
+  const start = parseDayKey(shanghaiDayKey(from))
+  const end = parseDayKey(shanghaiDayKey(to))
+  const diff = Math.floor((end.getTime() - start.getTime()) / 86_400_000)
+  return Math.max(1, diff + 1)
+}
+
+export function computeLongestStreak(dayKeys: string[]): number {
+  if (!dayKeys.length) return 0
+  const sorted = [...new Set(dayKeys)].sort()
+  let best = 1
+  let current = 1
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = parseDayKey(sorted[i - 1])
+    const cur = parseDayKey(sorted[i])
+    const gap = Math.round((cur.getTime() - prev.getTime()) / 86_400_000)
+    if (gap === 1) {
+      current += 1
+      best = Math.max(best, current)
+    } else {
+      current = 1
+    }
+  }
+  return best
+}
+
+export function computePointsInsights(input: {
+  netConsumedTotal: number
+  consumeRows: Array<{ createdAt: Date; amount: number }>
+  from: Date | null
+  to: Date
+}): PointsInsights {
+  const { netConsumedTotal, consumeRows, to } = input
+  if (!consumeRows.length) {
+    return {
+      netConsumedTotal,
+      peakDayConsumed: 0,
+      avgDailyConsumed: 0,
+      activeDays: 0,
+      longestStreakDays: 0,
+    }
+  }
+
+  const dayTotals = new Map<string, number>()
+  for (const row of consumeRows) {
+    const key = shanghaiDayKey(row.createdAt)
+    dayTotals.set(key, (dayTotals.get(key) ?? 0) + Math.abs(row.amount))
+  }
+
+  const activeDayKeys = [...dayTotals.keys()].sort()
+  const peakDayConsumed = Math.max(...[...dayTotals.values()])
+  const effectiveFrom = input.from ?? parseDayKey(activeDayKeys[0])
+  const windowDays = calendarDaysInclusive(effectiveFrom, to)
+
+  return {
+    netConsumedTotal,
+    peakDayConsumed,
+    avgDailyConsumed: netConsumedTotal / Math.max(1, windowDays),
+    activeDays: activeDayKeys.length,
+    longestStreakDays: computeLongestStreak(activeDayKeys),
+  }
+}

--- a/apps/web/src/pages/ProfilePage.test.ts
+++ b/apps/web/src/pages/ProfilePage.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { useAuthStore } from '@/stores/auth'
+import ProfilePage from './ProfilePage.vue'
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@/services/api', () => ({
+  api: {
+    get: vi.fn().mockResolvedValue({
+      data: { data: { nickname: '测', phone: '172****8608', points: 34, membership: 'free' } },
+    }),
+  },
+}))
+
+vi.mock('@/services/users-api', () => ({
+  membershipApi: {
+    pointsSummary: vi.fn().mockResolvedValue({
+      data: {
+        data: {
+          range: 'month',
+          from: null,
+          to: new Date().toISOString(),
+          byCategory: { text: 0, image: 20, audio: 0, video: 0 },
+          otherNetConsumed: 0,
+          refundTotal: 0,
+          grantTotal: 0,
+          insights: {
+            netConsumedTotal: 20,
+            peakDayConsumed: 20,
+            avgDailyConsumed: 1,
+            activeDays: 1,
+            longestStreakDays: 1,
+          },
+        },
+      },
+    }),
+    transactions: vi.fn().mockResolvedValue({
+      data: { data: { items: [], nextCursor: null, from: null, to: new Date().toISOString() } },
+    }),
+  },
+}))
+
+vi.mock('@/components/membership/MembershipModal.vue', () => ({
+  default: { template: '<div class="membership-modal-stub" />' },
+}))
+
+describe('ProfilePage', () => {
+  it('renders insight KPI labels and recharge CTA', async () => {
+    setActivePinia(createPinia())
+    const auth = useAuthStore()
+    auth.token = 'tok'
+    auth.user = { id: '1', phone: '17200008608', nickname: '测', points: 34, membership: 'free' } as never
+
+    const wrapper = mount(ProfilePage)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('净消耗')
+    expect(wrapper.text()).toContain('单日峰值')
+    expect(wrapper.text()).toContain('充值')
+    expect(wrapper.text()).toContain('全部')
+    expect(wrapper.text()).toContain('消耗')
+  })
+})

--- a/apps/web/src/pages/ProfilePage.vue
+++ b/apps/web/src/pages/ProfilePage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
+import MembershipModal from '@/components/membership/MembershipModal.vue'
 import { useAuthStore } from '@/stores/auth'
 import { membershipApi } from '@/services/users-api'
 import { api } from '@/services/api'
@@ -25,6 +26,16 @@ const nextCursor = ref<string | null>(null)
 const isLoading = ref(false)
 const isLoadingMore = ref(false)
 const loadError = ref('')
+const showMembership = ref(false)
+
+const membershipLabel = computed(() => {
+  const m = profile.value?.membership
+  if (m === 'pro') return '专业版'
+  if (m === 'studio') return '工作室版'
+  return '免费版'
+})
+
+const isFreeMembership = computed(() => !profile.value?.membership || profile.value.membership === 'free')
 
 /** Monotonic generation; stale responses are discarded when range/filters change. */
 let fetchGeneration = 0
@@ -176,18 +187,26 @@ onMounted(async () => {
           <p class="text-sm text-white/50">{{ profile.phone }}</p>
         </div>
       </div>
-      <div class="mt-6 grid grid-cols-2 gap-4">
-        <div class="rounded-xl bg-[#242424] p-4">
-          <p class="text-xs text-white/40">积分余额</p>
-          <p class="text-2xl font-semibold text-[#818cf8]">{{ profile.points ?? 0 }}</p>
+      <div class="mt-6 rounded-xl border border-white/8 bg-[#242424] p-5">
+        <div class="flex items-end justify-between gap-4">
+          <div>
+            <p class="text-xs text-white/40">可用总积分</p>
+            <p class="text-3xl font-semibold text-[#818cf8]">{{ profile.points ?? 0 }}</p>
+          </div>
+          <span class="rounded-full bg-white/[0.06] px-3 py-1 text-xs text-white/60">{{ membershipLabel }}</span>
         </div>
-        <div class="rounded-xl bg-[#242424] p-4">
-          <p class="text-xs text-white/40">会员等级</p>
-          <p class="text-lg font-medium">
-            {{ profile.membership === 'pro' ? '专业版' : profile.membership === 'studio' ? '工作室版' : '免费版' }}
-          </p>
+        <p v-if="isFreeMembership" class="mt-3 text-xs text-white/35">开通会员，获得更多积分与高级能力</p>
+        <div class="mt-4 flex gap-3">
+          <button type="button" class="flex-1 rounded-xl bg-white px-4 py-2.5 text-sm font-medium text-black" @click="showMembership = true">
+            充值
+          </button>
+          <button type="button" class="flex-1 rounded-xl border border-white/15 px-4 py-2.5 text-sm text-white/80" @click="showMembership = true">
+            {{ isFreeMembership ? '升级会员' : '管理会员' }}
+          </button>
         </div>
       </div>
+
+      <MembershipModal v-model="showMembership" />
     </div>
 
     <section class="mb-6 rounded-2xl border border-white/8 bg-[#1a1a1a] p-5">

--- a/apps/web/src/pages/ProfilePage.vue
+++ b/apps/web/src/pages/ProfilePage.vue
@@ -29,6 +29,19 @@ const isLoadingMore = ref(false)
 const loadError = ref('')
 const showMembership = ref(false)
 
+type BillKindTab = 'all' | 'consume' | 'grant'
+
+const billKindTab = ref<BillKindTab>('all')
+
+watch(billKindTab, (tab) => {
+  filterKind.value = tab === 'all' ? undefined : tab
+})
+
+watch(filterKind, (kind) => {
+  if (!kind) billKindTab.value = 'all'
+  else if (kind === 'consume' || kind === 'grant') billKindTab.value = kind
+})
+
 const membershipLabel = computed(() => {
   const m = profile.value?.membership
   if (m === 'pro') return '专业版'
@@ -319,32 +332,29 @@ onMounted(async () => {
         </button>
       </div>
 
-      <div class="mt-4 flex flex-wrap items-center gap-2 border-t border-white/8 pt-4">
-        <span class="mr-1 text-xs text-white/35">记录类型</span>
+      <div v-if="filterCategory || filterKind" class="mt-4 flex justify-end border-t border-white/8 pt-4">
         <button
-          v-for="kind in (['consume', 'refund', 'grant'] as PointKind[])"
-          :key="kind"
           type="button"
-          class="rounded-full border px-3 py-1 text-xs transition"
-          :class="
-            filterKind === kind
-              ? 'border-[#818cf8]/60 bg-[#6366f1]/15 text-[#a5b4fc]'
-              : 'border-white/10 text-white/45 hover:text-white/70'
-          "
-          @click="toggleKind(kind)"
-        >
-          {{ kindLabels[kind] }}
-        </button>
-        <button
-          v-if="filterCategory || filterKind"
-          type="button"
-          class="ml-auto text-xs text-white/40 transition hover:text-white/70"
+          class="text-xs text-white/40 transition hover:text-white/70"
           @click="filterCategory = undefined; filterKind = undefined"
         >
           清除筛选
         </button>
       </div>
     </section>
+
+    <div class="mb-4 flex rounded-xl bg-[#242424] p-1">
+      <button
+        v-for="tab in ([['all', '全部'], ['consume', '消耗'], ['grant', '获得']] as const)"
+        :key="tab[0]"
+        type="button"
+        class="flex-1 rounded-lg px-3 py-2 text-xs transition"
+        :class="billKindTab === tab[0] ? 'bg-[#6366f1] text-white' : 'text-white/50'"
+        @click="billKindTab = tab[0]"
+      >
+        {{ tab[1] }}
+      </button>
+    </div>
 
     <div v-if="isLoading" class="rounded-2xl border border-white/8 bg-[#1a1a1a] py-12 text-center text-sm text-white/35">
       正在加载积分账单…
@@ -383,9 +393,14 @@ onMounted(async () => {
         </div>
         <div class="mt-3 flex flex-wrap items-center justify-between gap-2 border-t border-white/5 pt-3">
           <time class="text-xs text-white/30" :datetime="tx.createdAt">{{ formatCreatedAt(tx.createdAt) }}</time>
-          <span v-if="tx.generationId" class="font-mono text-[11px] text-[#818cf8]/70" :title="tx.generationId">
-            生成 ID · {{ shortGenerationId(tx.generationId) }}
-          </span>
+          <div class="flex items-center gap-3">
+            <span v-if="tx.generationId" class="font-mono text-[11px] text-[#818cf8]/70" :title="tx.generationId">
+              生成 ID · {{ shortGenerationId(tx.generationId) }}
+            </span>
+            <span class="text-xs text-white/35">
+              余额 {{ tx.balanceAfter ?? '—' }}
+            </span>
+          </div>
         </div>
       </div>
       <p v-if="loadError" class="py-2 text-center text-xs text-red-300/70">{{ loadError }}</p>
@@ -400,7 +415,7 @@ onMounted(async () => {
         </button>
       </div>
       <p v-if="!transactions.length" class="rounded-2xl border border-white/8 bg-[#1a1a1a] py-12 text-center text-white/30">
-        暂无该时间范围的账单记录
+        {{ filterCategory || filterKind ? '该条件下暂无记录' : '暂无该时间范围的账单记录' }}
       </p>
     </div>
   </div>

--- a/apps/web/src/pages/ProfilePage.vue
+++ b/apps/web/src/pages/ProfilePage.vue
@@ -10,6 +10,7 @@ import type {
   PointCategory,
   PointKind,
   PointTransactionItem,
+  PointsInsights,
   PointsRangeKey,
   PointsSummary,
 } from '@/services/users-api'
@@ -74,6 +75,19 @@ const categoryLabels: Record<PointCategory, string> = {
   audio: '音频',
   video: '视频',
   other: '其他',
+}
+
+const insightOptions = [
+  { key: 'netConsumedTotal' as const, label: '净消耗' },
+  { key: 'peakDayConsumed' as const, label: '单日峰值' },
+  { key: 'avgDailyConsumed' as const, label: '日均消耗' },
+  { key: 'activeDays' as const, label: '活跃天数' },
+  { key: 'longestStreakDays' as const, label: '最长连续活跃' },
+]
+
+function formatInsightValue(key: keyof PointsInsights, value: number) {
+  if (key === 'avgDailyConsumed') return value < 10 ? value.toFixed(1) : Math.round(value).toString()
+  return String(Math.round(value))
 }
 
 function toggleCategory(category: PointCategory) {
@@ -247,6 +261,19 @@ onMounted(async () => {
             {{ summary.byCategory[category.value] }}
           </p>
         </button>
+      </div>
+
+      <div v-if="summary?.insights" class="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-5">
+        <div
+          v-for="item in insightOptions"
+          :key="item.key"
+          class="rounded-xl border border-white/8 bg-[#242424] p-4"
+        >
+          <p class="text-xs text-white/45">{{ item.label }}</p>
+          <p class="mt-2 text-xl font-semibold text-white/85">
+            {{ formatInsightValue(item.key, summary.insights[item.key]) }}
+          </p>
+        </div>
       </div>
 
       <div v-if="summary" class="mt-3 grid grid-cols-2 gap-3" :class="{ 'sm:grid-cols-3': summary.otherNetConsumed > 0 }">

--- a/apps/web/src/services/users-api.ts
+++ b/apps/web/src/services/users-api.ts
@@ -43,6 +43,14 @@ export interface PointTransactionItem {
   balanceAfter: number | null
 }
 
+export interface PointsInsights {
+  netConsumedTotal: number
+  peakDayConsumed: number
+  avgDailyConsumed: number
+  activeDays: number
+  longestStreakDays: number
+}
+
 export interface PointsSummary {
   range: PointsRangeKey
   from: string | null
@@ -51,6 +59,7 @@ export interface PointsSummary {
   otherNetConsumed: number
   refundTotal: number
   grantTotal: number
+  insights: PointsInsights
 }
 
 export const membershipApi = {

--- a/docs/superpowers/plans/2026-09-01-points-stats-neowow-adoption.md
+++ b/docs/superpowers/plans/2026-09-01-points-stats-neowow-adoption.md
@@ -1,0 +1,690 @@
+# 个人中心积分 UX 采纳（Neowow）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在 `#270` 积分统计基础上，扩展 `points-summary` 返回用量洞察 KPI，并增强 `ProfilePage` 的会员转化条、账单密度与 kind 分段筛选。
+
+**Architecture:** 将 insights 日聚合逻辑提取为 `points-insights.ts` 纯函数（TDD）；`MembershipService.pointsSummary` 在现有 `groupBy` 后追加 `findMany` 拉取窗口内 consume 行并计算 KPI；`ProfilePage` 单页三段布局复用现有 `MembershipModal` 与 `membershipApi`。
+
+**Tech Stack:** NestJS、Prisma、Vue 3 + Vitest、现有 `/membership/points-summary` 与 `/membership/transactions`
+
+**Spec:** `docs/superpowers/specs/2026-09-01-points-stats-neowow-adoption-design.md`
+
+## Global Constraints
+
+- 汇总与 insights 共用 `range`（`7d` | `month` | `all`，默认 `month`）；日界 `Asia/Shanghai`；响应带回 `from`/`to`
+- insights 净消耗口径与分类卡一致（consume − refund）；峰值/活跃/连续仅统计 `kind=consume`
+- `grant` 不参与 insights；`balanceAfter` 历史 null → UI 显示 `—`
+- kind 分段：全部 / 消耗（`consume`）/ 获得（`grant`）；退款仅在「全部」展示
+- 充值与升级均打开现有 `MembershipModal`；不新建支付流
+- 分支从最新 `origin/main`（含 `#270`）拉取：`feat/points-stats-neowow-adoption`
+- 验证：`pnpm --filter @lnkpi/server exec vitest run` 全绿；相关 web 测试通过
+- 不把 `.superpowers/`、deploy 审计 JSON 等无关文件加入 commit
+
+---
+
+## File Structure Map
+
+| 路径 | 职责 |
+|------|------|
+| `apps/server/src/points/points-insights.ts` | 上海日 bucket、streak、insights 纯函数 |
+| `apps/server/src/points/points-insights.test.ts` | insights 口径单测 |
+| `apps/server/src/membership/membership.service.ts` | `PointsSummaryDto.insights` + 查询 consume 行 |
+| `apps/server/src/membership/membership.service.test.ts` | 扩展 `pointsSummary` 断言含 insights |
+| `apps/web/src/services/users-api.ts` | `PointsSummary.insights` 类型 |
+| `apps/web/src/pages/ProfilePage.vue` | 资产卡、KPI 卡、kind 分段、balanceAfter |
+| `apps/web/src/pages/ProfilePage.test.ts` | 创建：渲染与分段映射冒烟 |
+
+---
+
+### Task 1: insights 纯函数（TDD）
+
+**Files:**
+- Create: `apps/server/src/points/points-insights.ts`
+- Create: `apps/server/src/points/points-insights.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `export interface PointsInsights { netConsumedTotal: number; peakDayConsumed: number; avgDailyConsumed: number; activeDays: number; longestStreakDays: number }`
+  - `export function shanghaiDayKey(d: Date): string` — 返回 `YYYY-MM-DD`（上海日历日）
+  - `export function calendarDaysInclusive(from: Date, to: Date): number`
+  - `export function computeLongestStreak(dayKeys: string[]): number`
+  - `export function computePointsInsights(input: { netConsumedTotal: number; consumeRows: Array<{ createdAt: Date; amount: number }>; from: Date | null; to: Date }): PointsInsights`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, expect, it } from 'vitest'
+import {
+  calendarDaysInclusive,
+  computeLongestStreak,
+  computePointsInsights,
+  shanghaiDayKey,
+} from './points-insights'
+
+describe('shanghaiDayKey', () => {
+  it('uses Asia/Shanghai calendar day', () => {
+    // 2026-08-01 00:30 CST = 2026-07-31T16:30:00Z
+    expect(shanghaiDayKey(new Date('2026-07-31T16:30:00.000Z'))).toBe('2026-08-01')
+  })
+})
+
+describe('computeLongestStreak', () => {
+  it('returns 0 for empty', () => {
+    expect(computeLongestStreak([])).toBe(0)
+  })
+
+  it('counts consecutive calendar days', () => {
+    expect(computeLongestStreak(['2026-08-01', '2026-08-02', '2026-08-03', '2026-08-05'])).toBe(3)
+  })
+})
+
+describe('computePointsInsights', () => {
+  const to = new Date('2026-08-10T12:00:00.000Z')
+  const from = new Date('2026-08-01T00:00:00.000Z')
+
+  it('computes peak, active days, streak, and avg from consume rows', () => {
+    const insights = computePointsInsights({
+      netConsumedTotal: 45,
+      from,
+      to,
+      consumeRows: [
+        { createdAt: new Date('2026-08-02T10:00:00.000Z'), amount: -20 },
+        { createdAt: new Date('2026-08-02T18:00:00.000Z'), amount: -10 },
+        { createdAt: new Date('2026-08-03T10:00:00.000Z'), amount: -15 },
+      ],
+    })
+    expect(insights.netConsumedTotal).toBe(45)
+    expect(insights.peakDayConsumed).toBe(30)
+    expect(insights.activeDays).toBe(2)
+    expect(insights.longestStreakDays).toBe(2)
+    expect(insights.avgDailyConsumed).toBeCloseTo(45 / calendarDaysInclusive(from, to), 5)
+  })
+
+  it('returns zeros when no consume rows', () => {
+    const insights = computePointsInsights({
+      netConsumedTotal: 0,
+      from,
+      to,
+      consumeRows: [],
+    })
+    expect(insights).toEqual({
+      netConsumedTotal: 0,
+      peakDayConsumed: 0,
+      avgDailyConsumed: 0,
+      activeDays: 0,
+      longestStreakDays: 0,
+    })
+  })
+
+  it('uses from=null with earliest consume day for calendar span', () => {
+    const insights = computePointsInsights({
+      netConsumedTotal: 10,
+      from: null,
+      to,
+      consumeRows: [{ createdAt: new Date('2026-08-09T10:00:00.000Z'), amount: -10 }],
+    })
+    expect(insights.activeDays).toBe(1)
+    expect(insights.avgDailyConsumed).toBe(10)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @lnkpi/server exec vitest run src/points/points-insights.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+export interface PointsInsights {
+  netConsumedTotal: number
+  peakDayConsumed: number
+  avgDailyConsumed: number
+  activeDays: number
+  longestStreakDays: number
+}
+
+const SH_OFFSET_MS = 8 * 60 * 60 * 1000
+
+export function shanghaiDayKey(d: Date): string {
+  const shifted = new Date(d.getTime() + SH_OFFSET_MS)
+  const y = shifted.getUTCFullYear()
+  const m = String(shifted.getUTCMonth() + 1).padStart(2, '0')
+  const day = String(shifted.getUTCDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+function parseDayKey(key: string): Date {
+  const [y, m, d] = key.split('-').map(Number)
+  return new Date(Date.UTC(y, m - 1, d))
+}
+
+export function calendarDaysInclusive(from: Date, to: Date): number {
+  const start = parseDayKey(shanghaiDayKey(from))
+  const end = parseDayKey(shanghaiDayKey(to))
+  const diff = Math.floor((end.getTime() - start.getTime()) / 86_400_000)
+  return Math.max(1, diff + 1)
+}
+
+export function computeLongestStreak(dayKeys: string[]): number {
+  if (!dayKeys.length) return 0
+  const sorted = [...new Set(dayKeys)].sort()
+  let best = 1
+  let current = 1
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = parseDayKey(sorted[i - 1])
+    const cur = parseDayKey(sorted[i])
+    const gap = Math.round((cur.getTime() - prev.getTime()) / 86_400_000)
+    if (gap === 1) {
+      current += 1
+      best = Math.max(best, current)
+    } else {
+      current = 1
+    }
+  }
+  return best
+}
+
+export function computePointsInsights(input: {
+  netConsumedTotal: number
+  consumeRows: Array<{ createdAt: Date; amount: number }>
+  from: Date | null
+  to: Date
+}): PointsInsights {
+  const { netConsumedTotal, consumeRows, to } = input
+  if (!consumeRows.length) {
+    return {
+      netConsumedTotal,
+      peakDayConsumed: 0,
+      avgDailyConsumed: 0,
+      activeDays: 0,
+      longestStreakDays: 0,
+    }
+  }
+
+  const dayTotals = new Map<string, number>()
+  for (const row of consumeRows) {
+    const key = shanghaiDayKey(row.createdAt)
+    dayTotals.set(key, (dayTotals.get(key) ?? 0) + Math.abs(row.amount))
+  }
+
+  const activeDayKeys = [...dayTotals.keys()].sort()
+  const peakDayConsumed = Math.max(...[...dayTotals.values()])
+  const effectiveFrom =
+    input.from ?? parseDayKey(activeDayKeys[0])
+  const windowDays = calendarDaysInclusive(effectiveFrom, to)
+
+  return {
+    netConsumedTotal,
+    peakDayConsumed,
+    avgDailyConsumed: netConsumedTotal / Math.max(1, windowDays),
+    activeDays: activeDayKeys.length,
+    longestStreakDays: computeLongestStreak(activeDayKeys),
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter @lnkpi/server exec vitest run src/points/points-insights.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/points/points-insights.ts apps/server/src/points/points-insights.test.ts
+git commit -m "feat(server): add points insights pure functions"
+```
+
+---
+
+### Task 2: 扩展 MembershipService.pointsSummary
+
+**Files:**
+- Modify: `apps/server/src/membership/membership.service.ts`
+- Modify: `apps/server/src/membership/membership.service.test.ts`
+
+**Interfaces:**
+- Consumes: `computePointsInsights`, `PointsInsights` from `../points/points-insights`
+- Produces: `PointsSummaryDto` 含 `insights: PointsInsights`
+
+- [ ] **Step 1: Update failing service test**
+
+在 `membership.service.test.ts` 的 `beforeEach` mock 中增加 `findFirst = vi.fn()`（用于 `all` 最早交易日），并更新聚合测试期望：
+
+```ts
+const findMany = vi.fn()
+const findFirst = vi.fn()
+// prisma mock:
+pointTransaction: { findMany, groupBy, findFirst },
+
+it('aggregates non-negative net consumption and insights for the selected range', async () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-08-20T12:00:00.000Z'))
+  groupBy.mockResolvedValue([
+    { kind: 'consume', category: 'image', _sum: { amount: -30 } },
+    { kind: 'refund', category: 'image', _sum: { amount: 10 } },
+    { kind: 'grant', category: 'other', _sum: { amount: 100 } },
+  ])
+  findMany.mockResolvedValue([
+    { createdAt: new Date('2026-08-18T10:00:00.000Z'), amount: -20 },
+    { createdAt: new Date('2026-08-19T10:00:00.000Z'), amount: -10 },
+  ])
+
+  const result = await service.pointsSummary('u1', 'month')
+  expect(result.byCategory.image).toBe(20)
+  expect(result.insights).toEqual({
+    netConsumedTotal: 20,
+    peakDayConsumed: 20,
+    avgDailyConsumed: expect.any(Number),
+    activeDays: 2,
+    longestStreakDays: 2,
+  })
+  expect(findMany).toHaveBeenCalledWith(
+    expect.objectContaining({
+      where: expect.objectContaining({ userId: 'u1', kind: 'consume' }),
+      select: { createdAt: true, amount: true },
+    }),
+  )
+  vi.useRealTimers()
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @lnkpi/server exec vitest run src/membership/membership.service.test.ts`
+Expected: FAIL — `insights` undefined
+
+- [ ] **Step 3: Implement in membership.service.ts**
+
+在 `PointsSummaryDto` 增加 `insights: PointsInsights`，`pointsSummary` 末尾：
+
+```ts
+import { computePointsInsights, type PointsInsights } from '../points/points-insights'
+
+export interface PointsSummaryDto {
+  // ...existing
+  insights: PointsInsights
+}
+
+async pointsSummary(userId: string, range: PointsRangeKey): Promise<PointsSummaryDto> {
+  const { from, to } = resolvePointsRange(range)
+  // ...existing groupBy loop...
+
+  const netConsumedTotal =
+    netConsumed('text') +
+    netConsumed('image') +
+    netConsumed('audio') +
+    netConsumed('video') +
+    netConsumed('other')
+
+  const consumeRows = await this.prisma.pointTransaction.findMany({
+    where: {
+      userId,
+      kind: 'consume',
+      createdAt: from ? { gte: from, lte: to } : { lte: to },
+    },
+    select: { createdAt: true, amount: true },
+  })
+
+  const insights = computePointsInsights({
+    netConsumedTotal,
+    consumeRows,
+    from,
+    to,
+  })
+
+  return {
+    range,
+    from: from?.toISOString() ?? null,
+    to: to.toISOString(),
+    byCategory: { /* unchanged */ },
+    otherNetConsumed: netConsumed('other'),
+    refundTotal,
+    grantTotal,
+    insights,
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm --filter @lnkpi/server exec vitest run src/membership/membership.service.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/membership/membership.service.ts apps/server/src/membership/membership.service.test.ts
+git commit -m "feat(server): extend points-summary with usage insights"
+```
+
+---
+
+### Task 3: 同步 Web API 类型
+
+**Files:**
+- Modify: `apps/web/src/services/users-api.ts`
+
+**Interfaces:**
+- Produces: `PointsSummary.insights: PointsInsights`
+
+- [ ] **Step 1: Add types**
+
+```ts
+export interface PointsInsights {
+  netConsumedTotal: number
+  peakDayConsumed: number
+  avgDailyConsumed: number
+  activeDays: number
+  longestStreakDays: number
+}
+
+export interface PointsSummary {
+  // ...existing
+  insights: PointsInsights
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm --filter @lnkpi/web exec vue-tsc --noEmit`
+Expected: PASS（或仅 ProfilePage 尚未用 insights 时不报错）
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/services/users-api.ts
+git commit -m "feat(web): add PointsInsights type for points-summary"
+```
+
+---
+
+### Task 4: ProfilePage 资产卡 + MembershipModal
+
+**Files:**
+- Modify: `apps/web/src/pages/ProfilePage.vue`
+
+**Interfaces:**
+- Consumes: `MembershipModal` from `@/components/membership/MembershipModal.vue`
+- Produces: `showMembership` ref；充值/升级按钮
+
+- [ ] **Step 1: Add script imports and state**
+
+```ts
+import MembershipModal from '@/components/membership/MembershipModal.vue'
+
+const showMembership = ref(false)
+
+const membershipLabel = computed(() => {
+  const m = profile.value?.membership
+  if (m === 'pro') return '专业版'
+  if (m === 'studio') return '工作室版'
+  return '免费版'
+})
+
+const isFreeMembership = computed(() => !profile.value?.membership || profile.value.membership === 'free')
+```
+
+- [ ] **Step 2: Replace profile grid with asset card**
+
+将原 `积分余额` + `会员等级` 双格改为单资产卡：
+
+```vue
+<div class="mt-6 rounded-xl border border-white/8 bg-[#242424] p-5">
+  <div class="flex items-end justify-between gap-4">
+    <div>
+      <p class="text-xs text-white/40">可用总积分</p>
+      <p class="text-3xl font-semibold text-[#818cf8]">{{ profile.points ?? 0 }}</p>
+    </div>
+    <span class="rounded-full bg-white/[0.06] px-3 py-1 text-xs text-white/60">{{ membershipLabel }}</span>
+  </div>
+  <p v-if="isFreeMembership" class="mt-3 text-xs text-white/35">开通会员，获得更多积分与高级能力</p>
+  <div class="mt-4 flex gap-3">
+    <button type="button" class="flex-1 rounded-xl bg-white px-4 py-2.5 text-sm font-medium text-black" @click="showMembership = true">
+      充值
+    </button>
+    <button type="button" class="flex-1 rounded-xl border border-white/15 px-4 py-2.5 text-sm text-white/80" @click="showMembership = true">
+      {{ isFreeMembership ? '升级会员' : '管理会员' }}
+    </button>
+  </div>
+</div>
+
+<MembershipModal v-model="showMembership" />
+```
+
+- [ ] **Step 3: Manual smoke**
+
+启动 web，登录后打开 `/profile`，点击充值/升级应弹出「积分与会员」对话框。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/pages/ProfilePage.vue
+git commit -m "feat(web): profile asset card with membership modal CTAs"
+```
+
+---
+
+### Task 5: ProfilePage 用量洞察 KPI 卡
+
+**Files:**
+- Modify: `apps/web/src/pages/ProfilePage.vue`
+
+**Interfaces:**
+- Consumes: `summary.insights` from `pointsSummary` response
+
+- [ ] **Step 1: Add KPI config**
+
+```ts
+const insightOptions = [
+  { key: 'netConsumedTotal' as const, label: '净消耗' },
+  { key: 'peakDayConsumed' as const, label: '单日峰值' },
+  { key: 'avgDailyConsumed' as const, label: '日均消耗' },
+  { key: 'activeDays' as const, label: '活跃天数' },
+  { key: 'longestStreakDays' as const, label: '最长连续活跃' },
+]
+
+function formatInsightValue(key: keyof import('@/services/users-api').PointsInsights, value: number) {
+  if (key === 'avgDailyConsumed') return value < 10 ? value.toFixed(1) : Math.round(value).toString()
+  return String(Math.round(value))
+}
+```
+
+- [ ] **Step 2: Add template block below category grid**
+
+```vue
+<div v-if="summary?.insights" class="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-5">
+  <div
+    v-for="item in insightOptions"
+    :key="item.key"
+    class="rounded-xl border border-white/8 bg-[#242424] p-4"
+  >
+    <p class="text-xs text-white/45">{{ item.label }}</p>
+    <p class="mt-2 text-xl font-semibold text-white/85">
+      {{ formatInsightValue(item.key, summary.insights[item.key]) }}
+    </p>
+  </div>
+</div>
+```
+
+- [ ] **Step 3: Verify range switch updates KPI numbers**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/pages/ProfilePage.vue
+git commit -m "feat(web): profile usage insight KPI cards"
+```
+
+---
+
+### Task 6: 账单 kind 分段 + balanceAfter 密度
+
+**Files:**
+- Modify: `apps/web/src/pages/ProfilePage.vue`
+
+**Interfaces:**
+- Consumes: `filterKind` ref；映射到 `membershipApi.transactions({ kind })`
+
+- [ ] **Step 1: Replace chip kind filter with segmented control**
+
+```ts
+type BillKindTab = 'all' | 'consume' | 'grant'
+
+const billKindTab = ref<BillKindTab>('all')
+
+watch(billKindTab, (tab) => {
+  filterKind.value = tab === 'all' ? undefined : tab
+})
+
+watch(filterKind, (kind) => {
+  if (!kind) billKindTab.value = 'all'
+  else if (kind === 'consume' || kind === 'grant') billKindTab.value = kind
+  // refund chip from summary cards still sets filterKind='refund' without changing tab
+})
+```
+
+模板：在汇总区下方、明细列表上方放分段：
+
+```vue
+<div class="mb-4 flex rounded-xl bg-[#242424] p-1">
+  <button
+    v-for="tab in ([['all','全部'],['consume','消耗'],['grant','获得']] as const)"
+    :key="tab[0]"
+    type="button"
+    class="flex-1 rounded-lg px-3 py-2 text-xs transition"
+    :class="billKindTab === tab[0] ? 'bg-[#6366f1] text-white' : 'text-white/50'"
+    @click="billKindTab = tab[0]"
+  >
+    {{ tab[1] }}
+  </button>
+</div>
+```
+
+保留「退款积分」对照卡点击 → `filterKind='refund'`（与分段并存）。
+
+- [ ] **Step 2: Add balanceAfter to transaction card footer**
+
+```vue
+<div class="mt-3 flex flex-wrap items-center justify-between gap-2 border-t border-white/5 pt-3">
+  <time class="text-xs text-white/30" :datetime="tx.createdAt">{{ formatCreatedAt(tx.createdAt) }}</time>
+  <div class="flex items-center gap-3">
+    <span v-if="tx.generationId" class="font-mono text-[11px] text-[#818cf8]/70">
+      生成 ID · {{ shortGenerationId(tx.generationId) }}
+    </span>
+    <span class="text-xs text-white/35">
+      余额 {{ tx.balanceAfter ?? '—' }}
+    </span>
+  </div>
+</div>
+```
+
+- [ ] **Step 3: Refine empty state copy**
+
+```vue
+<p v-if="!transactions.length" class="...">
+  {{ filterCategory || filterKind ? '该条件下暂无记录' : '暂无该时间范围的账单记录' }}
+</p>
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/pages/ProfilePage.vue
+git commit -m "feat(web): profile bill kind tabs and balance-after display"
+```
+
+---
+
+### Task 7: ProfilePage 冒烟测试
+
+**Files:**
+- Create: `apps/web/src/pages/ProfilePage.test.ts`
+
+- [ ] **Step 1: Write test**
+
+```ts
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import ProfilePage from './ProfilePage.vue'
+
+vi.mock('@/services/api', () => ({
+  api: { get: vi.fn().mockResolvedValue({ data: { data: { nickname: '测', phone: '1', points: 34, membership: 'free' } } }) },
+}))
+vi.mock('@/services/users-api', () => ({
+  membershipApi: {
+    pointsSummary: vi.fn().mockResolvedValue({
+      data: {
+        data: {
+          range: 'month',
+          from: null,
+          to: new Date().toISOString(),
+          byCategory: { text: 0, image: 20, audio: 0, video: 0 },
+          otherNetConsumed: 0,
+          refundTotal: 0,
+          grantTotal: 0,
+          insights: { netConsumedTotal: 20, peakDayConsumed: 20, avgDailyConsumed: 1, activeDays: 1, longestStreakDays: 1 },
+        },
+      },
+    }),
+    transactions: vi.fn().mockResolvedValue({ data: { data: { items: [], nextCursor: null, from: null, to: new Date().toISOString() } } }),
+  },
+}))
+vi.mock('@/components/membership/MembershipModal.vue', () => ({ default: { template: '<div />' } }))
+
+describe('ProfilePage', () => {
+  it('renders insight KPI labels', async () => {
+    setActivePinia(createPinia())
+    const wrapper = mount(ProfilePage, { global: { stubs: ['router-link'] } })
+    await vi.waitFor(() => expect(wrapper.text()).toContain('净消耗'))
+    expect(wrapper.text()).toContain('单日峰值')
+    expect(wrapper.text()).toContain('充值')
+  })
+})
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `pnpm --filter @lnkpi/web exec vitest run src/pages/ProfilePage.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Run full server suite**
+
+Run: `pnpm --filter @lnkpi/server exec vitest run`
+Expected: all PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/pages/ProfilePage.test.ts
+git commit -m "test(web): profile page insights and CTA smoke"
+```
+
+---
+
+## Spec Coverage Checklist
+
+| Spec 要求 | Task |
+|-----------|------|
+| 扩展 `points-summary` insights 五指标 | Task 1–2 |
+| 共用 range | Task 2, 5 |
+| 资产卡双 CTA → MembershipModal | Task 4 |
+| KPI 卡展示 | Task 5 |
+| kind 分段 全部/消耗/获得 | Task 6 |
+| balanceAfter 展示 | Task 6 |
+| 退款仅在全部 | Task 6 |
+| 测试要点 | Task 1, 2, 7 |
+
+## Pre-flight
+
+执行前确保本地基于 `#270`：
+
+```bash
+git fetch origin
+git checkout main && git merge origin/main   # 或从 origin/main 新建分支
+git checkout -b feat/points-stats-neowow-adoption
+```

--- a/docs/superpowers/specs/2026-09-01-points-stats-neowow-adoption-design.md
+++ b/docs/superpowers/specs/2026-09-01-points-stats-neowow-adoption-design.md
@@ -1,0 +1,237 @@
+# 个人中心积分 UX 采纳（Neowow 借鉴 · P0/P1）
+
+**日期：** 2026-09-01  
+**状态：** 设计已确认，待实现  
+**前置：** `#270` 个人中心积分统计（分类汇总 + 结构化明细 + `points-summary` API）  
+**范围：** 在 `#270` 基础上增强账单可读性、会员转化条、用量洞察 KPI；不含热力图、新支付流、账号侧栏壳
+
+## 背景
+
+`#270` 已交付：扩展 `PointTransaction` 结构化字段、`GET /membership/points-summary`、`GET /membership/transactions`（分页/筛选）、`ProfilePage` 卡片式四分类汇总与明细。
+
+对标 Neowow 账号中心实机调研，我们仍有缺口：
+
+1. **账单密度**：模型/分类标签已有，但缺变动后余额展示、kind 分段不够直观  
+2. **转化路径**：个人信息区未突出「充值 / 升级会员」双 CTA  
+3. **用量洞察**：缺总消耗、峰值、日均、活跃天、最长连续活跃等行为指标  
+
+## 目标
+
+1. 单页三段式信息架构：账户条 → 统计区（分类汇总 + 用量 KPI）→ 账单明细  
+2. 统计区与账单区共用 `range`（`7d` / `month` / `all`），切换时同步刷新  
+3. `points-summary` 扩展 `insights`，一次请求返回 KPI  
+4. 充值 / 升级均打开现有 `MembershipModal`  
+5. 账单明细展示 `balanceAfter`（历史 null 显示 `—`）
+
+## 非目标
+
+- GitHub 风格热力图、趋势折线图  
+- 独立 `points-insights` 路由或弹层  
+- 项目维度筛选（个人/协作）  
+- token 明细标签（暂无字段）  
+- 新 Prisma 字段 / 支付渠道改造  
+- 账号中心侧栏图标壳（Neowow 完整 IA）
+
+## 已确认决策
+
+| 项 | 决策 |
+|----|------|
+| 范围 | C：账单可读性 + 会员转化条 + 用量 KPI |
+| 信息架构 | A：同页三段，无 Tab / 侧栏 |
+| KPI 时间口径 | A：与账单共用 `range` |
+| 充值/升级行为 | A：均打开 `MembershipModal` |
+| KPI 指标集 | B：净消耗、单日峰值、日均消耗、活跃天数、最长连续活跃天 |
+| API 方案 | 扩展现有 `points-summary`，不新开接口 |
+
+---
+
+## §1 页面布局（ProfilePage）
+
+自上而下三段，沿用 `/profile` 单路由：
+
+### 1.1 账户条
+
+- 头像 / 昵称 / 手机（保留）  
+- **资产卡**：大号可用积分 + 会员等级徽章  
+- 并排 CTA：**充值** | **升级会员**（`membership !== 'free'` 时后者文案可为「管理会员」）  
+- 免费版弱文案：「开通会员，获得更多积分与高级能力」  
+- 两按钮均 `v-model` 打开 `MembershipModal`（与 `CanvasAccountChrome` / `AppHeader` 一致）
+
+### 1.2 统计区
+
+顶部 **range 切换**（`近 7 天` | `本月` | `全部`），切换时刷新 summary + transactions。
+
+**上：分类汇总**（`#270` 已有，保留）  
+- 四分类净消耗卡，可点击联动 `category` 筛选  
+- 退款合计 / 获得合计 / other 卡（条件展示）
+
+**下：用量洞察 KPI**（新增）  
+五卡横排（窄屏 2+3 或纵向）：
+
+| KPI | 说明 |
+|-----|------|
+| 净消耗 | 四类 + other 净消耗之和 |
+| 单日峰值 | 窗口内单日 consume 绝对值之和的最大值 |
+| 日均消耗 | `netConsumedTotal / max(1, 窗口日历天数)` |
+| 活跃天数 | 至少一笔 `kind=consume` 的上海日历日数 |
+| 最长连续活跃 | 活跃日中连续日历日的最长 streak |
+
+加载态：summary 区 skeleton，避免数字闪烁。
+
+### 1.3 账单区
+
+- kind 分段：**全部 | 消耗 | 获得**  
+- 明细卡列表 + 加载更多（`#270` 分页保留）  
+- 空态区分：无记录 vs 筛选无结果
+
+---
+
+## §2 API 与口径
+
+### 2.1 扩展 `GET /membership/points-summary?range=`
+
+在现有 `PointsSummaryDto` 上增加 `insights`：
+
+```ts
+interface PointsInsights {
+  netConsumedTotal: number
+  peakDayConsumed: number
+  avgDailyConsumed: number
+  activeDays: number
+  longestStreakDays: number
+}
+
+interface PointsSummaryDto {
+  // ...existing fields
+  insights: PointsInsights
+}
+```
+
+**`netConsumedTotal`**  
+`byCategory` 四值 + `otherNetConsumed` 之和（与分类卡一致）。
+
+**`peakDayConsumed`**  
+在 `[from, to]` 窗口内，按 `Asia/Shanghai` 日历日 bucket；每日 `sum(|amount|)` where `kind=consume`；取最大值。无 consume 则为 `0`。
+
+**`avgDailyConsumed`**  
+`netConsumedTotal / max(1, windowCalendarDays)`。  
+- `7d` / `month`：`windowCalendarDays` = `from` 至 `to` 的上海日历日数（含首尾）  
+- `all`：`from` = 用户最早一笔 `pointTransaction.createdAt` 所在上海日 00:00；若无交易则 `windowCalendarDays = 1`
+
+**`activeDays`**  
+窗口内，至少有一笔 `kind=consume` 的上海日历日数。
+
+**`longestStreakDays`**  
+将活跃日排序后，计算最长连续日历日 streak（相邻日差 1 天则连续）。无活跃日为 `0`。
+
+**不计入 insights 的流水**  
+- `peakDayConsumed` / `activeDays` / `longestStreakDays`：仅 `kind=consume`  
+- `netConsumedTotal` / `avgDailyConsumed`：沿用净消耗公式（consume − refund），与分类汇总一致  
+- `grant` 不参与任何 insights 分子
+
+**实现建议**  
+在 `MembershipService.pointsSummary` 内，在现有 `groupBy` 之后增加按日聚合查询（`findMany` select `createdAt, amount, kind` 或 raw SQL / Prisma groupBy on date bucket）。数据量按单用户 + range 可控；`all` 需注意索引 `(userId, createdAt)`。
+
+### 2.2 `GET /membership/transactions`
+
+**不变**。字段已含 `balanceAfter`、`model`、`generationId` 等。
+
+**UI kind 分段映射**
+
+| Tab | API `kind` |
+|-----|------------|
+| 全部 | 不传 |
+| 消耗 | `consume` |
+| 获得 | `grant` |
+
+退款（`kind=refund`）仅在「全部」展示，带「退款」徽章；不纳入「消耗」tab。  
+保留点击「退款积分」对照卡 → `kind=refund` 的快捷筛选（`#270` 行为，可与分段并存）。
+
+### 2.3 共享 types
+
+- 服务端 `PointsSummaryDto` 与 `@lnkpi/shared`（若有）及 `apps/web/src/services/users-api.ts` 的 `PointsSummary` 同步扩展 `insights`  
+- 前端 `membershipApi.pointsSummary` 类型一并更新
+
+---
+
+## §3 UI 细节
+
+### 3.1 明细卡结构
+
+| 区域 | 内容 |
+|------|------|
+| 主行左 | `reason` + kind 徽章 |
+| 主行右 | 金额（消耗负向红色；退款/获得正向绿色） |
+| 次行 | `createdAt` 本地格式化 |
+| 标签行 | `category` 徽章；`model` tag（有则显示） |
+| 尾行 | 左：`generationId` 短码（有则）；右：**余额** `balanceAfter`，null → `—` |
+
+### 3.2 筛选交互
+
+- range 切换 → 重置或保留 kind/category 筛选（实现选 **保留**，与 `#270` 一致）  
+- 点击分类卡 → `filterCategory` toggle  
+- 「清除筛选」保留  
+- kind 分段与 chip 筛选互斥：选中分段时清掉 chip 式 kind 筛选，避免双重状态
+
+### 3.3 MembershipModal
+
+`ProfilePage` 引入 `MembershipModal`，本地 `showMembership` ref；不新建支付组件。
+
+---
+
+## §4 边界与一致性
+
+- summary、insights、transactions 必须使用同一 `range` 与 `from`/`to`  
+- `balanceAfter` 历史 null 不阻断展示  
+- insights 全 0 时 KPI 卡仍展示 `0`，不隐藏  
+- `all` + 无交易：insights 全 0，`avgDailyConsumed` 为 0  
+- 金额符号：消费 `amount < 0`；退款/获得 `amount > 0`（与 `#270` 一致）
+
+---
+
+## §5 测试要点
+
+### 服务端
+
+- `insights.netConsumedTotal` = 四分类净消耗 + other  
+- 单日多笔 consume：峰值取日合计而非单笔  
+- 活跃日不连续：streak 正确（如 Mon+Wed = longest 1）  
+- 连续三天 consume：streak = 3  
+- refund 不改变 activeDays，但减少 netConsumedTotal  
+- `range=7d|month|all` 边界与 `resolvePointsRange` 一致  
+- `all` 无交易 → insights 全 0
+
+### 前端
+
+- range 切换同时更新 KPI 与明细  
+- kind 分段：消耗不含 refund；全部含 refund 徽章  
+- `balanceAfter` null 显示 `—`  
+- 充值/升级打开 `MembershipModal`  
+- 筛选空态文案正确  
+- fetch race guard（`#270` 已有 generation 机制）对 insights 仍有效
+
+---
+
+## §6 建议落地顺序
+
+1. 扩展 `PointsSummaryDto` + `pointsSummary()` insights 计算 + 单测  
+2. 同步 shared / `users-api.ts` 类型  
+3. `ProfilePage`：资产卡 + MembershipModal  
+4. `ProfilePage`：insights KPI 卡  
+5. `ProfilePage`：kind 分段 + 明细 `balanceAfter` + 密度微调  
+6. 冒烟：三 range × 有/无交易账号
+
+---
+
+## §7 与 Neowow 对照（采纳清单）
+
+| Neowow | 我们 | 本期 |
+|--------|------|------|
+| 密集账单表 + 余额列 | 明细卡 + balanceAfter | ✅ |
+| 全部/消耗/获得筛选 | kind 分段 | ✅ |
+| 个人信息充值/升级双 CTA | MembershipModal | ✅ |
+| 用量 KPI 五指标 | insights | ✅ |
+| 365 天固定窗口 | 共用 range | ✅（更一致） |
+| 热力图 | — | ❌ |
+| 侧栏账号壳 | — | ❌ |
+| token/项目标签 | model tag only | 部分 |


### PR DESCRIPTION
## Summary
- Extend `GET /membership/points-summary` with usage `insights` (net consumed, peak day, daily avg, active days, longest streak) over shared `range`
- Profile page: asset card with recharge/upgrade CTAs → `MembershipModal`, five KPI cards, bill kind tabs (全部/消耗/获得), and `balanceAfter` on ledger rows
- Add `points-insights` pure functions + ProfilePage smoke test

## Test plan
- [x] `pnpm build`
- [x] `pnpm --filter @lnkpi/server exec vitest run` (347 passed)
- [x] `pnpm --filter @lnkpi/web exec vitest run src/pages/ProfilePage.test.ts`
- [ ] CI green
- [ ] Prod smoke: `/membership/points-summary` returns `insights`; profile bill UI


Made with [Cursor](https://cursor.com)