### PR TITLE
fix(runtime): single sidebar image edit → atomic (tiger glasses)

### DIFF
--- a/services/agent-runtime/app/graph/l0_action.py
+++ b/services/agent-runtime/app/graph/l0_action.py
@@ -9,7 +9,36 @@ if TYPE_CHECKING:
     from app.graph.planning_guard import ActionKind
 
 PRESERVE_MARKERS = ("不变", "保持", "维持", "沿用")
-TRANSFORM_VERBS = ("穿上", "换装", "替换", "融合", "上身", "换上", "换穿", "试穿", "佩戴", "搭配")
+TRANSFORM_VERBS = (
+    "穿上",
+    "换装",
+    "替换",
+    "融合",
+    "上身",
+    "换上",
+    "换穿",
+    "试穿",
+    "佩戴",
+    "搭配",
+    "带上",
+    "戴上",
+    "加上",
+)
+# Single sidebar/ref image edits — exclude bare 「搭配」 to avoid hijacking soft chat.
+SIDEBAR_SINGLE_EDIT_VERBS = (
+    "穿上",
+    "换装",
+    "替换",
+    "融合",
+    "上身",
+    "换上",
+    "换穿",
+    "试穿",
+    "佩戴",
+    "带上",
+    "戴上",
+    "加上",
+)
 _REF_KEY_PATTERN = re.compile(r"@([ITVA]\d+)", re.IGNORECASE)
 
 

--- a/services/agent-runtime/app/graph/route_precedence.py
+++ b/services/agent-runtime/app/graph/route_precedence.py
@@ -15,7 +15,12 @@ from app.graph.atomic_intent_ir import AtomicIntent, intent_suggests_atomic_crea
 from app.graph.clarify_reply import ClarifyReplyResult, classify_clarify_reply
 from app.graph.explore_route import explore_canvas_signal
 from app.graph.intent import modify_intent, single_node_gen_intent
-from app.graph.l0_action import TRANSFORM_VERBS, detect_l0_action, has_preserve_intent
+from app.graph.l0_action import (
+    SIDEBAR_SINGLE_EDIT_VERBS,
+    TRANSFORM_VERBS,
+    detect_l0_action,
+    has_preserve_intent,
+)
 from app.graph.route_context import RouteContext
 from app.graph.route_features import RouteFeatures, orchestration_campaign_signal
 
@@ -169,15 +174,21 @@ def has_planning_image_conflict(utterance: str) -> bool:
 def _sidebar_img2img_match(
     intent: AtomicIntent, features: RouteFeatures, ctx: RouteContext
 ) -> bool:
+    """Multi-image transform OR single sidebar/ref image edit (e.g. 给这只老虎带上眼镜)."""
     utterance = intent.utterance
-    if not features.get("has_multi_image_ref"):
-        return False
     keys = list(ctx.get("mentioned_keys") or [])
     image_keys = [k for k in keys if str(k).upper().startswith("I")]
-    has_transform = any(v in utterance for v in TRANSFORM_VERBS) or (
-        len(image_keys) >= 2 and ("让" in utterance or "请" in utterance)
-    )
-    return has_transform or bool(features.get("preserve_composition"))
+    multi = bool(features.get("has_multi_image_ref"))
+    single_ctx = bool(features.get("has_sidebar_media") or features.get("has_image_ref"))
+    if not multi and not single_ctx:
+        return False
+    if multi:
+        has_transform = any(v in utterance for v in TRANSFORM_VERBS) or (
+            len(image_keys) >= 2 and ("让" in utterance or "请" in utterance)
+        )
+        return has_transform or bool(features.get("preserve_composition"))
+    # Single image: require explicit edit/accessory verbs (not bare 「搭配」).
+    return any(v in utterance for v in SIDEBAR_SINGLE_EDIT_VERBS)
 
 
 def _ref_backed_generate_match(intent: AtomicIntent, features: RouteFeatures) -> bool:

--- a/services/agent-runtime/skills/atomic-create/eval-route-set.yaml
+++ b/services/agent-runtime/skills/atomic-create/eval-route-set.yaml
@@ -243,3 +243,11 @@ cases:
     state:
       messages: [{ role: user, content: "生成东北虎图片" }]
     gold: { flow_mode: atomic_create }
+
+  - id: rt-sidebar-edit-01
+    state:
+      messages: [{ role: user, content: "给这只小老虎带上眼镜和帽子" }]
+      sidebar_mentioned_keys: [I1]
+      sidebar_attachments:
+        - { refKey: I1, mediaType: image, url: "https://a/tiger.jpg" }
+    gold: { flow_mode: atomic_create, reason: sidebar_img2img_p1 }

--- a/services/agent-runtime/tests/test_route_precedence.py
+++ b/services/agent-runtime/tests/test_route_precedence.py
@@ -82,6 +82,35 @@ def test_precedence_sidebar_img2img():
     assert d["reason"] == "sidebar_img2img_p1"
 
 
+def test_sidebar_single_tiger_edit_not_chat():
+    """Prod: sidebar chip image + 给这只小老虎带上眼镜和帽子 → atomic, not chat."""
+    d = _decide(
+        {
+            "messages": [{"role": "user", "content": "给这只小老虎带上眼镜和帽子"}],
+            "sidebar_attachments": [
+                {"refKey": "I1", "mediaType": "image", "url": "https://a/tiger.jpg"}
+            ],
+            "sidebar_mentioned_keys": ["I1"],
+        }
+    )
+    assert d["flow_mode"] == "atomic_create"
+    assert d["precedence_rule_id"] == "sidebar_img2img"
+    assert d["precedence_rule_id"] != "default_chat"
+
+
+def test_sidebar_open_without_edit_verb_stays_chat():
+    d = _decide(
+        {
+            "messages": [{"role": "user", "content": "这只老虎看起来不错"}],
+            "sidebar_attachments": [
+                {"refKey": "I1", "mediaType": "image", "url": "https://a/tiger.jpg"}
+            ],
+        }
+    )
+    assert d["flow_mode"] == "chat"
+    assert d["precedence_rule_id"] == "default_chat"
+
+
 def test_precedence_product_visual_beats_ref_backed_with_product_photo():
     d = _decide(
         {


### PR DESCRIPTION
## Summary
- Root cause: `sidebar_img2img` required `has_multi_image_ref` (2+ images) and `TRANSFORM_VERBS` lacked 「带上」, so sidebar chip +「给这只小老虎带上眼镜和帽子」fell to `default_chat`
- Fix: allow single `has_sidebar_media`/`has_image_ref` + `SIDEBAR_SINGLE_EDIT_VERBS` (带上/戴上/加上/…); keep multi-image path; eval `rt-sidebar-edit-01`

## Test plan
- [ ] pytest route_precedence + eval-route-set
- [ ] Prod: sidebar tiger chip +「给这只小老虎带上眼镜和帽子」→ atomic / canvas edit, not 日常对话


Made with [Cursor](https://cursor.com)