### PR TITLE
feat(agent): mid-run interrupt and post-cancel intent for product_visual

### DIFF
--- a/.superpowers/sdd/task-4-report.md
+++ b/.superpowers/sdd/task-4-report.md
@@ -64,3 +64,13 @@
 - 覆盖回归：`tests/test_runs_cancel_api.py tests/test_runs_stream.py tests/test_gen_scheduler_cancel.py tests/test_gen_scheduler.py tests/test_gen_node.py` → `33 passed, 2 warnings`。
 - 语法检查：`python3 -m py_compile app/runs.py app/graph/nodes/gen_scheduler.py app/graph/nodes/gen_node.py tests/test_runs_cancel_api.py tests/test_gen_scheduler_cancel.py` → exit 0。
 - 仓库门禁：`pnpm install --frozen-lockfile`、Prisma generate、`pnpm build` 均 exit 0；`pnpm --filter @lnkpi/agent test` → `19 files / 124 tests passed`。
+
+## Remaining review findings 修复（2026-09-06）
+
+- `stream_run_events` 对持有线程锁的运行在释放锁前无条件清除 cooperative cancel flag，覆盖最后一次循环检查后才到达的迟到取消，避免污染下一轮 scheduler。
+- `cancel_run` 将空白请求 `session_id` 视为缺失，并回退读取 checkpoint 的 `session_id`；构造默认 Nest 时继续使用 checkpoint `user_id`，不再误报 `flow_not_supported`。
+- RED：`tests/test_runs_cancel_api.py` 新增/加强两个断言，旧实现结果为 `2 failed, 9 passed`，分别复现 sticky cancel 与空白 session 未回退。
+- GREEN：同一定向测试 → `11 passed, 1 warning`。
+- 覆盖回归：`tests/test_runs_cancel_api.py tests/test_runs_stream.py tests/test_gen_scheduler_cancel.py tests/test_gen_scheduler.py tests/test_gen_node.py` → `34 passed, 2 warnings`。
+- 语法：`python3 -m py_compile app/runs.py tests/test_runs_cancel_api.py` → exit 0。
+- 仓库门禁：Prisma generate 与 `pnpm build` 通过；`pnpm --filter @lnkpi/agent test` → `19 files / 124 tests passed`。安装阶段镜像源曾返回一次既有 `403` 提示，但组合门禁最终 exit 0。

--- a/.superpowers/sdd/task-4-report.md
+++ b/.superpowers/sdd/task-4-report.md
@@ -53,3 +53,14 @@
 - 语法：`python3 -m py_compile app/runs.py tests/test_runs_cancel_api.py` → exit 0。
 - 仓库门禁：Prisma generate、`pnpm build` 均通过；`pnpm --filter @lnkpi/agent test` → `19 files / 124 tests passed`。
 - 扩展回归：`tests/test_runs_stream.py` 与 3 个 scheduler cancel 测试通过；`tests/test_thread_busy.py` 两个既有测试单独复跑仍在进入 fake LLM 前的 5 秒等待点超时（`2 failed, 1 passed`），未修改该测试或其前置运行路径。
+
+## Critical/Major follow-up（2026-09-06）
+
+- `gen_scheduler` 与 `gen_node` 仅在 `flow_mode == "product_visual"` 时消费 cooperative cancel；scheduler 将 `flow_mode` 透传给 fan-out worker，campaign/atomic 不再进入 cancelled 分支。
+- stream 遇到未设置或非 PV flow 时立即 `clear_cancel(thread_id)`；PV cancelled checkpoint 使用 `peek_cancel_reason(thread_id) or "user"` 保留请求原因。
+- 无 Nest/session 且本地线程未活跃时不再留下 cancel flag；锁探测异常、非 PV skip、checkpoint 写入异常路径都会清理无法保证被消费的 flag。
+- RED：新增 scheduler payload/campaign、gen_node campaign、unknown idle flow、stream missing/campaign flow 与 cancel reason 断言；旧实现首先在 scheduler payload 断言以 `KeyError: flow_mode` 失败。
+- GREEN：定向测试 `tests/test_gen_scheduler_cancel.py tests/test_runs_cancel_api.py` → `15 passed, 1 warning`。
+- 覆盖回归：`tests/test_runs_cancel_api.py tests/test_runs_stream.py tests/test_gen_scheduler_cancel.py tests/test_gen_scheduler.py tests/test_gen_node.py` → `33 passed, 2 warnings`。
+- 语法检查：`python3 -m py_compile app/runs.py app/graph/nodes/gen_scheduler.py app/graph/nodes/gen_node.py tests/test_runs_cancel_api.py tests/test_gen_scheduler_cancel.py` → exit 0。
+- 仓库门禁：`pnpm install --frozen-lockfile`、Prisma generate、`pnpm build` 均 exit 0；`pnpm --filter @lnkpi/agent test` → `19 files / 124 tests passed`。

--- a/.superpowers/sdd/task-4-report.md
+++ b/.superpowers/sdd/task-4-report.md
@@ -1,46 +1,55 @@
-# Task 4 Report: RefStrip Role Labels + videoMode Validation (G-09)
+# Task 4 报告：Runtime POST /v1/runs/cancel
 
-**Status:** ✅ Complete  
-**Branch:** `feature/i2v-capability-productization`  
-**Commit:** _(see git log after commit)_
+## 提交
 
-## Summary
+- `4fc2f8f feat(runtime): POST /v1/runs/cancel for product_visual`
 
-Implemented ref role badges on `DockRefStrip`, pre-generate validation in `VideoDockPanel`, and unit/component tests per plan Task 4.
+## 实现结果
 
-## Changes
+- 新增 `CancelRunRequest` 与 `cancel_run(...)`。
+- `request_cancel` 始终先设置线程取消标记；空 checkpoint、缺少 flow 或非 `product_visual` 返回 `ok: true`、`skipped: true`、`reason: flow_not_supported`。
+- Product Visual checkpoint 会统计完成数与总任务数，对未完成且有 `node_id` 的生成执行 best-effort `cancel_generation`，随后持久化 `phase=cancelled`、`run_cancelled=true` 与取消展示文案。
+- 已取消 checkpoint 幂等返回，不重复调用远端取消。
+- 新增带 `x-lnkpi-service-token` 鉴权的 `POST /v1/runs/cancel`，测试通过 monkeypatch 对齐 `settings.effective_runtime_auth_token`。
+- `astream` 每轮 update 后检查取消标记，持久化 cancelled checkpoint，发送 `run_cancelled` 事件并退出流循环。
 
-| File | Change |
-|------|--------|
-| `apps/web/src/components/canvas/dock-studio/shared/dockRefRoleLabels.ts` | **New** — pure helpers: `resolveRefRoleLabel`, `countValidImageRefs`, `hasUnsupportedMediaRefs` |
-| `apps/web/src/components/canvas/dock-studio/shared/dockRefRoleLabels.test.ts` | **New** — 7 unit tests for role label matrix |
-| `apps/web/src/components/canvas/dock-studio/shared/DockRefStrip.test.ts` | **New** — mount test: 2 image refs + `first_last_frame` → 首帧/末帧 |
-| `apps/web/src/components/canvas/dock-studio/shared/DockRefStrip.vue` | Accept `videoMode`; compute and pass `roleLabel` to chips |
-| `apps/web/src/components/canvas/dock-studio/shared/DockRefChip.vue` | Render bottom role badge (首帧/末帧/参考/运镜/音频) |
-| `apps/web/src/components/canvas/dock-studio/shared/DockGenerateButton.vue` | Optional `title` prop for disabled tooltip |
-| `apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue` | Pass `videoMode` to strip; disable generate when FLF ≠ 2 images; warning banner for unsupported V/A refs |
+## TDD 证据
 
-## Role Label Matrix
+### RED
 
-| Condition | @I1 | @I2 | @V1 | @A1 |
-|-----------|-----|-----|-----|-----|
-| `first_last_frame` + 2 images | 首帧 | 末帧 | 运镜 | 音频 |
-| `image_to_video` + N images | 参考 | 参考 | 运镜 | 音频 |
+`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -p pytest_asyncio.plugin tests/test_runs_cancel_api.py -v`
 
-## Validation Rules
+首次运行在收集阶段失败：`ImportError: cannot import name 'CancelRunRequest' from 'app.runs'`，证明新增接口测试在实现前确实失败。
 
-1. **`first_last_frame` + image ref count ≠ 2** → generate button disabled, tooltip: 「严格首尾帧模式需要恰好 2 张参考图」
-2. **V/A refs present but `!supportsVideoRef` / `!supportsAudioRef`** → amber warning banner: 「当前模型不支持视频/音频参考，请换 Seedance」
+### GREEN
 
-## Test Summary
+同一定向命令最终退出码 0：`2 passed`。
 
-| Command | Result |
-|---------|--------|
-| `pnpm exec vitest run src/components/canvas/dock-studio/shared/dockRefRoleLabels.test.ts src/components/canvas/dock-studio/shared/DockRefStrip.test.ts` | ✅ 8/8 passed |
-| `pnpm --filter @lnkpi/web build` | ❌ Pre-existing TS errors in `VideoSettingsSelector.vue` (Task 3), unrelated to Task 4 |
+覆盖：
 
-## Gap Register
+- 空 / 非 PV checkpoint 的 flag、skip 响应和重复请求幂等性；
+- PV checkpoint 的 pending node 取消、完成/总数统计、cancelled 状态写入和重复请求不重复取消。
 
-| Gap ID | Status |
-|--------|--------|
-| G-09 | ✅ Covered |
+## 回归验证
+
+`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -p pytest_asyncio.plugin tests/test_runs_stream.py tests/test_health.py tests/test_gen_scheduler_cancel.py -v`
+
+退出码 0：`7 passed`。覆盖既有 NDJSON 流、运行时鉴权以及 Task 3 scheduler/gen_node 协作取消。
+
+测试仅出现既有 Pydantic、Starlette 与 pytest-asyncio 弃用警告。
+
+## 关注项
+
+- Runtime cancel 路由在生产调用中没有用户身份，按 brief 仅注入 checkpointer；活跃任务依赖已设置的 cooperative cancel flag 在 gen scheduler/node 边界停止。传入 `nest`（测试/DI）时会立即 best-effort 调用远端 cancel。
+- 已完成 brief 中可选的 `astream` 取消事件发送；现有 stream smoke test 回归通过。
+
+## Review findings 修复（2026-09-06）
+
+- 非 PV / 空闲未知 flow 返回 `flow_not_supported` 且清除遗留 flag；流内仅对 `flow_mode=product_visual` 执行取消收口。
+- cancel endpoint 通过现有线程锁探测区分活跃与空闲：持锁 PV 仅设置 cooperative flag，不调用 `aupdate_state` 或远端取消；空闲 PV 持锁完成远端 best-effort cancel 与 checkpoint 写入后清除 flag。
+- 未注入 Nest 且有 `session_id` 时构造并关闭生产 `default_nest`；`completed_tasks` 在 HTTP/SSE 统一使用 `gen_completed_keys` 数量；空白 `thread_id` 校验拒绝。
+- RED：新增断言在旧实现下为 `5 failed`（sticky flag、忙锁竞态、流清理、空白 ID）。
+- GREEN：`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -p pytest_asyncio.plugin tests/test_runs_cancel_api.py -v` → `7 passed, 1 warning`。
+- 语法：`python3 -m py_compile app/runs.py tests/test_runs_cancel_api.py` → exit 0。
+- 仓库门禁：Prisma generate、`pnpm build` 均通过；`pnpm --filter @lnkpi/agent test` → `19 files / 124 tests passed`。
+- 扩展回归：`tests/test_runs_stream.py` 与 3 个 scheduler cancel 测试通过；`tests/test_thread_busy.py` 两个既有测试单独复跑仍在进入 fake LLM 前的 5 秒等待点超时（`2 failed, 1 passed`），未修改该测试或其前置运行路径。

--- a/.superpowers/sdd/task-4-report.md
+++ b/.superpowers/sdd/task-4-report.md
@@ -74,3 +74,9 @@
 - 覆盖回归：`tests/test_runs_cancel_api.py tests/test_runs_stream.py tests/test_gen_scheduler_cancel.py tests/test_gen_scheduler.py tests/test_gen_node.py` → `34 passed, 2 warnings`。
 - 语法：`python3 -m py_compile app/runs.py tests/test_runs_cancel_api.py` → exit 0。
 - 仓库门禁：Prisma generate 与 `pnpm build` 通过；`pnpm --filter @lnkpi/agent test` → `19 files / 124 tests passed`。安装阶段镜像源曾返回一次既有 `403` 提示，但组合门禁最终 exit 0。
+
+## stream finally 清理顺序（2026-09-06）
+
+- `stream_run_events` finally 块改为先 `await _release_thread(...)` 再 `clear_cancel(thread_id)`，避免 cancel_run 在锁仍持有时看到 busy 路径并重新设置 sticky flag。
+- 新增 `test_stream_finally_releases_lock_before_clearing_cancel` 断言 release→clear 顺序。
+- GREEN：`tests/test_runs_cancel_api.py tests/test_gen_scheduler_cancel.py tests/test_run_cancel_registry.py tests/test_cancel_checkpoint.py` → `20 passed, 1 warning`。

--- a/apps/server/src/agent/agent-runtime.client.test.ts
+++ b/apps/server/src/agent/agent-runtime.client.test.ts
@@ -146,4 +146,50 @@ describe('AgentRuntimeClient', () => {
     expect(body.attachments).toEqual(attachments)
     expect(body.ref_order).toEqual(['a1'])
   })
+
+  it('cancelRun posts snake_case input and maps response to camelCase', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        phase: 'cancelled',
+        cancelled_node_ids: ['node-1'],
+        completed_tasks: 2,
+        total_tasks: 4,
+        skipped: false,
+        reason: 'user',
+      }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = new AgentRuntimeClient('http://runtime.test/', 'dev-token')
+    await expect(
+      client.cancelRun({
+        threadId: 'thread-1',
+        sessionId: 'session-1',
+        reason: 'user',
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      phase: 'cancelled',
+      cancelledNodeIds: ['node-1'],
+      completedTasks: 2,
+      totalTasks: 4,
+      skipped: false,
+      reason: 'user',
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith('http://runtime.test/v1/runs/cancel', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-lnkpi-service-token': 'dev-token',
+      },
+      body: JSON.stringify({
+        thread_id: 'thread-1',
+        session_id: 'session-1',
+        reason: 'user',
+      }),
+    })
+  })
 })

--- a/apps/server/src/agent/agent-runtime.client.test.ts
+++ b/apps/server/src/agent/agent-runtime.client.test.ts
@@ -192,4 +192,28 @@ describe('AgentRuntimeClient', () => {
       }),
     })
   })
+
+  it('cancelRun maps preserved-gate response fields', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          phase: 'await_shot_topo_confirm',
+          cancelled_node_ids: [],
+          completed_tasks: 0,
+          total_tasks: 0,
+          gate_preserved: true,
+          next_nodes: ['await_shot_topo_confirm'],
+        }),
+      }),
+    )
+
+    const client = new AgentRuntimeClient('http://runtime.test', 'dev-token')
+    const result = await client.cancelRun({ threadId: 't1', sessionId: 's1' })
+
+    expect(result.gatePreserved).toBe(true)
+    expect(result.nextNodes).toEqual(['await_shot_topo_confirm'])
+  })
 })

--- a/apps/server/src/agent/agent-runtime.client.ts
+++ b/apps/server/src/agent/agent-runtime.client.ts
@@ -181,6 +181,8 @@ export class AgentRuntimeClient {
     totalTasks?: number
     skipped?: boolean
     reason?: string
+    gatePreserved?: boolean
+    nextNodes?: string[]
   }> {
     const url = `${this.baseUrl.replace(/\/$/, '')}/v1/runs/cancel`
     const headers: Record<string, string> = {
@@ -216,6 +218,8 @@ export class AgentRuntimeClient {
       total_tasks?: number
       skipped?: boolean
       reason?: string
+      gate_preserved?: boolean
+      next_nodes?: string[]
     }
     return {
       ok: body.ok,
@@ -225,6 +229,8 @@ export class AgentRuntimeClient {
       totalTasks: body.total_tasks,
       skipped: body.skipped,
       reason: body.reason,
+      gatePreserved: body.gate_preserved,
+      nextNodes: body.next_nodes,
     }
   }
 

--- a/apps/server/src/agent/agent-runtime.client.ts
+++ b/apps/server/src/agent/agent-runtime.client.ts
@@ -25,6 +25,7 @@ export interface RuntimeThreadState {
   nextNodes: string[]
   interrupted: boolean
   finished: boolean
+  runCancelled?: boolean | null
   hasAtomicCheckpoint?: boolean
   atomicNodeId?: string | null
   atomicTargetType?: string | null
@@ -165,6 +166,65 @@ export class AgentRuntimeClient {
       return (await res.json()) as RuntimeThreadTimeline
     } catch {
       return null
+    }
+  }
+
+  async cancelRun(input: {
+    threadId: string
+    sessionId: string
+    reason?: string
+  }): Promise<{
+    ok: boolean
+    phase?: string | null
+    cancelledNodeIds?: string[]
+    completedTasks?: number
+    totalTasks?: number
+    skipped?: boolean
+    reason?: string
+  }> {
+    const url = `${this.baseUrl.replace(/\/$/, '')}/v1/runs/cancel`
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    }
+    const token =
+      this.serviceToken?.trim() || process.env.AGENT_RUNTIME_SERVICE_TOKEN?.trim()
+    if (token) {
+      headers['x-lnkpi-service-token'] = token
+    }
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        thread_id: input.threadId,
+        session_id: input.sessionId,
+        reason: input.reason,
+      }),
+    })
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '')
+      throw new Error(
+        `Agent runtime /v1/runs/cancel failed: ${res.status}${detail ? ` ${detail}` : ''}`,
+      )
+    }
+
+    const body = (await res.json()) as {
+      ok: boolean
+      phase?: string | null
+      cancelled_node_ids?: string[]
+      completed_tasks?: number
+      total_tasks?: number
+      skipped?: boolean
+      reason?: string
+    }
+    return {
+      ok: body.ok,
+      phase: body.phase,
+      cancelledNodeIds: body.cancelled_node_ids,
+      completedTasks: body.completed_tasks,
+      totalTasks: body.total_tasks,
+      skipped: body.skipped,
+      reason: body.reason,
     }
   }
 

--- a/apps/server/src/agent/agent.controller.ts
+++ b/apps/server/src/agent/agent.controller.ts
@@ -16,6 +16,7 @@ import type { Request, Response } from 'express'
 import { AuthGuard } from '../auth/auth.guard'
 import { SessionsService } from '../sessions/sessions.service'
 import { AgentService } from './agent.service'
+import { CancelRunDto } from './dto/cancel-run.dto'
 
 const SESSION_FORBIDDEN_HINT =
   '⚠️ 此画布不属于当前账号，无法写入。请返回工作台新建画布，或使用画布所有者账号登录。'
