### PR TITLE
feat: Wave A A2 enable export pack (manifest + stream-download)

### DIFF
--- a/apps/server/src/agent/agent-canvas-tools.service.test.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.test.ts
@@ -1718,4 +1718,51 @@ describe('AgentCanvasToolsService', () => {
       expect(persistRemote).not.toHaveBeenCalled()
     })
   })
+
+  describe('exportMediaPackage', () => {
+    it('returns count 0 and empty items when nodeIds is empty', async () => {
+      const result = await svc.exportMediaPackage({
+        sessionId: 's1',
+        userId: 'u1',
+        nodeIds: [],
+      })
+      expect(result.manifest.count).toBe(0)
+      expect(result.manifest.items).toEqual([])
+      expect(result.manifest.exportedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    })
+
+    it('skips nodes without url and builds stream-download downloadPath', async () => {
+      canvas = {
+        nodes: [
+          {
+            id: 'img-1',
+            type: 'image',
+            position: { x: 0, y: 0 },
+            data: { title: '主图', url: 'https://cdn.example/img.png' },
+          },
+          {
+            id: 'img-no-url',
+            type: 'image',
+            position: { x: 0, y: 0 },
+            data: { title: '无URL' },
+          },
+        ],
+        edges: [],
+      }
+      const result = await svc.exportMediaPackage({
+        sessionId: 's1',
+        userId: 'u1',
+        nodeIds: ['img-1', 'img-no-url'],
+      })
+      expect(result.manifest.count).toBe(1)
+      expect(result.manifest.items).toHaveLength(1)
+      expect(result.manifest.items[0]).toMatchObject({
+        nodeId: 'img-1',
+        url: 'https://cdn.example/img.png',
+        fileName: '主图.png',
+      })
+      expect(result.manifest.items[0].downloadPath).toMatch(/^\/api\/media\/stream-download\?/)
+      expect(result.manifest.items[0].downloadPath).toContain('sessionId=s1')
+    })
+  })
 })

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -142,6 +142,7 @@ const emit = defineEmits<{
   turnComplete: []
   focusNode: [nodeId: string]
   focusAll: [nodeIds: string[]]
+  exportPack: [nodeIds: string[]]
   undo: []
   redo: []
   openImageEditor: [nodeId: string]
@@ -1049,6 +1050,10 @@ function onFocusNode(nodeId: string) {
 function onFocusAll(nodeIds: string[]) {
   emit('focusAll', nodeIds)
   if (isMobileLayout.value) closePanel()
+}
+
+function onExportPack(nodeIds: string[]) {
+  emit('exportPack', nodeIds)
 }
 
 function toggleFloating() {
@@ -2326,6 +2331,7 @@ defineExpose({
                 :disabled="agent.isStreaming"
                 @focus-node="onFocusNode($event)"
                 @focus-all="onFocusAll($event)"
+                @export-pack="onExportPack($event)"
               />
             </div>
           </div>

--- a/apps/web/src/components/agent/presentation/AgentPresentationHost.vue
+++ b/apps/web/src/components/agent/presentation/AgentPresentationHost.vue
@@ -12,6 +12,7 @@ import type { JourneyTraceSnapshot } from '@/components/agent/journeyTraceTypes'
 import type { AgentPresentationEnvelope, AgentPresentationPrimaryAction } from './types'
 
 const FOCUS_ALL_MESSAGE = '__focus_all_canvas__'
+const EXPORT_PACK_MESSAGE = '__export_pack__'
 
 const props = defineProps<{
   presentation: AgentPresentationEnvelope
@@ -26,8 +27,11 @@ const emit = defineEmits<{
   macroToggle: [schemeId: string, checked: boolean]
   focusNode: [nodeId: string]
   focusAll: [nodeIds: string[]]
+  exportPack: [nodeIds: string[]]
   deliverySwitch: [shotId: string, variantKey: string]
 }>()
+
+const exportBusy = ref(false)
 
 const macroSelections = ref<string[]>(props.macroSelectedIds ?? [])
 
@@ -83,6 +87,19 @@ function onPrimaryAction() {
   if (action.message === FOCUS_ALL_MESSAGE) {
     const ids = collectAllNodeIds()
     if (ids.length) emit('focusAll', ids)
+    return
+  }
+  emit('primaryAction', action.message)
+}
+
+function onSecondaryAction(action: AgentPresentationPrimaryAction) {
+  if (action.message === EXPORT_PACK_MESSAGE) {
+    if (exportBusy.value) return
+    exportBusy.value = true
+    emit('exportPack', collectAllNodeIds())
+    window.setTimeout(() => {
+      exportBusy.value = false
+    }, 800)
     return
   }
   emit('primaryAction', action.message)
@@ -215,9 +232,9 @@ function onPrimaryAction() {
         :key="`${action.label}-${idx}`"
         type="button"
         class="neo-ctl rounded-lg px-3 py-1.5 text-xs"
-        :disabled="disabled || action.disabled"
+        :disabled="disabled || action.disabled || (action.message === EXPORT_PACK_MESSAGE && exportBusy)"
         data-testid="secondary-action"
-        @click="emit('primaryAction', action.message)"
+        @click="onSecondaryAction(action)"
       >
         {{ action.label }}
       </button>

--- a/apps/web/src/components/agent/presentation/presentation.test.ts
+++ b/apps/web/src/components/agent/presentation/presentation.test.ts
@@ -55,7 +55,7 @@ const doneEnvelope: AgentPresentationEnvelope = {
     basics_section_title: '基础资产',
   },
   primary_action: { label: '在画布中定位全部', message: '__focus_all_canvas__' },
-  secondary_actions: [{ label: '导出打包（二期）', message: '__export_pack__', disabled: true }],
+  secondary_actions: [{ label: '导出打包', message: '__export_pack__' }],
 }
 
 describe('AgentStepper', () => {
@@ -100,6 +100,31 @@ describe('AgentPresentationHost', () => {
     expect(wrapper.find('[data-testid="primary-action"]').text()).toBe('在画布中定位全部')
     await wrapper.find('[data-testid="primary-action"]').trigger('click')
     expect(wrapper.emitted('focusAll')?.[0]?.[0]).toEqual(['node-hero', 'node-gift', 'node-seed'])
+  })
+
+  it('emits exportPack on secondary export action without primaryAction', async () => {
+    const wrapper = mount(AgentPresentationHost, {
+      props: { presentation: doneEnvelope },
+    })
+    const secondary = wrapper.find('[data-testid="secondary-action"]')
+    expect(secondary.text()).toBe('导出打包')
+    expect(secondary.attributes('disabled')).toBeUndefined()
+    await secondary.trigger('click')
+    expect(wrapper.emitted('exportPack')?.[0]?.[0]).toEqual(['node-hero', 'node-gift', 'node-seed'])
+    expect(wrapper.emitted('primaryAction')).toBeUndefined()
+  })
+
+  it('emits exportPack with empty ids when no node_ids', async () => {
+    const emptyDone: AgentPresentationEnvelope = {
+      ...doneEnvelope,
+      body: { ...doneEnvelope.body!, finalized: [], basics: [] },
+    }
+    const wrapper = mount(AgentPresentationHost, {
+      props: { presentation: emptyDone },
+    })
+    await wrapper.find('[data-testid="secondary-action"]').trigger('click')
+    expect(wrapper.emitted('exportPack')?.[0]?.[0]).toEqual([])
+    expect(wrapper.emitted('primaryAction')).toBeUndefined()
   })
 
   it('renders shot_topo_merged with topo cards and merged primary label', () => {

--- a/apps/web/src/composables/useCanvasMedia.test.ts
+++ b/apps/web/src/composables/useCanvasMedia.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ElMessage } from 'element-plus'
 import {
   downloadMediaFile,
+  downloadMediaPackage,
   isUpstreamMediaUrl,
   UPSTREAM_MEDIA_DOWNLOAD_HINT,
 } from './useCanvasMedia'
@@ -74,5 +76,22 @@ describe('downloadMediaFile', () => {
 describe('UPSTREAM_MEDIA_DOWNLOAD_HINT', () => {
   it('has expiry copy', () => {
     expect(UPSTREAM_MEDIA_DOWNLOAD_HINT).toMatch(/过期/)
+  })
+})
+
+describe('downloadMediaPackage', () => {
+  beforeEach(() => {
+    vi.mocked(ElMessage.warning).mockClear()
+  })
+
+  it('toasts when no media in selection', async () => {
+    const count = await downloadMediaPackage(
+      [{ id: 'n1', type: 'image', data: {} }],
+      ['n1'],
+    )
+    expect(count).toBe(0)
+    expect(ElMessage.warning).toHaveBeenCalledWith(
+      '没有可导出的媒体，请确认定稿节点已生成',
+    )
   })
 })

--- a/apps/web/src/composables/useCanvasMedia.ts
+++ b/apps/web/src/composables/useCanvasMedia.ts
@@ -103,7 +103,10 @@ export async function downloadMediaPackage(
   opts?: DownloadMediaOptions,
 ) {
   const items = collectMediaFromNodes(nodes, selectedIds)
-  if (!items.length) return 0
+  if (!items.length) {
+    ElMessage.warning('没有可导出的媒体，请确认定稿节点已生成')
+    return 0
+  }
 
   const manifest = {
     exportedAt: new Date().toISOString(),

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -2136,6 +2136,14 @@ async function handlePackageDownload() {
   )
 }
 
+async function handleExportPack(nodeIds: string[]) {
+  await downloadMediaPackage(
+    nodes.value.map((n) => ({ id: n.id, type: n.type, data: n.data as Record<string, unknown> })),
+    nodeIds,
+    { sessionId: sessionId.value },
+  )
+}
+
 function connectSelectionToTarget(targetId: string, sourceIds = multiSelectedIds.value) {
   for (const sourceId of sourceIds) {
     if (sourceId === targetId) continue
@@ -3365,6 +3373,7 @@ onUnmounted(() => {
         @turn-complete="handleAgentTurnComplete"
         @focus-node="focusNodeById"
         @focus-all="focusNodesByIds"
+        @export-pack="handleExportPack"
         @undo="handleAgentUndo"
         @redo="handleAgentRedo"
         @open-image-editor="handleAgentOpenImageEditor"

--- a/docs/superpowers/plans/2026-09-11-wave-a-a2-export-pack.md
+++ b/docs/superpowers/plans/2026-09-11-wave-a-a2-export-pack.md
@@ -1,0 +1,462 @@
+# Wave A · A2 导出打包 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 启用交付完成态「导出打包」芯片；人侧经 Host 拦截 `__export_pack__` → `downloadMediaPackage`（manifest + stream-download）；不发聊天消息；真 zip 留给 A2.1。
+
+**Architecture:** Runtime 去掉 `disabled` 并改文案；`AgentPresentationHost` 对 secondary 识别 `__export_pack__`，收集 `finalized`/`basics` 的 `node_id` 后 `emit('exportPack')`；`AgentSideRail`（完成态 Host）与 `CanvasPage` 接到已有 `downloadMediaPackage`。Agent Nest `exportMediaPackage` 保持 manifest/`downloadPath`，本 PR 不造 zip。COS 未配置不得阻塞导出。
+
+**Tech Stack:** Vue 3 + Vitest（web）、Python pytest（agent-runtime）、现有 Nest `exportMediaPackage` / `useCanvasMedia.downloadMediaPackage`
+
+**Spec:** [docs/superpowers/specs/2026-09-11-wave-a-a2-export-pack-design.md](../specs/2026-09-11-wave-a-a2-export-pack-design.md)  
+**Program:** [docs/superpowers/specs/2026-09-10-wave-a-delivery-program-design.md](../specs/2026-09-10-wave-a-delivery-program-design.md)
+
+## Global Constraints
+
+- MVP = 启用芯片 + manifest JSON + 多文件 stream-download；**禁止**本 PR 实现真 zip（A2.1）。
+- `__export_pack__` **不得**写入用户对话 / 不得触发 `sendMessage` / `onDeliveryPrimaryAction`。
+- COS / `persist-remote` 未配置 **不得**阻塞导出。
+- 人机最终下载都经 `/api/media/stream-download`。
+- Commit per task；PR 前：`pnpm build`、相关 web/runtime 测试、`pnpm --filter @lnkpi/agent test`（若触及）。
+
+## File map
+
+| File | Role |
+| --- | --- |
+| `services/agent-runtime/skills/ecommerce-product-visual/assets/copy/1.0.0.yaml` | `done.export_label` →「导出打包」 |
+| `services/agent-runtime/app/graph/product_visual_v2/delivery.py` | 去掉 export secondary `disabled: True` |
+| `services/agent-runtime/tests/test_product_visual_delivery_v2.py` | 断言文案与可点 |
+| `apps/web/src/components/agent/presentation/AgentPresentationHost.vue` | 拦截 `__export_pack__` → `exportPack` |
+| `apps/web/src/components/agent/presentation/presentation.test.ts` | Host 导出行为单测 |
+| `apps/web/src/components/agent/AgentSideRail.vue` | emit `exportPack`；完成态 Host 接线 |
+| `apps/web/src/pages/CanvasPage.vue` | `@export-pack` → `downloadMediaPackage` |
+| `apps/web/src/composables/useCanvasMedia.ts` | 空选择 toast |
+| `apps/web/src/composables/useCanvasMedia.test.ts` | 空包 toast 单测 |
+| Nest `exportMediaPackage` | **默认不改**；仅当发现空选择契约缺口时补测 |
+
+---
+
+### Task 1: Runtime — 文案与启用芯片
+
+**Files:**
+- Modify: `services/agent-runtime/skills/ecommerce-product-visual/assets/copy/1.0.0.yaml`
+- Modify: `services/agent-runtime/app/graph/product_visual_v2/delivery.py`（约 294–300 行）
+- Test: `services/agent-runtime/tests/test_product_visual_delivery_v2.py`
+
+**Interfaces:**
+- Produces: `build_done_presentation(...).secondary_actions[0]` = `{ label: "导出打包", message: "__export_pack__" }`，**无** `disabled: True`
+
+- [ ] **Step 1: 扩展失败测试断言**
+
+在 `test_build_done_presentation_delivery_summary_table` 末尾追加：
+
+```python
+    export = pres["secondary_actions"][0]
+    assert export["label"] == "导出打包"
+    assert export["message"] == "__export_pack__"
+    assert export.get("disabled") in (None, False)
+```
+
+- [ ] **Step 2: 跑测确认失败**
+
+Run:
+
+```bash
+cd services/agent-runtime && python -m pytest tests/test_product_visual_delivery_v2.py::test_build_done_presentation_delivery_summary_table -v
+```
+
+Expected: FAIL（仍为「导出打包（二期）」或 `disabled: True`）
+
+- [ ] **Step 3: 改 copy**
+
+`1.0.0.yaml`：
+
+```yaml
+  export_label: "导出打包"
+```
+
+- [ ] **Step 4: 改 delivery.py**
+
+将：
+
+```python
+        "secondary_actions": [
+            {
+                "label": copy.get("done.export_label"),
+                "message": _EXPORT_PACK_MESSAGE,
+                "disabled": True,
+            }
+        ],
+```
+
+改为：
+
+```python
+        "secondary_actions": [
+            {
+                "label": copy.get("done.export_label"),
+                "message": _EXPORT_PACK_MESSAGE,
+            }
+        ],
+```
+
+- [ ] **Step 5: 跑测确认通过**
+
+同 Step 2 命令。Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  services/agent-runtime/skills/ecommerce-product-visual/assets/copy/1.0.0.yaml \
+  services/agent-runtime/app/graph/product_visual_v2/delivery.py \
+  services/agent-runtime/tests/test_product_visual_delivery_v2.py
+git commit -m "$(cat <<'EOF'
+feat(runtime): enable export pack chip on delivery done
+
+EOF
+)"
+```
+
+---
+
+### Task 2: Web Host — 拦截 `__export_pack__`
+
+**Files:**
+- Modify: `apps/web/src/components/agent/presentation/AgentPresentationHost.vue`
+- Modify: `apps/web/src/components/agent/presentation/presentation.test.ts`
+
+**Interfaces:**
+- Consumes: `collectAllNodeIds()`（已有，finalized + basics）
+- Produces: `emit('exportPack', nodeIds: string[])`；点击导出时 **不** `emit('primaryAction', '__export_pack__')`
+- Constant: `EXPORT_PACK_MESSAGE = '__export_pack__'`
+
+- [ ] **Step 1: 写失败单测**
+
+更新 `doneEnvelope.secondary_actions`：
+
+```typescript
+  secondary_actions: [{ label: '导出打包', message: '__export_pack__' }],
+```
+
+追加用例：
+
+```typescript
+  it('emits exportPack on secondary export action without primaryAction', async () => {
+    const wrapper = mount(AgentPresentationHost, {
+      props: { presentation: doneEnvelope },
+    })
+    const secondary = wrapper.find('[data-testid="secondary-action"]')
+    expect(secondary.text()).toBe('导出打包')
+    expect(secondary.attributes('disabled')).toBeUndefined()
+    await secondary.trigger('click')
+    expect(wrapper.emitted('exportPack')?.[0]?.[0]).toEqual(['node-hero', 'node-gift', 'node-seed'])
+    expect(wrapper.emitted('primaryAction')).toBeUndefined()
+  })
+
+  it('emits exportPack with empty ids when no node_ids', async () => {
+    const emptyDone: AgentPresentationEnvelope = {
+      ...doneEnvelope,
+      body: { ...doneEnvelope.body!, finalized: [], basics: [] },
+    }
+    const wrapper = mount(AgentPresentationHost, {
+      props: { presentation: emptyDone },
+    })
+    await wrapper.find('[data-testid="secondary-action"]').trigger('click')
+    expect(wrapper.emitted('exportPack')?.[0]?.[0]).toEqual([])
+    expect(wrapper.emitted('primaryAction')).toBeUndefined()
+  })
+```
+
+- [ ] **Step 2: 跑测确认失败**
+
+Run:
+
+```bash
+pnpm --filter @lnkpi/web exec vitest run src/components/agent/presentation/presentation.test.ts
+```
+
+Expected: FAIL（仍 emit `primaryAction` / 文案仍为二期）
+
+- [ ] **Step 3: 实现 Host 拦截**
+
+在 `AgentPresentationHost.vue` script：
+
+```typescript
+const EXPORT_PACK_MESSAGE = '__export_pack__'
+
+const emit = defineEmits<{
+  primaryAction: [message: string]
+  macroToggle: [schemeId: string, checked: boolean]
+  focusNode: [nodeId: string]
+  focusAll: [nodeIds: string[]]
+  exportPack: [nodeIds: string[]]
+  deliverySwitch: [shotId: string, variantKey: string]
+}>()
+
+const exportBusy = ref(false)
+
+function onSecondaryAction(action: AgentPresentationPrimaryAction) {
+  if (action.message === EXPORT_PACK_MESSAGE) {
+    if (exportBusy.value) return
+    exportBusy.value = true
+    emit('exportPack', collectAllNodeIds())
+    window.setTimeout(() => {
+      exportBusy.value = false
+    }, 800)
+    return
+  }
+  emit('primaryAction', action.message)
+}
+```
+
+模板 secondary 按钮：
+
+```vue
+      <button
+        v-for="(action, idx) in secondaryActions"
+        :key="`${action.label}-${idx}`"
+        type="button"
+        class="neo-ctl rounded-lg px-3 py-1.5 text-xs"
+        :disabled="disabled || action.disabled || (action.message === EXPORT_PACK_MESSAGE && exportBusy)"
+        data-testid="secondary-action"
+        @click="onSecondaryAction(action)"
+      >
+        {{ action.label }}
+      </button>
+```
+
+确保文件顶部已 `import { computed, ref } from 'vue'`（已有则不改）。
+
+- [ ] **Step 4: 跑测确认通过**
+
+同 Step 2。Expected: PASS（含原有 focusAll 用例）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  apps/web/src/components/agent/presentation/AgentPresentationHost.vue \
+  apps/web/src/components/agent/presentation/presentation.test.ts
+git commit -m "$(cat <<'EOF'
+feat(web): intercept export pack presentation action
+
+EOF
+)"
+```
+
+---
+
+### Task 3: 接线 SideRail → CanvasPage + 空选择 toast
+
+**Files:**
+- Modify: `apps/web/src/components/agent/AgentSideRail.vue`
+- Modify: `apps/web/src/pages/CanvasPage.vue`
+- Modify: `apps/web/src/composables/useCanvasMedia.ts`
+- Test: `apps/web/src/composables/useCanvasMedia.test.ts`
+
+**Interfaces:**
+- Consumes: `downloadMediaPackage(nodes, selectedIds, { sessionId })`
+- Produces: `AgentSideRail` emit `exportPack: [nodeIds: string[]]`；`CanvasPage` `@export-pack="handleExportPack"`
+
+- [ ] **Step 1: 空包 toast 失败测试**
+
+在 `useCanvasMedia.test.ts` 增加：
+
+```typescript
+import { downloadMediaPackage } from './useCanvasMedia'
+import { ElMessage } from 'element-plus'
+
+describe('downloadMediaPackage', () => {
+  beforeEach(() => {
+    vi.mocked(ElMessage.warning).mockClear()
+  })
+
+  it('toasts when no media in selection', async () => {
+    const count = await downloadMediaPackage(
+      [{ id: 'n1', type: 'image', data: {} }],
+      ['n1'],
+    )
+    expect(count).toBe(0)
+    expect(ElMessage.warning).toHaveBeenCalledWith(expect.stringMatching(/没有可导出|无可导出|没有媒体/))
+  })
+})
+```
+
+（文案以 Step 3 最终字符串为准，测试用同一句。）
+
+- [ ] **Step 2: 跑测确认失败**
+
+```bash
+pnpm --filter @lnkpi/web exec vitest run src/composables/useCanvasMedia.test.ts
+```
+
+Expected: FAIL（当前空选择静默 `return 0`）
+
+- [ ] **Step 3: 实现空选择 toast**
+
+`downloadMediaPackage`：
+
+```typescript
+  const items = collectMediaFromNodes(nodes, selectedIds)
+  if (!items.length) {
+    ElMessage.warning('没有可导出的媒体，请确认定稿节点已生成')
+    return 0
+  }
+```
+
+- [ ] **Step 4: AgentSideRail 转发**
+
+`defineEmits` 增加：
+
+```typescript
+  exportPack: [nodeIds: string[]]
+```
+
+增加：
+
+```typescript
+function onExportPack(nodeIds: string[]) {
+  emit('exportPack', nodeIds)
+}
+```
+
+完成态 Host（约 2323–2329，`showCompletionPresentation`）增加：
+
+```vue
+                @export-pack="onExportPack($event)"
+```
+
+（历史消息 Host 为 `disabled`，可不接；若其他可点 Host 将来出现 export，同样接线。）
+
+- [ ] **Step 5: CanvasPage 处理**
+
+在 `handlePackageDownload` 旁增加：
+
+```typescript
+async function handleExportPack(nodeIds: string[]) {
+  await downloadMediaPackage(
+    nodes.value.map((n) => ({ id: n.id, type: n.type, data: n.data as Record<string, unknown> })),
+    nodeIds,
+    { sessionId: sessionId.value },
+  )
+}
+```
+
+`AgentSideRail` 上增加：
+
+```vue
+        @export-pack="handleExportPack"
+```
+
+（与现有 `@focus-all="focusNodesByIds"` 同级。）
+
+- [ ] **Step 6: 跑测**
+
+```bash
+pnpm --filter @lnkpi/web exec vitest run src/composables/useCanvasMedia.test.ts src/components/agent/presentation/presentation.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add \
+  apps/web/src/components/agent/AgentSideRail.vue \
+  apps/web/src/pages/CanvasPage.vue \
+  apps/web/src/composables/useCanvasMedia.ts \
+  apps/web/src/composables/useCanvasMedia.test.ts
+git commit -m "$(cat <<'EOF'
+feat(web): wire export pack to downloadMediaPackage
+
+EOF
+)"
+```
+
+---
+
+### Task 4: Nest Agent 路径冒烟（无行为变更优先）
+
+**Files:**
+- Read-only 确认: `apps/server/src/agent/agent-canvas-tools.service.ts` `exportMediaPackage`
+- Optional Test: 若仓内已有 agent tools 单测文件则追加空 `nodeIds` → `count: 0`；**无现成 harness 则跳过实现、只在 PR 描述写明手工/契约已满足**
+
+**Interfaces:**
+- Produces: `{ manifest: { exportedAt, count, items: [{ nodeId, url, fileName, downloadPath }] } }`；`downloadPath` 含 `/api/media/stream-download`
+
+- [ ] **Step 1: 契约核对**
+
+确认 `exportMediaPackage`：无 URL 节点跳过；空 `nodeIds` → `count: 0`；每项 `downloadPath` 以 `/api/media/stream-download?` 开头。与规格 §2.1.5 / §4.1.5 一致则 **不改代码**。
+
+- [ ] **Step 2: Commit（仅当有测试文件变更）**
+
+若写了测试：
+
+```bash
+git add apps/server/src/agent/<test-file>
+git commit -m "$(cat <<'EOF'
+test(server): cover exportMediaPackage empty selection
+
+EOF
+)"
+```
+
+否则本 Task 无 commit。
+
+---
+
+### Task 5: 本地验证与 PR 准备
+
+**Files:** 无功能改动（或纲领勾选延后到合入后）
+
+- [ ] **Step 1: 构建与测试**
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @lnkpi/server exec prisma generate
+pnpm build
+pnpm --filter @lnkpi/web exec vitest run src/composables/useCanvasMedia.test.ts src/components/agent/presentation/presentation.test.ts
+cd services/agent-runtime && python -m pytest tests/test_product_visual_delivery_v2.py::test_build_done_presentation_delivery_summary_table -v
+```
+
+Expected: 全部 PASS / build 成功
+
+- [ ] **Step 2: PR**
+
+按 `.cursor/skills/mydev-github-workflow`：push 当前分支、`gh pr create`。
+
+标题建议：`feat: Wave A A2 enable export pack (manifest + stream-download)`
+
+Body 要点：
+
+- Summary：启用完成态导出；Host 拦截；接 `downloadMediaPackage`；真 zip = A2.1
+- Test plan：上述命令；生产：完成态点「导出打包」→ 本机 JSON+媒体；对话无 `__export_pack__`；未配 COS 仍可下
+
+- [ ] **Step 3: 生产 smoke（合入部署后）**
+
+1. 登录生产画布  
+2. 有媒体节点时可用多选打包菜单对照；完成态点「导出打包」  
+3. 确认下载发生且聊天无 `__export_pack__`  
+4. COS 未配不影响导出（与收藏 503 解耦）
+
+---
+
+## Spec coverage (self-review)
+
+| Spec 要求 | Task |
+| --- | --- |
+| copy 去「（二期）」 | T1 |
+| `disabled` 解除 | T1 |
+| Host 拦截 `__export_pack__` 不发 chat | T2 |
+| emit nodeIds（finalized+basics） | T2（`collectAllNodeIds`） |
+| SideRail / CanvasPage → `downloadMediaPackage` | T3 |
+| 空媒体 toast | T3 |
+| 短防抖 / busy | T2（`exportBusy` 800ms） |
+| Nest Agent 路径 / 空 count | T4 |
+| COS 不挡导出 | 无代码依赖（约束 + T5 smoke） |
+| 真 zip A2.1 | Non-goal，未排 Task |
+| 单测 copy/delivery/Host | T1–T3 |
+
+**Placeholder scan:** 无 TBD。  
+**Type consistency:** `exportPack: [nodeIds: string[]]` 贯穿 Host → SideRail → CanvasPage。

--- a/docs/superpowers/specs/2026-09-11-wave-a-a2-export-pack-design.md
+++ b/docs/superpowers/specs/2026-09-11-wave-a-a2-export-pack-design.md
@@ -1,0 +1,143 @@
+# Wave A · A2 导出打包设计
+
+> 日期：2026-09-11  
+> 状态：已批准（对话确认 §1–§3）  
+> 上级纲领：[2026-09-10-wave-a-delivery-program-design.md](./2026-09-10-wave-a-delivery-program-design.md)  
+> 前置依赖：[2026-09-10-wave-a-a3-media-persist-design.md](./2026-09-10-wave-a-a3-media-persist-design.md)（已合入；导出**不**要求 COS 已配置）  
+> 方案：**C** — MVP 启用芯片 + manifest / 多文件 stream-download；真 zip 标为 **A2.1**
+
+## 1. 背景与目标
+
+Wave A 北极星是**成片导出成功率**。A3 已提供流式下载与可选 COS 持久化；A2 要让用户在交付完成态能真正「导出打包」，而不是灰掉的「（二期）」按钮。
+
+仓内现状：
+
+| 能力 | 状态 |
+|------|------|
+| Nest `exportMediaPackage` | **已有**：按 nodeIds 返回 manifest + 各条目 `downloadPath`（指向 `/api/media/stream-download`），**不是**真 zip |
+| 前端 `downloadMediaPackage`（`useCanvasMedia.ts`） | **已有**：写 `lnkpi-export-*.json` + 逐个 `downloadMediaFile`（stream-download） |
+| 画布菜单「打包下载」 | **已有**：`CanvasPage.handlePackageDownload` → `downloadMediaPackage` |
+| 交付完成态二次操作 | **禁用**：`delivery.py` `secondary_actions` 含 `disabled: True`；copy `export_label: "导出打包（二期）"` |
+| Web 对 `__export_pack__` | **未接**：仅 `__focus_all_canvas__` 在 `AgentPresentationHost` 拦截；导出 message 若发出会进对话 |
+
+**A2 目标（MVP）：** 完成态「导出打包」可点；人与 Agent 走同一套「清单 + 多文件鉴权下载」路径；COS 未配置不得阻塞导出。
+
+**A2.1（本规格预留，本 PR 不做）：** 服务端或浏览器流式真 zip；部分失败写入 `errors[]`；不落 CVM 大临时文件。
+
+## 2. 范围
+
+### 2.1 做（MVP）
+
+1. **Copy：** `services/agent-runtime/skills/ecommerce-product-visual/assets/copy/1.0.0.yaml`  
+   - `done.export_label`：去掉「（二期）」，定为「导出打包」。
+2. **Runtime：** `delivery.py` `build_done_presentation`  
+   - 去掉 export secondary action 的 `disabled: True`（可省略 `disabled` 字段，或显式 `false`）。
+3. **Web 拦截：** `AgentPresentationHost`  
+   - 识别 `__export_pack__`（与 `__focus_all_canvas__` 同模式）；  
+   - 从当前 presentation body 收集交付相关 `node_id`（finalized + 可选 basics 中有 id 的项）；  
+   - `emit('exportPack', nodeIds)`，**不** `emit('primaryAction', message)`，避免写入用户对话。
+4. **接线：** `AgentSideRail` → `CanvasPage`  
+   - 监听 `exportPack`；调用已有 `downloadMediaPackage(nodes, nodeIds, { sessionId })`。  
+   - 空 `nodeIds` / 无可下载媒体：toast 提示，不抛未处理异常。
+5. **后端 / Agent tool：** 保持现有 `exportMediaPackage` 契约（manifest + stream-download paths）。若文案或空选择行为有缺口则补齐；**不**改成真 zip。
+6. **单测：** copy 文案、delivery presentation 无 disabled、Host 拦截 `__export_pack__` 不发 chat。
+
+### 2.2 不做
+
+- 真 zip / 单文件归档（→ **A2.1**）  
+- 导出前强制 COS persist（A3 收藏路径独立；未配 COS 时导出仍须可用）  
+- 完整 NLE 时间线导出、跨 session 批量归档  
+- worldModel / OpenClaw 双入口 / 默认生成即 rehost（纲领非目标）  
+- 改写 Media 模块或重做 stream-download
+
+### 2.3 人机同路径原则
+
+```text
+用户点「导出打包」
+  → Host 拦截 __export_pack__
+  → downloadMediaPackage(交付 nodeIds)
+  → 本机：manifest JSON + 各文件经 GET /api/media/stream-download
+
+Agent tool export_media_package
+  → Nest exportMediaPackage
+  → 返回同一类 downloadPath（客户端/运行时自行拉取）
+```
+
+人侧不强制先调 Nest export API；前端已有收集节点 URL 的逻辑即可。Agent 侧继续用 Nest 返回的路径。两者最终都经 **stream-download**，与 A3 解耦。
+
+## 3. 交互与数据流
+
+### 3.1 UI
+
+- 完成态 secondary：「导出打包」，可点。  
+- 点击后按钮进入短暂 busy / 防抖，避免连点重复下。  
+- 成功：本机出现 `lnkpi-export-*.json` 与至少一个媒体文件（有定稿媒体时）。  
+- 部分失败：**MVP 沿用**现有逐项 try/continue（单文件失败不中断）；不强制「成功 x / 失败 y」汇总（可作为同 PR 小增强，非门禁）。  
+- 无媒体：友好 toast，不崩溃。
+
+### 3.2 nodeId 来源
+
+从当前 `delivery_summary_table` presentation：
+
+- `body.finalized[].node_id`（定稿镜头，优先）  
+- `body.basics[].node_id`（可选基础图；有 id 则一并导出，与「导出本交付相关媒体」一致）
+
+去重、过滤空字符串。若 Host 拿不到 id，仍 emit 空数组并由 Canvas 层 toast。
+
+### 3.3 COS / A3 关系
+
+| 场景 | 行为 |
+|------|------|
+| COS 未配置 | 导出照常；stream-download 代理 upstream 或本站 uploads |
+| 用户已 persist 收藏 | 节点若已换成 persisted URL，导出更稳；**不**作为导出前置条件 |
+| persist-remote 503 | **不得**阻塞导出按钮或下载路径 |
+
+## 4. 验收
+
+### 4.1 MVP
+
+1. 交付完成态按钮文案为「导出打包」，可点击（非 disabled）。  
+2. 点击后**不**往对话里发 `__export_pack__` 用户消息；开始下载清单 + 媒体。  
+3. 有定稿媒体时：本机出现 `lnkpi-export-*.json` 与至少一个媒体文件（经 stream-download）。  
+4. 无媒体 nodeId：toast 提示，不报错崩溃。  
+5. Agent `export_media_package` 返回 `downloadPath` 指向 stream-download；空选择 `count: 0`。  
+6. 生产未配 COS 时导出仍可用。  
+7. 单测覆盖 copy / delivery presentation / Web 拦截。
+
+### 4.2 A2.1（预留）
+
+流式 zip 可下；部分失败写入 `errors[]`；不落 CVM 大临时文件。
+
+## 5. 风险与缓解
+
+| 风险 | 缓解 |
+|------|------|
+| upstream 部分 403/过期 | 逐个下载 try/continue；汇总或条数提示；A3 收藏可降低失败率但不强制 |
+| 二次点击重复下 | 按钮 busy 或短防抖 |
+| `__export_pack__` 误入 chat | Host 层拦截，与 focus-all 同模式 |
+| 真 zip 范围膨胀 | 严格标 A2.1；MVP PR 描述写 Non-goals |
+| 浏览器多文件下载被拦 | 已有 manifest + 逐文件模式；真 zip 留 A2.1 改善 UX |
+
+## 6. 实现切片（写入 plan 时拆 Task）
+
+1. Runtime copy + `disabled` 解除  
+2. Web：`AgentPresentationHost` 拦截 export → emit `exportPack(nodeIds)`  
+3. `AgentSideRail` / `CanvasPage` 接到 `downloadMediaPackage`  
+4. Nest/Agent：空选择与失败文案（若缺口）  
+5. 单测 + 生产 smoke（登录 → 完成态或手造节点 → 点导出）
+
+## 7. 文档与里程碑
+
+- 本文件：A2 设计规格。  
+- 实现计划：`docs/superpowers/plans/2026-09-11-wave-a-a2-export-pack.md`（规格审阅通过后由 writing-plans 产出）。  
+- 纲领 [Wave A delivery program](./2026-09-10-wave-a-delivery-program-design.md)：A2 合入并生产手测通过后勾选 **M-A1** 相关项（流式下载 + 导出打包）。
+
+## 8. 关键决策摘要
+
+| 决策 | 选择 |
+|------|------|
+| MVP 形态 | 启用芯片 + manifest + 多 stream-download（方案 C） |
+| 真 zip | A2.1，不进本 PR |
+| 人机路径 | 人：前端 `downloadMediaPackage`；Agent：Nest manifest/`downloadPath`；共用 stream-download |
+| COS | 未配置不挡导出 |
+| 对话污染 | Host 拦截 `__export_pack__`，不发 chat |

--- a/services/agent-runtime/app/graph/product_visual_v2/delivery.py
+++ b/services/agent-runtime/app/graph/product_visual_v2/delivery.py
@@ -295,7 +295,6 @@ def build_done_presentation(
             {
                 "label": copy.get("done.export_label"),
                 "message": _EXPORT_PACK_MESSAGE,
-                "disabled": True,
             }
         ],
     }

--- a/services/agent-runtime/skills/ecommerce-product-visual/assets/copy/1.0.0.yaml
+++ b/services/agent-runtime/skills/ecommerce-product-visual/assets/copy/1.0.0.yaml
@@ -45,7 +45,7 @@ done:
   headline: "✅ 您的{product}视觉稿已就绪"
   primary_label: "在画布中定位全部"
   basics_section_title: "基础资产"
-  export_label: "导出打包（二期）"
+  export_label: "导出打包"
 guidance:
   macro_style_in_cards: "风格在这里选；需求用口语描述即可。"
   attachment_hint: "建议清晰 product 图；白底更佳，非白底也可继续。"

--- a/services/agent-runtime/tests/test_product_visual_delivery_v2.py
+++ b/services/agent-runtime/tests/test_product_visual_delivery_v2.py
@@ -217,6 +217,10 @@ def test_build_done_presentation_delivery_summary_table():
     assert pres["primary_action"]["label"] == "在画布中定位全部"
     assert pres["primary_action"]["message"] == "__focus_all_canvas__"
     assert "成功" not in pres["body"]["headline"]
+    export = pres["secondary_actions"][0]
+    assert export["label"] == "导出打包"
+    assert export["message"] == "__export_pack__"
+    assert export.get("disabled") in (None, False)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- 启用完成态「导出打包」：去掉「（二期）」文案并解除 disabled
- Host 拦截 `__export_pack__`，不发 chat；收集 finalized+basics nodeIds 并 emit
- SideRail / CanvasPage 接到事件后调用 `downloadMediaPackage`（空媒体 toast；短防抖/busy）
- Nest `exportMediaPackage` 空选择路径覆盖；真 zip 留待 A2.1
- COS 未配置不挡导出（与收藏 503 解耦）

## Test plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @lnkpi/server exec prisma generate`
- [x] `pnpm build`
- [x] `pnpm --filter @lnkpi/web exec vitest run src/composables/useCanvasMedia.test.ts src/components/agent/presentation/presentation.test.ts` (14 passed)
- [x] `cd services/agent-runtime && python3 -m pytest tests/test_product_visual_delivery_v2.py::test_build_done_presentation_delivery_summary_table -v` (1 passed)
- [ ] **生产 smoke（合入部署后）**
  - [ ] 登录生产画布
  - [ ] 有媒体节点时可用多选打包菜单对照；完成态点「导出打包」
  - [ ] 确认下载发生且聊天无 `__export_pack__`
  - [ ] COS 未配不影响导出（与收藏 503 解耦）


Made with [Cursor](https://cursor.com)