@@ -155,6 +156,17 @@ export class AgentController {
   @Get('runtime-health')
   async runtimeHealth() {
     const data = await this.agentService.checkRuntimeHealth()
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('runs/cancel')
+  @UseGuards(AuthGuard)
+  async cancelRun(
+    @Body() dto: CancelRunDto,
+    @Req() req: Request & { user: { sub: string } },
+  ) {
+    await this.sessionsService.findOne(dto.sessionId, req.user.sub)
+    const data = await this.agentService.cancelRun(dto)
     return { code: 0, message: 'ok', data }
   }
 

--- a/apps/server/src/agent/agent.service.ts
+++ b/apps/server/src/agent/agent.service.ts
@@ -1,4 +1,9 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common'
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  ServiceUnavailableException,
+} from '@nestjs/common'
 import { applyCanvasActions, type AgentStreamEvent } from '@lnkpi/agent'
 import type {
   AgentMessageMetadata,
@@ -273,6 +278,18 @@ export class AgentService {
   }
 
   // ── Runtime Health ───────────────────────────────────────────
+
+  async cancelRun(input: {
+    threadId: string
+    sessionId: string
+    reason?: 'user' | 'timeout'
+  }) {
+    const runtimeUrl = process.env.AGENT_RUNTIME_URL?.trim()
+    if (!runtimeUrl) {
+      throw new ServiceUnavailableException('Agent runtime is not configured')
+    }
+    return this.createRuntimeClient(runtimeUrl).cancelRun(input)
+  }
 
   /** Proxy agent-runtime health check for frontend heartbeat detection. */
   async checkRuntimeHealth(): Promise<{ ok: boolean; latencyMs?: number }> {

--- a/apps/server/src/agent/agent.service.ts
+++ b/apps/server/src/agent/agent.service.ts
@@ -308,6 +308,7 @@ export class AgentService {
     nextNodes: string[]
     interrupted: boolean
     finished: boolean
+    runCancelled?: boolean | null
     hasAtomicCheckpoint?: boolean
     atomicNodeId?: string | null
     atomicTargetType?: string | null

--- a/apps/server/src/agent/dto/cancel-run.dto.ts
+++ b/apps/server/src/agent/dto/cancel-run.dto.ts
@@ -1,0 +1,15 @@
+import { IsIn, IsOptional, IsString, MinLength } from 'class-validator'
+
+export class CancelRunDto {
+  @IsString()
+  @MinLength(1)
+  threadId!: string
+
+  @IsString()
+  @MinLength(1)
+  sessionId!: string
+
+  @IsOptional()
+  @IsIn(['user', 'timeout'])
+  reason?: 'user' | 'timeout'
+}

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -16,7 +16,10 @@ import AgentCanvasOutputs from '@/components/agent/AgentCanvasOutputs.vue'
 import AgentExecutionTrace from '@/components/agent/AgentExecutionTrace.vue'
 import { resolveMessageOutputs } from '@/components/agent/agentCanvasOutputs'
 import type { AgentStreamMessage } from '@/stores/agent'
-import { cancelAgentRun } from '@/components/agent/cancelAgentRun'
+import {
+  cancelAgentRun,
+  cancelledCalloutTextFromProgress,
+} from '@/components/agent/cancelAgentRun'
 import {
   applyTaskEvent,
   applyPollRecordToTask,
@@ -431,6 +434,8 @@ let streamAbortController: AbortController | null = null
 const runCancelled = ref(false)
 const threadRunState = ref<{ phase?: string | null; runCancelled?: boolean | null } | null>(null)
 const cancelledPresentation = ref<AgentPresentationEnvelope | null>(null)
+/** Progress line built from the cancel API response, before the checkpoint refresh lands. */
+const cancelledProgressText = ref<string | null>(null)
 const reconnecting = ref(false)
 const recoveredPhaseHint = ref<string | null>(null)
 /** P0-06: authoritative gate from SSE interrupt or thread-state reconnect */
@@ -489,7 +494,9 @@ const showCancelledCallout = computed(
   () => isRunCancelledState(threadRunState.value) || runCancelled.value,
 )
 const cancelledCalloutText = computed(() => {
-  const text = String(cancelledPresentation.value?.body?.text ?? '').trim()
+  const text =
+    String(cancelledPresentation.value?.body?.text ?? '').trim() ||
+    (cancelledProgressText.value ?? '')
   return text || '当前任务已停止，你可以发起新任务或直接输入新的需求。'
 })
 const awaitingSchemeSelect = computed(() => chipSet.value === 'scheme_select')
@@ -957,6 +964,7 @@ async function selectThread(threadId: string) {
   runCancelled.value = false
   threadRunState.value = null
   cancelledPresentation.value = null
+  cancelledProgressText.value = null
   hasAtomicCheckpoint.value = false
   retakePending.value = false
   effectiveUtterance.value = null
@@ -1011,6 +1019,7 @@ watch(
     runCancelled.value = false
     threadRunState.value = null
     cancelledPresentation.value = null
+    cancelledProgressText.value = null
     hasAtomicCheckpoint.value = false
     retakePending.value = false
     effectiveUtterance.value = null
@@ -1110,6 +1119,7 @@ function newAgentSession() {
   runCancelled.value = false
   threadRunState.value = null
   cancelledPresentation.value = null
+  cancelledProgressText.value = null
   threadJourneyTrace.value = null
   hasAtomicCheckpoint.value = false
   retakePending.value = false
@@ -1134,7 +1144,13 @@ function syncCancelledFromThreadState(
     ? { phase: state.phase ?? null, runCancelled: state.runCancelled ?? null }
     : null
   const cancelled = isRunCancelledState(state)
-  cancelledPresentation.value = cancelled ? (state?.presentation ?? null) : null
+  if (cancelled) {
+    cancelledPresentation.value = state?.presentation ?? null
+  } else if (!runCancelled.value) {
+    // A gate-preserved stop leaves the checkpoint uncancelled; keep the local callout.
+    cancelledPresentation.value = null
+    cancelledProgressText.value = null
+  }
   return cancelled
 }
 
@@ -1203,9 +1219,9 @@ async function refreshThreadCheckpoint() {
         json.data?.deliveryGenByKey,
       )
     }
-    const cancelled = syncCancelledFromThreadState(json.data)
-    const gatePayload = cancelled ? null : interruptPayloadFromThreadState(json.data)
-    interruptGate.value = gatePayload
+    syncCancelledFromThreadState(json.data)
+    // A cancelled run can still hold a pending gate; chips stay under the callout.
+    interruptGate.value = interruptPayloadFromThreadState(json.data)
   } catch {
     // ignore — checkpoint hint is best-effort
   }
@@ -1256,7 +1272,7 @@ function authHeaders(): Record<string, string> {
 async function cancelActiveStream() {
   if (!agent.isStreaming) return
   runCancelled.value = true
-  const { apiOk } = await cancelAgentRun({
+  const { apiOk, completedTasks, totalTasks } = await cancelAgentRun({
     threadId: agentThreadId.value,
     sessionId: props.sessionId,
     abort: () => {
@@ -1270,9 +1286,14 @@ async function cancelActiveStream() {
         headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify(body),
         signal: AbortSignal.timeout(3000),
-      }).then((r) => r.json()),
+      }).then((r) => {
+        if (!r.ok) throw new Error(`cancel failed: ${r.status}`)
+        return r.json()
+      }),
   })
+  cancelledProgressText.value = cancelledCalloutTextFromProgress(completedTasks, totalTasks)
   ElMessage.info(apiOk ? '已停止当前任务，您可以发送新需求' : '已断开回复，后台可能仍在收尾')
+  if (apiOk) await refreshThreadCheckpoint()
 }
 
 async function send() {
@@ -1420,6 +1441,7 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
   runCancelled.value = false
   threadRunState.value = null
   cancelledPresentation.value = null
+  cancelledProgressText.value = null
   streamAbortController = new AbortController()
   agentStream.start()
 
@@ -1578,7 +1600,7 @@ async function reconnectStream() {
       )
     }
     const cancelled = syncCancelledFromThreadState(json.data)
-    interruptGate.value = cancelled ? null : interruptPayloadFromThreadState(json.data)
+    interruptGate.value = interruptPayloadFromThreadState(json.data)
 
     const hint = phaseHintFromInterrupt(interruptGate.value)
     if (hint) {
@@ -2333,7 +2355,7 @@ defineExpose({
                 发起新任务
               </button>
             </div>
-            <div v-else-if="awaitingConfirm" class="mb-2 flex flex-wrap gap-2 px-0.5">
+            <div v-if="awaitingConfirm" class="mb-2 flex flex-wrap gap-2 px-0.5">
               <button
                 type="button"
                 class="neo-ctl agent-preset-primary rounded-lg px-3 py-1.5 text-xs font-medium"

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -47,6 +47,7 @@ import {
   chipSetFromInterrupt,
   interruptPayloadFromThreadState,
   buildRetakeContinueMessage,
+  isRunCancelledState,
   isRetakePendingPhase,
   resolveImageQaBodyText,
   resolveImageQaChecks,
@@ -428,6 +429,8 @@ function pollTasksFromProgress() {
 
 let streamAbortController: AbortController | null = null
 const runCancelled = ref(false)
+const threadRunState = ref<{ phase?: string | null; runCancelled?: boolean | null } | null>(null)
+const cancelledPresentation = ref<AgentPresentationEnvelope | null>(null)
 const reconnecting = ref(false)
 const recoveredPhaseHint = ref<string | null>(null)
 /** P0-06: authoritative gate from SSE interrupt or thread-state reconnect */
@@ -482,6 +485,13 @@ const retakeCalloutText = computed(() => {
 const retakeContinueLabel = computed(
   () => gatePresentation.value?.secondary_actions?.[0]?.label ?? '继续',
 )
+const showCancelledCallout = computed(
+  () => isRunCancelledState(threadRunState.value) || runCancelled.value,
+)
+const cancelledCalloutText = computed(() => {
+  const text = String(cancelledPresentation.value?.body?.text ?? '').trim()
+  return text || '当前任务已停止，你可以发起新任务或直接输入新的需求。'
+})
 const awaitingSchemeSelect = computed(() => chipSet.value === 'scheme_select')
 const awaitingMacroSchemeSelect = computed(() => chipSet.value === 'macro_scheme_select')
 const awaitingShotConfirm = computed(
@@ -564,7 +574,8 @@ const hasDockPresentation = computed(
     || (awaitingDeliveryConfirm.value && Boolean(productVisualPlan.value) && !productVisualSchemeV2.value)
     || awaitingShotConfirm.value
     || (awaitingTopoConfirm.value && !awaitingShotConfirm.value)
-    || isRetakePending.value,
+    || isRetakePending.value
+    || showCancelledCallout.value,
 )
 const awaitingDeliveryConfirm = computed(() => chipSet.value === 'delivery_confirm')
 const userRequestLabels = ref<string[]>([])
@@ -943,6 +954,9 @@ async function selectThread(threadId: string) {
   historyOpen.value = false
   taskProgress.value = emptyTaskProgress()
   interruptGate.value = null
+  runCancelled.value = false
+  threadRunState.value = null
+  cancelledPresentation.value = null
   hasAtomicCheckpoint.value = false
   retakePending.value = false
   effectiveUtterance.value = null
@@ -994,6 +1008,9 @@ watch(
   () => {
     taskProgress.value = emptyTaskProgress()
     interruptGate.value = null
+    runCancelled.value = false
+    threadRunState.value = null
+    cancelledPresentation.value = null
     hasAtomicCheckpoint.value = false
     retakePending.value = false
     effectiveUtterance.value = null
@@ -1090,6 +1107,9 @@ function newAgentSession() {
   agent.clear()
   taskProgress.value = emptyTaskProgress()
   interruptGate.value = null
+  runCancelled.value = false
+  threadRunState.value = null
+  cancelledPresentation.value = null
   threadJourneyTrace.value = null
   hasAtomicCheckpoint.value = false
   retakePending.value = false
@@ -1098,6 +1118,24 @@ function newAgentSession() {
   agentThreadId.value = createAgentThreadId(props.sessionId)
   persistActiveThreadId(props.sessionId, agentThreadId.value)
   ElMessage.info('已新建对话')
+}
+
+function syncCancelledFromThreadState(
+  state:
+    | {
+        phase?: string | null
+        runCancelled?: boolean | null
+        presentation?: AgentPresentationEnvelope | null
+      }
+    | null
+    | undefined,
+): boolean {
+  threadRunState.value = state
+    ? { phase: state.phase ?? null, runCancelled: state.runCancelled ?? null }
+    : null
+  const cancelled = isRunCancelledState(state)
+  cancelledPresentation.value = cancelled ? (state?.presentation ?? null) : null
+  return cancelled
 }
 
 async function refreshThreadCheckpoint() {
@@ -1112,6 +1150,7 @@ async function refreshThreadCheckpoint() {
         hasAtomicCheckpoint?: boolean
         interrupted?: boolean
         phase?: string | null
+        runCancelled?: boolean | null
         productVisualPlan?: ProductVisualPlan | null
         macroSchemes?: ProductVisualMacroScheme[] | null
         shotManifest?: ProductVisualShot[] | null
@@ -1164,7 +1203,8 @@ async function refreshThreadCheckpoint() {
         json.data?.deliveryGenByKey,
       )
     }
-    const gatePayload = interruptPayloadFromThreadState(json.data)
+    const cancelled = syncCancelledFromThreadState(json.data)
+    const gatePayload = cancelled ? null : interruptPayloadFromThreadState(json.data)
     interruptGate.value = gatePayload
   } catch {
     // ignore — checkpoint hint is best-effort
@@ -1277,6 +1317,11 @@ async function sendPreset(text: string) {
   await sendMessage(text.trim(), decision)
 }
 
+async function startNewTask() {
+  if (agent.isStreaming || isUploading.value) return
+  await sendMessage('__new_task__')
+}
+
 /** 把按钮文本映射为后端可识别的 userDecision 值。 */
 function mapPresetToDecision(text: string): 'confirm' | 'revise' | undefined {
   const t = (text || '').trim()
@@ -1373,6 +1418,8 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
   effectiveUtterance.value = null
   completionPresentation.value = null
   runCancelled.value = false
+  threadRunState.value = null
+  cancelledPresentation.value = null
   streamAbortController = new AbortController()
   agentStream.start()
 
@@ -1480,6 +1527,7 @@ async function reconnectStream() {
     const json = (await res.json()) as {
       data?: {
         phase?: string | null
+        runCancelled?: boolean | null
         interrupted?: boolean
         finished?: boolean
         nextNodes?: string[]
@@ -1529,7 +1577,8 @@ async function reconnectStream() {
         json.data?.deliveryGenByKey,
       )
     }
-    interruptGate.value = interruptPayloadFromThreadState(json.data)
+    const cancelled = syncCancelledFromThreadState(json.data)
+    interruptGate.value = cancelled ? null : interruptPayloadFromThreadState(json.data)
 
     const hint = phaseHintFromInterrupt(interruptGate.value)
     if (hint) {
@@ -1545,7 +1594,9 @@ async function reconnectStream() {
 
     const label = formatPhaseLabel(phase)
     recoveredPhaseHint.value =
-      json.data?.finished
+      cancelled
+        ? '服务已恢复。上一轮已停止，可发起新任务。'
+        : json.data?.finished
         ? '服务已恢复。上一轮已完成，可继续新的指令。'
         : `服务已恢复。当前阶段：${label}。请继续操作。`
     pollTasksFromProgress()
@@ -1750,7 +1801,12 @@ function handleEvent(event: { type: string; data: unknown }) {
       break
     case 'run_cancelled': {
       runCancelled.value = true
-      const text = String((event.data as { text?: string }).text ?? '').trim()
+      const data = event.data as {
+        text?: string
+        presentation?: AgentPresentationEnvelope | null
+      }
+      if (data.presentation) cancelledPresentation.value = data.presentation
+      const text = String(data.text ?? '').trim()
       if (text) {
         agent.appendText(`\n\n${text}`)
         scrollToBottom()
@@ -2257,7 +2313,27 @@ defineExpose({
             class="agent-input-area shrink-0 px-2.5 pb-2.5 pt-1"
             :class="{ 'agent-input-area--scrollable': hasDockPresentation }"
           >
-            <div v-if="awaitingConfirm" class="mb-2 flex flex-wrap gap-2 px-0.5">
+            <div
+              v-if="showCancelledCallout"
+              class="mb-2 px-0.5"
+              data-testid="run-cancelled-callout"
+            >
+              <p
+                class="mb-2 rounded-lg border border-[var(--neo-border)] bg-[var(--neo-panel)] px-2 py-1.5 text-xs leading-relaxed text-[var(--neo-text-secondary)]"
+              >
+                {{ cancelledCalloutText }}
+              </p>
+              <button
+                type="button"
+                class="neo-ctl agent-preset-primary rounded-lg px-3 py-1.5 text-xs font-medium"
+                data-testid="new-task-chip"
+                :disabled="agent.isStreaming || isUploading"
+                @click="startNewTask()"
+              >
+                发起新任务
+              </button>
+            </div>
+            <div v-else-if="awaitingConfirm" class="mb-2 flex flex-wrap gap-2 px-0.5">
               <button
                 type="button"
                 class="neo-ctl agent-preset-primary rounded-lg px-3 py-1.5 text-xs font-medium"

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -16,6 +16,7 @@ import AgentCanvasOutputs from '@/components/agent/AgentCanvasOutputs.vue'
 import AgentExecutionTrace from '@/components/agent/AgentExecutionTrace.vue'
 import { resolveMessageOutputs } from '@/components/agent/agentCanvasOutputs'
 import type { AgentStreamMessage } from '@/stores/agent'
+import { cancelAgentRun } from '@/components/agent/cancelAgentRun'
 import {
   applyTaskEvent,
   applyPollRecordToTask,
@@ -426,6 +427,7 @@ function pollTasksFromProgress() {
 }
 
 let streamAbortController: AbortController | null = null
+const runCancelled = ref(false)
 const reconnecting = ref(false)
 const recoveredPhaseHint = ref<string | null>(null)
 /** P0-06: authoritative gate from SSE interrupt or thread-state reconnect */
@@ -1206,18 +1208,37 @@ function toggleVoice() {
   })
 }
 
-function cancelActiveStream() {
+function authHeaders(): Record<string, string> {
+  const token = localStorage.getItem('token')
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}
+
+async function cancelActiveStream() {
   if (!agent.isStreaming) return
-  streamAbortController?.abort()
-  agentStream.stop()
-  agent.finishStreaming()
-  ElMessage.info('已停止当前回复，您可以发送新需求')
+  runCancelled.value = true
+  const { apiOk } = await cancelAgentRun({
+    threadId: agentThreadId.value,
+    sessionId: props.sessionId,
+    abort: () => {
+      streamAbortController?.abort()
+      agentStream.stop()
+      agent.finishStreaming()
+    },
+    postCancel: (body) =>
+      fetch(apiUrl('/api/agent/runs/cancel'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(3000),
+      }).then((r) => r.json()),
+  })
+  ElMessage.info(apiOk ? '已停止当前任务，您可以发送新需求' : '已断开回复，后台可能仍在收尾')
 }
 
 async function send() {
   if (isUploading.value) return
   if (agent.isStreaming) {
-    cancelActiveStream()
+    await cancelActiveStream()
     return
   }
   if (!canSubmitComposer.value) return
@@ -1351,6 +1372,7 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
   retakePending.value = false
   effectiveUtterance.value = null
   completionPresentation.value = null
+  runCancelled.value = false
   streamAbortController = new AbortController()
   agentStream.start()
 
@@ -1411,7 +1433,7 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
     agentStream.stop()
     streamAbortController = null
     // SSE abnormal-end detection: stream broke without [DONE]
-    if (!streamEndedNormally) {
+    if (!streamEndedNormally && !runCancelled.value) {
       const last = agent.messages[agent.messages.length - 1]
       if (last?.role === 'assistant' && !last.content.trim()) {
         agent.appendText('\n\n⚠️ 连接意外断开，请稍后重试。')
@@ -1423,7 +1445,7 @@ async function sendMessage(message: string, userDecision?: 'confirm' | 'revise')
     }
 
     const last = agent.messages[agent.messages.length - 1]
-    if (last?.role === 'assistant' && !last.content.trim()) {
+    if (!runCancelled.value && last?.role === 'assistant' && !last.content.trim()) {
       agent.appendText('（本轮无文本回复。若在确认方案，可再发「确认」；或点「新建对话」后重试。）')
     }
     agent.finishStreaming()
@@ -1726,6 +1748,15 @@ function handleEvent(event: { type: string; data: unknown }) {
     }
     case 'ping':
       break
+    case 'run_cancelled': {
+      runCancelled.value = true
+      const text = String((event.data as { text?: string }).text ?? '').trim()
+      if (text) {
+        agent.appendText(`\n\n${text}`)
+        scrollToBottom()
+      }
+      break
+    }
     case 'interrupt': {
       const data = event.data as AgentInterruptPayload & {
         imageQaReason?: string | null

--- a/apps/web/src/components/agent/agentInterruptGate.test.ts
+++ b/apps/web/src/components/agent/agentInterruptGate.test.ts
@@ -13,6 +13,7 @@ import {
   resolveGatePrimaryActionLabel,
   IMAGE_QA_OPTIONS,
   interruptPayloadFromThreadState,
+  isRunCancelledState,
   isRetakePendingPhase,
   resolveImageQaChecks,
   resolveImageQaBodyText,
@@ -145,6 +146,13 @@ describe('interruptPayloadFromThreadState', () => {
   })
 })
 
+describe('isRunCancelledState', () => {
+  it('detects cancelled thread state', () => {
+    expect(isRunCancelledState({ phase: 'cancelled', runCancelled: true })).toBe(true)
+    expect(isRunCancelledState({ phase: 'done', runCancelled: false })).toBe(false)
+  })
+})
+
 describe('defaultMacroSchemeSelection', () => {
   it('prefers recommended macro schemes up to 2', () => {
     const schemes = [
@@ -247,6 +255,10 @@ describe('filterAssistantVisibleText', () => {
         '"__macro_scheme_decision__{\\"action\\":\\"confirm\\",\\"selected_ids\\":[\\"A\\",\\"B\\"]}"',
       ),
     ).toBe('')
+  })
+
+  it('hides the new-task machine message from user bubbles', () => {
+    expect(filterUserVisibleText('__new_task__')).toBe('')
   })
 
   it('filters internal QA error strings from assistant text', () => {

--- a/apps/web/src/components/agent/agentInterruptGate.ts
+++ b/apps/web/src/components/agent/agentInterruptGate.ts
@@ -21,6 +21,18 @@ export interface RetakePhaseInput {
   retakePending?: boolean | null
 }
 
+export interface RunCancelledStateInput {
+  phase?: string | null
+  runCancelled?: boolean | null
+}
+
+export function isRunCancelledState(
+  state: RunCancelledStateInput | null | undefined,
+): boolean {
+  if (!state) return false
+  return state.runCancelled === true || state.phase === 'cancelled'
+}
+
 export interface ProductVisualScheme {
   scheme_id: string
   name?: string | null
@@ -99,6 +111,7 @@ const MACHINE_PAYLOAD_PREFIXES = [
   SCHEME_DECISION_PREFIX,
   MACRO_SCHEME_DECISION_PREFIX,
   DELIVERY_DECISION_PREFIX,
+  '__new_task__',
 ] as const
 
 const INTERNAL_QA_ERROR_SNIPPETS = [

--- a/apps/web/src/components/agent/cancelAgentRun.test.ts
+++ b/apps/web/src/components/agent/cancelAgentRun.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { cancelAgentRun } from './cancelAgentRun'
+import { cancelAgentRun, cancelledCalloutTextFromProgress } from './cancelAgentRun'
 
 describe('cancelAgentRun', () => {
   it('calls API then abort even if API fails', async () => {
@@ -31,5 +31,56 @@ describe('cancelAgentRun', () => {
     expect(result.apiOk).toBe(true)
     expect(result.skipped).toBe(true)
     expect(abort).toHaveBeenCalled()
+  })
+
+  it('treats a response without ok:true as failure', async () => {
+    const abort = vi.fn()
+    const postCancel = vi.fn().mockResolvedValue({ code: 500, message: 'boom' })
+    const result = await cancelAgentRun({
+      threadId: 't1',
+      sessionId: 's1',
+      abort,
+      postCancel,
+    })
+    expect(result.apiOk).toBe(false)
+    expect(abort).toHaveBeenCalled()
+  })
+
+  it('surfaces gen progress and preserved gate from the cancel response', async () => {
+    const postCancel = vi.fn().mockResolvedValue({
+      code: 0,
+      data: {
+        ok: true,
+        phase: 'cancelled',
+        completedTasks: 2,
+        totalTasks: 5,
+        gatePreserved: false,
+      },
+    })
+    const result = await cancelAgentRun({
+      threadId: 't1',
+      sessionId: 's1',
+      abort: vi.fn(),
+      postCancel,
+    })
+    expect(result).toMatchObject({
+      apiOk: true,
+      completedTasks: 2,
+      totalTasks: 5,
+      gatePreserved: false,
+    })
+  })
+})
+
+describe('cancelledCalloutTextFromProgress', () => {
+  it('renders the completed / total progress line', () => {
+    expect(cancelledCalloutTextFromProgress(2, 5)).toBe(
+      '已停止出图（完成 2/5）。直接说修改意见，或点「发起新任务」。',
+    )
+  })
+
+  it('returns null without usable task counts', () => {
+    expect(cancelledCalloutTextFromProgress(undefined, undefined)).toBeNull()
+    expect(cancelledCalloutTextFromProgress(0, 0)).toBeNull()
   })
 })

--- a/apps/web/src/components/agent/cancelAgentRun.test.ts
+++ b/apps/web/src/components/agent/cancelAgentRun.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest'
+import { cancelAgentRun } from './cancelAgentRun'
+
+describe('cancelAgentRun', () => {
+  it('calls API then abort even if API fails', async () => {
+    const abort = vi.fn()
+    const postCancel = vi.fn().mockRejectedValue(new Error('network'))
+    const result = await cancelAgentRun({
+      threadId: 't1',
+      sessionId: 's1',
+      abort,
+      postCancel,
+    })
+    expect(postCancel).toHaveBeenCalledWith({ threadId: 't1', sessionId: 's1', reason: 'user' })
+    expect(abort).toHaveBeenCalled()
+    expect(result.apiOk).toBe(false)
+  })
+
+  it('reports skipped when runtime skips non-PV', async () => {
+    const abort = vi.fn()
+    const postCancel = vi.fn().mockResolvedValue({
+      code: 0,
+      data: { ok: true, skipped: true, reason: 'flow_not_supported' },
+    })
+    const result = await cancelAgentRun({
+      threadId: 't1',
+      sessionId: 's1',
+      abort,
+      postCancel,
+    })
+    expect(result.apiOk).toBe(true)
+    expect(result.skipped).toBe(true)
+    expect(abort).toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/components/agent/cancelAgentRun.ts
+++ b/apps/web/src/components/agent/cancelAgentRun.ts
@@ -1,3 +1,11 @@
+export interface CancelAgentRunResult {
+  apiOk: boolean
+  skipped?: boolean
+  completedTasks?: number
+  totalTasks?: number
+  gatePreserved?: boolean
+}
+
 export async function cancelAgentRun(opts: {
   threadId: string
   sessionId: string
@@ -7,9 +15,8 @@ export async function cancelAgentRun(opts: {
     sessionId: string
     reason: 'user'
   }) => Promise<unknown>
-}): Promise<{ apiOk: boolean; skipped?: boolean }> {
-  let apiOk = false
-  let skipped: boolean | undefined
+}): Promise<CancelAgentRunResult> {
+  const result: CancelAgentRunResult = { apiOk: false }
 
   try {
     if (opts.postCancel) {
@@ -17,15 +24,42 @@ export async function cancelAgentRun(opts: {
         threadId: opts.threadId,
         sessionId: opts.sessionId,
         reason: 'user',
-      })) as { data?: { ok?: boolean; skipped?: boolean } }
-      apiOk = res?.data?.ok !== false
-      skipped = res?.data?.skipped
+      })) as {
+        data?: {
+          ok?: boolean
+          skipped?: boolean
+          completedTasks?: number
+          totalTasks?: number
+          gatePreserved?: boolean
+        }
+      }
+      result.apiOk = res?.data?.ok === true
+      result.skipped = res?.data?.skipped
+      result.gatePreserved = res?.data?.gatePreserved
+      if (typeof res?.data?.completedTasks === 'number') {
+        result.completedTasks = res.data.completedTasks
+      }
+      if (typeof res?.data?.totalTasks === 'number') {
+        result.totalTasks = res.data.totalTasks
+      }
     }
   } catch {
-    apiOk = false
+    result.apiOk = false
   } finally {
     opts.abort()
   }
 
-  return { apiOk, skipped }
+  return result
+}
+
+/** Callout text for a stopped run; mirrors the runtime cancelled presentation. */
+export function cancelledCalloutTextFromProgress(
+  completedTasks?: number,
+  totalTasks?: number,
+): string | null {
+  if (typeof completedTasks !== 'number' || typeof totalTasks !== 'number') return null
+  if (totalTasks <= 0) return null
+  const done = Math.max(0, completedTasks)
+  const total = Math.max(done, totalTasks)
+  return `已停止出图（完成 ${done}/${total}）。直接说修改意见，或点「发起新任务」。`
 }

--- a/apps/web/src/components/agent/cancelAgentRun.ts
+++ b/apps/web/src/components/agent/cancelAgentRun.ts
@@ -1,0 +1,31 @@
+export async function cancelAgentRun(opts: {
+  threadId: string
+  sessionId: string
+  abort: () => void
+  postCancel?: (body: {
+    threadId: string
+    sessionId: string
+    reason: 'user'
+  }) => Promise<unknown>
+}): Promise<{ apiOk: boolean; skipped?: boolean }> {
+  let apiOk = false
+  let skipped: boolean | undefined
+
+  try {
+    if (opts.postCancel) {
+      const res = (await opts.postCancel({
+        threadId: opts.threadId,
+        sessionId: opts.sessionId,
+        reason: 'user',
+      })) as { data?: { ok?: boolean; skipped?: boolean } }
+      apiOk = res?.data?.ok !== false
+      skipped = res?.data?.skipped
+    }
+  } catch {
+    apiOk = false
+  } finally {
+    opts.abort()
+  }
+
+  return { apiOk, skipped }
+}

--- a/docs/superpowers/plans/2026-09-06-agent-mid-run-interrupt-pv.md
+++ b/docs/superpowers/plans/2026-09-06-agent-mid-run-interrupt-pv.md
@@ -1,0 +1,1092 @@
+# Agent Mid-Run Interrupt (product_visual) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 `product_visual` 侧栏 Agent 在运行中可真正停止，停止后再发话按启发式分流为门控续跑 / 改意图 / 新任务（含 callout 与「发起新任务」chip）。
+
+**Architecture:** Run Cancel Token（进程内 `RunCancelRegistry`）+ Nest 代理 `POST /agent/runs/cancel`；活跃 `astream` 在 `gen_scheduler` / 节点边界协作退出并写 `phase=cancelled`；下一轮 `runs.py` 在 `should_resume_interrupt` 之前调用 `classify_post_cancel_intent`。非 PV 首期返回 `skipped: flow_not_supported`。
+
+**Tech Stack:** FastAPI agent-runtime (Python 3.11+), LangGraph, pytest, NestJS, Vue 3 + Vitest, SSE/NDJSON
+
+**Spec:** [2026-08-12-agent-mid-run-interrupt-design.md](../specs/2026-08-12-agent-mid-run-interrupt-design.md)（v2.0 Accepted）
+
+## Global Constraints
+
+- 首期仅 `flow_mode == "product_visual"`；其它 flow：`ok: true, skipped: true, reason: "flow_not_supported"`
+- 禁止同 thread 双 run 并行；cancel 不抢锁，只 set flag 让持锁 run 协作退出
+- 上游 gen 取消 **best-effort**（`nest.cancel_generation`）；UI 可提示「部分任务可能仍在后台结束」
+- 取消后下一轮 conversation **必须**使用新 `Idempotency-Key`
+- 改意图分类：**启发式 + `__new_task__` chip**；禁止 LLM 分类器
+- Pre-PR 测试：  
+  `cd services/agent-runtime && uv run pytest tests/test_run_cancel*.py tests/test_post_cancel_intent.py tests/test_gen_scheduler_cancel.py -v`  
+  `cd apps/server && pnpm exec vitest run src/agent/agent-runtime.client.test.ts`  
+  `cd apps/web && pnpm exec vitest run src/components/agent/cancelAgentRun.test.ts src/components/agent/agentInterruptGate.test.ts`
+
+---
+
+## File Map
+
+| File | Action | 职责 |
+|------|--------|------|
+| `services/agent-runtime/app/run_cancel.py` | **Create** | `RunCancelRegistry` + cancel flag API |
+| `services/agent-runtime/app/graph/post_cancel.py` | **Create** | `classify_post_cancel_intent` + revise/new_task CLEAR 表 + Command 构建 |
+| `services/agent-runtime/app/graph/cancel_checkpoint.py` | **Create** | `build_cancelled_checkpoint_update` presentation callout |
+| `services/agent-runtime/app/graph/state.py` | Modify | `phase` 增 `"cancelled"`；`run_cancelled` / `cancel_reason` |
+| `services/agent-runtime/app/graph/hitl_resume.py` | Modify | `FRESH_TURN_STATE_CLEAR` 含 cancel 字段 |
+| `services/agent-runtime/app/graph/nodes/gen_scheduler.py` | Modify | 波次前读 cancel → 停派发 → collect |
+| `services/agent-runtime/app/graph/nodes/gen_node.py` | Modify | 入口读 cancel → 跳过 gen + 可选 cancel_generation |
+| `services/agent-runtime/app/runs.py` | Modify | cancel 协作、emit `run_cancelled`、post-cancel 分流、thread-state 字段 |
+| `services/agent-runtime/app/main.py` | Modify | `POST /v1/runs/cancel` |
+| `services/agent-runtime/tests/test_run_cancel_registry.py` | **Create** | Registry 单测 |
+| `services/agent-runtime/tests/test_post_cancel_intent.py` | **Create** | 分类 + CLEAR 单测 |
+| `services/agent-runtime/tests/test_gen_scheduler_cancel.py` | **Create** | scheduler 停派发 |
+| `services/agent-runtime/tests/test_runs_cancel_api.py` | **Create** | HTTP cancel + 幂等 |
+| `apps/server/src/agent/agent-runtime.client.ts` | Modify | `cancelRun` + `RuntimeThreadState.runCancelled` |
+| `apps/server/src/agent/agent.service.ts` | Modify | `cancelRun` 代理 |
+| `apps/server/src/agent/agent.controller.ts` | Modify | `POST runs/cancel` |
+| `apps/server/src/agent/dto/cancel-run.dto.ts` | **Create** | DTO |
+| `apps/server/src/agent/agent-runtime.client.test.ts` | Modify | cancel 客户端测 |
+| `packages/agent/src/types.ts` | Modify | `AgentStreamEvent` 增 `run_cancelled` |
+| `apps/web/src/components/agent/cancelAgentRun.ts` | **Create** | 先 API 后 abort |
+| `apps/web/src/components/agent/cancelAgentRun.test.ts` | **Create** | 前端单元测 |
+| `apps/web/src/components/agent/AgentSideRail.vue` | Modify | 停止钮、callout、新任务 chip、事件处理 |
+| `apps/web/src/components/agent/agentInterruptGate.ts` | Modify | cancelled 重连态解析（若需） |
+
+---
+
+## Task 1: RunCancelRegistry
+
+**Files:**
+- Create: `services/agent-runtime/app/run_cancel.py`
+- Create: `services/agent-runtime/tests/test_run_cancel_registry.py`
+
+**Interfaces:**
+- Produces:
+  ```python
+  def request_cancel(thread_id: str, *, reason: str = "user") -> None: ...
+  def is_cancel_requested(thread_id: str) -> bool: ...
+  def clear_cancel(thread_id: str) -> None: ...
+  def peek_cancel_reason(thread_id: str) -> str | None: ...
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# services/agent-runtime/tests/test_run_cancel_registry.py
+from app.run_cancel import clear_cancel, is_cancel_requested, peek_cancel_reason, request_cancel
+
+
+def test_request_cancel_sets_flag():
+    tid = "t-cancel-1"
+    clear_cancel(tid)
+    assert is_cancel_requested(tid) is False
+    request_cancel(tid, reason="user")
+    assert is_cancel_requested(tid) is True
+    assert peek_cancel_reason(tid) == "user"
+    clear_cancel(tid)
+    assert is_cancel_requested(tid) is False
+
+
+def test_request_cancel_idempotent():
+    tid = "t-cancel-2"
+    clear_cancel(tid)
+    request_cancel(tid, reason="user")
+    request_cancel(tid, reason="user")
+    assert is_cancel_requested(tid) is True
+    clear_cancel(tid)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/agent-runtime && uv run pytest tests/test_run_cancel_registry.py -v`  
+Expected: FAIL (`ModuleNotFoundError: app.run_cancel` or import error)
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# services/agent-runtime/app/run_cancel.py
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+_lock = threading.Lock()
+_flags: dict[str, dict[str, Any]] = {}
+
+
+def request_cancel(thread_id: str, *, reason: str = "user") -> None:
+    tid = (thread_id or "").strip()
+    if not tid:
+        return
+    with _lock:
+        _flags[tid] = {"reason": reason or "user"}
+
+
+def is_cancel_requested(thread_id: str) -> bool:
+    tid = (thread_id or "").strip()
+    if not tid:
+        return False
+    with _lock:
+        return tid in _flags
+
+
+def peek_cancel_reason(thread_id: str) -> str | None:
+    tid = (thread_id or "").strip()
+    if not tid:
+        return None
+    with _lock:
+        entry = _flags.get(tid)
+        return str(entry["reason"]) if entry else None
+
+
+def clear_cancel(thread_id: str) -> None:
+    tid = (thread_id or "").strip()
+    if not tid:
+        return
+    with _lock:
+        _flags.pop(tid, None)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd services/agent-runtime && uv run pytest tests/test_run_cancel_registry.py -v`  
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/agent-runtime/app/run_cancel.py services/agent-runtime/tests/test_run_cancel_registry.py
+git commit -m "feat(runtime): add RunCancelRegistry for mid-run interrupt"
+```
+
+---
+
+## Task 2: Cancelled checkpoint update + state fields
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/cancel_checkpoint.py`
+- Create: `services/agent-runtime/tests/test_cancel_checkpoint.py`
+- Modify: `services/agent-runtime/app/graph/state.py` — `phase` Literal 增加 `"cancelled"`；增加 `run_cancelled: bool | None`、`cancel_reason: str | None`
+- Modify: `services/agent-runtime/app/graph/hitl_resume.py` — `FRESH_TURN_STATE_CLEAR` 增加 `"run_cancelled": None`、`"cancel_reason": None`
+
+**Interfaces:**
+- Produces:
+  ```python
+  def build_cancelled_checkpoint_update(
+      *,
+      completed_tasks: int = 0,
+      total_tasks: int = 0,
+      reason: str = "user",
+  ) -> dict[str, Any]: ...
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# services/agent-runtime/tests/test_cancel_checkpoint.py
+from app.graph.cancel_checkpoint import build_cancelled_checkpoint_update
+
+
+def test_build_cancelled_checkpoint_update_shape():
+    upd = build_cancelled_checkpoint_update(completed_tasks=2, total_tasks=5, reason="user")
+    assert upd["phase"] == "cancelled"
+    assert upd["run_cancelled"] is True
+    assert upd["cancel_reason"] == "user"
+    assert upd["presentation"]["kind"] == "callout_info"
+    assert "2/5" in upd["presentation"]["body"]["text"]
+    assert "发起新任务" in upd["presentation"]["body"]["text"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/agent-runtime && uv run pytest tests/test_cancel_checkpoint.py -v`  
+Expected: FAIL (module missing)
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# services/agent-runtime/app/graph/cancel_checkpoint.py
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_cancelled_checkpoint_update(
+    *,
+    completed_tasks: int = 0,
+    total_tasks: int = 0,
+    reason: str = "user",
+) -> dict[str, Any]:
+    done = max(0, int(completed_tasks))
+    total = max(done, int(total_tasks))
+    if total > 0:
+        progress = f"已停止出图（完成 {done}/{total}）。"
+    else:
+        progress = "已停止当前任务。"
+    text = f"{progress}直接说修改意见，或点「发起新任务」。"
+    return {
+        "phase": "cancelled",
+        "run_cancelled": True,
+        "cancel_reason": reason or "user",
+        "presentation": {
+            "kind": "callout_info",
+            "body": {"text": text},
+        },
+    }
+```
+
+在 `state.py` 的 `phase` Literal 列表末尾加入 `"cancelled"`，并在 TypedDict 中增加：
+
+```python
+    run_cancelled: bool | None
+    cancel_reason: str | None
+```
+
+在 `hitl_resume.py` 的 `FRESH_TURN_STATE_CLEAR` 中增加：
+
+```python
+    "run_cancelled": None,
+    "cancel_reason": None,
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd services/agent-runtime && uv run pytest tests/test_cancel_checkpoint.py -v`  
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/agent-runtime/app/graph/cancel_checkpoint.py \
+  services/agent-runtime/tests/test_cancel_checkpoint.py \
+  services/agent-runtime/app/graph/state.py \
+  services/agent-runtime/app/graph/hitl_resume.py
+git commit -m "feat(runtime): cancelled checkpoint update and state fields"
+```
+
+---
+
+## Task 3: `gen_scheduler` / `gen_node` 协作取消
+
+**Files:**
+- Modify: `services/agent-runtime/app/graph/nodes/gen_scheduler.py`
+- Modify: `services/agent-runtime/app/graph/nodes/gen_node.py`
+- Create: `services/agent-runtime/tests/test_gen_scheduler_cancel.py`
+
+**Interfaces:**
+- Consumes: `is_cancel_requested(thread_id)` from Task 1；`build_cancelled_checkpoint_update` from Task 2
+- Produces: scheduler 在 cancel 时 `Command(update=..., goto=["collect_gen"])` 且不 `Send` 新节点
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# services/agent-runtime/tests/test_gen_scheduler_cancel.py
+import pytest
+from langgraph.types import Command
+
+from app.graph.nodes.gen_scheduler import make_gen_scheduler_node
+from app.run_cancel import clear_cancel, request_cancel
+
+
+@pytest.mark.asyncio
+async def test_gen_scheduler_stops_dispatch_when_cancel_requested():
+    tid = "t-sched-cancel"
+    clear_cancel(tid)
+    request_cancel(tid, reason="user")
+    node = make_gen_scheduler_node(max_concurrency=4)
+    state = {
+        "thread_id": tid,
+        "gen_ordered_keys": ["a", "b"],
+        "gen_deps_of": {"a": [], "b": ["a"]},
+        "gen_by_key": {
+            "a": {"node_id": "n1", "title": "A"},
+            "b": {"node_id": "n2", "title": "B"},
+        },
+        "gen_completed_keys": [],
+        "gen_failed_keys": [],
+        "gen_needs_user_keys": [],
+    }
+    cmd = await node(state)
+    assert isinstance(cmd, Command)
+    assert cmd.goto == ["collect_gen"]
+    assert cmd.update.get("phase") == "cancelled"
+    assert cmd.update.get("run_cancelled") is True
+    # no Send fan-out
+    assert not any(getattr(g, "node", None) == "gen_node" for g in (cmd.goto if isinstance(cmd.goto, list) else []))
+    clear_cancel(tid)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/agent-runtime && uv run pytest tests/test_gen_scheduler_cancel.py -v`  
+Expected: FAIL（仍派发 `gen_node` 或无 cancelled update）
+
+- [ ] **Step 3: Implement scheduler cancel branch**
+
+在 `make_gen_scheduler_node` 的 `gen_scheduler` **开头**（读 keys 之后、cascade 之前）加入：
+
+```python
+        from app.graph.cancel_checkpoint import build_cancelled_checkpoint_update
+        from app.run_cancel import is_cancel_requested, peek_cancel_reason
+
+        thread_id = str(state.get("thread_id") or "")
+        if thread_id and is_cancel_requested(thread_id):
+            completed = set(state.get("gen_completed_keys") or [])
+            ordered = list(state.get("gen_ordered_keys") or [])
+            reason = peek_cancel_reason(thread_id) or "user"
+            upd = build_cancelled_checkpoint_update(
+                completed_tasks=len(completed),
+                total_tasks=len(ordered),
+                reason=reason,
+            )
+            # mark remaining as needs_user/cancelled via fail details optional
+            return Command(update=upd, goto=["collect_gen"])
+```
+
+在 `gen_node` 入口（取得 `node_id` 之后、真正 `run_image_generation` 之前）：
+
+```python
+        from app.run_cancel import is_cancel_requested
+
+        thread_id = str(state.get("thread_id") or "")
+        # Send payload may not include thread_id — prefer nest/session context if wired;
+        # if missing, skip this check (scheduler already blocks new Sends).
+        if thread_id and is_cancel_requested(thread_id):
+            try:
+                await nest.cancel_generation(node_id=str(node_id))
+            except Exception:
+                pass
+            return {
+                "gen_needs_user_keys": [key],
+                "gen_fail_details": {
+                    key: {"node_id": node_id, "title": title, "reason": "cancelled"}
+                },
+            }
+```
+
+**注意：** `Send` 到 `gen_node` 的 payload 当前不含 `thread_id`。本 Task 须在 `gen_scheduler` 的 `Send(..., {..., "thread_id": state.get("thread_id")})` 中传入 `thread_id`，否则 gen_node 无法读 flag。同步改 Send 字典。
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd services/agent-runtime && uv run pytest tests/test_gen_scheduler_cancel.py -v`  
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/agent-runtime/app/graph/nodes/gen_scheduler.py \
+  services/agent-runtime/app/graph/nodes/gen_node.py \
+  services/agent-runtime/tests/test_gen_scheduler_cancel.py
+git commit -m "feat(runtime): cooperative cancel in gen_scheduler and gen_node"
+```
+
+---
+
+## Task 4: Runtime `POST /v1/runs/cancel` + apply cancel
+
+**Files:**
+- Modify: `services/agent-runtime/app/main.py`
+- Modify: `services/agent-runtime/app/runs.py` — 新增 `CancelRunRequest`、`cancel_run(...)`
+- Create: `services/agent-runtime/tests/test_runs_cancel_api.py`
+
+**Interfaces:**
+- Produces:
+  ```python
+  class CancelRunRequest(BaseModel):
+      thread_id: str
+      session_id: str | None = None
+      reason: str = "user"
+
+  async def cancel_run(req: CancelRunRequest, *, checkpointer: Any | None = None, nest: Any | None = None) -> dict[str, Any]:
+      """Returns {ok, phase, cancelled_node_ids, completed_tasks, total_tasks, skipped?, reason?}"""
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# services/agent-runtime/tests/test_runs_cancel_api.py
+import pytest
+from httpx import ASGITransport, AsyncClient
+from langgraph.checkpoint.memory import MemorySaver
+
+from app.main import app, clear_run_overrides, configure_run_overrides
+from app.run_cancel import clear_cancel, is_cancel_requested
+
+
+@pytest.mark.asyncio
+async def test_cancel_run_sets_flag_and_is_idempotent(monkeypatch):
+    clear_run_overrides()
+    cp = MemorySaver()
+    configure_run_overrides(checkpointer=cp)
+    tid = "thread-cancel-api-1"
+    clear_cancel(tid)
+
+    # Minimal: even without PV checkpoint, flag must set; non-PV / empty may skipped
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        headers = {"x-lnkpi-service-token": "test-token"}
+        # Ensure auth: monkeypatch settings or use configured test token from conftest
+        r1 = await client.post(
+            "/v1/runs/cancel",
+            json={"thread_id": tid, "session_id": "s1", "reason": "user"},
+            headers=headers,
+        )
+        r2 = await client.post(
+            "/v1/runs/cancel",
+            json={"thread_id": tid, "session_id": "s1", "reason": "user"},
+            headers=headers,
+        )
+    assert r1.status_code == 200
+    assert r1.json()["ok"] is True
+    assert r2.json()["ok"] is True
+    assert is_cancel_requested(tid) is True
+    clear_cancel(tid)
+    clear_run_overrides()
+```
+
+若现有测试用固定 service token，对齐 `conftest` / `settings`（参考 `tests/test_health.py`）。
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/agent-runtime && uv run pytest tests/test_runs_cancel_api.py -v`  
+Expected: FAIL (404 on `/v1/runs/cancel`)
+
+- [ ] **Step 3: Implement `cancel_run` + route**
+
+`cancel_run` 逻辑：
+
+1. `request_cancel(thread_id, reason=...)`
+2. 读 checkpoint（同 `get_thread_state` 构图方式）
+3. 若 `flow_mode != "product_visual"` → return `{ok: True, skipped: True, reason: "flow_not_supported", phase: ...}`
+4. 若无活跃 gen：对 `gen_by_key` 中未完成且有 `node_id` 的项 best-effort `nest.cancel_generation`；`graph.aupdate_state(config, build_cancelled_checkpoint_update(...))`
+5. 若 checkpoint 已是 `phase=cancelled` → 幂等返回
+6. 返回 `cancelled_node_ids` / `completed_tasks` / `total_tasks`
+
+`main.py`：
+
+```python
+@app.post("/v1/runs/cancel")
+async def cancel_run_route(
+    body: CancelRunRequest,
+    x_lnkpi_service_token: str | None = Header(default=None),
+):
+    _require_runtime_auth(x_lnkpi_service_token)
+    from app.runs import cancel_run
+    return await cancel_run(body, checkpointer=_run_overrides.get("checkpointer"))
+```
+
+同时在 `stream_run_events` 的 `astream` 循环内：每处理完一个 update 后若 `is_cancel_requested(thread_id)`，`await emit({"type": "run_cancelled", "data": {...}})`，然后 `break`（finally 仍 release lock + `clear_cancel` 仅在成功写完 cancelled 后由 cancel 路径或 turn 结束清理——**规范：持锁 run 退出前 `aupdate_state` cancelled，再 `clear_cancel` 可留到下一轮 intake 前**；推荐 cancel flag 保留到下一轮 `classify` 读完再 `clear_cancel`）。
+
+更稳妥：`run_cancelled` 写入 checkpoint 后，flag 可 `clear_cancel`；下一轮靠 checkpoint `run_cancelled` / `phase`。
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd services/agent-runtime && uv run pytest tests/test_runs_cancel_api.py -v`  
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/agent-runtime/app/main.py services/agent-runtime/app/runs.py \
+  services/agent-runtime/tests/test_runs_cancel_api.py
+git commit -m "feat(runtime): POST /v1/runs/cancel for product_visual"
+```
+
+---
+
+## Task 5: Nest 代理 `POST /api/agent/runs/cancel`
+
+**Files:**
+- Create: `apps/server/src/agent/dto/cancel-run.dto.ts`
+- Modify: `apps/server/src/agent/agent-runtime.client.ts`
+- Modify: `apps/server/src/agent/agent.service.ts`
+- Modify: `apps/server/src/agent/agent.controller.ts`
+- Modify: `apps/server/src/agent/agent-runtime.client.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```typescript
+  // AgentRuntimeClient
+  cancelRun(input: { threadId: string; sessionId: string; reason?: string }): Promise<{
+    ok: boolean
+    phase?: string | null
+    cancelledNodeIds?: string[]
+    completedTasks?: number
+    totalTasks?: number
+    skipped?: boolean
+    reason?: string
+  }>
+  ```
+- `RuntimeThreadState` 增加 `runCancelled?: boolean | null`
+
+- [ ] **Step 1: Write the failing client test**
+
+在 `agent-runtime.client.test.ts` 增加：mock `fetch` 断言 `POST .../v1/runs/cancel` body 为 snake_case，响应映射为 camelCase。
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/server && pnpm exec vitest run src/agent/agent-runtime.client.test.ts -t cancel`  
+Expected: FAIL
+
+- [ ] **Step 3: Implement DTO + client + service + controller**
+
+```typescript
+// dto/cancel-run.dto.ts
+import { IsIn, IsOptional, IsString, MinLength } from 'class-validator'
+
+export class CancelRunDto {
+  @IsString()
+  @MinLength(1)
+  threadId!: string
+
+  @IsString()
+  @MinLength(1)
+  sessionId!: string
+
+  @IsOptional()
+  @IsIn(['user', 'timeout'])
+  reason?: 'user' | 'timeout'
+}
+```
+
+Controller（`AuthGuard`）：
+
+```typescript
+  @Post('runs/cancel')
+  @UseGuards(AuthGuard)
+  async cancelRun(@Body() dto: CancelRunDto, @Req() req: Request & { user: { sub: string } }) {
+    await this.sessionsService.findOne(dto.sessionId, req.user.sub)
+    const data = await this.agentService.cancelRun(dto)
+    return { code: 0, message: 'ok', data }
+  }
+```
+
+Client：`POST ${base}/v1/runs/cancel`，headers 带 service token，body `{ thread_id, session_id, reason }`。
+
+`getThreadState` 类型增加 `runCancelled`；Runtime 已在 Task 4 的 `get_thread_state` 返回中加 `"runCancelled": bool(vals.get("run_cancelled"))`。
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd apps/server && pnpm exec vitest run src/agent/agent-runtime.client.test.ts -t cancel`  
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/server/src/agent/dto/cancel-run.dto.ts \
+  apps/server/src/agent/agent-runtime.client.ts \
+  apps/server/src/agent/agent.service.ts \
+  apps/server/src/agent/agent.controller.ts \
+  apps/server/src/agent/agent-runtime.client.test.ts
+git commit -m "feat(server): proxy POST /agent/runs/cancel to runtime"
+```
+
+---
+
+## Task 6: 前端 `cancelAgentRun`（先 API 后 abort）
+
+**Files:**
+- Create: `apps/web/src/components/agent/cancelAgentRun.ts`
+- Create: `apps/web/src/components/agent/cancelAgentRun.test.ts`
+- Modify: `packages/agent/src/types.ts` — `AgentStreamEvent.type` 增加 `'run_cancelled'`
+- Modify: `apps/web/src/components/agent/AgentSideRail.vue` — 替换 `cancelActiveStream`
+
+**Interfaces:**
+- Produces:
+  ```typescript
+  export async function cancelAgentRun(opts: {
+    threadId: string
+    sessionId: string
+    abort: () => void
+    postCancel?: (body: { threadId: string; sessionId: string; reason: 'user' }) => Promise<unknown>
+  }): Promise<{ apiOk: boolean; skipped?: boolean }>
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// cancelAgentRun.test.ts
+import { describe, expect, it, vi } from 'vitest'
+import { cancelAgentRun } from './cancelAgentRun'
+
+describe('cancelAgentRun', () => {
+  it('calls API then abort even if API fails', async () => {
+    const abort = vi.fn()
+    const postCancel = vi.fn().mockRejectedValue(new Error('network'))
+    const result = await cancelAgentRun({
+      threadId: 't1',
+      sessionId: 's1',
+      abort,
+      postCancel,
+    })
+    expect(postCancel).toHaveBeenCalledWith({ threadId: 't1', sessionId: 's1', reason: 'user' })
+    expect(abort).toHaveBeenCalled()
+    expect(result.apiOk).toBe(false)
+  })
+
+  it('reports skipped when runtime skips non-PV', async () => {
+    const abort = vi.fn()
+    const postCancel = vi.fn().mockResolvedValue({
+      code: 0,
+      data: { ok: true, skipped: true, reason: 'flow_not_supported' },
+    })
+    const result = await cancelAgentRun({
+      threadId: 't1',
+      sessionId: 's1',
+      abort,
+      postCancel,
+    })
+    expect(result.apiOk).toBe(true)
+    expect(result.skipped).toBe(true)
+    expect(abort).toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm exec vitest run src/components/agent/cancelAgentRun.test.ts`  
+Expected: FAIL
+
+- [ ] **Step 3: Implement + wire SideRail**
+
+```typescript
+// cancelAgentRun.ts
+export async function cancelAgentRun(opts: {
+  threadId: string
+  sessionId: string
+  abort: () => void
+  postCancel?: (body: { threadId: string; sessionId: string; reason: 'user' }) => Promise<unknown>
+}): Promise<{ apiOk: boolean; skipped?: boolean }> {
+  let apiOk = false
+  let skipped: boolean | undefined
+  try {
+    if (opts.postCancel) {
+      const res = (await opts.postCancel({
+        threadId: opts.threadId,
+        sessionId: opts.sessionId,
+        reason: 'user',
+      })) as { data?: { ok?: boolean; skipped?: boolean } }
+      apiOk = res?.data?.ok !== false
+      skipped = res?.data?.skipped
+    }
+  } catch {
+    apiOk = false
+  } finally {
+    opts.abort()
+  }
+  return { apiOk, skipped }
+}
+```
+
+`AgentSideRail.vue`：
+
+```typescript
+async function cancelActiveStream() {
+  if (!agent.isStreaming) return
+  const { apiOk } = await cancelAgentRun({
+    threadId: agentThreadId.value,
+    sessionId: props.sessionId,
+    abort: () => {
+      streamAbortController?.abort()
+      agentStream.stop()
+      agent.finishStreaming()
+    },
+    postCancel: (body) =>
+      fetch(apiUrl('/api/agent/runs/cancel'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(3000),
+      }).then((r) => r.json()),
+  })
+  ElMessage.info(apiOk ? '已停止当前任务，您可以发送新需求' : '已断开回复，后台可能仍在收尾')
+}
+```
+
+处理 SSE：`event.type === 'run_cancelled'` 时设置本地 `runCancelled` / 展示 presentation（若 data 含 text）。
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd apps/web && pnpm exec vitest run src/components/agent/cancelAgentRun.test.ts`  
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/agent/cancelAgentRun.ts \
+  apps/web/src/components/agent/cancelAgentRun.test.ts \
+  apps/web/src/components/agent/AgentSideRail.vue \
+  packages/agent/src/types.ts
+git commit -m "feat(web): cancelAgentRun calls backend before aborting SSE"
+```
+
+---
+
+## Task 7: `classify_post_cancel_intent` + revise/new_task CLEAR
+
+**Files:**
+- Create: `services/agent-runtime/app/graph/post_cancel.py`
+- Create: `services/agent-runtime/tests/test_post_cancel_intent.py`
+- Modify: `services/agent-runtime/app/graph/hitl_resume.py` — 导出/复用 `should_resume_interrupt`、`build_fresh_turn_command`（post_cancel 调用即可，可不改）
+
+**Interfaces:**
+- Produces:
+  ```python
+  PostCancelIntent = Literal["gate_resume", "revise", "new_task"]
+
+  def classify_post_cancel_intent(
+      message: str,
+      *,
+      next_nodes: list[str],
+      user_decision: str | None = None,
+      run_cancelled: bool,
+      phase: str | None,
+  ) -> PostCancelIntent | None:
+      """None = not a post-cancel turn (caller uses normal path)."""
+
+  def build_revise_turn_command(*, phase_hint: str | None, update: dict[str, Any]) -> Command: ...
+  def revise_state_clear_for_phase(phase: str | None) -> dict[str, Any]: ...
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# services/agent-runtime/tests/test_post_cancel_intent.py
+from app.graph.post_cancel import classify_post_cancel_intent, revise_state_clear_for_phase
+
+
+def test_new_task_chip():
+    assert (
+        classify_post_cancel_intent(
+            "__new_task__",
+            next_nodes=[],
+            run_cancelled=True,
+            phase="cancelled",
+        )
+        == "new_task"
+    )
+
+
+def test_gate_resume_after_cancel():
+    assert (
+        classify_post_cancel_intent(
+            "确认出图",
+            next_nodes=["await_shot_topo_confirm"],
+            run_cancelled=True,
+            phase="cancelled",
+        )
+        == "gate_resume"
+    )
+
+
+def test_revise_phrase():
+    assert (
+        classify_post_cancel_intent(
+            "换成白底风格",
+            next_nodes=[],
+            run_cancelled=True,
+            phase="cancelled",
+        )
+        == "revise"
+    )
+
+
+def test_long_ref_is_new_task():
+    msg = "请用 @I1 帮我做另一套耳机主图方案并出白底图"
+    assert (
+        classify_post_cancel_intent(
+            msg,
+            next_nodes=[],
+            run_cancelled=True,
+            phase="cancelled",
+        )
+        == "new_task"
+    )
+
+
+def test_not_post_cancel_returns_none():
+    assert (
+        classify_post_cancel_intent(
+            "你好",
+            next_nodes=[],
+            run_cancelled=False,
+            phase="done",
+        )
+        is None
+    )
+
+
+def test_revise_clear_generating_keeps_macro_clears_gen():
+    clear = revise_state_clear_for_phase("orchestrate_gen")
+    assert "gen_completed_keys" in clear  # reset to None
+    assert clear.get("selected_macro_scheme_ids") is None or "selected_macro_scheme_ids" not in clear
+    # selected_macro should NOT be in clear dict (keep) — only keys to overwrite appear
+    assert "macro_schemes" not in clear or clear.get("macro_schemes") is not None
+```
+
+按 spec §4.3 实现 `revise_state_clear_for_phase`：返回**需要写入的覆盖字段**（清空用 `None`），保留字段不出现在 dict 中。
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd services/agent-runtime && uv run pytest tests/test_post_cancel_intent.py -v`  
+Expected: FAIL
+
+- [ ] **Step 3: Implement classifiers**
+
+优先级严格按 spec §4.2。改意图词 / 新任务词用模块级常量。`build_revise_turn_command`：
+
+```python
+def build_revise_turn_command(*, phase_hint: str | None, update: dict[str, Any]) -> Command:
+    clear = revise_state_clear_for_phase(phase_hint)
+    # Prefer jump to intake for safety in PV-1; refine goto per phase table in PV-2 if tests demand.
+    return Command(goto="intake", update={**clear, "run_cancelled": None, "cancel_reason": None, "phase": None, **update})
+```
+
+首期 revise **统一 `goto="intake"`** 并带 CLEAR 表，避免错误跳 gate；UAT-02 验收「保留上游字段」靠 CLEAR 表不删 `selected_macro_scheme_ids` / `shot_manifest`（按 phase 分档）。若 `phase_hint` 为 `orchestrate_gen`，CLEAR gen_* 与 `delivery_selections`，保留 macro/shot。
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd services/agent-runtime && uv run pytest tests/test_post_cancel_intent.py -v`  
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/agent-runtime/app/graph/post_cancel.py \
+  services/agent-runtime/tests/test_post_cancel_intent.py
+git commit -m "feat(runtime): classify post-cancel intent revise vs new_task"
+```
+
+---
+
+## Task 8: Wire `runs.py` 下一轮分流 + thread-state
+
+**Files:**
+- Modify: `services/agent-runtime/app/runs.py`
+- Modify: `services/agent-runtime/tests/test_hitl_resume.py` 或新增 `tests/test_runs_post_cancel.py`（用 MemorySaver 模拟 cancelled checkpoint + 新消息）
+
+**Interfaces:**
+- Consumes: Task 7 classifiers；现有 `should_resume_interrupt` / `build_fresh_turn_command` / `prepare_interrupt_resume`
+
+- [ ] **Step 1: Write failing integration-style unit test**
+
+```python
+# services/agent-runtime/tests/test_runs_post_cancel.py
+import pytest
+from langgraph.checkpoint.memory import MemorySaver
+from langchain_core.messages import HumanMessage
+
+# Prefer testing classify+command wiring via a small helper extracted from stream_run_events:
+# resolve_turn_input(pre_vals, next_nodes, message, user_decision, turn_update) -> input_state
+
+from app.runs import resolve_turn_input  # extract in Step 3 if not present
+
+
+def test_resolve_turn_input_new_task_after_cancel():
+    pre = {"phase": "cancelled", "run_cancelled": True, "flow_mode": "product_visual", "shot_manifest": [{"shot_id": "s1"}]}
+    turn_update = {"messages": [HumanMessage(content="__new_task__")], "session_id": "s"}
+    inp = resolve_turn_input(pre, [], "__new_task__", None, turn_update)
+    # Command to intake with cleared shot
+    assert inp.goto == "intake"
+    assert inp.update.get("shot_manifest") is None or "shot_manifest" in inp.update
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `cd services/agent-runtime && uv run pytest tests/test_runs_post_cancel.py -v`  
+Expected: FAIL
+
+- [ ] **Step 3: Extract `resolve_turn_input` and call from `stream_run_events`**
+
+在现有 `is_gate_resume` 分支**之前**：
+
+```python
+    from app.graph.post_cancel import (
+        classify_post_cancel_intent,
+        build_revise_turn_command,
+    )
+    from app.graph.hitl_resume import build_fresh_turn_command, should_resume_interrupt, ...
+
+    intent = classify_post_cancel_intent(
+        req.message,
+        next_nodes=list(next_nodes),
+        user_decision=req.user_decision,
+        run_cancelled=bool(pre_vals.get("run_cancelled")) or pre_vals.get("phase") == "cancelled",
+        phase=str(pre_vals.get("phase") or "") or None,
+    )
+    if intent == "new_task":
+        input_state = build_fresh_turn_command(update=turn_update)
+    elif intent == "revise":
+        input_state = build_revise_turn_command(
+            phase_hint=str(pre_vals.get("phase") or "") or None,
+            update=turn_update,
+        )
+    elif intent == "gate_resume":
+        # existing gate resume path
+        ...
+    elif next_nodes and is_gate_resume:
+        ...
+    elif next_nodes:
+        input_state = build_fresh_turn_command(update=turn_update)
+    else:
+        input_state = turn_update
+```
+
+`get_thread_state` 增加：
+
+```python
+        "runCancelled": bool(vals.get("run_cancelled")) if vals.get("run_cancelled") is not None else None,
+```
+
+且 `finished` 在 `phase_str == "cancelled"` 时为 `False`（可继续对话）。
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd services/agent-runtime && uv run pytest tests/test_runs_post_cancel.py tests/test_post_cancel_intent.py tests/test_hitl_resume.py -v`  
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add services/agent-runtime/app/runs.py services/agent-runtime/tests/test_runs_post_cancel.py
+git commit -m "feat(runtime): wire post-cancel intent into turn resolution"
+```
+
+---
+
+## Task 9: 侧栏 cancelled UX +「发起新任务」chip
+
+**Files:**
+- Modify: `apps/web/src/components/agent/AgentSideRail.vue`
+- Modify: `apps/web/src/components/agent/agentInterruptGate.ts`（如需从 thread-state 解析 cancelled）
+- Modify: `apps/web/src/components/agent/agentInterruptGate.test.ts`
+- Modify: `apps/server/src/agent/agent-runtime.client.ts` — `RuntimeThreadState.runCancelled`（若 Task 5 未加）
+
+**Interfaces:**
+- Consumes: `presentation.kind === 'callout_info'`；`runCancelled` / `phase === 'cancelled'`
+- Produces: chip 发送 `message: '__new_task__'`（经 `sendMessage`，**新** idempotency key）
+
+- [ ] **Step 1: Write failing test for gate helper**
+
+```typescript
+// agentInterruptGate.test.ts 追加
+import { isRunCancelledState } from './agentInterruptGate'
+
+it('detects cancelled thread state', () => {
+  expect(isRunCancelledState({ phase: 'cancelled', runCancelled: true })).toBe(true)
+  expect(isRunCancelledState({ phase: 'done', runCancelled: false })).toBe(false)
+})
+```
+
+- [ ] **Step 2: Run to fail**
+
+Run: `cd apps/web && pnpm exec vitest run src/components/agent/agentInterruptGate.test.ts -t cancelled`  
+Expected: FAIL
+
+- [ ] **Step 3: Implement UI**
+
+```typescript
+export function isRunCancelledState(s: { phase?: string | null; runCancelled?: boolean | null } | null): boolean {
+  if (!s) return false
+  return s.runCancelled === true || s.phase === 'cancelled'
+}
+```
+
+在 `AgentSideRail.vue`：
+
+- `const showCancelledCallout = computed(() => isRunCancelledState(...) || localRunCancelled)`
+- 展示 `presentation.body.text` 或默认文案
+- 按钮：`发起新任务` → `sendMessage('__new_task__')`
+- 重连 `thread-state` 时若 cancelled，设置 callout，**不要**当成 HITL interrupt 挡发送
+- `send()` 在 cancelled 后照常；确保 `buildIdempotencyKey` 每次新 key（已有则确认取消不会复用 processing 缓存）
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd apps/web && pnpm exec vitest run src/components/agent/agentInterruptGate.test.ts src/components/agent/cancelAgentRun.test.ts`  
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/agent/AgentSideRail.vue \
+  apps/web/src/components/agent/agentInterruptGate.ts \
+  apps/web/src/components/agent/agentInterruptGate.test.ts \
+  apps/server/src/agent/agent-runtime.client.ts
+git commit -m "feat(web): cancelled callout and new-task chip after mid-run stop"
+```
+
+---
+
+## Task 10: 回归清单与手动 UAT 记录
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-08-12-agent-mid-run-interrupt-design.md` — §七 UAT 旁注「实现 PR」勾选说明（可选）
+- Create: （可选）`deploy/prod-mid-run-interrupt-pv-verify.py` 仅当团队惯例需要 prod smoke；**本 Task 默认不做脚本**，只跑本地套件
+
+- [ ] **Step 1: Run full related suite**
+
+```bash
+cd services/agent-runtime && uv run pytest \
+  tests/test_run_cancel_registry.py \
+  tests/test_cancel_checkpoint.py \
+  tests/test_gen_scheduler_cancel.py \
+  tests/test_runs_cancel_api.py \
+  tests/test_post_cancel_intent.py \
+  tests/test_runs_post_cancel.py \
+  tests/test_hitl_resume.py -v
+
+cd apps/server && pnpm exec vitest run src/agent/agent-runtime.client.test.ts
+
+cd apps/web && pnpm exec vitest run \
+  src/components/agent/cancelAgentRun.test.ts \
+  src/components/agent/agentInterruptGate.test.ts
+```
+
+Expected: 全部 PASS
+
+- [ ] **Step 2: Manual UAT checklist（staging）**
+
+对照 spec：UAT-INT-PV-01～07，在 PR 描述中逐条勾选。
+
+- [ ] **Step 3: Commit**（若有文档勾选更新）
+
+```bash
+git add docs/superpowers/specs/2026-08-12-agent-mid-run-interrupt-design.md
+git commit -m "docs: note mid-run PV UAT checklist for implementation PR"
+```
+
+---
+
+## Spec coverage (self-review)
+
+| Spec 项 | Task |
+|---------|------|
+| Run Cancel Token / Registry | T1 |
+| `phase=cancelled` + presentation callout | T2, T4, T9 |
+| `gen_scheduler` 停派发 + 在途 cancel | T3 |
+| `POST /v1/runs/cancel` + 幂等 + 非 PV skipped | T4 |
+| Nest 代理 | T5 |
+| 前端先 cancel 再 abort | T6 |
+| 启发式 classify + revise/new_task CLEAR | T7–T8 |
+| 新任务 chip / thread-state | T9 |
+| UAT-INT-PV-01～07 | T10 |
+| Expand-B atomic/campaign | **明确不在本 plan** |
+| LLM 分类 / Dock 统一取消 | **非目标** |
+
+**Placeholder scan:** 无 TBD；revise 首期统一 `goto=intake` + CLEAR 表（已写明，避免错误跳 gate）。
+
+**Type consistency:** `run_cancelled` / `runCancelled`、`CancelRunRequest`/`CancelRunDto`、`__new_task__` 全文一致。
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-09-06-agent-mid-run-interrupt-pv.md`.
+
+**Two execution options:**
+
+1. **Subagent-Driven (recommended)** — 每 Task 派一个新 subagent，Task 间审查，迭代快  
+2. **Inline Execution** — 本会话用 executing-plans 按 Task 批量推进并设检查点  
+
+Which approach?

--- a/docs/superpowers/specs/2026-08-12-agent-mid-run-interrupt-design.md
+++ b/docs/superpowers/specs/2026-08-12-agent-mid-run-interrupt-design.md
@@ -141,7 +141,7 @@ classify_post_cancel_intent → gate_resume | revise | new_task
 取消收口写：
 
 - `phase: "cancelled"`
-- `run_cancelled: true`、`cancel_reason: "user"`
+- `run_cancelled: true`、`cancel_reason: "user"`、`cancelled_from_phase: <取消前阶段>`（供 §4.3 revise 分档）
 - `presentation: callout_info`（人话）
 - gen 通道：未派发标 cancelled；在途 best-effort cancel
 - **不**清画布节点 / 本会话附件 SSOT
@@ -179,12 +179,16 @@ classify_post_cancel_intent → gate_resume | revise | new_task
 
 原则：**改意图不丢已确认的上游门控结果；下游未确认产物可作废。**
 
+分档依据是 `cancelled_from_phase`（`phase` 已被覆写成 `cancelled`，不能用作依据）；缺失时退化为最保守的 QA 及下游全清。
+
+**gate_resume** → 清 `run_cancelled` / `cancel_reason` / `cancelled_from_phase`，并把 `phase` 恢复为 `cancelled_from_phase`，其余一律保留。
+
 ### 4.4 侧栏 UX
 
 | 状态 | 生成钮 | Composer | 提示 |
 |------|--------|----------|------|
 | streaming（含 generating） | ⏹ 停止 | disabled | 现有 banner |
-| cancelled | ↑ 发送 | enabled | callout +「发起新任务」chip |
+| cancelled | ↑ 发送 | enabled | callout +「发起新任务」chip；若仍有 pending 门控，门控 chips 同时保留在 callout 下方 |
 | await_* 门控 | ↑ / 确认 chips | enabled | 现有 HITL；未 new_task 时可继续确认 |
 
 ---
@@ -211,6 +215,7 @@ Nest → Runtime：`POST /v1/runs/cancel`（`thread_id` / `session_id` / `reason
 
 - 幂等：重复 cancel → `ok: true`
 - 无活跃 run：仍 `ok: true`
+- 无活跃 run 且停在 `interrupt_before` 门控：**不写** cancelled checkpoint（否则 `next` 被抹掉、门控再也答不了），返回 `ok: true, gate_preserved: true, next_nodes: [...]`，`phase` 为当前门控；callout 由前端本地状态渲染，门控 chips 继续可用（UAT-INT-PV-05）
 - 非 PV 首期：可 `ok: true, skipped: true, reason: "flow_not_supported"`（Expand-B 再接）
 
 ### 5.2 Runtime cancel 步骤

--- a/docs/superpowers/specs/2026-08-12-agent-mid-run-interrupt-design.md
+++ b/docs/superpowers/specs/2026-08-12-agent-mid-run-interrupt-design.md
@@ -1,19 +1,31 @@
 # Agent 运行中中断与改意图 — 设计规格
 
-> **状态**：草案待审  
-> **日期**：2026-08-12  
+> **状态**：Accepted（PV 首期）  
+> **初稿**：2026-08-12  
+> **Accepted**：2026-09-06  
 > **触发**：UX-PV 交付后用户反馈 — 任务进行中无法随时中断、点生成钮改发新需求、系统识别意图再执行  
 > **读者**：产品、前端、Agent Runtime、Nest API  
 > **前置**：  
 > - [2026-08-11-agent-conversation-ux-product-visual-design.md](./2026-08-11-agent-conversation-ux-product-visual-design.md)  
 > - [2026-08-06-agent-sidebar-copy-design.md](./2026-08-06-agent-sidebar-copy-design.md)  
-> - LangGraph `interrupt_before` + checkpoint（W5 / P0-05）
+> - LangGraph `interrupt_before` + checkpoint（W5 / P0-05）  
+> - [2026-08-08-agent-canvas-control-surface-design.md](./2026-08-08-agent-canvas-control-surface-design.md)
 
 | 字段 | 值 |
 |------|-----|
-| 文档版本 | v1.0 |
-| 适用范围 | 侧栏 Agent 全 flow（product_visual / campaign / atomic / explore）；**P0 实现聚焦 product_visual v2 + atomic** |
-| 非范围 | 画布 Dock 单节点生成取消（已有 `cancel_generation` explore 路径）；多 thread 并行；Cloud Agent |
+| 文档版本 | v2.0 |
+| 首期范围 | **`product_visual` only**：真正停止 + 启发式改意图协议 |
+| 后续 | **Expand-B**：同一 cancel 协议扩 atomic → campaign → explore |
+| 非范围 | Dock 单节点取消（已有 `cancel_generation`）；多 thread 并行；Cloud Agent；LLM 意图分类；自动猜「改主意」 |
+
+**产品决策（2026-09-06 brainstorming）**
+
+| # | 决策 |
+|---|------|
+| D1 | 交付深度 = 停止 + 改意图协议（含 callout / 新任务 chip），非仅 abort SSE |
+| D2 | 首期只做 `product_visual`；完成后再扩全 flow |
+| D3 | 改意图分类用**启发式 +「发起新任务」chip**（不用 LLM 分类器；取消后不一律 fresh intake） |
+| D4 | 实现采用 **Run Cancel Token**（方案 1），不用懒取消或弃 thread |
 
 ---
 
@@ -23,85 +35,51 @@
 
 ```
 任务进行中（出图/写方案/任意阶段）
-  → 用户点侧栏右下角「生成」钮（或等价中断）
+  → 用户点侧栏右下角「停止」
   → 当前 run 安全停止
   → 用户输入新话术
-  → 系统理解新意图（继续 / 修改 / 全新任务）
-  → 执行对应 flow，上下文衔接清晰
+  → 系统理解：门控续跑 / 改意图 / 全新任务
+  → 执行对应路径，上下文衔接清晰
 ```
 
 ### 1.2 现状与缺口
 
-| 环节 | 现状（2026-08-12 前） | v2.1 补丁 | 仍缺 |
-|------|----------------------|-----------|------|
-| 前端取消 | 生成钮文案「点击取消」但 `send()` 直接 return | ✅ abort SSE + toast | 后端 run / 出图未停 |
-| 流式中发新话 | composer disabled | 取消后可输入 | 无统一「改意图」协议 |
-| 门控中改意图 | `should_resume_interrupt` 短句 resume；长句 `@ref` → fresh restart | 部分可用 | 规则不透明、无确认 |
-| 出图阶段 | 无 `interrupt_before` | — | 无法 cancel in-flight gen |
-| 意图路由 | 仅 `intake` 节点 | fresh restart 清 checkpoint | 运行中无 REPL 式改道 |
+| 环节 | 现状 | 仍缺 |
+|------|------|------|
+| 前端取消 | abort SSE + toast（Phase 0） | 后端 run / 出图未停 |
+| 流式中发新话 | 取消后可输入 | 无统一「改意图」协议 |
+| 门控中改意图 | `should_resume_interrupt` / fresh restart 部分可用 | 规则不透明；与 cancel 未串联 |
+| 出图阶段 | `gen_scheduler` 无 cancel flag | 无法协作停派发 + 在途 cancel |
+| 意图路由 | 仅 intake / gate 路径 | 取消后无 `classify_post_cancel_intent` |
 
 **根因：** 系统是 **checkpoint 续跑 + 固定 HITL 门控**，不是 **可任意打断的对话式 REPL**。
 
 ---
 
-## 二、设计目标与非目标
+## 二、目标与非目标
 
-### 2.1 目标（Must）
+### 2.1 目标（Must，PV 首期）
 
-1. **任意可见阶段**，用户可显式 **中断当前 Agent turn**（侧栏生成钮 / Esc / 可选「停止」chip）。
-2. 中断后 **≤3s** 内 composer 可输入；发送新话时 **明确识别**：门控回复 / 改意图 / 新任务。
-3. **出图阶段**中断时：停止调度新节点 + 取消进行中的 generation record（best-effort）。
-4. 改意图后 **状态清理可预测**（哪些保留、哪些清空）+ 侧栏 **一句摘要**说明。
-5. product_visual v2 与 atomic_create **UAT 可验收**（§六）。
+1. **PV 任意可见阶段**，用户可显式中断当前 Agent turn（侧栏停止钮；Esc 可选）。
+2. 中断后 **≤3s** 内 composer 可输入；发送新话时明确识别：门控回复 / 改意图 / 新任务。
+3. **出图阶段**中断：停止调度新节点 + 取消进行中的 generation record（best-effort）。
+4. 改意图后状态清理可预测（§四字段表）+ 侧栏一句摘要。
+5. UAT 表（§七）可验收。
 
 ### 2.2 非目标（Won't，本期）
 
-- 同一 thread 两路 run **并行**执行  
-- 自动猜测用户是否「改主意」（须显式中断或门控规则命中）  
-- 画布 Dock 底部生成栏与侧栏 Agent **统一取消**（可二期对齐 UX）  
-- Campaign 全链路（可复用协议，implementation P2）
+- 同一 thread 两路 run **并行**
+- 自动猜测用户是否「改主意」（须显式中断或门控规则命中）
+- 画布 Dock 与侧栏 Agent **统一取消**
+- Campaign / atomic / explore 全链路（Expand-B）
+- LLM 意图分类器
+- 上游 provider 保证秒级杀进程
 
 ---
 
-## 三、方案对比与推荐
+## 三、架构（Run Cancel Token）
 
-### 方案 A — 前端 abort + 后端 noop（现状增强）
-
-仅断 SSE；后端 LangGraph 继续跑到下一 interrupt 或 END。
-
-| 优点 | 缺点 |
-|------|------|
-| 改动最小 | 出图继续、积分消耗、改意图不可靠 |
-| 已部分落地 | 不符合用户「中断任务」语义 |
-
-**结论：** 仅作 **Phase 0 过渡**（v2.1 已做），不是终态。
-
-### 方案 B — Run Cancel Token + Checkpoint 分支（推荐）
-
-引入 **Run 级 cancel flag**；前端 abort 调 `POST /api/agent/runs/cancel`；Runtime 在节点边界 / gen scheduler 轮询 cancel，跳转到 **`intake` 或 `done(aborted)`**；新消息走正常 intake。
-
-| 优点 | 缺点 |
-|------|------|
-| 语义清晰、可测 | 需 Runtime + Nest 协作 |
-| 与 LangGraph checkpoint 兼容 | gen 中途 cancel 需 nest cancel API |
-| 可渐进 rollout | |
-
-### 方案 C — 每轮新 thread
-
-中断 = 新 `threadId`；旧 thread 遗弃。
-
-| 优点 | 缺点 |
-|------|------|
-| 无 checkpoint 污染 | 丢失画布 SSOT / 定稿上下文 |
-| | 与「同画布续聊」产品方向冲突 |
-
-**推荐：方案 B**，分三期交付（§七）。
-
----
-
-## 四、架构（方案 B）
-
-### 4.1 组件与职责
+### 3.1 序列
 
 ```mermaid
 sequenceDiagram
@@ -111,130 +89,200 @@ sequenceDiagram
   participant RT as Agent Runtime
   participant Gen as Studio/Gen
 
-  U->>Web: 点击生成钮(取消)
-  Web->>Nest: POST /agent/runs/cancel {threadId}
+  U->>Web: 点击停止
+  Web->>Nest: POST /agent/runs/cancel {threadId, sessionId}
   Nest->>RT: POST /v1/runs/cancel
-  RT->>RT: set cancel_flag on thread
-  RT->>Gen: cancel_generation (in-flight nodes)
-  RT-->>Web: SSE run_cancelled (或 abort 后 thread-state)
-  U->>Web: 输入新话术 + 生成
+  RT->>RT: RunCancelRegistry.set(thread_id)
+  RT->>Gen: cancel_generation (in-flight nodes, best-effort)
+  RT-->>Web: SSE run_cancelled 或 abort 后 thread-state
+  U->>Web: 输入新话术 + 发送
   Web->>Nest: POST /agent/chat/conversation
-  Nest->>RT: POST /v1/runs {message, threadId}
-  RT->>RT: intake → decide_route → ...
+  Nest->>RT: POST /v1/runs
+  RT->>RT: classify_post_cancel_intent → gate_resume / revise / new_task
 ```
 
-| 层 | 新增/变更 |
-|----|-----------|
-| **Web** | `cancelActiveStream()` 升级为 `cancelAgentRun()`；取消后 composer 解锁；可选 `改意图` callout |
-| **Nest** | 代理 `POST /v1/runs/cancel`；传递 `sessionId` / `threadId` |
-| **Runtime** | `RunCancelRegistry`；`gen_scheduler` / 长节点协作式取消；cancel 后 checkpoint 写入 `phase: cancelled` |
-| **State** | `run_cancelled: bool`、`cancel_reason: user \| timeout` |
+### 3.2 组件职责
 
-### 4.2 中断后新消息的意图分类
+| 层 | 变更 |
+|----|------|
+| **Web** | `cancelActiveStream()` → `cancelAgentRun()`：先 cancel API，再 abort；cancelled callout +「发起新任务」chip |
+| **Nest** | 代理 `POST /v1/runs/cancel`；thread-state 透传 `runCancelled` / `phase=cancelled` |
+| **Runtime** | `RunCancelRegistry`；`gen_scheduler` / 长节点协作取消；cancel 后 checkpoint 收口；`classify_post_cancel_intent` |
+| **State** | `phase` 增 `cancelled`；`run_cancelled`；`cancel_reason` |
 
-在现有 `should_resume_interrupt` **之前**增加：
+### 3.3 出图阶段取消（PV）
 
-```
-if run_was_cancelled or explicit_new_task_marker:
-    → Command(goto="intake", update=FRESH_TURN_STATE_CLEAR + message)
+`gen_scheduler` 在波次边界 in-flight=0，适合协作式取消：
 
-elif next_nodes and should_resume_interrupt(message):
-    → 现有 gate resume
+1. 每 wave 派发前读 `cancel_flag` → 不再 `Send` 新 `gen_node`
+2. 对已派发节点：Nest `cancel_generation(node_id)`（与 explore 共用）
+3. checkpoint：`phase=cancelled`，presentation callout「已停止出图，已完成 a/b」
+4. 进度卡剩余项标 `cancelled`
 
-elif next_nodes and long_message_with_refs:
-    → 现有 fresh restart
-
-else:
-    → 正常 turn_update（续跑）
-```
-
-**显式新任务标记（任一）：**
-
-- 用户在中断后首条消息 ≥12 字且 **不** 命中门控关键词  
-- 消息以 `@T`/`@I` 引用开头  
-- 用户点「发起新任务」chip（message=`__new_task__`）
-
-**改意图 vs 全新任务（product_visual）：**
-
-| 用户话术倾向 | 策略 | 保留 state |
-|--------------|------|------------|
-| 「换成白底风格」「不要礼盒了」 | 改意图续 thread | `effective_utterance`、附件、`visual_intent` 部分 |
-| 「帮我做另一套耳机主图」 | 新任务 | 清空 SSOT/shot/delivery；保留 session 画布 |
-| 门控短回复「确认出图」 | gate resume | 不清 |
-
-### 4.3 出图阶段取消
-
-1. `gen_scheduler` 每 wave 前读 `cancel_flag` → 停止 Send 新 `gen_node`  
-2. 对已 dispatch 的 node：调 Nest `cancel_generation(node_id)`（与 explore 共用）  
-3. 写 checkpoint：`phase=cancelled`，`presentation` = callout「已停止出图，已完成 a/b」  
-4. `task_progress_card` 标记剩余项 `cancelled`
-
-### 4.4 侧栏 UX 规范
-
-| 状态 | 生成钮 | Composer | 提示 |
-|------|--------|----------|------|
-| streaming | ⏹ 停止 | disabled | — |
-| 已取消 / 门控 | ↑ 发送 | enabled | callout：「已停止。直接说新需求，或点上方按钮继续当前步骤。」 |
-| 出图中 | ⏹ 停止 | disabled | banner 已有「请勿切 tab」 |
-
-**与 UX-PV 关系：** `generating` 阶段主按钮从占位「取消生成」改为 **真实 cancel**（本规格 Phase 1）。
+长节点（非 gen）入口同样读 flag → 跳转 cancelled 收口，不进入下一门控。
 
 ---
 
-## 五、API 草案
+## 四、状态机与改意图字段表
 
-### 5.1 `POST /v1/runs/cancel`
+### 4.1 运行态
+
+```
+streaming_active
+  ├─ gate_waiting   (interrupt_before)
+  ├─ planning       (dialog_draft / decompose / …)
+  └─ generating     (start_gen → gen_scheduler ⇄ gen_node → collect_gen)
+         ↓ 用户停止
+phase = cancelled, run_cancelled = true
+         ↓ 用户再发话
+classify_post_cancel_intent → gate_resume | revise | new_task
+```
+
+取消收口写：
+
+- `phase: "cancelled"`
+- `run_cancelled: true`、`cancel_reason: "user"`
+- `presentation: callout_info`（人话）
+- gen 通道：未派发标 cancelled；在途 best-effort cancel
+- **不**清画布节点 / 本会话附件 SSOT
+
+### 4.2 取消后意图分类（启发式，优先级自上而下）
+
+| 优先级 | 条件 | 结果 |
+|--------|------|------|
+| 1 | 消息 = `__new_task__` 或点「发起新任务」chip | **new_task** |
+| 2 | 仍有 `next` 门控 **且** `should_resume_interrupt` = true | **gate_resume** |
+| 3 | 命中改意图词且非新任务词 | **revise** |
+| 4 | ≥12 字 + `@T/@I/...`，或明确新任务词 | **new_task** |
+| 5 | 其余 ≥12 字自由需求（取消后首条） | **new_task**（偏安全） |
+| 6 | 短句且无门控 | 含改意图词 → **revise**；否则 **new_task** + callout 提示可用 chip |
+
+**改意图词（首期）：** `换成|改成|改为|不要|去掉|调整|修改|改一下|换成白底|只要…`  
+**新任务词：** `另一套|重新做|新任务|换个产品|帮我做一套|从头`
+
+取消后**不在** generating 中途直接吃改意图（先停再发）。与 `thread_busy` 对齐：停止解锁后再分类。
+
+`runs.py` 入口顺序：若 `run_cancelled` 或 `phase=cancelled` → `classify_post_cancel_intent` → 分支；成功开跑后清 `run_cancelled`。
+
+### 4.3 字段保留 / 清空
+
+**new_task** → 复用并扩展 `FRESH_TURN_STATE_CLEAR`，额外清 `run_cancelled`、`cancel_reason`、gen_* 全套、`journey_trace`、`presentation`。保留 `messages`（追加）、`session_id` / `thread_id`；侧栏附件随本轮 `turn_update` 覆盖。
+
+**revise**（按取消时所在阶段分档）：
+
+| 取消时大致阶段 | 保留 | 清空 / 重置 | 回跳 |
+|----------------|------|-------------|------|
+| image_qa 前后 | 更新后的 `effective_utterance`、附件、`visual_intent` 骨架 | QA 决策、retake 旗 | `intake` 或 `await_image_qa` |
+| macro / scheme 附近 | utterance、附件、已过 QA 资产键；`macro_schemes` 草稿可选留 | `selected_macro_*`、shot、delivery、gen_* | `await_macro_scheme_select` 或 `dialog_draft` |
+| shot / topo 附近 | utterance、macro 已选、附件 | 可重分解 `shot_manifest`、gen_*、delivery | `decompose_from_ssot` / `await_shot_confirm` |
+| 出图中 / 出图后 | utterance、macro+shot SSOT、已完成节点 | gen 进度通道、部分 `delivery_selections` | 重跑未完成 shot；话术像整单重做 → 升 **new_task** |
+
+原则：**改意图不丢已确认的上游门控结果；下游未确认产物可作废。**
+
+### 4.4 侧栏 UX
+
+| 状态 | 生成钮 | Composer | 提示 |
+|------|--------|----------|------|
+| streaming（含 generating） | ⏹ 停止 | disabled | 现有 banner |
+| cancelled | ↑ 发送 | enabled | callout +「发起新任务」chip |
+| await_* 门控 | ↑ / 确认 chips | enabled | 现有 HITL；未 new_task 时可继续确认 |
+
+---
+
+## 五、API / SSE / 前端契约
+
+### 5.1 `POST /api/agent/runs/cancel`（Nest）
 
 ```json
 // Request
-{ "thread_id": "...", "session_id": "...", "reason": "user" }
+{ "threadId": "...", "sessionId": "...", "reason": "user" }
 
 // Response
-{ "ok": true, "cancelled_nodes": ["gen_node:white_bg", "..."], "phase": "cancelled" }
+{
+  "ok": true,
+  "phase": "cancelled",
+  "cancelledNodeIds": ["node_..."],
+  "completedTasks": 2,
+  "totalTasks": 5
+}
 ```
 
-幂等：重复 cancel 返回 `ok: true`。
+Nest → Runtime：`POST /v1/runs/cancel`（`thread_id` / `session_id` / `reason`）。
 
-### 5.2 SSE 事件（可选）
+- 幂等：重复 cancel → `ok: true`
+- 无活跃 run：仍 `ok: true`
+- 非 PV 首期：可 `ok: true, skipped: true, reason: "flow_not_supported"`（Expand-B 再接）
+
+### 5.2 Runtime cancel 步骤
+
+1. `RunCancelRegistry.set(thread_id, reason)`
+2. astream 协作退出（scheduler 波次前 / 长节点入口读 flag）
+3. 在途 PV 节点 `cancel_generation`
+4. checkpoint 写 §4.1 收口
+5. 若 SSE 仍连：发 `run_cancelled` 后结束；若前端已 abort：靠 thread-state
+
+### 5.3 SSE / thread-state
 
 ```json
-{ "type": "run_cancelled", "data": { "phase": "cancelled", "completed_tasks": 2, "total_tasks": 5 } }
+{ "type": "run_cancelled", "data": { "phase": "cancelled", "completedTasks": 2, "totalTasks": 5 } }
 ```
-
-### 5.3 thread-state 扩展
 
 ```json
 {
   "phase": "cancelled",
-  "run_cancelled": true,
-  "presentation": { "kind": "callout_info", "body": { "text": "..." } }
+  "runCancelled": true,
+  "interrupted": false,
+  "presentation": {
+    "kind": "callout_info",
+    "body": { "text": "已停止出图（完成 2/5）。直接说修改意见，或点「发起新任务」。" }
+  }
 }
 ```
 
+### 5.4 前端
+
+| 现状 | 升级 |
+|------|------|
+| 仅 abort SSE | `cancelAgentRun()`：先 POST cancel，再 abort；API 失败仍 abort + toast |
+| 无 cancelled UX | 消费 SSE / thread-state：callout +「发起新任务」chip |
+| — | 取消后下一轮 **新** idempotency key |
+
+### 5.5 错误与降级
+
+| 情况 | 行为 |
+|------|------|
+| cancel API 超时 / 5xx | 仍 abort；toast「后台可能仍在收尾」 |
+| 上游 gen 无法取消 | 节点标 cancelled/可能仍完成；UI 提示部分任务可能仍在后台结束 |
+| cancel 与 gate resume 竞态 | 用户先点确认 chip 且未停 → 现有 resume；先停再确认 → §4.2 |
+
 ---
 
-## 六、验收标准（UAT）
+## 六、分期
+
+| 阶段 | 范围 | 状态 |
+|------|------|------|
+| **Phase 0** | 前端 SSE abort + toast | ✅ 已交付 |
+| **Phase PV-1** | Cancel API + Registry + `gen_scheduler` 协作 + PV generating 收口 + thread-state/SSE | 首交付 |
+| **Phase PV-2** | `classify_post_cancel_intent` + revise/new_task 字段表 + callout + 新任务 chip | 紧随 PV-1（同属「停止+改意图」） |
+| **Expand-B** | 协议扩 atomic → campaign → explore | PV 验收后再开 |
+
+PV-1 / PV-2 可同一实现 PR 串行，验收按 §七分项勾选。
+
+**Implementation Plan：** 本 spec 用户审阅通过后，由 `writing-plans` 产出 `docs/superpowers/plans/2026-09-06-agent-mid-run-interrupt-pv.md`（或更新日期）。
+
+---
+
+## 七、验收标准（UAT）
 
 | UAT-ID | 场景 | Pass |
 |--------|------|------|
-| UAT-INT-01 | product_visual 出图中途点停止 | ≤5s 内无新节点 dispatch；进度卡停止增长 |
-| UAT-INT-02 | 停止后发全新话术（≥20 字） | 走 intake；旧 SSOT 不阻塞；侧栏无 machine payload |
-| UAT-INT-03 | 拓扑门控停止后点「确认出图」 | 仍 resume topo gate（未发新任务） |
-| UAT-INT-04 | atomic 单节点生成中停止 | `cancel_generation` 调用；节点非 generating |
-| UAT-INT-05 | 停止后立即重连 thread-state | phase=cancelled；composer 可用 |
-
----
-
-## 七、分期交付
-
-| 阶段 | 范围 | 依赖 |
-|------|------|------|
-| **Phase 0** | 前端 SSE abort + toast | ✅ v2.1 已交付 |
-| **Phase 1** | Cancel API + gen_scheduler 协作 + product_visual | Nest proxy + Runtime registry |
-| **Phase 2** | 改意图分类 + presentation callout + atomic | Phase 1 |
-| **Phase 3** | campaign / 门控中「新任务」确认 chip | Phase 2 |
-
-**Implementation Plan：** Phase 1 通过后由 `writing-plans` 产出 `docs/superpowers/plans/2026-08-12-agent-mid-run-interrupt.md`。
+| UAT-INT-PV-01 | PV 出图中点「停止」 | ≤5s 无新 `gen_node` 派发；进度卡停止增长；`phase=cancelled` |
+| UAT-INT-PV-02 | 停止后发改意图（如「换成白底风格」） | **revise**：保留已确认上游；侧栏一句说明 |
+| UAT-INT-PV-03 | 停止后点「发起新任务」或 `__new_task__` | **new_task**：PV SSOT/shot/delivery 清空；intake；画布可保留 |
+| UAT-INT-PV-04 | 停止后 ≥20 字新需求（含 `@I`） | **new_task**；旧 SSOT 不阻塞 |
+| UAT-INT-PV-05 | 门控下先停止，再点「确认出图」 | 仍在该 gate 且命中 resume → **gate_resume** |
+| UAT-INT-PV-06 | 停止后重连 thread-state | `runCancelled` + callout；composer 可用 |
+| UAT-INT-PV-07 | 重复停止 / cancel 幂等 | 两次 `ok: true`，无异常 |
 
 ---
 
@@ -242,10 +290,12 @@ else:
 
 | 风险 | 缓解 |
 |------|------|
-| cancel 后 checkpoint 半态 | 统一写 `phase=cancelled` + 明确 CLEAR 字段表 |
-| 上游 gen 无法取消 | best-effort + UI 标记「可能仍在生成」 |
-| 与 idempotency-key 冲突 | cancel 后下一轮新 idempotency key |
-| 误触停止 | 停止后 3s 内 toast + 可选 undo chip（P2） |
+| cancel 后 checkpoint 半态 | 统一 `phase=cancelled` + §4.3 表；单测 |
+| 上游 gen 杀不掉 | best-effort + UI 提示 |
+| 启发式误判 revise↔new_task | 显式 chip；UAT-02/03/04；日志 `post_cancel_intent` |
+| idempotency-key 冲突 | 取消后强制新 key |
+| 误触停止 | toast + callout；P2 再考虑「撤销停止」 |
+| 非 PV 误调 cancel | `skipped: flow_not_supported`，前端不报红 |
 
 ---
 
@@ -254,3 +304,4 @@ else:
 | 日期 | 版本 | 说明 |
 |------|------|------|
 | 2026-08-12 | v1.0 | 初稿：问题、方案 B、API、UAT、分期 |
+| 2026-09-06 | v2.0 | Accepted：收窄为 PV 首期；锁定启发式改意图 + Run Cancel Token；补状态机/字段表/UAT-PV；Expand-B 后置 |

--- a/docs/superpowers/specs/2026-08-12-agent-mid-run-interrupt-design.md
+++ b/docs/superpowers/specs/2026-08-12-agent-mid-run-interrupt-design.md
@@ -284,6 +284,15 @@ PV-1 / PV-2 可同一实现 PR 串行，验收按 §七分项勾选。
 | UAT-INT-PV-06 | 停止后重连 thread-state | `runCancelled` + callout；composer 可用 |
 | UAT-INT-PV-07 | 重复停止 / cancel 幂等 | 两次 `ok: true`，无异常 |
 
+**实现 PR 手动验收清单（staging，由人工执行）：**
+- [ ] UAT-INT-PV-01
+- [ ] UAT-INT-PV-02
+- [ ] UAT-INT-PV-03
+- [ ] UAT-INT-PV-04
+- [ ] UAT-INT-PV-05
+- [ ] UAT-INT-PV-06
+- [ ] UAT-INT-PV-07
+
 ---
 
 ## 八、风险与缓解

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -60,6 +60,7 @@ export interface AgentStreamEvent {
     | 'interrupt'
     | 'journey_update'
     | 'force_choice'
+    | 'run_cancelled'
     | 'ping'
     | 'done'
     | 'error'

--- a/services/agent-runtime/app/graph/cancel_checkpoint.py
+++ b/services/agent-runtime/app/graph/cancel_checkpoint.py
@@ -2,12 +2,20 @@ from __future__ import annotations
 
 from typing import Any
 
+# Cancel bookkeeping cleared once the next turn starts successfully.
+CANCEL_STATE_CLEAR: dict[str, Any] = {
+    "run_cancelled": None,
+    "cancel_reason": None,
+    "cancelled_from_phase": None,
+}
+
 
 def build_cancelled_checkpoint_update(
     *,
     completed_tasks: int = 0,
     total_tasks: int = 0,
     reason: str = "user",
+    from_phase: str | None = None,
 ) -> dict[str, Any]:
     done = max(0, int(completed_tasks))
     total = max(done, int(total_tasks))
@@ -16,8 +24,11 @@ def build_cancelled_checkpoint_update(
     else:
         progress = "已停止当前任务。"
     text = f"{progress}直接说修改意见，或点「发起新任务」。"
+    origin = (from_phase or "").strip() or None
     return {
         "phase": "cancelled",
+        # Keeps the pre-cancel phase so a later revise can tier its CLEAR table.
+        "cancelled_from_phase": None if origin == "cancelled" else origin,
         "run_cancelled": True,
         "cancel_reason": reason or "user",
         "presentation": {

--- a/services/agent-runtime/app/graph/cancel_checkpoint.py
+++ b/services/agent-runtime/app/graph/cancel_checkpoint.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_cancelled_checkpoint_update(
+    *,
+    completed_tasks: int = 0,
+    total_tasks: int = 0,
+    reason: str = "user",
+) -> dict[str, Any]:
+    done = max(0, int(completed_tasks))
+    total = max(done, int(total_tasks))
+    if total > 0:
+        progress = f"已停止出图（完成 {done}/{total}）。"
+    else:
+        progress = "已停止当前任务。"
+    text = f"{progress}直接说修改意见，或点「发起新任务」。"
+    return {
+        "phase": "cancelled",
+        "run_cancelled": True,
+        "cancel_reason": reason or "user",
+        "presentation": {
+            "kind": "callout_info",
+            "body": {"text": text},
+        },
+    }

--- a/services/agent-runtime/app/graph/hitl_resume.py
+++ b/services/agent-runtime/app/graph/hitl_resume.py
@@ -21,13 +21,44 @@ from langchain_core.messages import HumanMessage
 from langgraph.errors import InvalidUpdateError
 from langgraph.types import Command
 
+from app.graph.cancel_checkpoint import CANCEL_STATE_CLEAR
+
 GATE_DECISION_CLEAR = {"user_decision": "none", "force_choice": None}
 
+# ``interrupt_before`` nodes registered in builder.py / product_visual_v2 routing.
+HITL_GATE_NODES: frozenset[str] = frozenset(
+    {
+        "await_confirm",
+        "await_topo",
+        "await_copy_confirm",
+        "await_atomic_confirm",
+        "await_image_qa",
+        "await_scheme_select",
+        "await_macro_scheme_select",
+        "await_shot_confirm",
+        "await_shot_topo_confirm",
+        "await_delivery_confirm",
+    }
+)
+
 REF_MENTION_RE = re.compile(r"@[TIVA]\d+", re.IGNORECASE)
+
+# Tier-B gen run channel; a fresh task or a gen-phase revise must drop all of it.
+GEN_STATE_CLEAR: dict[str, None] = {
+    "gen_progress_id": None,
+    "gen_ordered_keys": None,
+    "gen_deps_of": None,
+    "gen_by_key": None,
+    "gen_completed_keys": None,
+    "gen_failed_keys": None,
+    "gen_needs_user_keys": None,
+    "gen_fail_details": None,
+}
 
 # Cleared when a new user task arrives while a HITL gate is still pending.
 FRESH_TURN_STATE_CLEAR: dict[str, Any] = {
     **GATE_DECISION_CLEAR,
+    **GEN_STATE_CLEAR,
     "phase": None,
     "flow_mode": None,
     "mode": None,
@@ -55,12 +86,22 @@ FRESH_TURN_STATE_CLEAR: dict[str, Any] = {
     "selected_macro_scheme_ids": None,
     "macro_scheme_decision": None,
     "shot_manifest": None,
+    "expected_delivery_count": None,
+    "retake_pending": None,
     "visual_intent": None,
     "presentation": None,
     "journey_trace": None,
-    "run_cancelled": None,
-    "cancel_reason": None,
+    **CANCEL_STATE_CLEAR,
 }
+
+
+def cancel_state_clear_for_resume(pre_vals: dict[str, Any]) -> dict[str, Any]:
+    """Cancel fields to clear (and phase to restore) when resuming a gate post-cancel."""
+    cancelled = bool(pre_vals.get("run_cancelled")) or pre_vals.get("phase") == "cancelled"
+    if not cancelled:
+        return {}
+    origin = str(pre_vals.get("cancelled_from_phase") or "").strip() or None
+    return {**CANCEL_STATE_CLEAR, "phase": None if origin == "cancelled" else origin}
 
 
 def should_resume_interrupt(
@@ -219,11 +260,15 @@ def build_interrupt_resume_command(
     message: str,
     *,
     user_decision: str | None = None,
+    extra_update: dict[str, Any] | None = None,
 ) -> Command:
     """Jump directly to a gate with user reply (fixes interrupt_before no-op resume)."""
     return Command(
         goto=gate,
-        update=build_interrupt_state_update(message, user_decision=user_decision),
+        update={
+            **(extra_update or {}),
+            **build_interrupt_state_update(message, user_decision=user_decision),
+        },
     )
 
 
@@ -255,7 +300,10 @@ async def prepare_interrupt_resume(
     gate_node = next_nodes[0] if next_nodes else None
     resume_as_node = as_node or (GATE_RESUME_AS_NODE.get(gate_node or "") if gate_node else None)
     assistant_save_after = len(vals.get("messages") or []) + 1
-    update = build_interrupt_state_update(message, user_decision=user_decision)
+    update = {
+        **cancel_state_clear_for_resume(vals),
+        **build_interrupt_state_update(message, user_decision=user_decision),
+    }
     update_kwargs: dict[str, Any] = {}
     if resume_as_node:
         update_kwargs["as_node"] = resume_as_node

--- a/services/agent-runtime/app/graph/hitl_resume.py
+++ b/services/agent-runtime/app/graph/hitl_resume.py
@@ -58,6 +58,8 @@ FRESH_TURN_STATE_CLEAR: dict[str, Any] = {
     "visual_intent": None,
     "presentation": None,
     "journey_trace": None,
+    "run_cancelled": None,
+    "cancel_reason": None,
 }
 
 

--- a/services/agent-runtime/app/graph/nodes/gen_node.py
+++ b/services/agent-runtime/app/graph/nodes/gen_node.py
@@ -97,7 +97,11 @@ def make_gen_node(*, nest: Any) -> Callable:
             }
 
         thread_id = str(state.get("thread_id") or "")
-        if thread_id and is_cancel_requested(thread_id):
+        if (
+            state.get("flow_mode") == "product_visual"
+            and thread_id
+            and is_cancel_requested(thread_id)
+        ):
             try:
                 await nest.cancel_generation(node_id=str(node_id))
             except Exception:  # noqa: BLE001

--- a/services/agent-runtime/app/graph/nodes/gen_node.py
+++ b/services/agent-runtime/app/graph/nodes/gen_node.py
@@ -21,6 +21,7 @@ from app.errors import AgentToolError, from_exception
 from app.graph.chain_refs import build_chain_ref_order
 from app.graph.gen_copy import format_gen_progress_line
 from app.graph.task_events import hint_for_error, is_recoverable, max_auto_retries
+from app.run_cancel import is_cancel_requested
 
 
 async def _emit_task_update(nest: Any, **payload: Any) -> None:
@@ -93,6 +94,19 @@ def make_gen_node(*, nest: Any) -> Callable:
             return {
                 "gen_failed_keys": [key],
                 "gen_fail_details": {key: {"node_id": None, "title": title, "reason": "missing_node_id"}},
+            }
+
+        thread_id = str(state.get("thread_id") or "")
+        if thread_id and is_cancel_requested(thread_id):
+            try:
+                await nest.cancel_generation(node_id=str(node_id))
+            except Exception:  # noqa: BLE001
+                pass
+            return {
+                "gen_needs_user_keys": [key],
+                "gen_fail_details": {
+                    key: {"node_id": node_id, "title": title, "reason": "cancelled"}
+                },
             }
 
         plan_node_id = state.get("plan_node_id")

--- a/services/agent-runtime/app/graph/nodes/gen_scheduler.py
+++ b/services/agent-runtime/app/graph/nodes/gen_scheduler.py
@@ -28,6 +28,8 @@ from typing import Any, Callable
 from langgraph.types import Command, Send
 
 from app.config import settings
+from app.graph.cancel_checkpoint import build_cancelled_checkpoint_update
+from app.run_cancel import is_cancel_requested, peek_cancel_reason
 
 
 def _detail(by_key: dict[str, dict], key: str, reason: str) -> dict[str, dict]:
@@ -49,6 +51,16 @@ def make_gen_scheduler_node(*, max_concurrency: int | None = None) -> Callable:
         completed: set[str] = set(state.get("gen_completed_keys") or [])
         failed: set[str] = set(state.get("gen_failed_keys") or [])
         needs_user: set[str] = set(state.get("gen_needs_user_keys") or [])
+
+        thread_id = str(state.get("thread_id") or "")
+        if thread_id and is_cancel_requested(thread_id):
+            reason = peek_cancel_reason(thread_id) or "user"
+            update = build_cancelled_checkpoint_update(
+                completed_tasks=len(completed),
+                total_tasks=len(ordered_keys),
+                reason=reason,
+            )
+            return Command(update=update, goto=["collect_gen"])
 
         # 1. Forward topo cascade: mark dependency_failed / dependency_skipped.
         # ordered_keys is topo-sorted, so a key's deps are classified before it.
@@ -103,6 +115,7 @@ def make_gen_scheduler_node(*, max_concurrency: int | None = None) -> Callable:
                             "key": k,
                             "gen_by_key": by_key,
                             "plan_node_id": plan_node_id,
+                            "thread_id": state.get("thread_id"),
                         },
                     )
                     for k in to_dispatch

--- a/services/agent-runtime/app/graph/nodes/gen_scheduler.py
+++ b/services/agent-runtime/app/graph/nodes/gen_scheduler.py
@@ -53,7 +53,12 @@ def make_gen_scheduler_node(*, max_concurrency: int | None = None) -> Callable:
         needs_user: set[str] = set(state.get("gen_needs_user_keys") or [])
 
         thread_id = str(state.get("thread_id") or "")
-        if thread_id and is_cancel_requested(thread_id):
+        flow_mode = state.get("flow_mode")
+        if (
+            flow_mode == "product_visual"
+            and thread_id
+            and is_cancel_requested(thread_id)
+        ):
             reason = peek_cancel_reason(thread_id) or "user"
             update = build_cancelled_checkpoint_update(
                 completed_tasks=len(completed),
@@ -116,6 +121,7 @@ def make_gen_scheduler_node(*, max_concurrency: int | None = None) -> Callable:
                             "gen_by_key": by_key,
                             "plan_node_id": plan_node_id,
                             "thread_id": state.get("thread_id"),
+                            "flow_mode": flow_mode,
                         },
                     )
                     for k in to_dispatch

--- a/services/agent-runtime/app/graph/post_cancel.py
+++ b/services/agent-runtime/app/graph/post_cancel.py
@@ -1,0 +1,160 @@
+"""Post-cancel intent routing and phase-aware revision state clearing."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Literal
+
+from langgraph.types import Command
+
+from app.graph.hitl_resume import should_resume_interrupt
+
+PostCancelIntent = Literal["gate_resume", "revise", "new_task"]
+
+REVISE_INTENT_HINTS: tuple[str, ...] = (
+    "换成",
+    "改成",
+    "改为",
+    "不要",
+    "去掉",
+    "调整",
+    "修改",
+    "改一下",
+    "只要",
+)
+NEW_TASK_HINTS: tuple[str, ...] = (
+    "另一套",
+    "重新做",
+    "新任务",
+    "换个产品",
+    "帮我做一套",
+    "从头",
+)
+REF_MENTION_RE = re.compile(r"@[TIVA]\d+", re.IGNORECASE)
+
+_GEN_STATE_CLEAR: dict[str, None] = {
+    "gen_progress_id": None,
+    "gen_ordered_keys": None,
+    "gen_deps_of": None,
+    "gen_by_key": None,
+    "gen_completed_keys": None,
+    "gen_failed_keys": None,
+    "gen_needs_user_keys": None,
+    "gen_fail_details": None,
+}
+_DELIVERY_AND_GEN_CLEAR: dict[str, None] = {
+    "delivery_selections": None,
+    **_GEN_STATE_CLEAR,
+}
+_SHOT_AND_DOWNSTREAM_CLEAR: dict[str, None] = {
+    "shot_manifest": None,
+    "expected_delivery_count": None,
+    **_DELIVERY_AND_GEN_CLEAR,
+}
+_MACRO_AND_DOWNSTREAM_CLEAR: dict[str, None] = {
+    "selected_macro_scheme_ids": None,
+    "macro_scheme_decision": None,
+    **_SHOT_AND_DOWNSTREAM_CLEAR,
+}
+_QA_AND_DOWNSTREAM_CLEAR: dict[str, None] = {
+    "image_qa_result": None,
+    "image_qa_decision": None,
+    "retake_pending": None,
+    "macro_scheme_draft": None,
+    "macro_schemes": None,
+    **_MACRO_AND_DOWNSTREAM_CLEAR,
+}
+
+_IMAGE_QA_PHASES = frozenset(
+    {"image_qa", "await_image_qa", "phase1_seed_lazy", "phase1_seed_eager"}
+)
+_MACRO_PHASES = frozenset(
+    {"plan_product_visual", "dialog_draft", "await_macro_scheme_select"}
+)
+_SHOT_PHASES = frozenset(
+    {
+        "canvas_ssot_commit",
+        "decompose_from_ssot",
+        "await_shot_confirm",
+        "await_shot_topo_confirm",
+        "synthesize_gen_prompt",
+        "orchestrate_shots",
+    }
+)
+_GEN_PHASES = frozenset(
+    {
+        "start_gen",
+        "orchestrate_gen",
+        "collect_gen",
+        "delivery_confirm",
+        "await_delivery_confirm",
+        "done",
+    }
+)
+
+
+def classify_post_cancel_intent(
+    message: str,
+    *,
+    next_nodes: list[str],
+    user_decision: str | None = None,
+    run_cancelled: bool,
+    phase: str | None,
+) -> PostCancelIntent | None:
+    """Classify the first turn after cancellation by the §4.2 priority rules."""
+    if not run_cancelled and phase != "cancelled":
+        return None
+
+    text = (message or "").strip()
+    if text == "__new_task__":
+        return "new_task"
+
+    if next_nodes and should_resume_interrupt(
+        text,
+        next_nodes,
+        user_decision=user_decision,
+    ):
+        return "gate_resume"
+
+    has_revise_hint = any(hint in text for hint in REVISE_INTENT_HINTS)
+    has_new_task_hint = any(hint in text for hint in NEW_TASK_HINTS)
+    if has_revise_hint and not has_new_task_hint:
+        return "revise"
+
+    if has_new_task_hint or (len(text) >= 12 and REF_MENTION_RE.search(text)):
+        return "new_task"
+    if len(text) >= 12:
+        return "new_task"
+
+    return "revise" if has_revise_hint else "new_task"
+
+
+def revise_state_clear_for_phase(phase: str | None) -> dict[str, Any]:
+    """Return only checkpoint fields that a revision must overwrite."""
+    normalized = (phase or "").strip()
+    if normalized in _GEN_PHASES:
+        return dict(_DELIVERY_AND_GEN_CLEAR)
+    if normalized in _SHOT_PHASES:
+        return dict(_SHOT_AND_DOWNSTREAM_CLEAR)
+    if normalized in _MACRO_PHASES:
+        return dict(_MACRO_AND_DOWNSTREAM_CLEAR)
+    if normalized in _IMAGE_QA_PHASES:
+        return dict(_QA_AND_DOWNSTREAM_CLEAR)
+
+    # A missing/originally-cancelled phase cannot safely retain downstream work.
+    return dict(_QA_AND_DOWNSTREAM_CLEAR)
+
+
+def build_revise_turn_command(*, phase_hint: str | None, update: dict[str, Any]) -> Command:
+    """Restart intake with phase-aware CLEAR fields for a revised request."""
+    clear = revise_state_clear_for_phase(phase_hint)
+    return Command(
+        goto="intake",
+        update={
+            **clear,
+            "run_cancelled": None,
+            "cancel_reason": None,
+            "phase": None,
+            **update,
+        },
+    )

--- a/services/agent-runtime/app/graph/post_cancel.py
+++ b/services/agent-runtime/app/graph/post_cancel.py
@@ -7,7 +7,8 @@ from typing import Any, Literal
 
 from langgraph.types import Command
 
-from app.graph.hitl_resume import should_resume_interrupt
+from app.graph.cancel_checkpoint import CANCEL_STATE_CLEAR
+from app.graph.hitl_resume import GEN_STATE_CLEAR, should_resume_interrupt
 
 PostCancelIntent = Literal["gate_resume", "revise", "new_task"]
 
@@ -32,19 +33,9 @@ NEW_TASK_HINTS: tuple[str, ...] = (
 )
 REF_MENTION_RE = re.compile(r"@[TIVA]\d+", re.IGNORECASE)
 
-_GEN_STATE_CLEAR: dict[str, None] = {
-    "gen_progress_id": None,
-    "gen_ordered_keys": None,
-    "gen_deps_of": None,
-    "gen_by_key": None,
-    "gen_completed_keys": None,
-    "gen_failed_keys": None,
-    "gen_needs_user_keys": None,
-    "gen_fail_details": None,
-}
 _DELIVERY_AND_GEN_CLEAR: dict[str, None] = {
     "delivery_selections": None,
-    **_GEN_STATE_CLEAR,
+    **GEN_STATE_CLEAR,
 }
 _SHOT_AND_DOWNSTREAM_CLEAR: dict[str, None] = {
     "shot_manifest": None,
@@ -132,6 +123,9 @@ def classify_post_cancel_intent(
 def revise_state_clear_for_phase(phase: str | None) -> dict[str, Any]:
     """Return only checkpoint fields that a revision must overwrite."""
     normalized = (phase or "").strip()
+    if normalized == "cancelled":
+        # ``phase`` alone says nothing about where the run stopped.
+        normalized = ""
     if normalized in _GEN_PHASES:
         return dict(_DELIVERY_AND_GEN_CLEAR)
     if normalized in _SHOT_PHASES:
@@ -152,8 +146,7 @@ def build_revise_turn_command(*, phase_hint: str | None, update: dict[str, Any])
         goto="intake",
         update={
             **clear,
-            "run_cancelled": None,
-            "cancel_reason": None,
+            **CANCEL_STATE_CLEAR,
             "phase": None,
             **update,
         },

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -237,3 +237,5 @@ class AgentRuntimeState(TypedDict, total=False):
     journey_trace: dict | None
     run_cancelled: bool | None
     cancel_reason: str | None
+    # Phase the run was in when cancelled; drives revise CLEAR tiering (§4.3)
+    cancelled_from_phase: str | None

--- a/services/agent-runtime/app/graph/state.py
+++ b/services/agent-runtime/app/graph/state.py
@@ -124,6 +124,7 @@ class AgentRuntimeState(TypedDict, total=False):
         "orchestrate_shots",
         "phase1_seed_lazy",
         "phase1_seed_eager",
+        "cancelled",
     ]
     skill_id: str | None
     requested_skill_id: str | None  # explicit Dock/API skill; intake reads each turn
@@ -234,3 +235,5 @@ class AgentRuntimeState(TypedDict, total=False):
     presentation: dict | None
     # UX-PV: journey trace snapshot (synced with presentation stepper)
     journey_trace: dict | None
+    run_cancelled: bool | None
+    cancel_reason: str | None

--- a/services/agent-runtime/app/main.py
+++ b/services/agent-runtime/app/main.py
@@ -10,7 +10,7 @@ from contextlib import asynccontextmanager
 
 from app.config import settings
 from app.metrics import metrics_payload
-from app.runs import RunRequest, get_thread_state, stream_run_events
+from app.runs import CancelRunRequest, RunRequest, get_thread_state, stream_run_events
 from app.tracing import setup_tracing, shutdown_tracing
 
 
@@ -112,3 +112,18 @@ async def create_run(
             yield json.dumps(event, ensure_ascii=False) + "\n"
 
     return StreamingResponse(ndjson(), media_type="application/x-ndjson")
+
+
+@app.post("/v1/runs/cancel")
+async def cancel_run_route(
+    body: CancelRunRequest,
+    x_lnkpi_service_token: str | None = Header(default=None),
+):
+    _require_runtime_auth(x_lnkpi_service_token)
+    from app.runs import cancel_run
+
+    return await cancel_run(
+        body,
+        checkpointer=_run_overrides.get("checkpointer"),
+        nest=_run_overrides.get("nest"),
+    )

--- a/services/agent-runtime/app/run_cancel.py
+++ b/services/agent-runtime/app/run_cancel.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+_lock = threading.Lock()
+_flags: dict[str, dict[str, Any]] = {}
+
+
+def request_cancel(thread_id: str, *, reason: str = "user") -> None:
+    tid = (thread_id or "").strip()
+    if not tid:
+        return
+    with _lock:
+        _flags[tid] = {"reason": reason or "user"}
+
+
+def is_cancel_requested(thread_id: str) -> bool:
+    tid = (thread_id or "").strip()
+    if not tid:
+        return False
+    with _lock:
+        return tid in _flags
+
+
+def peek_cancel_reason(thread_id: str) -> str | None:
+    tid = (thread_id or "").strip()
+    if not tid:
+        return None
+    with _lock:
+        entry = _flags.get(tid)
+        return str(entry["reason"]) if entry else None
+
+
+def clear_cancel(thread_id: str) -> None:
+    tid = (thread_id or "").strip()
+    if not tid:
+        return
+    with _lock:
+        _flags.pop(tid, None)

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -1239,8 +1239,10 @@ async def stream_run_events(
             await hb_task
         except asyncio.CancelledError:
             pass
-        clear_cancel(thread_id)
         await _release_thread(thread_id, holder_id, lock_nest)
+        # Release lock before clearing cancel: cancel_run busy-path checks
+        # local lock; clearing first lets it re-set the sticky flag.
+        clear_cancel(thread_id)
         if owns_nest:
             await lock_nest.close()
         if not task.done():

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -40,6 +40,8 @@ from app.graph.sidebar_attachments import (
     normalize_mentioned_keys,
     normalize_sidebar_attachments,
 )
+from app.graph.cancel_checkpoint import build_cancelled_checkpoint_update
+from app.run_cancel import is_cancel_requested, request_cancel
 from app.tools.nest_client import NestCanvasClient
 
 EmitFn = Callable[[dict[str, Any]], Awaitable[None]]
@@ -281,6 +283,12 @@ class RunRequest(BaseModel):
         default=None,
         validation_alias="mentioned_keys",
     )
+
+
+class CancelRunRequest(BaseModel):
+    thread_id: str
+    session_id: str | None = None
+    reason: str = "user"
 
 
 class NestEventProxy:
@@ -684,6 +692,97 @@ async def get_thread_state(
     }
 
 
+async def cancel_run(
+    req: CancelRunRequest,
+    *,
+    checkpointer: Any | None = None,
+    nest: Any | None = None,
+) -> dict[str, Any]:
+    """Request cooperative cancellation and persist it for product-visual runs."""
+    thread_id = req.thread_id.strip()
+    request_cancel(thread_id, reason=req.reason)
+
+    class _NoOpNest:
+        async def close(self) -> None:
+            pass
+
+    cp = checkpointer if checkpointer is not None else await _get_checkpointer()
+    graph = build_agent_graph(
+        nest=_NoOpNest(),
+        llm=default_llm(),
+        skills_dir=resolve_skills_dir(),
+        checkpointer=cp,
+    )
+    config = {"configurable": {"thread_id": thread_id}}
+    snap = await graph.aget_state(config)
+    vals = getattr(snap, "values", None) or {}
+    phase = str(vals["phase"]) if vals.get("phase") is not None else None
+    gen_by_key = vals.get("gen_by_key")
+    by_key = gen_by_key if isinstance(gen_by_key, dict) else {}
+    completed_keys = {
+        str(key) for key in (vals.get("gen_completed_keys") or [])
+    }
+    completed_tasks = sum(
+        1
+        for key, item in by_key.items()
+        if str(key) in completed_keys
+        or (
+            isinstance(item, dict)
+            and (
+                str(item.get("status") or "").lower() in {"completed", "done", "success"}
+                or bool(item.get("url"))
+            )
+        )
+    )
+    total_tasks = len(by_key)
+    base = {
+        "ok": True,
+        "phase": phase,
+        "cancelled_node_ids": [],
+        "completed_tasks": completed_tasks,
+        "total_tasks": total_tasks,
+    }
+
+    if vals.get("flow_mode") != "product_visual":
+        return {**base, "skipped": True, "reason": "flow_not_supported"}
+    if phase == "cancelled":
+        return base
+
+    cancelled_node_ids: list[str] = []
+    for key, item in by_key.items():
+        if not isinstance(item, dict):
+            continue
+        is_completed = (
+            str(key) in completed_keys
+            or str(item.get("status") or "").lower() in {"completed", "done", "success"}
+            or bool(item.get("url"))
+        )
+        node_id = item.get("node_id")
+        if is_completed or not node_id:
+            continue
+        if nest is not None:
+            try:
+                await nest.cancel_generation(node_id=str(node_id))
+            except Exception:  # noqa: BLE001 — cancellation remains cooperative
+                pass
+        cancelled_node_ids.append(str(node_id))
+
+    await graph.aupdate_state(
+        config,
+        build_cancelled_checkpoint_update(
+            completed_tasks=completed_tasks,
+            total_tasks=total_tasks,
+            reason=req.reason,
+        ),
+        as_node="gen_scheduler",
+    )
+    return {
+        **base,
+        "phase": "cancelled",
+        "cancelled_node_ids": cancelled_node_ids,
+    }
+
+
 async def _load_history(nest: NestCanvasClient, thread_id: str) -> list[Any]:
     """Load conversation history for the current thread only (Nest single-writer)."""
     try:
@@ -846,6 +945,7 @@ async def stream_run_events(
         executed_nodes: set[str] = set()
         stream_input: Any = input_state
         stream_vals: dict[str, Any] = dict(pre_vals)
+        cancelled_during_stream = False
         try:
             for pass_idx in range(2):
                 async for update in graph.astream(stream_input, config, stream_mode="updates"):
@@ -922,7 +1022,41 @@ async def stream_run_events(
                                 ms=int((time.monotonic() - t0) * 1000),
                             )
                         )
+                    if is_cancel_requested(thread_id):
+                        cancel_snap = await graph.aget_state(config)
+                        cancel_vals = getattr(cancel_snap, "values", None) or {}
+                        by_key = cancel_vals.get("gen_by_key")
+                        by_key = by_key if isinstance(by_key, dict) else {}
+                        completed = {
+                            str(key)
+                            for key in (cancel_vals.get("gen_completed_keys") or [])
+                        }
+                        completed_tasks = len(completed.intersection(str(key) for key in by_key))
+                        total_tasks = len(by_key)
+                        if cancel_vals.get("phase") != "cancelled":
+                            await graph.aupdate_state(
+                                config,
+                                build_cancelled_checkpoint_update(
+                                    completed_tasks=completed_tasks,
+                                    total_tasks=total_tasks,
+                                ),
+                                as_node="gen_scheduler",
+                            )
+                        await emit(
+                            {
+                                "type": "run_cancelled",
+                                "data": {
+                                    "phase": "cancelled",
+                                    "completedTasks": completed_tasks,
+                                    "totalTasks": total_tasks,
+                                },
+                            }
+                        )
+                        cancelled_during_stream = True
+                        break
 
+                if cancelled_during_stream:
+                    break
                 mid = await graph.aget_state(config)
                 mid_next = [str(n) for n in (getattr(mid, "next", None) or [])]
                 gate = pre_next[0] if pre_next else None

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -22,9 +22,11 @@ from app.graph.builder import build_agent_graph
 from app.graph.hitl_resume import (
     GATE_RESUME_AS_NODE,
     GATE_RESUME_COMMAND_GOTO,
+    HITL_GATE_NODES,
     build_fresh_turn_command,
     build_interrupt_resume_command,
     build_interrupt_state_update,
+    cancel_state_clear_for_resume,
     interrupt_event_payload,
     prepare_interrupt_resume,
     should_resume_interrupt,
@@ -650,6 +652,9 @@ def resolve_turn_input(
     """Resolve synchronous turn routing; ``None`` defers a gate resume."""
     nodes = [str(node) for node in next_nodes]
     phase = str(pre_vals.get("phase") or "") or None
+    # Post-cancel revise must tier off the phase the run was stopped in, not "cancelled".
+    cancelled_from = str(pre_vals.get("cancelled_from_phase") or "") or None
+    phase_hint = cancelled_from or (None if phase == "cancelled" else phase)
     intent = classify_post_cancel_intent(
         message,
         next_nodes=nodes,
@@ -660,7 +665,7 @@ def resolve_turn_input(
     if intent == "new_task":
         return build_fresh_turn_command(update=turn_update)
     if intent == "revise":
-        return build_revise_turn_command(phase_hint=phase, update=turn_update)
+        return build_revise_turn_command(phase_hint=phase_hint, update=turn_update)
 
     is_gate_resume = bool(
         nodes
@@ -769,6 +774,11 @@ async def cancel_run(
     config = {"configurable": {"thread_id": thread_id}}
     snap = await graph.aget_state(config)
     vals = getattr(snap, "values", None) or {}
+    pending_gate_nodes = [
+        str(node)
+        for node in (getattr(snap, "next", None) or ())
+        if str(node) in HITL_GATE_NODES
+    ]
     phase = str(vals["phase"]) if vals.get("phase") is not None else None
     gen_by_key = vals.get("gen_by_key")
     by_key = gen_by_key if isinstance(gen_by_key, dict) else {}
@@ -833,6 +843,17 @@ async def cancel_run(
             clear_cancel(thread_id)
             return {**base, "skipped": True, "reason": "flow_not_supported"}
 
+        if pending_gate_nodes:
+            # Idle thread paused at an interrupt_before gate: writing the cancelled
+            # checkpoint would drop ``next`` and strand the gate, so the user could no
+            # longer answer it. Report ok and let the client show its local callout.
+            clear_cancel(thread_id)
+            return {
+                **base,
+                "gate_preserved": True,
+                "next_nodes": pending_gate_nodes,
+            }
+
         request_cancel(thread_id, reason=req.reason)
         try:
             cancelled_node_ids: list[str] = []
@@ -859,6 +880,7 @@ async def cancel_run(
                     completed_tasks=completed_tasks,
                     total_tasks=total_tasks,
                     reason=req.reason,
+                    from_phase=phase,
                 ),
                 as_node="gen_scheduler",
             )
@@ -1020,6 +1042,7 @@ async def stream_run_events(
                 gate,
                 req.message,
                 user_decision=req.user_decision,
+                extra_update=cancel_state_clear_for_resume(pre_vals),
             )
         else:
             input_state, _ = await prepare_interrupt_resume(
@@ -1140,6 +1163,11 @@ async def stream_run_events(
                                     completed_tasks=completed_tasks,
                                     total_tasks=total_tasks,
                                     reason=peek_cancel_reason(thread_id) or "user",
+                                    from_phase=(
+                                        str(cancel_vals.get("phase"))
+                                        if cancel_vals.get("phase") is not None
+                                        else None
+                                    ),
                                 ),
                                 as_node="gen_scheduler",
                             )

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -751,6 +751,14 @@ async def get_thread_state(
     }
 
 
+def _hitl_gate_nodes(next_nodes: Any) -> list[str]:
+    return [
+        str(node)
+        for node in (next_nodes or ())
+        if str(node).startswith("await_") or str(node) in HITL_GATE_NODES
+    ]
+
+
 async def cancel_run(
     req: CancelRunRequest,
     *,
@@ -774,11 +782,7 @@ async def cancel_run(
     config = {"configurable": {"thread_id": thread_id}}
     snap = await graph.aget_state(config)
     vals = getattr(snap, "values", None) or {}
-    pending_gate_nodes = [
-        str(node)
-        for node in (getattr(snap, "next", None) or ())
-        if str(node) in HITL_GATE_NODES
-    ]
+    pending_gate_nodes = _hitl_gate_nodes(getattr(snap, "next", None))
     phase = str(vals["phase"]) if vals.get("phase") is not None else None
     gen_by_key = vals.get("gen_by_key")
     by_key = gen_by_key if isinstance(gen_by_key, dict) else {}
@@ -1145,6 +1149,9 @@ async def stream_run_events(
                     if is_cancel_requested(thread_id):
                         cancel_snap = await graph.aget_state(config)
                         cancel_vals = getattr(cancel_snap, "values", None) or {}
+                        cancel_gate_nodes = _hitl_gate_nodes(
+                            getattr(cancel_snap, "next", None)
+                        )
                         if cancel_vals.get("flow_mode") != "product_visual":
                             clear_cancel(thread_id)
                             continue
@@ -1156,7 +1163,10 @@ async def stream_run_events(
                         }
                         completed_tasks = len(completed)
                         total_tasks = len(by_key)
-                        if cancel_vals.get("phase") != "cancelled":
+                        if (
+                            cancel_vals.get("phase") != "cancelled"
+                            and not cancel_gate_nodes
+                        ):
                             await graph.aupdate_state(
                                 config,
                                 build_cancelled_checkpoint_update(

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -751,11 +751,14 @@ async def cancel_run(
         clear_cancel(thread_id)
         return base
 
-    owns_cancel_nest = nest is None and bool(req.session_id)
+    request_session_id = (req.session_id or "").strip()
+    checkpoint_session_id = str(vals.get("session_id") or "").strip()
+    cancel_session_id = request_session_id or checkpoint_session_id
+    owns_cancel_nest = nest is None and bool(cancel_session_id)
     cancel_nest = nest
-    if cancel_nest is None and req.session_id:
+    if cancel_nest is None and cancel_session_id:
         cancel_nest = default_nest(
-            session_id=req.session_id,
+            session_id=cancel_session_id,
             user_id=str(vals.get("user_id") or ""),
         )
 
@@ -893,7 +896,6 @@ async def stream_run_events(
     )
 
     queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
-    cooperative_cancel_handled = False
 
     async def emit(event: dict[str, Any]) -> None:
         await queue.put(event)
@@ -990,7 +992,6 @@ async def stream_run_events(
         input_state = turn_update
 
     async def run_graph() -> None:
-        nonlocal cooperative_cancel_handled
         last_text_delta: str | None = None
         executed_nodes: set[str] = set()
         stream_input: Any = input_state
@@ -1107,7 +1108,6 @@ async def stream_run_events(
                             }
                         )
                         cancelled_during_stream = True
-                        cooperative_cancel_handled = True
                         break
 
                 if cancelled_during_stream:
@@ -1239,9 +1239,8 @@ async def stream_run_events(
             await hb_task
         except asyncio.CancelledError:
             pass
+        clear_cancel(thread_id)
         await _release_thread(thread_id, holder_id, lock_nest)
-        if cooperative_cancel_handled:
-            clear_cancel(thread_id)
         if owns_nest:
             await lock_nest.close()
         if not task.done():

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -13,7 +13,7 @@ import aiosqlite
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from app.config import settings
 from app.checkpoint_observability import checkpoint_diagnostics
@@ -41,7 +41,7 @@ from app.graph.sidebar_attachments import (
     normalize_sidebar_attachments,
 )
 from app.graph.cancel_checkpoint import build_cancelled_checkpoint_update
-from app.run_cancel import is_cancel_requested, request_cancel
+from app.run_cancel import clear_cancel, is_cancel_requested, request_cancel
 from app.tools.nest_client import NestCanvasClient
 
 EmitFn = Callable[[dict[str, Any]], Awaitable[None]]
@@ -289,6 +289,13 @@ class CancelRunRequest(BaseModel):
     thread_id: str
     session_id: str | None = None
     reason: str = "user"
+
+    @field_validator("thread_id")
+    @classmethod
+    def validate_thread_id(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("thread_id must not be blank")
+        return value
 
 
 class NestEventProxy:
@@ -700,7 +707,6 @@ async def cancel_run(
 ) -> dict[str, Any]:
     """Request cooperative cancellation and persist it for product-visual runs."""
     thread_id = req.thread_id.strip()
-    request_cancel(thread_id, reason=req.reason)
 
     class _NoOpNest:
         async def close(self) -> None:
@@ -722,18 +728,7 @@ async def cancel_run(
     completed_keys = {
         str(key) for key in (vals.get("gen_completed_keys") or [])
     }
-    completed_tasks = sum(
-        1
-        for key, item in by_key.items()
-        if str(key) in completed_keys
-        or (
-            isinstance(item, dict)
-            and (
-                str(item.get("status") or "").lower() in {"completed", "done", "success"}
-                or bool(item.get("url"))
-            )
-        )
-    )
+    completed_tasks = len(completed_keys)
     total_tasks = len(by_key)
     base = {
         "ok": True,
@@ -743,44 +738,82 @@ async def cancel_run(
         "total_tasks": total_tasks,
     }
 
-    if vals.get("flow_mode") != "product_visual":
+    flow_mode = vals.get("flow_mode")
+    if flow_mode is not None and flow_mode != "product_visual":
+        clear_cancel(thread_id)
         return {**base, "skipped": True, "reason": "flow_not_supported"}
     if phase == "cancelled":
+        clear_cancel(thread_id)
         return base
 
-    cancelled_node_ids: list[str] = []
-    for key, item in by_key.items():
-        if not isinstance(item, dict):
-            continue
-        is_completed = (
-            str(key) in completed_keys
-            or str(item.get("status") or "").lower() in {"completed", "done", "success"}
-            or bool(item.get("url"))
+    owns_cancel_nest = nest is None and bool(req.session_id)
+    cancel_nest = nest
+    if cancel_nest is None and req.session_id:
+        cancel_nest = default_nest(
+            session_id=req.session_id,
+            user_id=str(vals.get("user_id") or ""),
         )
-        node_id = item.get("node_id")
-        if is_completed or not node_id:
-            continue
-        if nest is not None:
+
+    if cancel_nest is None:
+        request_cancel(thread_id, reason=req.reason)
+        return base
+
+    acquired = False
+    holder_id: str | None = None
+    try:
+        try:
+            acquired, holder_id = await _try_acquire_thread(thread_id, cancel_nest)
+        except Exception:  # noqa: BLE001 — lock uncertainty must avoid checkpoint races
+            request_cancel(thread_id, reason=req.reason)
+            return base
+
+        if not acquired:
+            request_cancel(thread_id, reason=req.reason)
+            return base
+
+        if flow_mode != "product_visual":
+            clear_cancel(thread_id)
+            return {**base, "skipped": True, "reason": "flow_not_supported"}
+
+        request_cancel(thread_id, reason=req.reason)
+        cancelled_node_ids: list[str] = []
+        for key, item in by_key.items():
+            if not isinstance(item, dict):
+                continue
+            is_completed = (
+                str(key) in completed_keys
+                or str(item.get("status") or "").lower() in {"completed", "done", "success"}
+                or bool(item.get("url"))
+            )
+            node_id = item.get("node_id")
+            if is_completed or not node_id:
+                continue
             try:
-                await nest.cancel_generation(node_id=str(node_id))
+                await cancel_nest.cancel_generation(node_id=str(node_id))
             except Exception:  # noqa: BLE001 — cancellation remains cooperative
                 pass
-        cancelled_node_ids.append(str(node_id))
+            cancelled_node_ids.append(str(node_id))
 
-    await graph.aupdate_state(
-        config,
-        build_cancelled_checkpoint_update(
-            completed_tasks=completed_tasks,
-            total_tasks=total_tasks,
-            reason=req.reason,
-        ),
-        as_node="gen_scheduler",
-    )
-    return {
-        **base,
-        "phase": "cancelled",
-        "cancelled_node_ids": cancelled_node_ids,
-    }
+        await graph.aupdate_state(
+            config,
+            build_cancelled_checkpoint_update(
+                completed_tasks=completed_tasks,
+                total_tasks=total_tasks,
+                reason=req.reason,
+            ),
+            as_node="gen_scheduler",
+        )
+        clear_cancel(thread_id)
+        return {
+            **base,
+            "phase": "cancelled",
+            "cancelled_node_ids": cancelled_node_ids,
+        }
+    finally:
+        if acquired:
+            await _release_thread(thread_id, holder_id, cancel_nest)
+        if owns_cancel_nest:
+            await cancel_nest.close()
 
 
 async def _load_history(nest: NestCanvasClient, thread_id: str) -> list[Any]:
@@ -845,6 +878,7 @@ async def stream_run_events(
     )
 
     queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
+    cooperative_cancel_handled = False
 
     async def emit(event: dict[str, Any]) -> None:
         await queue.put(event)
@@ -941,6 +975,7 @@ async def stream_run_events(
         input_state = turn_update
 
     async def run_graph() -> None:
+        nonlocal cooperative_cancel_handled
         last_text_delta: str | None = None
         executed_nodes: set[str] = set()
         stream_input: Any = input_state
@@ -1025,13 +1060,15 @@ async def stream_run_events(
                     if is_cancel_requested(thread_id):
                         cancel_snap = await graph.aget_state(config)
                         cancel_vals = getattr(cancel_snap, "values", None) or {}
+                        if cancel_vals.get("flow_mode") != "product_visual":
+                            continue
                         by_key = cancel_vals.get("gen_by_key")
                         by_key = by_key if isinstance(by_key, dict) else {}
                         completed = {
                             str(key)
                             for key in (cancel_vals.get("gen_completed_keys") or [])
                         }
-                        completed_tasks = len(completed.intersection(str(key) for key in by_key))
+                        completed_tasks = len(completed)
                         total_tasks = len(by_key)
                         if cancel_vals.get("phase") != "cancelled":
                             await graph.aupdate_state(
@@ -1053,6 +1090,7 @@ async def stream_run_events(
                             }
                         )
                         cancelled_during_stream = True
+                        cooperative_cancel_handled = True
                         break
 
                 if cancelled_during_stream:
@@ -1185,6 +1223,8 @@ async def stream_run_events(
         except asyncio.CancelledError:
             pass
         await _release_thread(thread_id, holder_id, lock_nest)
+        if cooperative_cancel_handled:
+            clear_cancel(thread_id)
         if owns_nest:
             await lock_nest.close()
         if not task.done():

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -29,6 +29,7 @@ from app.graph.hitl_resume import (
     prepare_interrupt_resume,
     should_resume_interrupt,
 )
+from app.graph.post_cancel import build_revise_turn_command, classify_post_cancel_intent
 from app.graph.product_visual_v2.utterance import extract_user_request_labels, resolve_effective_utterance
 from app.graph.step_copy import phase_hint_event, step_event
 from app.graph.route_trace import route_decision_event
@@ -639,6 +640,43 @@ def resolve_vision_creds(req: RunRequest) -> dict[str, str | None]:
     }
 
 
+def resolve_turn_input(
+    pre_vals: dict[str, Any],
+    next_nodes: list[str] | tuple[str, ...],
+    message: str,
+    user_decision: str | None,
+    turn_update: dict[str, Any],
+) -> Any | None:
+    """Resolve synchronous turn routing; ``None`` defers a gate resume."""
+    nodes = [str(node) for node in next_nodes]
+    phase = str(pre_vals.get("phase") or "") or None
+    intent = classify_post_cancel_intent(
+        message,
+        next_nodes=nodes,
+        user_decision=user_decision,
+        run_cancelled=bool(pre_vals.get("run_cancelled")) or phase == "cancelled",
+        phase=phase,
+    )
+    if intent == "new_task":
+        return build_fresh_turn_command(update=turn_update)
+    if intent == "revise":
+        return build_revise_turn_command(phase_hint=phase, update=turn_update)
+
+    is_gate_resume = bool(
+        nodes
+        and should_resume_interrupt(
+            message,
+            nodes,
+            user_decision=user_decision,
+        )
+    )
+    if intent == "gate_resume" or is_gate_resume:
+        return None
+    if nodes:
+        return build_fresh_turn_command(update=turn_update)
+    return turn_update
+
+
 async def get_thread_state(
     thread_id: str,
     *,
@@ -672,7 +710,11 @@ async def get_thread_state(
         "phase": phase_str,
         "nextNodes": next_nodes,
         "interrupted": bool(next_nodes),
-        "finished": phase_str == "done" or (not next_nodes and bool(vals)),
+        "finished": phase_str == "done"
+        or (phase_str != "cancelled" and not next_nodes and bool(vals)),
+        "runCancelled": bool(vals.get("run_cancelled"))
+        if vals.get("run_cancelled") is not None
+        else None,
         "productVisualPlan": plan if isinstance(plan, dict) else None,
         "macroSchemes": vals.get("macro_schemes") if isinstance(vals.get("macro_schemes"), list) else None,
         "shotManifest": vals.get("shot_manifest") if isinstance(vals.get("shot_manifest"), list) else None,
@@ -960,8 +1002,15 @@ async def stream_run_events(
 
     pre_next = [str(n) for n in (getattr(snap, "next", None) or [])]
     resume_attempt = False
+    input_state = resolve_turn_input(
+        pre_vals,
+        next_nodes,
+        req.message,
+        req.user_decision,
+        turn_update,
+    )
 
-    if next_nodes and is_gate_resume:
+    if input_state is None and next_nodes and is_gate_resume:
         # interrupt_before: inject user message, then continue with input=None.
         # See app/graph/hitl_resume.py — Command(resume=...) is for in-node interrupt() only.
         resume_attempt = True
@@ -979,7 +1028,7 @@ async def stream_run_events(
                 req.message,
                 user_decision=req.user_decision,
             )
-    elif next_nodes:
+    elif next_nodes and not is_gate_resume:
         # Fresh @ref task while a gate is still pending — restart at intake.
         logger.info(
             "agent_turn_fresh_restart thread_id=%s session_id=%s gate=%s",
@@ -987,9 +1036,6 @@ async def stream_run_events(
             req.session_id,
             list(next_nodes),
         )
-        input_state = build_fresh_turn_command(update=turn_update)
-    else:
-        input_state = turn_update
 
     async def run_graph() -> None:
         last_text_delta: str | None = None

--- a/services/agent-runtime/app/runs.py
+++ b/services/agent-runtime/app/runs.py
@@ -41,7 +41,12 @@ from app.graph.sidebar_attachments import (
     normalize_sidebar_attachments,
 )
 from app.graph.cancel_checkpoint import build_cancelled_checkpoint_update
-from app.run_cancel import clear_cancel, is_cancel_requested, request_cancel
+from app.run_cancel import (
+    clear_cancel,
+    is_cancel_requested,
+    peek_cancel_reason,
+    request_cancel,
+)
 from app.tools.nest_client import NestCanvasClient
 
 EmitFn = Callable[[dict[str, Any]], Awaitable[None]]
@@ -755,8 +760,16 @@ async def cancel_run(
         )
 
     if cancel_nest is None:
-        request_cancel(thread_id, reason=req.reason)
-        return base
+        local_lock = _thread_locks.get(thread_id)
+        if (
+            local_lock is not None
+            and local_lock.locked()
+            and flow_mode in (None, "product_visual")
+        ):
+            request_cancel(thread_id, reason=req.reason)
+            return base
+        clear_cancel(thread_id)
+        return {**base, "skipped": True, "reason": "flow_not_supported"}
 
     acquired = False
     holder_id: str | None = None
@@ -764,8 +777,8 @@ async def cancel_run(
         try:
             acquired, holder_id = await _try_acquire_thread(thread_id, cancel_nest)
         except Exception:  # noqa: BLE001 — lock uncertainty must avoid checkpoint races
-            request_cancel(thread_id, reason=req.reason)
-            return base
+            clear_cancel(thread_id)
+            return {**base, "skipped": True, "reason": "cancel_unavailable"}
 
         if not acquired:
             request_cancel(thread_id, reason=req.reason)
@@ -776,39 +789,41 @@ async def cancel_run(
             return {**base, "skipped": True, "reason": "flow_not_supported"}
 
         request_cancel(thread_id, reason=req.reason)
-        cancelled_node_ids: list[str] = []
-        for key, item in by_key.items():
-            if not isinstance(item, dict):
-                continue
-            is_completed = (
-                str(key) in completed_keys
-                or str(item.get("status") or "").lower() in {"completed", "done", "success"}
-                or bool(item.get("url"))
-            )
-            node_id = item.get("node_id")
-            if is_completed or not node_id:
-                continue
-            try:
-                await cancel_nest.cancel_generation(node_id=str(node_id))
-            except Exception:  # noqa: BLE001 — cancellation remains cooperative
-                pass
-            cancelled_node_ids.append(str(node_id))
+        try:
+            cancelled_node_ids: list[str] = []
+            for key, item in by_key.items():
+                if not isinstance(item, dict):
+                    continue
+                is_completed = (
+                    str(key) in completed_keys
+                    or str(item.get("status") or "").lower() in {"completed", "done", "success"}
+                    or bool(item.get("url"))
+                )
+                node_id = item.get("node_id")
+                if is_completed or not node_id:
+                    continue
+                try:
+                    await cancel_nest.cancel_generation(node_id=str(node_id))
+                except Exception:  # noqa: BLE001 — cancellation remains cooperative
+                    pass
+                cancelled_node_ids.append(str(node_id))
 
-        await graph.aupdate_state(
-            config,
-            build_cancelled_checkpoint_update(
-                completed_tasks=completed_tasks,
-                total_tasks=total_tasks,
-                reason=req.reason,
-            ),
-            as_node="gen_scheduler",
-        )
-        clear_cancel(thread_id)
-        return {
-            **base,
-            "phase": "cancelled",
-            "cancelled_node_ids": cancelled_node_ids,
-        }
+            await graph.aupdate_state(
+                config,
+                build_cancelled_checkpoint_update(
+                    completed_tasks=completed_tasks,
+                    total_tasks=total_tasks,
+                    reason=req.reason,
+                ),
+                as_node="gen_scheduler",
+            )
+            return {
+                **base,
+                "phase": "cancelled",
+                "cancelled_node_ids": cancelled_node_ids,
+            }
+        finally:
+            clear_cancel(thread_id)
     finally:
         if acquired:
             await _release_thread(thread_id, holder_id, cancel_nest)
@@ -1061,6 +1076,7 @@ async def stream_run_events(
                         cancel_snap = await graph.aget_state(config)
                         cancel_vals = getattr(cancel_snap, "values", None) or {}
                         if cancel_vals.get("flow_mode") != "product_visual":
+                            clear_cancel(thread_id)
                             continue
                         by_key = cancel_vals.get("gen_by_key")
                         by_key = by_key if isinstance(by_key, dict) else {}
@@ -1076,6 +1092,7 @@ async def stream_run_events(
                                 build_cancelled_checkpoint_update(
                                     completed_tasks=completed_tasks,
                                     total_tasks=total_tasks,
+                                    reason=peek_cancel_reason(thread_id) or "user",
                                 ),
                                 as_node="gen_scheduler",
                             )

--- a/services/agent-runtime/tests/test_cancel_checkpoint.py
+++ b/services/agent-runtime/tests/test_cancel_checkpoint.py
@@ -1,0 +1,11 @@
+from app.graph.cancel_checkpoint import build_cancelled_checkpoint_update
+
+
+def test_build_cancelled_checkpoint_update_shape():
+    upd = build_cancelled_checkpoint_update(completed_tasks=2, total_tasks=5, reason="user")
+    assert upd["phase"] == "cancelled"
+    assert upd["run_cancelled"] is True
+    assert upd["cancel_reason"] == "user"
+    assert upd["presentation"]["kind"] == "callout_info"
+    assert "2/5" in upd["presentation"]["body"]["text"]
+    assert "发起新任务" in upd["presentation"]["body"]["text"]

--- a/services/agent-runtime/tests/test_cancel_checkpoint.py
+++ b/services/agent-runtime/tests/test_cancel_checkpoint.py
@@ -2,10 +2,29 @@ from app.graph.cancel_checkpoint import build_cancelled_checkpoint_update
 
 
 def test_build_cancelled_checkpoint_update_shape():
-    upd = build_cancelled_checkpoint_update(completed_tasks=2, total_tasks=5, reason="user")
+    upd = build_cancelled_checkpoint_update(
+        completed_tasks=2,
+        total_tasks=5,
+        reason="user",
+        from_phase="orchestrate_gen",
+    )
     assert upd["phase"] == "cancelled"
+    assert upd["cancelled_from_phase"] == "orchestrate_gen"
     assert upd["run_cancelled"] is True
     assert upd["cancel_reason"] == "user"
     assert upd["presentation"]["kind"] == "callout_info"
     assert "2/5" in upd["presentation"]["body"]["text"]
     assert "发起新任务" in upd["presentation"]["body"]["text"]
+
+
+def test_build_cancelled_checkpoint_update_without_origin_phase():
+    assert build_cancelled_checkpoint_update()["cancelled_from_phase"] is None
+    assert (
+        build_cancelled_checkpoint_update(from_phase="   ")["cancelled_from_phase"] is None
+    )
+
+
+def test_build_cancelled_checkpoint_update_never_stores_cancelled_as_origin():
+    """Re-cancelling must not overwrite the origin phase with the sentinel."""
+    upd = build_cancelled_checkpoint_update(from_phase="cancelled")
+    assert upd["cancelled_from_phase"] is None

--- a/services/agent-runtime/tests/test_cancel_gate_preserved.py
+++ b/services/agent-runtime/tests/test_cancel_gate_preserved.py
@@ -1,0 +1,155 @@
+"""C2: cancelling an idle thread must not strand a pending interrupt_before gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from langchain_core.messages import HumanMessage
+from langgraph.checkpoint.memory import MemorySaver
+
+from app.graph.builder import build_agent_graph
+from app.graph.hitl_resume import cancel_state_clear_for_resume
+from app.graph.product_visual_v2.routing import shot_confirm_gate_name
+from app.run_cancel import clear_cancel, is_cancel_requested
+from app.runs import CancelRunRequest, cancel_run, get_thread_state, resolve_turn_input
+
+SKILLS_DIR = Path(__file__).resolve().parents[1] / "skills"
+
+
+class _Nest:
+    def __init__(self) -> None:
+        self.cancelled_node_ids: list[str] = []
+        self._db_locks: set[str] = set()
+
+    async def close(self) -> None:
+        pass
+
+    async def acquire_thread_lock(
+        self, thread_id: str, holder_id: str, ttl_seconds: float = 300
+    ) -> dict[str, bool]:
+        if thread_id in self._db_locks:
+            return {"acquired": False}
+        self._db_locks.add(thread_id)
+        return {"acquired": True}
+
+    async def renew_thread_lock(
+        self, thread_id: str, holder_id: str, ttl_seconds: float = 300
+    ) -> dict[str, bool]:
+        return {"renewed": True}
+
+    async def release_thread_lock(self, thread_id: str, holder_id: str) -> dict[str, bool]:
+        self._db_locks.discard(thread_id)
+        return {"released": True}
+
+    async def cancel_generation(self, *, node_id: str) -> dict[str, Any]:
+        self.cancelled_node_ids.append(node_id)
+        return {"ok": True}
+
+
+def _graph(cp: MemorySaver):
+    return build_agent_graph(nest=_Nest(), llm=None, skills_dir=SKILLS_DIR, checkpointer=cp)
+
+
+async def _pause_at_shot_gate(cp: MemorySaver, thread_id: str) -> list[str]:
+    """Seed a checkpoint paused before the shot-confirm gate."""
+    graph = _graph(cp)
+    config = {"configurable": {"thread_id": thread_id}}
+    await graph.aupdate_state(
+        config,
+        {
+            "messages": [HumanMessage(content="帮我出图")],
+            "thread_id": thread_id,
+            "session_id": "s1",
+            "user_id": "u1",
+            "flow_mode": "product_visual",
+            "phase": shot_confirm_gate_name(),
+            "selected_macro_scheme_ids": ["m1"],
+            "shot_manifest": [{"shot_id": "s1"}],
+        },
+        as_node="decompose_from_ssot",
+    )
+    snap = await graph.aget_state(config)
+    return [str(node) for node in (snap.next or ())]
+
+
+@pytest.mark.asyncio
+async def test_cancel_run_preserves_pending_gate_next_nodes():
+    cp = MemorySaver()
+    tid = "thread-cancel-gate-pending"
+    clear_cancel(tid)
+    gate_before = await _pause_at_shot_gate(cp, tid)
+    assert gate_before == [shot_confirm_gate_name()]
+
+    try:
+        result = await cancel_run(
+            CancelRunRequest(thread_id=tid, session_id="s1", reason="user"),
+            checkpointer=cp,
+            nest=_Nest(),
+        )
+
+        assert result["ok"] is True
+        assert result["gate_preserved"] is True
+        assert result["next_nodes"] == gate_before
+        assert result["phase"] == shot_confirm_gate_name()
+        assert is_cancel_requested(tid) is False
+
+        state = await get_thread_state(tid, checkpointer=cp)
+        assert state["nextNodes"] == gate_before
+        assert state["interrupted"] is True
+        assert state["phase"] == shot_confirm_gate_name()
+    finally:
+        clear_cancel(tid)
+
+
+@pytest.mark.asyncio
+async def test_gate_resume_still_classifies_after_cancel():
+    """UAT-INT-PV-05: 「确认出图」 must still resume the gate after a stop."""
+    cp = MemorySaver()
+    tid = "thread-cancel-gate-resume"
+    clear_cancel(tid)
+    gate_before = await _pause_at_shot_gate(cp, tid)
+
+    try:
+        await cancel_run(
+            CancelRunRequest(thread_id=tid, session_id="s1", reason="user"),
+            checkpointer=cp,
+            nest=_Nest(),
+        )
+        snap = await _graph(cp).aget_state({"configurable": {"thread_id": tid}})
+        next_nodes = [str(node) for node in (snap.next or ())]
+        assert next_nodes == gate_before
+
+        deferred = resolve_turn_input(
+            {**snap.values, "run_cancelled": True},
+            next_nodes,
+            "确认出图",
+            None,
+            {"messages": [HumanMessage(content="确认出图")], "session_id": "s1"},
+        )
+        assert deferred is None  # deferred to the async gate-resume path
+    finally:
+        clear_cancel(tid)
+
+
+def test_cancel_state_clear_for_resume_restores_origin_phase():
+    """I3: gate resume clears cancel bookkeeping and restores the pre-cancel phase."""
+    assert cancel_state_clear_for_resume({"phase": "await_shot_topo_confirm"}) == {}
+
+    cleared = cancel_state_clear_for_resume(
+        {
+            "phase": "cancelled",
+            "run_cancelled": True,
+            "cancel_reason": "user",
+            "cancelled_from_phase": "orchestrate_gen",
+        }
+    )
+    assert cleared == {
+        "run_cancelled": None,
+        "cancel_reason": None,
+        "cancelled_from_phase": None,
+        "phase": "orchestrate_gen",
+    }
+
+    assert cancel_state_clear_for_resume({"run_cancelled": True})["phase"] is None

--- a/services/agent-runtime/tests/test_gen_scheduler_cancel.py
+++ b/services/agent-runtime/tests/test_gen_scheduler_cancel.py
@@ -13,6 +13,7 @@ from app.run_cancel import clear_cancel, request_cancel
 def _state(thread_id: str) -> dict[str, Any]:
     return {
         "thread_id": thread_id,
+        "flow_mode": "product_visual",
         "gen_ordered_keys": ["a", "b"],
         "gen_deps_of": {"a": [], "b": ["a"]},
         "gen_by_key": {
@@ -56,6 +57,26 @@ async def test_gen_scheduler_passes_thread_id_to_gen_node():
     sends = [target for target in cmd.goto if isinstance(target, Send)]
     assert sends
     assert sends[0].arg["thread_id"] == tid
+    assert sends[0].arg["flow_mode"] == "product_visual"
+
+
+@pytest.mark.asyncio
+async def test_gen_scheduler_does_not_consume_cancel_for_campaign():
+    tid = "t-sched-campaign-cancel"
+    clear_cancel(tid)
+    request_cancel(tid, reason="user")
+    try:
+        state = _state(tid)
+        state["flow_mode"] = "campaign"
+        node = make_gen_scheduler_node(max_concurrency=4)
+
+        cmd = await node(state)
+
+        sends = [target for target in cmd.goto if isinstance(target, Send)]
+        assert [target.arg["key"] for target in sends] == ["a"]
+        assert cmd.update.get("phase") != "cancelled"
+    finally:
+        clear_cancel(tid)
 
 
 class _CancelNest:
@@ -82,6 +103,7 @@ async def test_gen_node_cancels_before_generation():
         out = await node(
             {
                 "thread_id": tid,
+                "flow_mode": "product_visual",
                 "key": "a",
                 "gen_by_key": {"a": {"node_id": "n1", "title": "A"}},
             }
@@ -91,5 +113,29 @@ async def test_gen_node_cancels_before_generation():
         assert nest.generated_node_ids == []
         assert out["gen_needs_user_keys"] == ["a"]
         assert out["gen_fail_details"]["a"]["reason"] == "cancelled"
+    finally:
+        clear_cancel(tid)
+
+
+@pytest.mark.asyncio
+async def test_gen_node_does_not_consume_cancel_for_campaign():
+    tid = "t-node-campaign-cancel"
+    clear_cancel(tid)
+    request_cancel(tid, reason="user")
+    nest = _CancelNest()
+    try:
+        node = make_gen_node(nest=nest)
+        out = await node(
+            {
+                "thread_id": tid,
+                "flow_mode": "campaign",
+                "key": "a",
+                "gen_by_key": {"a": {"node_id": "n1", "title": "A"}},
+            }
+        )
+
+        assert nest.cancelled_node_ids == []
+        assert nest.generated_node_ids == ["n1"]
+        assert out["gen_completed_keys"] == ["a"]
     finally:
         clear_cancel(tid)

--- a/services/agent-runtime/tests/test_gen_scheduler_cancel.py
+++ b/services/agent-runtime/tests/test_gen_scheduler_cancel.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from langgraph.types import Command, Send
+
+from app.graph.nodes.gen_node import make_gen_node
+from app.graph.nodes.gen_scheduler import make_gen_scheduler_node
+from app.run_cancel import clear_cancel, request_cancel
+
+
+def _state(thread_id: str) -> dict[str, Any]:
+    return {
+        "thread_id": thread_id,
+        "gen_ordered_keys": ["a", "b"],
+        "gen_deps_of": {"a": [], "b": ["a"]},
+        "gen_by_key": {
+            "a": {"node_id": "n1", "title": "A"},
+            "b": {"node_id": "n2", "title": "B"},
+        },
+        "gen_completed_keys": [],
+        "gen_failed_keys": [],
+        "gen_needs_user_keys": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_gen_scheduler_stops_dispatch_when_cancel_requested():
+    tid = "t-sched-cancel"
+    clear_cancel(tid)
+    request_cancel(tid, reason="user")
+    try:
+        node = make_gen_scheduler_node(max_concurrency=4)
+        cmd = await node(_state(tid))
+
+        assert isinstance(cmd, Command)
+        assert cmd.goto == ["collect_gen"]
+        assert cmd.update.get("phase") == "cancelled"
+        assert cmd.update.get("run_cancelled") is True
+        assert not any(
+            getattr(target, "node", None) == "gen_node"
+            for target in (cmd.goto if isinstance(cmd.goto, list) else [])
+        )
+    finally:
+        clear_cancel(tid)
+
+
+@pytest.mark.asyncio
+async def test_gen_scheduler_passes_thread_id_to_gen_node():
+    tid = "t-sched-payload"
+    node = make_gen_scheduler_node(max_concurrency=4)
+
+    cmd = await node(_state(tid))
+
+    sends = [target for target in cmd.goto if isinstance(target, Send)]
+    assert sends
+    assert sends[0].arg["thread_id"] == tid
+
+
+class _CancelNest:
+    def __init__(self) -> None:
+        self.cancelled_node_ids: list[str] = []
+        self.generated_node_ids: list[str] = []
+
+    async def cancel_generation(self, node_id: str) -> None:
+        self.cancelled_node_ids.append(node_id)
+
+    async def run_image_generation(self, node_id: str) -> dict[str, Any]:
+        self.generated_node_ids.append(node_id)
+        return {"status": "completed"}
+
+
+@pytest.mark.asyncio
+async def test_gen_node_cancels_before_generation():
+    tid = "t-node-cancel"
+    clear_cancel(tid)
+    request_cancel(tid, reason="user")
+    nest = _CancelNest()
+    try:
+        node = make_gen_node(nest=nest)
+        out = await node(
+            {
+                "thread_id": tid,
+                "key": "a",
+                "gen_by_key": {"a": {"node_id": "n1", "title": "A"}},
+            }
+        )
+
+        assert nest.cancelled_node_ids == ["n1"]
+        assert nest.generated_node_ids == []
+        assert out["gen_needs_user_keys"] == ["a"]
+        assert out["gen_fail_details"]["a"]["reason"] == "cancelled"
+    finally:
+        clear_cancel(tid)

--- a/services/agent-runtime/tests/test_post_cancel_intent.py
+++ b/services/agent-runtime/tests/test_post_cancel_intent.py
@@ -1,0 +1,124 @@
+from app.graph.post_cancel import (
+    build_revise_turn_command,
+    classify_post_cancel_intent,
+    revise_state_clear_for_phase,
+)
+
+
+def classify(
+    message: str,
+    *,
+    next_nodes: list[str] | None = None,
+    user_decision: str | None = None,
+    run_cancelled: bool = True,
+    phase: str | None = "cancelled",
+):
+    return classify_post_cancel_intent(
+        message,
+        next_nodes=next_nodes or [],
+        user_decision=user_decision,
+        run_cancelled=run_cancelled,
+        phase=phase,
+    )
+
+
+def test_new_task_chip_has_highest_priority():
+    assert classify("__new_task__", next_nodes=["await_shot_topo_confirm"]) == "new_task"
+
+
+def test_gate_resume_after_cancel():
+    assert classify("确认出图", next_nodes=["await_shot_topo_confirm"]) == "gate_resume"
+
+
+def test_gate_resume_for_explicit_user_decision():
+    assert (
+        classify(
+            "继续",
+            next_nodes=["await_shot_topo_confirm"],
+            user_decision="confirm_gen",
+        )
+        == "gate_resume"
+    )
+
+
+def test_revise_phrase():
+    assert classify("换成白底风格") == "revise"
+
+
+def test_explicit_new_task_phrase_wins_over_revise_phrase():
+    assert classify("重新做另一套，换成白底风格") == "new_task"
+
+
+def test_long_ref_is_new_task():
+    msg = "请用 @I1 帮我做另一套耳机主图方案并出白底图"
+    assert classify(msg) == "new_task"
+
+
+def test_long_free_form_request_is_new_task():
+    assert classify("请帮这个产品设计一个面向户外场景的完整广告方案") == "new_task"
+
+
+def test_short_non_revise_message_is_new_task():
+    assert classify("做海报") == "new_task"
+
+
+def test_not_post_cancel_returns_none():
+    assert classify("你好", run_cancelled=False, phase="done") is None
+
+
+def test_cancelled_phase_is_enough_to_classify():
+    assert classify("换成白底", run_cancelled=False, phase="cancelled") == "revise"
+
+
+def test_revise_clear_generating_keeps_macro_and_shot_but_clears_gen():
+    clear = revise_state_clear_for_phase("orchestrate_gen")
+
+    assert clear["gen_completed_keys"] is None
+    assert clear["gen_by_key"] is None
+    assert clear["gen_progress_id"] is None
+    assert clear["delivery_selections"] is None
+    assert "selected_macro_scheme_ids" not in clear
+    assert "macro_schemes" not in clear
+    assert "shot_manifest" not in clear
+
+
+def test_revise_clear_shot_phase_keeps_macro_selection_and_clears_shot():
+    clear = revise_state_clear_for_phase("await_shot_topo_confirm")
+
+    assert clear["shot_manifest"] is None
+    assert clear["delivery_selections"] is None
+    assert clear["gen_completed_keys"] is None
+    assert "selected_macro_scheme_ids" not in clear
+    assert "macro_schemes" not in clear
+
+
+def test_revise_clear_macro_phase_keeps_draft_and_clears_selection_downstream():
+    clear = revise_state_clear_for_phase("await_macro_scheme_select")
+
+    assert clear["selected_macro_scheme_ids"] is None
+    assert clear["shot_manifest"] is None
+    assert clear["delivery_selections"] is None
+    assert "macro_schemes" not in clear
+
+
+def test_revise_clear_image_qa_phase_clears_qa_and_downstream():
+    clear = revise_state_clear_for_phase("await_image_qa")
+
+    assert clear["image_qa_decision"] is None
+    assert clear["retake_pending"] is None
+    assert clear["macro_schemes"] is None
+    assert clear["shot_manifest"] is None
+
+
+def test_build_revise_turn_command_jumps_to_intake_with_clear_and_update():
+    command = build_revise_turn_command(
+        phase_hint="orchestrate_gen",
+        update={"effective_utterance": "换成白底"},
+    )
+
+    assert command.goto == "intake"
+    assert command.update["gen_completed_keys"] is None
+    assert command.update["run_cancelled"] is None
+    assert command.update["cancel_reason"] is None
+    assert command.update["phase"] is None
+    assert command.update["effective_utterance"] == "换成白底"

--- a/services/agent-runtime/tests/test_run_cancel_registry.py
+++ b/services/agent-runtime/tests/test_run_cancel_registry.py
@@ -1,0 +1,21 @@
+from app.run_cancel import clear_cancel, is_cancel_requested, peek_cancel_reason, request_cancel
+
+
+def test_request_cancel_sets_flag():
+    tid = "t-cancel-1"
+    clear_cancel(tid)
+    assert is_cancel_requested(tid) is False
+    request_cancel(tid, reason="user")
+    assert is_cancel_requested(tid) is True
+    assert peek_cancel_reason(tid) == "user"
+    clear_cancel(tid)
+    assert is_cancel_requested(tid) is False
+
+
+def test_request_cancel_idempotent():
+    tid = "t-cancel-2"
+    clear_cancel(tid)
+    request_cancel(tid, reason="user")
+    request_cancel(tid, reason="user")
+    assert is_cancel_requested(tid) is True
+    clear_cancel(tid)

--- a/services/agent-runtime/tests/test_runs_cancel_api.py
+++ b/services/agent-runtime/tests/test_runs_cancel_api.py
@@ -409,6 +409,65 @@ async def test_stream_clears_late_cancel_requested_as_stream_exits(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_stream_finally_releases_lock_before_clearing_cancel(monkeypatch):
+    """Release-before-clear prevents cancel_run busy-path from re-sticking the flag."""
+    tid = "thread-stream-release-before-clear"
+    clear_cancel(tid)
+    order: list[str] = []
+
+    import app.runs as runs_mod
+
+    real_release = runs_mod._release_thread
+
+    async def _track_release(*args: Any, **kwargs: Any) -> None:
+        order.append("release")
+        await real_release(*args, **kwargs)
+
+    def _track_clear(thread_id: str) -> None:
+        order.append("clear")
+        clear_cancel(thread_id)
+
+    monkeypatch.setattr("app.runs._release_thread", _track_release)
+    monkeypatch.setattr("app.runs.clear_cancel", _track_clear)
+
+    class _Snapshot:
+        next: list[str] = []
+
+        def __init__(self, values: dict[str, Any]) -> None:
+            self.values = values
+
+    class _Graph:
+        async def aget_state(self, _config: dict[str, Any]) -> _Snapshot:
+            return _Snapshot({"flow_mode": "product_visual", "phase": "done"})
+
+        async def astream(self, *_args: Any, **_kwargs: Any):
+            yield {"intake": {"flow_mode": "product_visual"}}
+
+    monkeypatch.setattr("app.runs.build_agent_graph", lambda **_kwargs: _Graph())
+    monkeypatch.setattr("app.runs._load_history", lambda *_args: _async_empty_list())
+
+    try:
+        events = [
+            event
+            async for event in stream_run_events(
+                RunRequest(
+                    session_id="s1",
+                    user_id="u1",
+                    message="done",
+                    thread_id=tid,
+                ),
+                nest=_Nest(),
+                llm=object(),
+                checkpointer=object(),
+            )
+        ]
+        assert events[-1]["type"] == "done"
+        assert order == ["release", "clear"]
+    finally:
+        clear_cancel(tid)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("flow_mode", [None, "campaign"])
 async def test_stream_clears_cancel_for_non_product_visual_flow(monkeypatch, flow_mode):
     tid = f"thread-stream-clear-non-pv-{flow_mode}"

--- a/services/agent-runtime/tests/test_runs_cancel_api.py
+++ b/services/agent-runtime/tests/test_runs_cancel_api.py
@@ -10,16 +10,34 @@ from langgraph.checkpoint.memory import MemorySaver
 from app.config import settings
 from app.graph.builder import build_agent_graph
 from app.main import app, clear_run_overrides, configure_run_overrides
-from app.run_cancel import clear_cancel, is_cancel_requested
-from app.runs import CancelRunRequest, cancel_run
+from app.run_cancel import clear_cancel, is_cancel_requested, request_cancel
+from app.runs import CancelRunRequest, RunRequest, cancel_run, stream_run_events
 
 
 class _Nest:
     def __init__(self) -> None:
         self.cancelled_node_ids: list[str] = []
+        self._db_locks: set[str] = set()
 
     async def close(self) -> None:
         pass
+
+    async def acquire_thread_lock(
+        self, thread_id: str, holder_id: str, ttl_seconds: float = 300
+    ) -> dict[str, bool]:
+        if thread_id in self._db_locks:
+            return {"acquired": False}
+        self._db_locks.add(thread_id)
+        return {"acquired": True}
+
+    async def renew_thread_lock(
+        self, thread_id: str, holder_id: str, ttl_seconds: float = 300
+    ) -> dict[str, bool]:
+        return {"renewed": True}
+
+    async def release_thread_lock(self, thread_id: str, holder_id: str) -> dict[str, bool]:
+        self._db_locks.discard(thread_id)
+        return {"released": True}
 
     async def cancel_generation(self, *, node_id: str) -> dict[str, Any]:
         self.cancelled_node_ids.append(node_id)
@@ -43,7 +61,7 @@ async def _seed_checkpoint(cp: MemorySaver, thread_id: str, values: dict[str, An
 async def test_cancel_run_sets_flag_and_is_idempotent(monkeypatch):
     clear_run_overrides()
     cp = MemorySaver()
-    configure_run_overrides(checkpointer=cp)
+    configure_run_overrides(checkpointer=cp, nest=_Nest())
     tid = "thread-cancel-api-1"
     clear_cancel(tid)
     monkeypatch.setattr(
@@ -78,7 +96,7 @@ async def test_cancel_run_sets_flag_and_is_idempotent(monkeypatch):
             "reason": "flow_not_supported",
         }
         assert r2.json()["ok"] is True
-        assert is_cancel_requested(tid) is True
+        assert is_cancel_requested(tid) is False
     finally:
         clear_cancel(tid)
         clear_run_overrides()
@@ -132,6 +150,190 @@ async def test_cancel_run_applies_product_visual_checkpoint_and_cancels_pending_
             "total_tasks": 3,
         }
         assert nest.cancelled_node_ids == ["n-pending"]
-        assert is_cancel_requested(tid) is True
+        assert is_cancel_requested(tid) is False
     finally:
         clear_cancel(tid)
+
+
+@pytest.mark.asyncio
+async def test_cancel_run_busy_product_visual_only_sets_cooperative_flag():
+    cp = MemorySaver()
+    tid = "thread-cancel-api-busy-pv"
+    clear_cancel(tid)
+    await _seed_checkpoint(
+        cp,
+        tid,
+        {
+            "flow_mode": "product_visual",
+            "phase": "orchestrate_gen",
+            "gen_by_key": {"pending": {"node_id": "n-pending", "status": "generating"}},
+            "gen_completed_keys": [],
+        },
+    )
+    nest = _Nest()
+    nest._db_locks.add(tid)
+
+    try:
+        result = await cancel_run(
+            CancelRunRequest(thread_id=tid, session_id="s1", reason="user"),
+            checkpointer=cp,
+            nest=nest,
+        )
+
+        assert result["ok"] is True
+        assert result["phase"] == "orchestrate_gen"
+        assert result["cancelled_node_ids"] == []
+        assert is_cancel_requested(tid) is True
+        assert nest.cancelled_node_ids == []
+
+        graph = build_agent_graph(
+            nest=_Nest(),
+            llm=None,
+            skills_dir=Path(__file__).resolve().parents[1] / "skills",
+            checkpointer=cp,
+        )
+        snap = await graph.aget_state({"configurable": {"thread_id": tid}})
+        assert snap.values.get("phase") == "orchestrate_gen"
+        assert snap.values.get("run_cancelled") is not True
+    finally:
+        clear_cancel(tid)
+
+
+@pytest.mark.asyncio
+async def test_cancel_run_non_product_visual_clears_stale_flag():
+    cp = MemorySaver()
+    tid = "thread-cancel-api-atomic"
+    clear_cancel(tid)
+    await _seed_checkpoint(
+        cp,
+        tid,
+        {
+            "flow_mode": "atomic",
+            "phase": "execute",
+        },
+    )
+    request_cancel(tid)
+
+    try:
+        result = await cancel_run(
+            CancelRunRequest(thread_id=tid, session_id="s1", reason="user"),
+            checkpointer=cp,
+            nest=_Nest(),
+        )
+
+        assert result["skipped"] is True
+        assert result["reason"] == "flow_not_supported"
+        assert is_cancel_requested(tid) is False
+    finally:
+        clear_cancel(tid)
+
+
+@pytest.mark.asyncio
+async def test_cancel_run_builds_and_closes_default_nest(monkeypatch):
+    cp = MemorySaver()
+    tid = "thread-cancel-api-default-nest"
+    clear_cancel(tid)
+    await _seed_checkpoint(
+        cp,
+        tid,
+        {
+            "flow_mode": "product_visual",
+            "phase": "orchestrate_gen",
+            "gen_by_key": {"pending": {"node_id": "n-pending", "status": "generating"}},
+            "gen_completed_keys": [],
+        },
+    )
+    production_nest = _Nest()
+    closed = False
+
+    async def close() -> None:
+        nonlocal closed
+        closed = True
+
+    production_nest.close = close  # type: ignore[method-assign]
+    monkeypatch.setattr("app.runs.default_nest", lambda **_kwargs: production_nest)
+
+    result = await cancel_run(
+        CancelRunRequest(thread_id=tid, session_id="s1", reason="user"),
+        checkpointer=cp,
+    )
+
+    assert result["phase"] == "cancelled"
+    assert production_nest.cancelled_node_ids == ["n-pending"]
+    assert closed is True
+    assert is_cancel_requested(tid) is False
+
+
+@pytest.mark.asyncio
+async def test_stream_clears_flag_after_cooperative_product_visual_cancel(monkeypatch):
+    tid = "thread-stream-clear-cooperative-cancel"
+    clear_cancel(tid)
+    request_cancel(tid)
+
+    class _Snapshot:
+        next: list[str] = []
+
+        def __init__(self, values: dict[str, Any]) -> None:
+            self.values = values
+
+    class _Graph:
+        def __init__(self) -> None:
+            self.values = {
+                "flow_mode": "product_visual",
+                "phase": "orchestrate_gen",
+                "gen_by_key": {
+                    "done": {"node_id": "n-done"},
+                    "pending": {"node_id": "n-pending"},
+                },
+                "gen_completed_keys": ["done", "legacy-completed"],
+            }
+
+        async def aget_state(self, _config: dict[str, Any]) -> _Snapshot:
+            return _Snapshot(dict(self.values))
+
+        async def astream(self, *_args: Any, **_kwargs: Any):
+            yield {"gen_scheduler": {"gen_completed_keys": ["done"]}}
+
+        async def aupdate_state(
+            self,
+            _config: dict[str, Any],
+            update: dict[str, Any],
+            **_kwargs: Any,
+        ) -> None:
+            self.values.update(update)
+
+    graph = _Graph()
+    monkeypatch.setattr("app.runs.build_agent_graph", lambda **_kwargs: graph)
+    monkeypatch.setattr("app.runs._load_history", lambda *_args: _async_empty_list())
+    nest = _Nest()
+
+    try:
+        events = [
+            event
+            async for event in stream_run_events(
+                RunRequest(
+                    session_id="s1",
+                    user_id="u1",
+                    message="继续",
+                    thread_id=tid,
+                ),
+                nest=nest,
+                llm=object(),
+                checkpointer=object(),
+            )
+        ]
+        cancelled = next(event for event in events if event["type"] == "run_cancelled")
+        assert cancelled["data"]["completedTasks"] == 2
+        assert graph.values["phase"] == "cancelled"
+        assert is_cancel_requested(tid) is False
+    finally:
+        clear_cancel(tid)
+
+
+async def _async_empty_list() -> list[Any]:
+    return []
+
+
+def test_cancel_run_rejects_blank_thread_id():
+    with pytest.raises(ValueError):
+        CancelRunRequest(thread_id="   ", session_id="s1")

--- a/services/agent-runtime/tests/test_runs_cancel_api.py
+++ b/services/agent-runtime/tests/test_runs_cancel_api.py
@@ -229,6 +229,25 @@ async def test_cancel_run_non_product_visual_clears_stale_flag():
 
 
 @pytest.mark.asyncio
+async def test_cancel_run_unknown_idle_flow_without_nest_does_not_set_flag():
+    cp = MemorySaver()
+    tid = "thread-cancel-api-unknown-idle"
+    clear_cancel(tid)
+
+    try:
+        result = await cancel_run(
+            CancelRunRequest(thread_id=tid, reason="user"),
+            checkpointer=cp,
+        )
+
+        assert result["skipped"] is True
+        assert result["reason"] == "flow_not_supported"
+        assert is_cancel_requested(tid) is False
+    finally:
+        clear_cancel(tid)
+
+
+@pytest.mark.asyncio
 async def test_cancel_run_builds_and_closes_default_nest(monkeypatch):
     cp = MemorySaver()
     tid = "thread-cancel-api-default-nest"
@@ -268,7 +287,7 @@ async def test_cancel_run_builds_and_closes_default_nest(monkeypatch):
 async def test_stream_clears_flag_after_cooperative_product_visual_cancel(monkeypatch):
     tid = "thread-stream-clear-cooperative-cancel"
     clear_cancel(tid)
-    request_cancel(tid)
+    request_cancel(tid, reason="operator")
 
     class _Snapshot:
         next: list[str] = []
@@ -325,6 +344,61 @@ async def test_stream_clears_flag_after_cooperative_product_visual_cancel(monkey
         cancelled = next(event for event in events if event["type"] == "run_cancelled")
         assert cancelled["data"]["completedTasks"] == 2
         assert graph.values["phase"] == "cancelled"
+        assert graph.values["cancel_reason"] == "operator"
+        assert is_cancel_requested(tid) is False
+    finally:
+        clear_cancel(tid)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("flow_mode", [None, "campaign"])
+async def test_stream_clears_cancel_for_non_product_visual_flow(monkeypatch, flow_mode):
+    tid = f"thread-stream-clear-non-pv-{flow_mode}"
+    clear_cancel(tid)
+    request_cancel(tid)
+
+    class _Snapshot:
+        next: list[str] = []
+
+        def __init__(self, values: dict[str, Any]) -> None:
+            self.values = values
+
+    class _Graph:
+        def __init__(self) -> None:
+            self.values = {"flow_mode": flow_mode, "phase": "execute"}
+            self.updated = False
+
+        async def aget_state(self, _config: dict[str, Any]) -> _Snapshot:
+            return _Snapshot(dict(self.values))
+
+        async def astream(self, *_args: Any, **_kwargs: Any):
+            yield {"intake": {"flow_mode": flow_mode}}
+
+        async def aupdate_state(self, *_args: Any, **_kwargs: Any) -> None:
+            self.updated = True
+
+    graph = _Graph()
+    monkeypatch.setattr("app.runs.build_agent_graph", lambda **_kwargs: graph)
+    monkeypatch.setattr("app.runs._load_history", lambda *_args: _async_empty_list())
+
+    try:
+        events = [
+            event
+            async for event in stream_run_events(
+                RunRequest(
+                    session_id="s1",
+                    user_id="u1",
+                    message="继续",
+                    thread_id=tid,
+                ),
+                nest=_Nest(),
+                llm=object(),
+                checkpointer=object(),
+            )
+        ]
+
+        assert not any(event["type"] == "run_cancelled" for event in events)
+        assert graph.updated is False
         assert is_cancel_requested(tid) is False
     finally:
         clear_cancel(tid)

--- a/services/agent-runtime/tests/test_runs_cancel_api.py
+++ b/services/agent-runtime/tests/test_runs_cancel_api.py
@@ -358,6 +358,72 @@ async def test_stream_clears_flag_after_cooperative_product_visual_cancel(monkey
 
 
 @pytest.mark.asyncio
+async def test_stream_cooperative_cancel_preserves_gate_reached_by_astream(monkeypatch):
+    tid = "thread-stream-cancel-races-gate"
+    clear_cancel(tid)
+    request_cancel(tid, reason="operator")
+
+    class _Snapshot:
+        def __init__(self, values: dict[str, Any], next_nodes: list[str]) -> None:
+            self.values = values
+            self.next = next_nodes
+
+    class _Graph:
+        def __init__(self) -> None:
+            self.values = {
+                "flow_mode": "product_visual",
+                "phase": "await_future_confirm",
+                "gen_by_key": {"pending": {"node_id": "n-pending"}},
+                "gen_completed_keys": [],
+            }
+            self.next_nodes: list[str] = []
+            self.update_calls = 0
+
+        async def aget_state(self, _config: dict[str, Any]) -> _Snapshot:
+            return _Snapshot(dict(self.values), list(self.next_nodes))
+
+        async def astream(self, *_args: Any, **_kwargs: Any):
+            self.next_nodes = ["await_future_confirm"]
+            yield {"decompose_from_ssot": {"phase": "await_future_confirm"}}
+
+        async def aupdate_state(self, *_args: Any, **_kwargs: Any) -> None:
+            self.update_calls += 1
+            self.next_nodes = []
+
+    graph = _Graph()
+    monkeypatch.setattr("app.runs.build_agent_graph", lambda **_kwargs: graph)
+    monkeypatch.setattr("app.runs._load_history", lambda *_args: _async_empty_list())
+
+    try:
+        events = [
+            event
+            async for event in stream_run_events(
+                RunRequest(
+                    session_id="s1",
+                    user_id="u1",
+                    message="继续",
+                    thread_id=tid,
+                ),
+                nest=_Nest(),
+                llm=object(),
+                checkpointer=object(),
+            )
+        ]
+
+        assert any(event["type"] == "run_cancelled" for event in events)
+        assert graph.update_calls == 0
+        assert graph.next_nodes == ["await_future_confirm"]
+        assert any(
+            event["type"] == "interrupt"
+            and event["data"]["node"] == "await_future_confirm"
+            for event in events
+        )
+        assert is_cancel_requested(tid) is False
+    finally:
+        clear_cancel(tid)
+
+
+@pytest.mark.asyncio
 async def test_stream_clears_late_cancel_requested_as_stream_exits(monkeypatch):
     tid = "thread-stream-clear-late-cancel"
     clear_cancel(tid)

--- a/services/agent-runtime/tests/test_runs_cancel_api.py
+++ b/services/agent-runtime/tests/test_runs_cancel_api.py
@@ -264,21 +264,28 @@ async def test_cancel_run_builds_and_closes_default_nest(monkeypatch):
     )
     production_nest = _Nest()
     closed = False
+    nest_kwargs: dict[str, str] = {}
 
     async def close() -> None:
         nonlocal closed
         closed = True
 
     production_nest.close = close  # type: ignore[method-assign]
-    monkeypatch.setattr("app.runs.default_nest", lambda **_kwargs: production_nest)
+
+    def build_default_nest(**kwargs: str) -> _Nest:
+        nest_kwargs.update(kwargs)
+        return production_nest
+
+    monkeypatch.setattr("app.runs.default_nest", build_default_nest)
 
     result = await cancel_run(
-        CancelRunRequest(thread_id=tid, session_id="s1", reason="user"),
+        CancelRunRequest(thread_id=tid, session_id="   ", reason="user"),
         checkpointer=cp,
     )
 
     assert result["phase"] == "cancelled"
     assert production_nest.cancelled_node_ids == ["n-pending"]
+    assert nest_kwargs == {"session_id": "s1", "user_id": "u1"}
     assert closed is True
     assert is_cancel_requested(tid) is False
 
@@ -345,6 +352,57 @@ async def test_stream_clears_flag_after_cooperative_product_visual_cancel(monkey
         assert cancelled["data"]["completedTasks"] == 2
         assert graph.values["phase"] == "cancelled"
         assert graph.values["cancel_reason"] == "operator"
+        assert is_cancel_requested(tid) is False
+    finally:
+        clear_cancel(tid)
+
+
+@pytest.mark.asyncio
+async def test_stream_clears_late_cancel_requested_as_stream_exits(monkeypatch):
+    tid = "thread-stream-clear-late-cancel"
+    clear_cancel(tid)
+
+    class _Snapshot:
+        next: list[str] = []
+
+        def __init__(self, values: dict[str, Any]) -> None:
+            self.values = values
+
+    class _Graph:
+        def __init__(self) -> None:
+            self.state_reads = 0
+
+        async def aget_state(self, _config: dict[str, Any]) -> _Snapshot:
+            self.state_reads += 1
+            if self.state_reads == 3:
+                request_cancel(tid, reason="late")
+            return _Snapshot({"flow_mode": "product_visual", "phase": "done"})
+
+        async def astream(self, *_args: Any, **_kwargs: Any):
+            yield {"intake": {"flow_mode": "product_visual"}}
+
+    graph = _Graph()
+    monkeypatch.setattr("app.runs.build_agent_graph", lambda **_kwargs: graph)
+    monkeypatch.setattr("app.runs._load_history", lambda *_args: _async_empty_list())
+
+    try:
+        events = [
+            event
+            async for event in stream_run_events(
+                RunRequest(
+                    session_id="s1",
+                    user_id="u1",
+                    message="短任务",
+                    thread_id=tid,
+                ),
+                nest=_Nest(),
+                llm=object(),
+                checkpointer=object(),
+            )
+        ]
+
+        assert events[-1]["type"] == "done"
+        assert graph.state_reads == 3
         assert is_cancel_requested(tid) is False
     finally:
         clear_cancel(tid)

--- a/services/agent-runtime/tests/test_runs_cancel_api.py
+++ b/services/agent-runtime/tests/test_runs_cancel_api.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from langgraph.checkpoint.memory import MemorySaver
+
+from app.config import settings
+from app.graph.builder import build_agent_graph
+from app.main import app, clear_run_overrides, configure_run_overrides
+from app.run_cancel import clear_cancel, is_cancel_requested
+from app.runs import CancelRunRequest, cancel_run
+
+
+class _Nest:
+    def __init__(self) -> None:
+        self.cancelled_node_ids: list[str] = []
+
+    async def close(self) -> None:
+        pass
+
+    async def cancel_generation(self, *, node_id: str) -> dict[str, Any]:
+        self.cancelled_node_ids.append(node_id)
+        return {"ok": True}
+
+
+async def _seed_checkpoint(cp: MemorySaver, thread_id: str, values: dict[str, Any]) -> None:
+    graph = build_agent_graph(
+        nest=_Nest(),
+        llm=None,
+        skills_dir=Path(__file__).resolve().parents[1] / "skills",
+        checkpointer=cp,
+    )
+    await graph.aupdate_state(
+        {"configurable": {"thread_id": thread_id}},
+        {"thread_id": thread_id, "session_id": "s1", "user_id": "u1", **values},
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancel_run_sets_flag_and_is_idempotent(monkeypatch):
+    clear_run_overrides()
+    cp = MemorySaver()
+    configure_run_overrides(checkpointer=cp)
+    tid = "thread-cancel-api-1"
+    clear_cancel(tid)
+    monkeypatch.setattr(
+        type(settings),
+        "effective_runtime_auth_token",
+        property(lambda _self: "test-token"),
+    )
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            headers = {"x-lnkpi-service-token": "test-token"}
+            r1 = await client.post(
+                "/v1/runs/cancel",
+                json={"thread_id": tid, "session_id": "s1", "reason": "user"},
+                headers=headers,
+            )
+            r2 = await client.post(
+                "/v1/runs/cancel",
+                json={"thread_id": tid, "session_id": "s1", "reason": "user"},
+                headers=headers,
+            )
+
+        assert r1.status_code == 200
+        assert r1.json() == {
+            "ok": True,
+            "phase": None,
+            "cancelled_node_ids": [],
+            "completed_tasks": 0,
+            "total_tasks": 0,
+            "skipped": True,
+            "reason": "flow_not_supported",
+        }
+        assert r2.json()["ok"] is True
+        assert is_cancel_requested(tid) is True
+    finally:
+        clear_cancel(tid)
+        clear_run_overrides()
+
+
+@pytest.mark.asyncio
+async def test_cancel_run_applies_product_visual_checkpoint_and_cancels_pending_nodes():
+    cp = MemorySaver()
+    tid = "thread-cancel-api-pv"
+    clear_cancel(tid)
+    await _seed_checkpoint(
+        cp,
+        tid,
+        {
+            "flow_mode": "product_visual",
+            "phase": "orchestrate_gen",
+            "gen_by_key": {
+                "done": {"node_id": "n-done", "status": "completed", "url": "https://x/done.png"},
+                "pending": {"node_id": "n-pending", "status": "generating"},
+                "missing-node": {"status": "queued"},
+            },
+            "gen_completed_keys": ["done"],
+        },
+    )
+    nest = _Nest()
+
+    try:
+        result = await cancel_run(
+            CancelRunRequest(thread_id=tid, session_id="s1", reason="user"),
+            checkpointer=cp,
+            nest=nest,
+        )
+        again = await cancel_run(
+            CancelRunRequest(thread_id=tid, session_id="s1", reason="user"),
+            checkpointer=cp,
+            nest=nest,
+        )
+
+        assert result == {
+            "ok": True,
+            "phase": "cancelled",
+            "cancelled_node_ids": ["n-pending"],
+            "completed_tasks": 1,
+            "total_tasks": 3,
+        }
+        assert again == {
+            "ok": True,
+            "phase": "cancelled",
+            "cancelled_node_ids": [],
+            "completed_tasks": 1,
+            "total_tasks": 3,
+        }
+        assert nest.cancelled_node_ids == ["n-pending"]
+        assert is_cancel_requested(tid) is True
+    finally:
+        clear_cancel(tid)

--- a/services/agent-runtime/tests/test_runs_post_cancel.py
+++ b/services/agent-runtime/tests/test_runs_post_cancel.py
@@ -29,9 +29,43 @@ def test_resolve_turn_input_new_task_after_cancel():
     assert input_state.goto == "intake"
     assert input_state.update["shot_manifest"] is None
     assert input_state.update["run_cancelled"] is None
+    assert input_state.update["cancelled_from_phase"] is None
+    # M7: a fresh task must also drop the whole gen run channel.
+    for key in ("gen_by_key", "gen_completed_keys", "gen_failed_keys", "gen_progress_id"):
+        assert input_state.update[key] is None
 
 
-def test_resolve_turn_input_revise_after_cancel():
+def test_resolve_turn_input_revise_after_gen_phase_cancel_keeps_upstream_ssot():
+    """§4.3: a gen-phase revise reuses the confirmed macro + shot SSOT."""
+    turn_update = {
+        "messages": [HumanMessage(content="换成白底风格")],
+        "session_id": "s",
+    }
+
+    input_state = resolve_turn_input(
+        {
+            "phase": "cancelled",
+            "cancelled_from_phase": "orchestrate_gen",
+            "run_cancelled": True,
+        },
+        [],
+        "换成白底风格",
+        None,
+        turn_update,
+    )
+
+    assert input_state.goto == "intake"
+    assert "shot_manifest" not in input_state.update
+    assert "selected_macro_scheme_ids" not in input_state.update
+    assert input_state.update["gen_by_key"] is None
+    assert input_state.update["delivery_selections"] is None
+    assert input_state.update["cancel_reason"] is None
+    assert input_state.update["cancelled_from_phase"] is None
+    assert input_state.update["messages"] == turn_update["messages"]
+
+
+def test_resolve_turn_input_revise_without_origin_phase_clears_downstream():
+    """Without ``cancelled_from_phase`` nothing downstream can be trusted."""
     turn_update = {
         "messages": [HumanMessage(content="换成白底风格")],
         "session_id": "s",
@@ -47,8 +81,31 @@ def test_resolve_turn_input_revise_after_cancel():
 
     assert input_state.goto == "intake"
     assert input_state.update["shot_manifest"] is None
+    assert input_state.update["selected_macro_scheme_ids"] is None
     assert input_state.update["cancel_reason"] is None
-    assert input_state.update["messages"] == turn_update["messages"]
+    assert input_state.update["cancelled_from_phase"] is None
+
+
+def test_resolve_turn_input_revise_after_shot_phase_cancel_keeps_macro_choice():
+    turn_update = {
+        "messages": [HumanMessage(content="去掉第三张")],
+        "session_id": "s",
+    }
+
+    input_state = resolve_turn_input(
+        {
+            "phase": "cancelled",
+            "cancelled_from_phase": "await_shot_topo_confirm",
+            "run_cancelled": True,
+        },
+        [],
+        "去掉第三张",
+        None,
+        turn_update,
+    )
+
+    assert input_state.update["shot_manifest"] is None
+    assert "selected_macro_scheme_ids" not in input_state.update
 
 
 def test_resolve_turn_input_preserves_non_cancelled_paths():

--- a/services/agent-runtime/tests/test_runs_post_cancel.py
+++ b/services/agent-runtime/tests/test_runs_post_cancel.py
@@ -1,0 +1,116 @@
+"""Post-cancel turn resolution and reconnect thread-state tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from langchain_core.messages import HumanMessage
+from langgraph.checkpoint.memory import MemorySaver
+
+from app.graph.builder import build_agent_graph
+from app.runs import get_thread_state, resolve_turn_input
+
+
+def test_resolve_turn_input_new_task_after_cancel():
+    pre = {
+        "phase": "cancelled",
+        "run_cancelled": True,
+        "flow_mode": "product_visual",
+        "shot_manifest": [{"shot_id": "s1"}],
+    }
+    turn_update = {
+        "messages": [HumanMessage(content="__new_task__")],
+        "session_id": "s",
+    }
+
+    input_state = resolve_turn_input(pre, [], "__new_task__", None, turn_update)
+
+    assert input_state.goto == "intake"
+    assert input_state.update["shot_manifest"] is None
+    assert input_state.update["run_cancelled"] is None
+
+
+def test_resolve_turn_input_revise_after_cancel():
+    turn_update = {
+        "messages": [HumanMessage(content="换成白底风格")],
+        "session_id": "s",
+    }
+
+    input_state = resolve_turn_input(
+        {"phase": "cancelled", "run_cancelled": True},
+        [],
+        "换成白底风格",
+        None,
+        turn_update,
+    )
+
+    assert input_state.goto == "intake"
+    assert input_state.update["shot_manifest"] is None
+    assert input_state.update["cancel_reason"] is None
+    assert input_state.update["messages"] == turn_update["messages"]
+
+
+def test_resolve_turn_input_preserves_non_cancelled_paths():
+    turn_update = {
+        "messages": [HumanMessage(content="继续聊")],
+        "session_id": "s",
+    }
+
+    assert resolve_turn_input({}, [], "继续聊", None, turn_update) is turn_update
+
+    fresh = resolve_turn_input(
+        {"phase": "await_confirm"},
+        ["await_confirm"],
+        "@I1 这个是模特， @I2 这个是衣服，请让模特穿上这件衣服出图",
+        None,
+        turn_update,
+    )
+    assert fresh.goto == "intake"
+
+
+def test_resolve_turn_input_defers_gate_resume_to_async_path():
+    turn_update = {
+        "messages": [HumanMessage(content="确认出图")],
+        "session_id": "s",
+    }
+
+    assert (
+        resolve_turn_input(
+            {"phase": "cancelled", "run_cancelled": True},
+            ["await_shot_topo_confirm"],
+            "确认出图",
+            None,
+            turn_update,
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_thread_state_reports_cancelled_as_unfinished():
+    checkpointer = MemorySaver()
+    graph = build_agent_graph(
+        nest=type("_N", (), {"close": lambda self: None})(),
+        llm=None,
+        skills_dir=Path(__file__).resolve().parents[1] / "skills",
+        checkpointer=checkpointer,
+    )
+    config = {"configurable": {"thread_id": "cancelled-thread"}}
+    await graph.aupdate_state(
+        config,
+        {
+            "messages": [HumanMessage(content="停止")],
+            "phase": "cancelled",
+            "run_cancelled": True,
+            "thread_id": "cancelled-thread",
+            "session_id": "s",
+            "user_id": "u",
+        },
+    )
+
+    state = await get_thread_state("cancelled-thread", checkpointer=checkpointer)
+
+    assert state["phase"] == "cancelled"
+    assert state["runCancelled"] is True
+    assert state["finished"] is False


### PR DESCRIPTION
## Summary
- Add Run Cancel Token for `product_visual`: Nest `POST /api/agent/runs/cancel` → Runtime cooperative stop in `gen_scheduler` / `gen_node`, with sticky-flag and non-PV skip safeguards.
- After cancel, classify the next utterance as gate resume / revise / new task (heuristics +「发起新任务」chip); persist `cancelled_from_phase` so revise keeps confirmed upstream SSOT.
- SideRail: cancel API before SSE abort, cancelled callout from progress counts, keep HITL chips when a gate is preserved.

## Spec / plan
- Spec: `docs/superpowers/specs/2026-08-12-agent-mid-run-interrupt-design.md` (Accepted, PV-first)
- Plan: `docs/superpowers/plans/2026-09-06-agent-mid-run-interrupt-pv.md`

## Test plan
- [x] runtime cancel-related pytest
- [x] server cancel client vitest
- [x] web cancelAgentRun + interruptGate vitest
- [ ] Staging UAT-INT-PV-01～07 (manual; checklist in spec)
- [ ] Confirm single-replica agent-runtime (in-process cancel registry)


Made with [Cursor](https://cursor.com)