### PR TITLE
feat: Image Prompting Guide Catalog (P0)

### DIFF
--- a/.superpowers/sdd/task-6-report.md
+++ b/.superpowers/sdd/task-6-report.md
@@ -1,24 +1,56 @@
-# Task 6 Report: Eval-route-set 金标（AC-01..07）
+# Task 6 Report: Refine edit intent chips + gates
 
-## Status
-**Done** — 新增 `rt-chat-sink-01` 至 `rt-chat-sink-06`，锁定 chat-sink 与侧栏 vision 路由行为。
+**Status:** DONE  
+**Branch:** `feature/image-prompting-guide-catalog-spec`  
+**Commit:** `531a184` — `feat(web): Refine edit intent chips with capability gates`
 
-## Commit
-`ec3c5c5` — `test(runtime): add chat-sink and sidebar vision eval-route cases`
+## What landed
 
-## Changes
-- `生一个小女孩的图片`、`生成一张图` → `atomic_create`
-- 侧栏图片 + `这个图片是什么？` → `clarify_route`
-- `生活怎么样` → `chat`
-- 天猫详情页营销方案 → `clarify_route`
-- `弄张图看看` → `clarify_route`，明确禁止 media suspected case 落入 `chat`
-- AC-07 为 Chat 回复禁语约束，已由 Task 5 的 prompt golden 覆盖，不新增 route case
+### Helper
+- `guideEditIntentApply.ts`: `editIntentDisabledReason` (E5 without transparent → 中文/transparent reason) + `applyGuideEditIntent` via `resolveGuideRequest` + `changePreserveTemplate`
+- Vitest: E5 disable, E3 fill, E5 block, minRefImages fail
 
-## Verification
+### Refine UI
+- `RefineSidePanel`: chips from `listEditIntents()` beside stain preset; E5 disabled + tooltip from image2 `capabilities.transparentBackground: false`
+- Click fills prompt like stain preset; `runRefine` guards if active intent still capability-blocked
+
+## TDD evidence
+
+| Step | Result |
+|------|--------|
+| RED | import `./guideEditIntentApply` unresolved |
+| GREEN | `guideEditIntentApply.test.ts` 6 pass |
+
+## Self-review
+
+- No Agent taxonomy (Task 7); no Image 2.5 models; no fake transparent backgrounds.
+- Capabilities from `resolveImageEditProfile()` (image2 defaults).
+
+## Concerns
+
+- ~~Chip click uses `Math.max(1, minRefImages)` so E3/E4 templates fill despite Refine still being single-image; submit guard only checks capability disable (not min refs).~~ **Fixed below.**
+- Active intent id is local panel state only (not persisted on node).
+
+---
+
+## Review fix (Critical / Important)
+
+**Status:** FIXED  
+**Findings addressed:**
+1. Stop faking `refImageCount` on chip fill — pass real `refineRefImageCount` (1).
+2. Fill path still writes `changePreserveTemplate` when only `minRefImages` fails; capability failures (E5 transparent) still blocked.
+3. `runRefine` submit gate calls `applyGuideEditIntent(..., mode: 'submit')` with real ref count; blocks on min refs or capability and does not send edit.
+
+### Changes
+- `guideEditIntentApply.ts`: `mode: 'fill' | 'submit'` — fill allows template when refs insufficient; submit fails closed.
+- `RefineSidePanel.vue`: chip fill uses real ref count + `mode: 'fill'`; `runRefine` uses `mode: 'submit'` gate.
+- Tests: fill-with-insufficient-refs, submit minRef/capability gates.
+
+### Test evidence
+
 ```text
-python3 -m pytest tests/test_eval_route_set.py -v
-2 passed, 1 warning
+pnpm --filter @lnkpi/web exec vitest run src/components/canvas/refine/guideEditIntentApply.test.ts
+✓ guideEditIntentApply.test.ts (9 tests) 8ms
+Test Files  1 passed (1)
+Tests  9 passed (9)
 ```
-
-## Notes
-- 所有新增 gold 与 Task 3 既定行为一致，无需修改路由实现或扩张 hint 表。

--- a/.superpowers/sdd/task-7-report.md
+++ b/.superpowers/sdd/task-7-report.md
@@ -1,39 +1,50 @@
-# Task 7 Report: 前端 `saveAssetToLibrary` 接线
+# Task 7 Report: Agent taxonomy hooks
 
-## Status
-**Done**
+**Status:** DONE  
+**Branch:** `feature/image-prompting-guide-catalog-spec`  
+**Commit:** (see git log) — `feat(runtime): image prompting guide taxonomy hooks`
 
-## Changes
+## What landed
 
-### `apps/web/src/services/assets-api.ts`
-- Added `PersistRemotePayload`, `PersistRemoteResult` types.
-- Extended `SaveUserAssetPayload` with optional `sessionId`, `replaceNodeUrl`.
-- Added `assetsApi.persistRemote()` → `POST /assets/persist-remote`.
+### Taxonomy YAML (parallel copies)
+- `packages/agent/src/prompt-modes/image-prompting-guide-taxonomy.yaml`
+- `services/agent-runtime/skills/atomic-create/assets/image-prompting-guide-taxonomy.yaml`
+- P0 ids: `g3_exact_text`, `g1_style_lighting`, `e3_identity_clothing`, `e4_combine_refs`, `e5_transparent_cutout`
 
-### `apps/web/src/composables/useAssetLibrary.ts`
-- Upstream URLs (`isUpstreamMediaUrl`) → `assetsApi.persistRemote`.
-- Local `/api/uploads/` paths → `assetsApi.saveMine` (unchanged path).
-- 503 responses show storage-not-configured message.
+### Runtime resolver
+- `services/agent-runtime/app/tools/guide_taxonomy.py`
+  - `resolve_guide_scene` / `resolve_guide_edit_intent`
+  - `apply_guide_taxonomy_to_items` — if both match, prefer edit intent (换装/抠图/合成); never clears `prompt_mode`
 
-### Canvas call sites (optional `sessionId`)
-- `CanvasNodeImage.vue`, `CanvasNodeVideo.vue`, `CanvasNodeAudio.vue` pass `sessionId` from route.
+### Parse hook
+- `atomic_parse.py`: `_apply_taxonomies_to_result` (prompt_mode then guide) on LLM/clarify paths
+- `parse_outcome_to_state(..., utterance=)` stamps guide ids on rule/LLM outcomes
+- Schema + intent normalize preserve `guideSceneId` / `guideEditIntentId`
 
-### Tests
-- Created `useAssetLibrary.test.ts` (2 cases, TDD).
+### Node persistence
+- `atomic_create_node._atomic_batch_items` forwards `promptMode` / guide ids
+- `addNodesBatch` (controller DTO + service) writes them onto draft nodes
+- `runPromptGeneration` finish + turnaround expand re-persist guide ids alongside `promptMode`
 
-## Verification
+## TDD evidence
 
-```bash
-pnpm --filter @lnkpi/web test -- useAssetLibrary
-# ✓ 2 passed
+| Step | Result |
+|------|--------|
+| RED | `ModuleNotFoundError: app.tools.guide_taxonomy` |
+| GREEN | `tests/test_guide_taxonomy.py` 4 pass; `test_prompt_mode_taxonomy.py` 4 pass |
+
+```text
+.venv/bin/python -m pytest tests/test_guide_taxonomy.py tests/test_prompt_mode_taxonomy.py -v
+7+1 passed
 ```
 
-## Commit
+## Self-review
 
-```
-feat(web): persist upstream assets via persist-remote on save
-```
+- Hooks only — no multi-turn edit pipeline auto-run
+- No Image 2.5 models
+- `prompt_mode` still applied; guide stamps do not clear it
 
-## Concerns / Follow-ups
-- `CanvasAssetPanel` upload path still calls `saveAssetToLibrary` without `sessionId` (acceptable per spec — backend scans all user sessions).
-- No E2E against real COS; relies on server Task 5–6 + manual smoke when storage is configured.
+## Concerns
+
+- Guide resolve on rule path depends on `utterance=` passed into `parse_outcome_to_state`; call sites outside `atomic_parse` omit it (existing tests OK)
+- Nest `addNodesBatch` previously did not persist `promptMode`; now does when provided (behavior additive)

--- a/.superpowers/sdd/task-8-report.md
+++ b/.superpowers/sdd/task-8-report.md
@@ -154,5 +154,5 @@ a0dc0ae feat(agent): overlay guide scene rules on prompt generate
 
 ### Commit / push
 
-- Commit on `feature/image-prompting-guide-catalog-spec` (this fix pass)
-- Push to origin (no force); PR https://github.com/sev7n4/lnkpi/pull/278
+- Commit: `0f9a973` `fix(web): localize guide gates and scene apply UX`
+- Pushed to origin (no force); PR https://github.com/sev7n4/lnkpi/pull/278 (+ deferred preferredParams note comment)

--- a/.superpowers/sdd/task-8-report.md
+++ b/.superpowers/sdd/task-8-report.md
@@ -1,35 +1,158 @@
-# Task 8 Report: Agent `saveNodeToAssetLibrary` 同路径
+# Task 8 Report: End-to-end verification + PR
 
-## Status
-**Done**
+**Branch:** `feature/image-prompting-guide-catalog-spec`  
+**Date:** 2026-09-11  
+**Status:** Automated verification PASS; PR opened; Manual Dock checklist deferred
 
-## Changes
+---
 
-### `apps/server/src/agent/agent-canvas-tools.service.ts`
-- Injected `PersistRemoteService`.
-- Replaced `prisma.userAsset.upsert` with `persistRemote.persistRemote`.
-- Returns `{ assetId, url: persistedUrl, kind }` (`replaceNodeUrl: false`).
+## Step 1: Verification matrix
 
-### `apps/server/src/agent/agent.module.ts`
-- Imported `AssetsModule` so `PersistRemoteService` is available to `AgentCanvasToolsService`.
+### 1. `pnpm --filter @lnkpi/shared test`
 
-### Tests
-- `agent-canvas-tools.service.test.ts`: mock `PersistRemoteService`; 3 cases for save (persisted url, 503 propagation, missing URL).
-- `agent-canvas-tools.sidebar.test.ts`: provide `PersistRemoteService` mock for DI.
+```
+Test Files  23 passed (23)
+Tests       135 passed (135)
+Duration    18.58s
+Exit code   0
+```
 
-## Verification
+Includes guide-related: `imagePromptingGuide/resolveGuideRequest.test.ts` (4), `imagePromptingGuide/catalog.test.ts` (5).
+
+### 2. `pnpm --filter @lnkpi/agent test`
+
+```
+Test Files  21 passed (21)
+Tests       130 passed (130)
+Duration    18.70s
+Exit code   0
+```
+
+Includes `prompt-modes/generate-guide-overlay.test.ts` (2).
+
+### 3. Web guide unit tests
 
 ```bash
-pnpm --filter @lnkpi/server exec vitest run src/agent/agent-canvas-tools.service.test.ts src/agent/agent-canvas-tools.sidebar.test.ts
-# ✓ 62 passed (58 + 4)
+pnpm --filter @lnkpi/web exec vitest run \
+  src/components/canvas/dock-studio/panels/guideSceneApply.test.ts \
+  src/components/canvas/refine/guideEditIntentApply.test.ts
 ```
 
-## Commit
+```
+Test Files  2 passed (2)
+Tests       12 passed (12)
+Duration    7.76s
+Exit code   0
+```
+
+- `guideSceneApply.test.ts`: 3 passed  
+- `guideEditIntentApply.test.ts`: 9 passed  
+
+### 4. `python -m pytest tests/test_guide_taxonomy.py -v`
+
+Used venv: `services/agent-runtime/.venv/bin/python` (system `python` / `python3` lacked pytest).
 
 ```
-feat(server): agent save_node_to_asset_library uses persist-remote
+collected 4 items
+test_g3_exact_text PASSED
+test_e5_cutout PASSED
+test_no_false_positive_on_hello PASSED
+test_prefer_edit_intent_when_both_match PASSED
+4 passed, 1 warning in 0.60s
+Exit code   0
 ```
 
-## Concerns / Follow-ups
-- When adapter is unconfigured, 503 propagates from `PersistRemoteService` (via storage `putStream`); agent tool no longer writes upstream URL as a successful library entry.
-- `replaceNodeUrl: false` keeps canvas node URL unchanged after agent save (same as prior upsert behavior for the node itself).
+Warning: Pydantic V2 `class Config` deprecation in `app/config.py` (pre-existing, unrelated).
+
+### 5. `pnpm build`
+
+```
+Scope: 4 of 5 workspace projects
+packages/shared build: Done
+packages/agent build: Done
+apps/web build: Done (vue-tsc -b && vite build; ~58.83s)
+apps/server build: Done
+Exit code   0
+```
+
+Vite noted Rollup `#__PURE__` annotation warnings from `@vueuse/core` and chunk-size warnings (>500 kB) — pre-existing / non-blocking.
+
+**Automated matrix result: ALL PASS**
+
+---
+
+## Step 2: Manual checklist
+
+| Item | Result |
+|------|--------|
+| Prompt Dock G3/G1: empty prefill; non-empty keep text | **Manual follow-up** — no browser UI available in this verification session |
+| Refine E3/E4 templates; E5 disabled tooltip | **Manual follow-up** |
+| Stain preset still works | **Manual follow-up** |
+| Prompt generate works without `guideSceneId` | Covered by unit tests (`generate-guide-overlay`); UI path still **manual follow-up** |
+
+Unit coverage already asserts empty vs non-empty Dock prefill and Refine intent/E5 gating; interactive Dock/Refine UX still needs a human pass in the running app.
+
+---
+
+## Step 3: PR
+
+- Pushed `feature/image-prompting-guide-catalog-spec` to origin (via `gh` token HTTPS; plain HTTPS hit HTTP2/connect failures)  
+- **PR:** https://github.com/sev7n4/lnkpi/pull/278  
+- Body adapted: automated test-plan items checked; Manual Dock checklist left unchecked
+
+---
+
+## Commits on branch (vs main)
+
+```
+ef22a5a feat(runtime): image prompting guide taxonomy hooks
+436c61d fix(web): gate refine guide intents on real ref count
+531a184 feat(web): Refine edit intent chips with capability gates
+7abd824 feat(web): Prompt/Image Dock guide scene chips
+a0dc0ae feat(agent): overlay guide scene rules on prompt generate
+8b9243a feat(shared): add P0 image prompting guide scenes and intents
+0274460 feat(shared): resolveGuideRequest and profile capabilities
+6c23e14 feat(shared): scaffold imagePromptingGuide catalog types
+2b28e61 docs: add Image Prompting Guide Catalog implementation plan
+7e63a13 docs: add Image Prompting Guide Catalog design
+```
+
+---
+
+## Concerns / follow-ups
+
+1. **Manual Dock + Refine checklist** not executed in-browser — please verify before merge.  
+2. Image 2.5 model wiring remains deferred (design appendix A) — intentional.  
+3. Unrelated local dirty files (`.pnpm-store/`, deploy scripts, task-3/7 report edits) were **not** included in the PR.
+
+---
+
+## Final review fixes
+
+**Date:** 2026-09-11  
+**Status:** Done — one fix pass for whole-branch review findings
+
+### Changes
+
+1. **Chinese refine gate messages** — `resolveGuideRequest` blocked reasons are now Chinese and include missing ref roles when present (e.g. `需要至少 2 张参考图：人物 + 服装`; E5: `当前模型不支持透明背景`).
+2. **`refRoles` hints in RefineSidePanel** — when an edit intent chip is active, show `参考图：{hints}` under the chip row.
+3. **Non-empty scene apply feedback** — Prompt Dock + Image Dock toast when `didPrefill === false`: `已套用「…」场景约束（未改写现有提示词）`.
+4. **`preferredParams` P0** — Image Dock maps unambiguous `size` (e.g. `1024x1536` → `2:3`) via `mapPreferredSizeToAspect`; resolution/quality/background not mapped. Code comment + PR note: full merge deferred to Image 2.5 specialty.
+5. **Manual checklist** — Browser spot-check **not run** (no local/dev app tab or authenticated preview available in this session). Covered by unit tests instead:
+   - empty vs non-empty prefill (`guideSceneApply.test.ts`)
+   - E5 disabled Chinese tooltip (`guideEditIntentApply.test.ts` / `editIntentDisabledReason`)
+   - Chinese min-ref block with roles (`resolveGuideRequest.test.ts`)
+
+### Tests re-run (PASS)
+
+| Suite | Result |
+|-------|--------|
+| `@lnkpi/shared` resolveGuideRequest + catalog | 10 passed |
+| web: guideSceneApply + mapPreferredSizeToAspect + guideEditIntentApply | 15 passed |
+| `@lnkpi/agent` generate-guide-overlay | 2 passed |
+| `services/agent-runtime` test_guide_taxonomy.py | 4 passed |
+
+### Commit / push
+
+- Commit on `feature/image-prompting-guide-catalog-spec` (this fix pass)
+- Push to origin (no force); PR https://github.com/sev7n4/lnkpi/pull/278

--- a/apps/server/src/agent/agent-canvas-tools.controller.ts
+++ b/apps/server/src/agent/agent-canvas-tools.controller.ts
@@ -91,6 +91,18 @@ class BatchNodeItemDto {
   @IsOptional()
   @IsString()
   referenceImageUrl?: string
+
+  @IsOptional()
+  @IsString()
+  promptMode?: string
+
+  @IsOptional()
+  @IsString()
+  guideSceneId?: string
+
+  @IsOptional()
+  @IsString()
+  guideEditIntentId?: string
 }
 
 class AddNodesBatchDto {

--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -423,6 +423,9 @@ export class AgentCanvasToolsService {
       }
       videoMode?: string
       referenceImageUrl?: string
+      promptMode?: string
+      guideSceneId?: string
+      guideEditIntentId?: string
     }>
     stage?: boolean
   }): Promise<{ nodes: Array<{ key: string; nodeId: string }>; actions: CanvasAction[] }> {
@@ -461,6 +464,9 @@ export class AgentCanvasToolsService {
       }
       if (item.videoMode) nodeData.videoMode = item.videoMode
       if (item.referenceImageUrl) nodeData.referenceImageUrl = item.referenceImageUrl
+      if (item.promptMode) nodeData.promptMode = item.promptMode
+      if (item.guideSceneId) nodeData.guideSceneId = item.guideSceneId
+      if (item.guideEditIntentId) nodeData.guideEditIntentId = item.guideEditIntentId
       actions.push({
         type: 'add_node',
         payload: {
@@ -823,6 +829,12 @@ export class AgentCanvasToolsService {
               imageAspect: aspectRatio,
               imageResolution: resolution,
               ...(bumpedResolution !== userResolution ? { resolutionBump: true } : {}),
+              ...(pickString(node.data?.guideSceneId, '')
+                ? { guideSceneId: pickString(node.data?.guideSceneId, '') }
+                : {}),
+              ...(pickString(node.data?.guideEditIntentId, '')
+                ? { guideEditIntentId: pickString(node.data?.guideEditIntentId, '') }
+                : {}),
             },
           },
         },
@@ -1171,6 +1183,10 @@ export class AgentCanvasToolsService {
         errorMessage: null,
       }
       if (parsed.mode) finishData.promptMode = parsed.mode
+      const existingGuideScene = pickString(node.data?.guideSceneId, '')
+      if (existingGuideScene) finishData.guideSceneId = existingGuideScene
+      const existingGuideEdit = pickString(node.data?.guideEditIntentId, '')
+      if (existingGuideEdit) finishData.guideEditIntentId = existingGuideEdit
       const finishActions: CanvasAction[] = [
         { type: 'update_node', payload: { id: input.nodeId, data: finishData } },
       ]

--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -1153,12 +1153,14 @@ export class AgentCanvasToolsService {
     try {
       const prefs = await this.loadAccountGenPrefs(input.userId)
       const model = pickString(node.data?.textModel, prefs.defaultTextModel) || undefined
+      const guideSceneId = pickString(node.data?.guideSceneId, '') || undefined
       const record = await this.studio.generatePrompt(
         input.userId,
         prompt,
         model,
         undefined,
         { sessionId: input.sessionId, nodeId: input.nodeId },
+        guideSceneId,
       )
       const recordId = record.id
       const parsed = parseRecordPromptContent(record.metadata, prompt)

--- a/apps/server/src/studio/studio.controller.ts
+++ b/apps/server/src/studio/studio.controller.ts
@@ -209,6 +209,10 @@ class GeneratePromptDto extends CanvasScopeFields {
   @IsOptional()
   @IsString()
   model?: string
+
+  @IsOptional()
+  @IsString()
+  guideSceneId?: string
 }
 
 class ImageVariationDto extends CanvasScopeFields {
@@ -321,6 +325,7 @@ export class StudioController {
       dto.model,
       cancel,
       { sessionId: dto.sessionId, nodeId: dto.nodeId },
+      dto.guideSceneId,
     )
     return { code: 0, message: 'ok', data }
   }

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -592,6 +592,7 @@ export class StudioService {
     model?: string,
     cancel?: CancelFlag,
     scope?: CanvasGenerationScope,
+    guideSceneId?: string,
   ) {
     const trimmed = prompt?.trim()
     if (!trimmed) throw new BadRequestException('prompt 不能为空')
@@ -614,6 +615,7 @@ export class StudioService {
       gatewayModelId,
       channelId: resolved.channelId,
       ...(fallback && resolved.source === 'platform' ? { modelFallback: true } : {}),
+      ...(guideSceneId ? { guideSceneId } : {}),
     }
 
     try {
@@ -624,6 +626,7 @@ export class StudioService {
         model: gatewayModelId,
         apiKey: opts?.apiKey ?? process.env.OPENAI_API_KEY,
         baseUrl: opts?.baseUrl ?? process.env.OPENAI_BASE_URL,
+        guideSceneId,
       })
       if (cancel?.isCancelled()) {
         await this.points.refund(
@@ -1867,13 +1870,18 @@ export class StudioService {
         let text: string
         let promptMeta: Record<string, unknown> = {}
         if (record.type === 'prompt') {
+          const guideSceneId =
+            typeof meta.guideSceneId === 'string' && meta.guideSceneId.trim()
+              ? meta.guideSceneId.trim()
+              : undefined
           const { mode, content } = await generatePromptFromUserInput(record.prompt, {
             model: gatewayModelId,
             apiKey: process.env.OPENAI_API_KEY,
             baseUrl: process.env.OPENAI_BASE_URL,
+            guideSceneId,
           })
           text = content
-          promptMeta = { mode, content }
+          promptMeta = { mode, content, ...(guideSceneId ? { guideSceneId } : {}) }
         } else if (referenceImages.length > 0) {
           const providerRefs = await inlineUpstreamReferenceImages(referenceImages)
           const result = await generateTextForRefs(record.prompt, providerRefs, {

--- a/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { ElMessage } from 'element-plus'
 import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
 import type { MentionOption } from '@/components/canvas/MentionInput.vue'
@@ -22,10 +23,16 @@ import { useModelProviderSettings } from '@/composables/useModelProviderSettings
 import { resolveGenerationModel } from '@/constants/studioModels'
 import { estimateImageCredits } from '@/constants/credits'
 import { persistMediaUrl } from '@/composables/useMediaUpload'
-import { TURNAROUND_PIPELINE_DOCK_HINT, isTurnaroundLikePrompt, listGenerationScenes } from '@lnkpi/shared'
+import {
+  TURNAROUND_PIPELINE_DOCK_HINT,
+  getGenerationScene,
+  isTurnaroundLikePrompt,
+  listGenerationScenes,
+} from '@lnkpi/shared'
 import { CX_IMAGE_EDIT_ENABLED } from '@/utils/refineSession'
 import { applyGuideSceneToPrompt, clearGuideScene } from './guideSceneApply'
 import { isImageDockReadonly, shouldShowRefineEntry } from './imageDockRefineEntry'
+import { mapPreferredSizeToAspect } from './mapPreferredSizeToAspect'
 
 const { getConfig } = useModelProviderSettings()
 
@@ -91,7 +98,21 @@ function onSelectGuideScene(sceneId: string) {
   if (readonly.value) return
   const result = applyGuideSceneToPrompt({ sceneId, currentPrompt: prompt.value })
   prompt.value = result.prompt
-  emit('patch', { prompt: result.prompt, guideSceneId: result.guideSceneId })
+  const patch: Record<string, unknown> = {
+    prompt: result.prompt,
+    guideSceneId: result.guideSceneId,
+  }
+  // preferredParams.size → aspect when unambiguous; resolution/quality deferred (Image 2.5 specialty).
+  const preferredSize = getGenerationScene(sceneId)?.preferredParams?.size
+  const mappedAspect = mapPreferredSizeToAspect(preferredSize)
+  if (mappedAspect) {
+    imageAspect.value = mappedAspect
+    patch.imageAspect = mappedAspect
+  }
+  emit('patch', patch)
+  if (!result.didPrefill) {
+    ElMessage.info(`已套用「${result.label}」场景约束（未改写现有提示词）`)
+  }
 }
 
 function onClearGuideScene() {

--- a/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
@@ -22,8 +22,9 @@ import { useModelProviderSettings } from '@/composables/useModelProviderSettings
 import { resolveGenerationModel } from '@/constants/studioModels'
 import { estimateImageCredits } from '@/constants/credits'
 import { persistMediaUrl } from '@/composables/useMediaUpload'
-import { TURNAROUND_PIPELINE_DOCK_HINT, isTurnaroundLikePrompt } from '@lnkpi/shared'
+import { TURNAROUND_PIPELINE_DOCK_HINT, isTurnaroundLikePrompt, listGenerationScenes } from '@lnkpi/shared'
 import { CX_IMAGE_EDIT_ENABLED } from '@/utils/refineSession'
+import { applyGuideSceneToPrompt, clearGuideScene } from './guideSceneApply'
 import { isImageDockReadonly, shouldShowRefineEntry } from './imageDockRefineEntry'
 
 const { getConfig } = useModelProviderSettings()
@@ -79,6 +80,24 @@ const showTurnaroundHint = computed(() => {
   if (data.pipeline === 'turnaround_image') return true
   return isTurnaroundLikePrompt(prompt.value)
 })
+
+const guideScenes = listGenerationScenes()
+const activeGuideSceneId = computed(() => {
+  const id = props.node.data?.guideSceneId
+  return typeof id === 'string' && id.trim() ? id.trim() : ''
+})
+
+function onSelectGuideScene(sceneId: string) {
+  if (readonly.value) return
+  const result = applyGuideSceneToPrompt({ sceneId, currentPrompt: prompt.value })
+  prompt.value = result.prompt
+  emit('patch', { prompt: result.prompt, guideSceneId: result.guideSceneId })
+}
+
+function onClearGuideScene() {
+  if (readonly.value) return
+  emit('patch', clearGuideScene())
+}
 
 const effectiveRefUrl = computed(() => {
   const local = referenceImageUrl.value.trim()
@@ -264,6 +283,30 @@ function clearReferenceImage() {
       @update:model-value="onPromptInput"
       @submit="onGenerate"
     />
+
+    <div class="mx-3 mb-2 flex flex-wrap items-center gap-1.5">
+      <button
+        v-for="scene in guideScenes"
+        :key="scene.id"
+        type="button"
+        class="neo-chip rounded-md px-2 py-1 text-[10px]"
+        :class="activeGuideSceneId === scene.id ? 'border-indigo-400/50 bg-indigo-500/20 text-indigo-200' : ''"
+        :disabled="readonly"
+        :title="scene.description"
+        @click="onSelectGuideScene(scene.id)"
+      >
+        {{ scene.label }}
+      </button>
+      <button
+        v-if="activeGuideSceneId"
+        type="button"
+        class="neo-chip rounded-md px-2 py-1 text-[10px] text-white/55"
+        :disabled="readonly"
+        @click="onClearGuideScene"
+      >
+        清除场景
+      </button>
+    </div>
 
     <p
       v-if="showTurnaroundHint"

--- a/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { ElMessage } from 'element-plus'
 import type { EditableFlowNode } from '@/composables/useSelectedNodeEditor'
 import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
 import type { MentionOption } from '@/components/canvas/MentionInput.vue'
@@ -85,6 +86,9 @@ function onSelectGuideScene(sceneId: string) {
   const result = applyGuideSceneToPrompt({ sceneId, currentPrompt: prompt.value })
   prompt.value = result.prompt
   emit('patch', { prompt: result.prompt, guideSceneId: result.guideSceneId })
+  if (!result.didPrefill) {
+    ElMessage.info(`已套用「${result.label}」场景约束（未改写现有提示词）`)
+  }
 }
 
 function onClearGuideScene() {

--- a/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
@@ -20,7 +20,9 @@ import {
   PROMPT_MODE_LABELS,
   buildPromptNodeCardPreview,
   countMarkdownTableDataRows,
+  listGenerationScenes,
 } from '@lnkpi/shared'
+import { applyGuideSceneToPrompt, clearGuideScene } from './guideSceneApply'
 
 const MODE_LABELS = PROMPT_MODE_LABELS
 
@@ -72,6 +74,23 @@ const tableRowCount = computed(() =>
 )
 
 const textRefs = computed(() => (props.refs ?? []).filter((ref) => ref.mediaType === 'text'))
+const guideScenes = listGenerationScenes()
+const activeGuideSceneId = computed(() => {
+  const id = props.node.data?.guideSceneId
+  return typeof id === 'string' && id.trim() ? id.trim() : ''
+})
+
+function onSelectGuideScene(sceneId: string) {
+  if (readonly.value) return
+  const result = applyGuideSceneToPrompt({ sceneId, currentPrompt: prompt.value })
+  prompt.value = result.prompt
+  emit('patch', { prompt: result.prompt, guideSceneId: result.guideSceneId })
+}
+
+function onClearGuideScene() {
+  if (readonly.value) return
+  emit('patch', clearGuideScene())
+}
 
 function syncFromNode() {
   const data = props.node.data ?? {}
@@ -164,6 +183,30 @@ function onRefMention(refKey: string) {
       @update:model-value="onPromptInput"
       @submit="onGenerate"
     />
+
+    <div class="mx-3 mb-2 flex flex-wrap items-center gap-1.5">
+      <button
+        v-for="scene in guideScenes"
+        :key="scene.id"
+        type="button"
+        class="neo-chip rounded-md px-2 py-1 text-[10px]"
+        :class="activeGuideSceneId === scene.id ? 'border-fuchsia-400/50 bg-fuchsia-500/20 text-fuchsia-200' : ''"
+        :disabled="readonly"
+        :title="scene.description"
+        @click="onSelectGuideScene(scene.id)"
+      >
+        {{ scene.label }}
+      </button>
+      <button
+        v-if="activeGuideSceneId"
+        type="button"
+        class="neo-chip rounded-md px-2 py-1 text-[10px] text-white/55"
+        :disabled="readonly"
+        @click="onClearGuideScene"
+      >
+        清除场景
+      </button>
+    </div>
 
     <section
       v-if="generatedContent"

--- a/apps/web/src/components/canvas/dock-studio/panels/guideSceneApply.test.ts
+++ b/apps/web/src/components/canvas/dock-studio/panels/guideSceneApply.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { applyGuideSceneToPrompt, clearGuideScene } from './guideSceneApply'
+
+describe('applyGuideSceneToPrompt', () => {
+  it('prefills when prompt empty', () => {
+    const r = applyGuideSceneToPrompt({ sceneId: 'g3_exact_text', currentPrompt: '' })
+    expect(r.didPrefill).toBe(true)
+    expect(r.prompt.length).toBeGreaterThan(10)
+    expect(r.guideSceneId).toBe('g3_exact_text')
+  })
+
+  it('does not overwrite non-empty prompt', () => {
+    const r = applyGuideSceneToPrompt({ sceneId: 'g3_exact_text', currentPrompt: 'keep me' })
+    expect(r.didPrefill).toBe(false)
+    expect(r.prompt).toBe('keep me')
+    expect(r.guideSceneId).toBe('g3_exact_text')
+  })
+})
+
+describe('clearGuideScene', () => {
+  it('clears guideSceneId without touching prompt', () => {
+    expect(clearGuideScene()).toEqual({ guideSceneId: null })
+  })
+})

--- a/apps/web/src/components/canvas/dock-studio/panels/guideSceneApply.ts
+++ b/apps/web/src/components/canvas/dock-studio/panels/guideSceneApply.ts
@@ -1,0 +1,31 @@
+import { getGenerationScene } from '@lnkpi/shared'
+
+export function applyGuideSceneToPrompt(input: {
+  sceneId: string
+  currentPrompt: string
+}): { prompt: string; guideSceneId: string; didPrefill: boolean; label: string } {
+  const scene = getGenerationScene(input.sceneId)
+  const label = scene?.label ?? input.sceneId
+  const guideSceneId = input.sceneId
+  const empty = !input.currentPrompt.trim()
+
+  if (empty && scene?.promptScaffold) {
+    return {
+      prompt: scene.promptScaffold,
+      guideSceneId,
+      didPrefill: true,
+      label,
+    }
+  }
+
+  return {
+    prompt: input.currentPrompt,
+    guideSceneId,
+    didPrefill: false,
+    label,
+  }
+}
+
+export function clearGuideScene(): { guideSceneId: null } {
+  return { guideSceneId: null }
+}

--- a/apps/web/src/components/canvas/dock-studio/panels/mapPreferredSizeToAspect.test.ts
+++ b/apps/web/src/components/canvas/dock-studio/panels/mapPreferredSizeToAspect.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { mapPreferredSizeToAspect } from './mapPreferredSizeToAspect'
+
+describe('mapPreferredSizeToAspect', () => {
+  it('maps 1024x1536 to 2:3', () => {
+    expect(mapPreferredSizeToAspect('1024x1536')).toBe('2:3')
+  })
+
+  it('maps 1536x1024 to 3:2', () => {
+    expect(mapPreferredSizeToAspect('1536x1024')).toBe('3:2')
+  })
+
+  it('returns null for unknown / ambiguous sizes', () => {
+    expect(mapPreferredSizeToAspect('1000x700')).toBeNull()
+    expect(mapPreferredSizeToAspect(undefined)).toBeNull()
+    expect(mapPreferredSizeToAspect('')).toBeNull()
+  })
+})

--- a/apps/web/src/components/canvas/dock-studio/panels/mapPreferredSizeToAspect.ts
+++ b/apps/web/src/components/canvas/dock-studio/panels/mapPreferredSizeToAspect.ts
@@ -1,0 +1,60 @@
+/** Matches ImageParamsSelector aspect options (avoid importing the Vue SFC from plain TS). */
+type ImageAspectRatio =
+  | '1:1'
+  | '16:9'
+  | '9:16'
+  | '4:3'
+  | '3:4'
+  | '3:2'
+  | '2:3'
+  | '21:9'
+
+/**
+ * Best-effort map of guide preferredParams.size (e.g. "1024x1536") → Image Dock aspect.
+ * Only returns when the ratio matches an existing selector option unambiguously.
+ * Resolution / quality / background are NOT mapped here — full preferredParams merge
+ * is deferred to the Image 2.5 specialty (image2 ratio_resolution wire is ambiguous).
+ */
+const ASPECT_OPTIONS: ImageAspectRatio[] = [
+  '1:1',
+  '16:9',
+  '9:16',
+  '4:3',
+  '3:4',
+  '3:2',
+  '2:3',
+  '21:9',
+]
+
+function gcd(a: number, b: number): number {
+  let x = Math.abs(a)
+  let y = Math.abs(b)
+  while (y) {
+    const t = y
+    y = x % y
+    x = t
+  }
+  return x || 1
+}
+
+export function mapPreferredSizeToAspect(size?: string): ImageAspectRatio | null {
+  if (!size?.trim()) return null
+  const m = /^(\d+)\s*[x×]\s*(\d+)$/i.exec(size.trim())
+  if (!m) return null
+  const w = Number(m[1])
+  const h = Number(m[2])
+  if (!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0) return null
+
+  const g = gcd(w, h)
+  const simplified = `${w / g}:${h / g}`
+  if ((ASPECT_OPTIONS as string[]).includes(simplified)) {
+    return simplified as ImageAspectRatio
+  }
+
+  const target = w / h
+  for (const opt of ASPECT_OPTIONS) {
+    const [a, b] = opt.split(':').map(Number)
+    if (Math.abs(a / b - target) < 1e-9) return opt
+  }
+  return null
+}

--- a/apps/web/src/components/canvas/refine/RefineSidePanel.vue
+++ b/apps/web/src/components/canvas/refine/RefineSidePanel.vue
@@ -189,12 +189,11 @@ function editIntentChipTitle(intentId: string): string {
 
 function applyEditIntent(intentId: string) {
   if (editIntentChipDisabled(intentId)) return
-  const intent = getEditIntent(intentId)
-  const refImageCount = Math.max(refineRefImageCount, intent?.capability.minRefImages ?? 1)
   const result = applyGuideEditIntent({
     intentId,
     capabilities: guideCapabilities,
-    refImageCount,
+    refImageCount: refineRefImageCount,
+    mode: 'fill',
   })
   if (!result.ok) {
     ElMessage.warning(result.reason)
@@ -413,9 +412,14 @@ async function onPointSelect({ x, y }: { x: number; y: number }) {
 async function runRefine() {
   if (refineDisabled.value) return
   if (activeGuideEditIntentId.value) {
-    const blocked = editIntentDisabledReason(activeGuideEditIntentId.value, guideCapabilities)
-    if (blocked) {
-      errorMessage.value = blocked
+    const gate = applyGuideEditIntent({
+      intentId: activeGuideEditIntentId.value,
+      capabilities: guideCapabilities,
+      refImageCount: refineRefImageCount,
+      mode: 'submit',
+    })
+    if (!gate.ok) {
+      errorMessage.value = gate.reason
       return
     }
   }

--- a/apps/web/src/components/canvas/refine/RefineSidePanel.vue
+++ b/apps/web/src/components/canvas/refine/RefineSidePanel.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { ElMessage } from 'element-plus'
-import type { ImageVersionEntry } from '@lnkpi/shared'
+import {
+  getEditIntent,
+  listEditIntents,
+  resolveImageEditProfile,
+  type ImageVersionEntry,
+} from '@lnkpi/shared'
 import DockCreditBadge from '@/components/canvas/dock-studio/shared/DockCreditBadge.vue'
 import DockTypeIcon from '@/components/canvas/dock-studio/shared/DockTypeIcon.vue'
 import { persistMediaUrl } from '@/composables/useMediaUpload'
@@ -12,6 +17,7 @@ import { maskCoverageMessage } from '@/utils/maskCoverage'
 import type { CompareMode } from '@/utils/refineChrome'
 import { loupeSubcontrolsVisible, maskSubcontrolsVisible, nextCompareWorkspace, wipeCompareLocked } from '@/utils/refineChrome'
 import { STAIN_PRESET_PROMPT } from '@/utils/refineSession'
+import { applyGuideEditIntent, editIntentDisabledReason } from './guideEditIntentApply'
 import { syncRefineUrls } from './syncRefineUrls'
 import CompareLightbox from './CompareLightbox.vue'
 import CompareView from './CompareView.vue'
@@ -52,6 +58,16 @@ const emit = defineEmits<{
 const editor = useCanvasEditorStore()
 const promptRef = ref<HTMLTextAreaElement | null>(null)
 const prompt = ref('')
+const activeGuideEditIntentId = ref<string | null>(null)
+const editIntents = listEditIntents()
+const guideCapabilities =
+  resolveImageEditProfile().capabilities ?? {
+    transparentBackground: false,
+    qualityParam: true,
+    maxRefImages: 4,
+  }
+/** Refine work image always counts as one ref; multi-ref upload is out of scope for P0 chips. */
+const refineRefImageCount = 1
 const busy = ref(false)
 const segmentBusy = ref(false)
 const afterUrl = ref(props.beforeUrl)
@@ -157,10 +173,39 @@ function formatError(err: unknown, fallback: string): string {
 }
 
 function applyStainPreset() {
+  activeGuideEditIntentId.value = null
   prompt.value = STAIN_PRESET_PROMPT
 }
 
+function editIntentChipDisabled(intentId: string): boolean {
+  return busy.value || !!editIntentDisabledReason(intentId, guideCapabilities)
+}
+
+function editIntentChipTitle(intentId: string): string {
+  const disabled = editIntentDisabledReason(intentId, guideCapabilities)
+  if (disabled) return disabled
+  return getEditIntent(intentId)?.description ?? ''
+}
+
+function applyEditIntent(intentId: string) {
+  if (editIntentChipDisabled(intentId)) return
+  const intent = getEditIntent(intentId)
+  const refImageCount = Math.max(refineRefImageCount, intent?.capability.minRefImages ?? 1)
+  const result = applyGuideEditIntent({
+    intentId,
+    capabilities: guideCapabilities,
+    refImageCount,
+  })
+  if (!result.ok) {
+    ElMessage.warning(result.reason)
+    return
+  }
+  activeGuideEditIntentId.value = result.guideEditIntentId
+  prompt.value = result.prompt
+}
+
 function focusReplacePrompt() {
+  activeGuideEditIntentId.value = null
   promptRef.value?.focus()
 }
 
@@ -367,6 +412,13 @@ async function onPointSelect({ x, y }: { x: number; y: number }) {
 
 async function runRefine() {
   if (refineDisabled.value) return
+  if (activeGuideEditIntentId.value) {
+    const blocked = editIntentDisabledReason(activeGuideEditIntentId.value, guideCapabilities)
+    if (blocked) {
+      errorMessage.value = blocked
+      return
+    }
+  }
   const mask = editor.getRefineMask()
   const canvas = mask?.getCanvas()
   if (!mask || !canvas) return
@@ -667,6 +719,18 @@ onBeforeUnmount(() => {
         <div class="refine-dock__chips">
           <button type="button" class="refine-dock__chip" :disabled="busy" @click="applyStainPreset">去除污渍瑕疵</button>
           <button type="button" class="refine-dock__chip" :disabled="busy" @click="focusReplacePrompt">替换选区内容</button>
+          <button
+            v-for="intent in editIntents"
+            :key="intent.id"
+            type="button"
+            class="refine-dock__chip"
+            :class="{ 'is-active': activeGuideEditIntentId === intent.id }"
+            :disabled="editIntentChipDisabled(intent.id)"
+            :title="editIntentChipTitle(intent.id)"
+            @click="applyEditIntent(intent.id)"
+          >
+            {{ intent.label }}
+          </button>
         </div>
 
         <textarea
@@ -925,6 +989,7 @@ onBeforeUnmount(() => {
 }
 
 .refine-dock__tool.is-active,
+.refine-dock__chip.is-active,
 .refine-dock__chip:hover,
 .refine-dock__tool:hover {
   border-color: var(--neo-border-strong);

--- a/apps/web/src/components/canvas/refine/RefineSidePanel.vue
+++ b/apps/web/src/components/canvas/refine/RefineSidePanel.vue
@@ -68,6 +68,14 @@ const guideCapabilities =
   }
 /** Refine work image always counts as one ref; multi-ref upload is out of scope for P0 chips. */
 const refineRefImageCount = 1
+const activeEditIntent = computed(() =>
+  activeGuideEditIntentId.value ? getEditIntent(activeGuideEditIntentId.value) ?? null : null,
+)
+const activeRefRoleHints = computed(() => {
+  const roles = activeEditIntent.value?.refRoles
+  if (!roles?.length) return ''
+  return roles.map((r) => r.hint).join(' · ')
+})
 const busy = ref(false)
 const segmentBusy = ref(false)
 const afterUrl = ref(props.beforeUrl)
@@ -736,6 +744,10 @@ onBeforeUnmount(() => {
             {{ intent.label }}
           </button>
         </div>
+
+        <p v-if="activeRefRoleHints" class="refine-dock__hint">
+          参考图：{{ activeRefRoleHints }}
+        </p>
 
         <textarea
           ref="promptRef"

--- a/apps/web/src/components/canvas/refine/guideEditIntentApply.test.ts
+++ b/apps/web/src/components/canvas/refine/guideEditIntentApply.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { applyGuideEditIntent, editIntentDisabledReason } from './guideEditIntentApply'
+
+describe('editIntentDisabledReason', () => {
+  it('disables E5 without transparent capability', () => {
+    expect(
+      editIntentDisabledReason('e5_transparent_cutout', {
+        transparentBackground: false,
+        qualityParam: true,
+        maxRefImages: 4,
+      }),
+    ).toMatch(/透明|transparent/i)
+  })
+
+  it('allows E5 when transparent capability is present', () => {
+    expect(
+      editIntentDisabledReason('e5_transparent_cutout', {
+        transparentBackground: true,
+        qualityParam: true,
+        maxRefImages: 4,
+      }),
+    ).toBeNull()
+  })
+
+  it('does not disable E3 for missing transparent capability', () => {
+    expect(
+      editIntentDisabledReason('e3_identity_clothing', {
+        transparentBackground: false,
+        qualityParam: true,
+        maxRefImages: 4,
+      }),
+    ).toBeNull()
+  })
+})
+
+describe('applyGuideEditIntent', () => {
+  it('fills E3 template when ok', () => {
+    const r = applyGuideEditIntent({
+      intentId: 'e3_identity_clothing',
+      capabilities: { transparentBackground: false, qualityParam: true, maxRefImages: 4 },
+      refImageCount: 2,
+    })
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.prompt).toMatch(/clothing|衣服|face|身份/i)
+  })
+
+  it('blocks E5 when transparent capability is missing', () => {
+    const r = applyGuideEditIntent({
+      intentId: 'e5_transparent_cutout',
+      capabilities: { transparentBackground: false, qualityParam: true, maxRefImages: 4 },
+      refImageCount: 1,
+    })
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.disabled).toBe(true)
+      expect(r.reason).toMatch(/透明|transparent/i)
+    }
+  })
+
+  it('blocks when minRefImages not met', () => {
+    const r = applyGuideEditIntent({
+      intentId: 'e3_identity_clothing',
+      capabilities: { transparentBackground: false, qualityParam: true, maxRefImages: 4 },
+      refImageCount: 1,
+    })
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.disabled).toBe(false)
+      expect(r.reason).toMatch(/ref|参考/i)
+    }
+  })
+})

--- a/apps/web/src/components/canvas/refine/guideEditIntentApply.test.ts
+++ b/apps/web/src/components/canvas/refine/guideEditIntentApply.test.ts
@@ -39,6 +39,7 @@ describe('applyGuideEditIntent', () => {
       intentId: 'e3_identity_clothing',
       capabilities: { transparentBackground: false, qualityParam: true, maxRefImages: 4 },
       refImageCount: 2,
+      mode: 'fill',
     })
     expect(r.ok).toBe(true)
     if (r.ok) expect(r.prompt).toMatch(/clothing|衣服|face|身份/i)
@@ -49,6 +50,7 @@ describe('applyGuideEditIntent', () => {
       intentId: 'e5_transparent_cutout',
       capabilities: { transparentBackground: false, qualityParam: true, maxRefImages: 4 },
       refImageCount: 1,
+      mode: 'fill',
     })
     expect(r.ok).toBe(false)
     if (!r.ok) {
@@ -57,16 +59,55 @@ describe('applyGuideEditIntent', () => {
     }
   })
 
-  it('blocks when minRefImages not met', () => {
+  it('fill mode still writes template when minRefImages not met', () => {
     const r = applyGuideEditIntent({
       intentId: 'e3_identity_clothing',
       capabilities: { transparentBackground: false, qualityParam: true, maxRefImages: 4 },
       refImageCount: 1,
+      mode: 'fill',
+    })
+    expect(r.ok).toBe(true)
+    if (r.ok) {
+      expect(r.prompt).toMatch(/clothing|衣服|face|身份/i)
+      expect(r.guideEditIntentId).toBe('e3_identity_clothing')
+    }
+  })
+
+  it('submit mode blocks when minRefImages not met', () => {
+    const r = applyGuideEditIntent({
+      intentId: 'e3_identity_clothing',
+      capabilities: { transparentBackground: false, qualityParam: true, maxRefImages: 4 },
+      refImageCount: 1,
+      mode: 'submit',
     })
     expect(r.ok).toBe(false)
     if (!r.ok) {
       expect(r.disabled).toBe(false)
       expect(r.reason).toMatch(/ref|参考/i)
     }
+  })
+
+  it('submit mode blocks E5 when transparent capability is missing', () => {
+    const r = applyGuideEditIntent({
+      intentId: 'e5_transparent_cutout',
+      capabilities: { transparentBackground: false, qualityParam: true, maxRefImages: 4 },
+      refImageCount: 1,
+      mode: 'submit',
+    })
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.disabled).toBe(true)
+      expect(r.reason).toMatch(/透明|transparent/i)
+    }
+  })
+
+  it('submit mode allows when refs and capability ok', () => {
+    const r = applyGuideEditIntent({
+      intentId: 'e3_identity_clothing',
+      capabilities: { transparentBackground: false, qualityParam: true, maxRefImages: 4 },
+      refImageCount: 2,
+      mode: 'submit',
+    })
+    expect(r.ok).toBe(true)
   })
 })

--- a/apps/web/src/components/canvas/refine/guideEditIntentApply.ts
+++ b/apps/web/src/components/canvas/refine/guideEditIntentApply.ts
@@ -16,10 +16,18 @@ export function editIntentDisabledReason(
   return null
 }
 
+export type GuideEditIntentMode = 'fill' | 'submit'
+
 export function applyGuideEditIntent(input: {
   intentId: string
   capabilities: GuideCapabilities
+  /** Real refine ref count — do not inflate to satisfy minRefImages. */
   refImageCount: number
+  /**
+   * `fill`: chip select — still write template when only minRefImages fails.
+   * `submit`: runRefine gate — block on capability or insufficient refs.
+   */
+  mode: GuideEditIntentMode
 }):
   | { ok: true; prompt: string; guideEditIntentId: string; label: string }
   | { ok: false; reason: string; disabled: boolean } {
@@ -40,6 +48,20 @@ export function applyGuideEditIntent(input: {
   })
 
   if (resolved.blocked) {
+    // Fill path: allow selecting/filling template when only refs are insufficient.
+    if (input.mode === 'fill') {
+      const minRefs = intent.capability.minRefImages
+      const refsInsufficient =
+        minRefs != null && input.refImageCount < minRefs
+      if (refsInsufficient) {
+        return {
+          ok: true,
+          prompt: intent.changePreserveTemplate,
+          guideEditIntentId: intent.id,
+          label: intent.label,
+        }
+      }
+    }
     return {
       ok: false,
       reason: resolved.blocked.reason,

--- a/apps/web/src/components/canvas/refine/guideEditIntentApply.ts
+++ b/apps/web/src/components/canvas/refine/guideEditIntentApply.ts
@@ -1,0 +1,56 @@
+import {
+  getEditIntent,
+  resolveGuideRequest,
+  type GuideCapabilities,
+} from '@lnkpi/shared'
+
+export function editIntentDisabledReason(
+  intentId: string,
+  capabilities: GuideCapabilities,
+): string | null {
+  const intent = getEditIntent(intentId)
+  if (!intent) return null
+  if (intent.capability.requiresTransparentBackground && !capabilities.transparentBackground) {
+    return '当前模型不支持透明背景（transparent），E5 抠图暂不可用'
+  }
+  return null
+}
+
+export function applyGuideEditIntent(input: {
+  intentId: string
+  capabilities: GuideCapabilities
+  refImageCount: number
+}):
+  | { ok: true; prompt: string; guideEditIntentId: string; label: string }
+  | { ok: false; reason: string; disabled: boolean } {
+  const intent = getEditIntent(input.intentId)
+  if (!intent) {
+    return { ok: false, reason: '未知编辑意图', disabled: false }
+  }
+
+  const capabilityReason = editIntentDisabledReason(input.intentId, input.capabilities)
+  if (capabilityReason) {
+    return { ok: false, reason: capabilityReason, disabled: true }
+  }
+
+  const resolved = resolveGuideRequest({
+    guide: intent,
+    capabilities: input.capabilities,
+    refImageCount: input.refImageCount,
+  })
+
+  if (resolved.blocked) {
+    return {
+      ok: false,
+      reason: resolved.blocked.reason,
+      disabled: false,
+    }
+  }
+
+  return {
+    ok: true,
+    prompt: intent.changePreserveTemplate,
+    guideEditIntentId: intent.id,
+    label: intent.label,
+  }
+}

--- a/apps/web/src/composables/useNodeGeneration.test.ts
+++ b/apps/web/src/composables/useNodeGeneration.test.ts
@@ -1338,4 +1338,33 @@ describe('useNodeGeneration', () => {
     )
     expect(canvasApi.generateImage).not.toHaveBeenCalled()
   })
+
+  it('forwards guideSceneId from prompt node data to generatePrompt', async () => {
+    vi.mocked(studioApi.generatePrompt).mockResolvedValue(
+      mockAxiosResponse({
+        data: {
+          ...completedRecord,
+          type: 'prompt',
+          id: 'prompt-rec-1',
+          url: null,
+        },
+      }),
+    )
+    const node = createNode('prompt', {
+      prompt: 'expand this',
+      guideSceneId: 'g3_exact_text',
+      textModel: encodeChannelModel('platform', defaultModelKey('text')),
+    })
+    const { api } = createDeps([node])
+
+    await api.generateForNode(node)
+
+    expect(studioApi.generatePrompt).toHaveBeenCalledWith(
+      'expand this',
+      encodeChannelModel('platform', defaultModelKey('text')),
+      expect.any(AbortSignal),
+      canvasScope('prompt-1'),
+      'g3_exact_text',
+    )
+  })
 })

--- a/apps/web/src/composables/useNodeGeneration.ts
+++ b/apps/web/src/composables/useNodeGeneration.ts
@@ -586,11 +586,16 @@ async function cancelRemoteGeneration(nodeId: string) {
     try {
       if (nodeType === 'prompt') {
         deps.patchNodeData(node.id, { ...startedAtPatch(), status: NODE_GENERATION_STATUS.generating })
+        const guideSceneId =
+          typeof data.guideSceneId === 'string' && data.guideSceneId.trim()
+            ? data.guideSceneId.trim()
+            : undefined
         const { data: res } = await studioApi.generatePrompt(
           local,
           resolveGenerationModel('text', data.textModel as string | undefined),
           signal,
           canvasScope(node.id),
+          guideSceneId,
         )
         if (signal.aborted) return
         // Bump record id before resolve — otherwise poll gate treats the new

--- a/apps/web/src/services/studio-api.ts
+++ b/apps/web/src/services/studio-api.ts
@@ -127,10 +127,16 @@ export const studioApi = {
     model?: string,
     signal?: AbortSignal,
     scope?: CanvasGenerationScope,
+    guideSceneId?: string,
   ) =>
     api.post<{ data: GenerationRecord }>(
       '/studio/prompt/generate',
-      { prompt, model, ...scopeBody(scope) },
+      {
+        prompt,
+        model,
+        ...scopeBody(scope),
+        ...(guideSceneId ? { guideSceneId } : {}),
+      },
       { timeout: 180_000, signal },
     ),
   generateVideo: (

--- a/docs/superpowers/plans/2026-09-11-image-prompting-guide-catalog.md
+++ b/docs/superpowers/plans/2026-09-11-image-prompting-guide-catalog.md
@@ -1,0 +1,705 @@
+# Image Prompting Guide Catalog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Embed OpenAI API《Image prompting》P0 scenes/intents into lnkpi via a dual-track Catalog, Dock pickers, param capability gates, and Agent taxonomy hooks — without wiring Image 2.5 models yet.
+
+**Architecture:** Add `@lnkpi/shared` `imagePromptingGuide` catalog (generation scenes + edit intents + fundamentals). Resolve preferred params against model profile capabilities (`resolveGuideRequest`). Dock applies scaffolds; Refine applies change/preserve templates. Prompt expand optionally overlays scene system fragments. Agent-runtime adds parallel taxonomy that only writes `guideSceneId` / `guideEditIntentId`.
+
+**Tech Stack:** TypeScript (`@lnkpi/shared`, `@lnkpi/agent`), Vitest, Vue 3 Dock/Refine, Python agent-runtime + PyYAML taxonomy, Nest `studio.service` prompt generate path.
+
+**Spec:** [2026-09-11-image-prompting-guide-catalog-design.md](../specs/2026-09-11-image-prompting-guide-catalog-design.md)
+
+## Global Constraints
+
+- Branch: continue `feature/image-prompting-guide-catalog-spec` or rename to `feature/image-prompting-guide-catalog` before code PRs — **禁止直推 main**
+- 本期模型仍为 `image2`；不新增 `gpt-image-2.5-*` catalog 条目
+- 禁止假透明（棋盘格像素冒充 alpha）；E5 无 capability 时必须 blocked
+- 不把 E* / G* 塞进 `PromptModeId` 联合类型
+- Agent 钩子只写 guide id，不改变现有自动出图主路径
+- 本地验证：`pnpm --filter @lnkpi/shared test`、`pnpm --filter @lnkpi/agent test`、相关 web vitest、`pytest` taxonomy 单测；PR 前 `pnpm build`
+- Squash merge；Image 2.5 验证流程只保留在 design 附录，本期不实现模型接线
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `packages/shared/src/imagePromptingGuide/types.ts` | Guide 类型与 ParamContract / CapabilityGate |
+| `packages/shared/src/imagePromptingGuide/fundamentals.ts` | 官方 8 条 fundamentals 文本 |
+| `packages/shared/src/imagePromptingGuide/scenes/*.ts` | G3 / G1 资产 |
+| `packages/shared/src/imagePromptingGuide/intents/*.ts` | E3 / E4 / E5 资产 |
+| `packages/shared/src/imagePromptingGuide/catalog.ts` | 注册表 + getters |
+| `packages/shared/src/imagePromptingGuide/resolveGuideRequest.ts` | 参数契约解析 / blocked |
+| `packages/shared/src/imagePromptingGuide/index.ts` | 桶导出 |
+| `packages/shared/src/imageModelProfiles.ts` | 增加 `capabilities` |
+| `packages/shared/src/imageEditProfiles.ts` | 增加 `capabilities` |
+| `packages/shared/src/index.ts` | `export * from './imagePromptingGuide'` |
+| `packages/agent/src/prompt-modes/generate.ts` | 可选 `guideSceneId` 叠加 system |
+| `packages/agent/src/prompt-modes/image-prompting-guide-taxonomy.yaml` | 共享 taxonomy 源 |
+| `apps/web/.../guideSceneApply.ts` (+ test) | Dock 选 scene 纯函数 |
+| `apps/web/.../PromptDockPanel.vue` | 场景芯片 UI |
+| `apps/web/.../ImageDockPanel.vue` | 可选套用场景 |
+| `apps/web/.../guideEditIntentApply.ts` (+ test) | Refine intent 纯函数 |
+| `apps/web/.../RefineSidePanel.vue` | intent 芯片 + 门禁 |
+| `apps/server/src/studio/studio.service.ts` | generatePrompt 透传 guideSceneId |
+| `services/agent-runtime/app/tools/guide_taxonomy.py` | resolve_guide_* |
+| `services/agent-runtime/skills/atomic-create/assets/image-prompting-guide-taxonomy.yaml` | skill 同步副本 |
+| `services/agent-runtime/app/graph/nodes/atomic_parse.py` | 挂 guide id 到结果 |
+
+---
+
+### Task 1: Shared types + fundamentals + empty catalog registry
+
+**Files:**
+- Create: `packages/shared/src/imagePromptingGuide/types.ts`
+- Create: `packages/shared/src/imagePromptingGuide/fundamentals.ts`
+- Create: `packages/shared/src/imagePromptingGuide/catalog.ts`
+- Create: `packages/shared/src/imagePromptingGuide/index.ts`
+- Create: `packages/shared/src/imagePromptingGuide/catalog.test.ts`
+- Modify: `packages/shared/src/index.ts` — add `export * from './imagePromptingGuide'`
+
+**Interfaces:**
+- Produces: `GenerationScene`, `EditIntent`, `GuideCapabilities`, `listGenerationScenes()`, `listEditIntents()`, `getGenerationScene(id)`, `getEditIntent(id)`, `FUNDAMENTALS`, `formatFundamentalsBlock(ids?: string[])`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/shared/src/imagePromptingGuide/catalog.test.ts
+import { describe, expect, it } from 'vitest'
+import {
+  FUNDAMENTALS,
+  formatFundamentalsBlock,
+  listEditIntents,
+  listGenerationScenes,
+} from './catalog'
+
+describe('imagePromptingGuide catalog scaffold', () => {
+  it('exposes eight fundamentals', () => {
+    expect(FUNDAMENTALS).toHaveLength(8)
+    expect(FUNDAMENTALS[0]?.id).toBe('define_result')
+  })
+
+  it('lists empty P0 registries until scenes/intents land', () => {
+    expect(listGenerationScenes()).toEqual([])
+    expect(listEditIntents()).toEqual([])
+  })
+
+  it('formats fundamentals block', () => {
+    const block = formatFundamentalsBlock(['define_result', 'exact_text'])
+    expect(block).toContain('Define the result')
+    expect(block).toContain('Specify exact text')
+  })
+})
+```
+
+Note: after Task 3, update this test to expect P0 ids instead of empty arrays (or move empty-registry assertions into Task 3). For Task 1 only, keep registries as empty arrays in `catalog.ts`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @lnkpi/shared test -- src/imagePromptingGuide/catalog.test.ts`  
+Expected: FAIL (module not found)
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// types.ts (key exports)
+export type GuideKind = 'generation_scene' | 'edit_intent'
+
+export interface ParamContract {
+  size?: string
+  quality?: 'auto' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
+  background?: 'auto' | 'opaque' | 'transparent'
+  outputFormat?: 'png' | 'webp' | 'jpeg'
+}
+
+export interface CapabilityGate {
+  requiresTransparentBackground?: boolean
+  minRefImages?: number
+  maxRefImages?: number
+  requiresSubjectRef?: boolean
+}
+
+export interface GuideCapabilities {
+  transparentBackground: boolean
+  qualityParam: boolean
+  maxRefImages: number
+}
+
+export interface GenerationScene {
+  id: string
+  kind: 'generation_scene'
+  label: string
+  description: string
+  fundamentalsRefs: string[]
+  promptScaffold: string
+  systemOverlay?: string
+  fewShot?: { user: string; assistant: string }
+  preferredParams: ParamContract
+  capability: CapabilityGate
+  expandViaPromptMode?: string | null
+}
+
+export interface EditIntent {
+  id: string
+  kind: 'edit_intent'
+  label: string
+  description: string
+  changePreserveTemplate: string
+  refRoles: Array<{ role: string; required: boolean; hint: string }>
+  preferredParams: ParamContract
+  capability: CapabilityGate
+}
+```
+
+```ts
+// fundamentals.ts — 8 entries with id + enTitle + guidance
+export const FUNDAMENTALS = [
+  { id: 'define_result', enTitle: 'Define the result', guidance: 'Name subject, intended use, composition, and constraints.' },
+  { id: 'maintainable_format', enTitle: 'Choose a maintainable format', guidance: 'Prefer skimmable structure over clever syntax.' },
+  { id: 'visible_details', enTitle: 'Describe visible details', guidance: 'Materials, lighting, colors, medium; say photorealistic explicitly when needed.' },
+  { id: 'people_actions', enTitle: 'Specify people and actions', guidance: 'Body framing, gaze, and interaction with objects.' },
+  { id: 'exact_text', enTitle: 'Specify exact text', guidance: 'Quote required wording; forbid extra text; check spelling.' },
+  { id: 'separate_changes', enTitle: 'Separate changes from constraints', guidance: 'For edits: change only X; list what must stay.' },
+  { id: 'assign_ref_roles', enTitle: 'Assign roles to references', guidance: 'Number each input by purpose: subject, style, clothing, background.' },
+  { id: 'iterate', enTitle: 'Iterate deliberately', guidance: 'One change per turn; restate critical preserve constraints.' },
+] as const
+
+export function formatFundamentalsBlock(ids?: string[]): string {
+  const set = ids?.length ? new Set(ids) : null
+  const items = set ? FUNDAMENTALS.filter((f) => set.has(f.id)) : [...FUNDAMENTALS]
+  return items.map((f) => `- ${f.enTitle}: ${f.guidance}`).join('\n')
+}
+```
+
+```ts
+// catalog.ts Task 1 — empty registries
+import { FUNDAMENTALS, formatFundamentalsBlock } from './fundamentals'
+import type { EditIntent, GenerationScene } from './types'
+
+const GENERATION_SCENES: GenerationScene[] = []
+const EDIT_INTENTS: EditIntent[] = []
+
+export { FUNDAMENTALS, formatFundamentalsBlock }
+export function listGenerationScenes() { return GENERATION_SCENES }
+export function listEditIntents() { return EDIT_INTENTS }
+export function getGenerationScene(id: string) {
+  return GENERATION_SCENES.find((s) => s.id === id)
+}
+export function getEditIntent(id: string) {
+  return EDIT_INTENTS.find((i) => i.id === id)
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Run: `pnpm --filter @lnkpi/shared test -- src/imagePromptingGuide/catalog.test.ts`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/imagePromptingGuide packages/shared/src/index.ts
+git commit -m "feat(shared): scaffold imagePromptingGuide catalog types"
+```
+
+---
+
+### Task 2: `resolveGuideRequest` + profile capabilities
+
+**Files:**
+- Create: `packages/shared/src/imagePromptingGuide/resolveGuideRequest.ts`
+- Create: `packages/shared/src/imagePromptingGuide/resolveGuideRequest.test.ts`
+- Modify: `packages/shared/src/imageModelProfiles.ts` — add optional `capabilities?: GuideCapabilities`
+- Modify: `packages/shared/src/imageEditProfiles.ts` — same
+- Modify: existing profile tests — assert defaults
+- Modify: `packages/shared/src/imagePromptingGuide/index.ts` — export resolver
+
+**Interfaces:**
+- Consumes: `GenerationScene | EditIntent`, `GuideCapabilities`
+- Produces: `resolveGuideRequest(input)`, `defaultGuideCapabilities()`, `GuideResolveResult`
+
+```ts
+export interface GuideResolveInput {
+  guide: GenerationScene | EditIntent
+  capabilities: GuideCapabilities
+  userOverrides?: Partial<ParamContract>
+  refImageCount?: number
+}
+
+export interface GuideResolveResult {
+  params: ParamContract
+  applied: string[]
+  skipped: string[]
+  blocked?: { reason: string }
+}
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { resolveGuideRequest } from './resolveGuideRequest'
+import type { EditIntent } from './types'
+
+const e5: EditIntent = {
+  id: 'e5_transparent_cutout',
+  kind: 'edit_intent',
+  label: '透明抠图',
+  description: 'x',
+  changePreserveTemplate: 'Extract…',
+  refRoles: [{ role: 'product', required: true, hint: '产品图' }],
+  preferredParams: { background: 'transparent', outputFormat: 'png', quality: 'medium' },
+  capability: { requiresTransparentBackground: true, minRefImages: 1 },
+}
+
+describe('resolveGuideRequest', () => {
+  it('blocks E5 when transparentBackground is false', () => {
+    const r = resolveGuideRequest({
+      guide: e5,
+      capabilities: { transparentBackground: false, qualityParam: true, maxRefImages: 4 },
+      refImageCount: 1,
+    })
+    expect(r.blocked?.reason).toMatch(/transparent/i)
+    expect(r.applied).toEqual([])
+  })
+
+  it('applies transparent when capability true', () => {
+    const r = resolveGuideRequest({
+      guide: e5,
+      capabilities: { transparentBackground: true, qualityParam: true, maxRefImages: 4 },
+      refImageCount: 1,
+    })
+    expect(r.blocked).toBeUndefined()
+    expect(r.params.background).toBe('transparent')
+    expect(r.applied).toContain('background')
+  })
+
+  it('skips quality when qualityParam false', () => {
+    const r = resolveGuideRequest({
+      guide: e5,
+      capabilities: { transparentBackground: true, qualityParam: false, maxRefImages: 4 },
+      refImageCount: 1,
+    })
+    expect(r.skipped).toContain('quality')
+    expect(r.params.quality).toBeUndefined()
+  })
+
+  it('blocks when minRefImages not met', () => {
+    const r = resolveGuideRequest({
+      guide: e5,
+      capabilities: { transparentBackground: true, qualityParam: true, maxRefImages: 4 },
+      refImageCount: 0,
+    })
+    expect(r.blocked?.reason).toMatch(/ref/i)
+  })
+})
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `pnpm --filter @lnkpi/shared test -- src/imagePromptingGuide/resolveGuideRequest.test.ts`
+
+- [ ] **Step 3: Implement resolver + profile defaults**
+
+Logic order:
+1. If `requiresTransparentBackground && !capabilities.transparentBackground` → blocked
+2. If `minRefImages` and `(refImageCount ?? 0) < minRefImages` → blocked
+3. Merge preferredParams; unsupported keys → skipped; else applied
+4. `userOverrides` win over preferred for non-blocked keys
+5. `defaultGuideCapabilities()` → `{ transparentBackground: false, qualityParam: true, maxRefImages: 4 }`
+
+Add `capabilities?: GuideCapabilities` on `ImageModelProfile` and `ImageEditModelProfile`; wire image2/edit to defaults.
+
+- [ ] **Step 4: Run shared tests — PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(shared): resolveGuideRequest and profile capabilities"
+```
+
+---
+
+### Task 3: P0 scene + intent assets
+
+**Files:**
+- Create: `packages/shared/src/imagePromptingGuide/scenes/g3-exact-text.ts`
+- Create: `packages/shared/src/imagePromptingGuide/scenes/g1-style-lighting.ts`
+- Create: `packages/shared/src/imagePromptingGuide/intents/e3-identity-clothing.ts`
+- Create: `packages/shared/src/imagePromptingGuide/intents/e4-combine-refs.ts`
+- Create: `packages/shared/src/imagePromptingGuide/intents/e5-transparent-cutout.ts`
+- Modify: `packages/shared/src/imagePromptingGuide/catalog.ts` — register all five
+- Modify: `packages/shared/src/imagePromptingGuide/catalog.test.ts` — assert P0 ids (replace empty-registry expectations)
+
+**Interfaces:**
+- Stable ids: `g3_exact_text`, `g1_style_lighting`, `e3_identity_clothing`, `e4_combine_refs`, `e5_transparent_cutout`
+
+- [ ] **Step 1: Write failing catalog assertions**
+
+```ts
+it('registers P0 generation scenes', () => {
+  expect(listGenerationScenes().map((s) => s.id).sort()).toEqual([
+    'g1_style_lighting',
+    'g3_exact_text',
+  ])
+})
+
+it('registers P0 edit intents', () => {
+  expect(listEditIntents().map((i) => i.id).sort()).toEqual([
+    'e3_identity_clothing',
+    'e4_combine_refs',
+    'e5_transparent_cutout',
+  ])
+})
+
+it('E5 requires transparent capability', () => {
+  expect(getEditIntent('e5_transparent_cutout')?.capability.requiresTransparentBackground).toBe(true)
+})
+```
+
+- [ ] **Step 2: Run — FAIL on empty registry**
+
+- [ ] **Step 3: Fill assets from official guide patterns**
+
+Required content:
+- G3: quoted tagline slot, render exactly once, no extra text
+- G1: subject / framing / light / texture / no heavy retouching
+- E3: change only clothing; preserve face/identity/pose/background
+- E4: place subject from image 2 into scene of image 1; change nothing else
+- E5: isolate product; transparent background; no checkerboard/scenery
+
+Set `expandViaPromptMode: 'image_prompt_multi_style'` for G1/G3.  
+E3/E4 `minRefImages: 2`; E5 `minRefImages: 1` + `requiresTransparentBackground: true`.
+
+- [ ] **Step 4: Tests PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(shared): add P0 image prompting guide scenes and intents"
+```
+
+---
+
+### Task 4: Prompt generate overlay for `guideSceneId`
+
+**Files:**
+- Modify: `packages/agent/src/prompt-modes/generate.ts`
+- Create: `packages/agent/src/prompt-modes/generate-guide-overlay.test.ts`
+- Modify: `apps/server/src/studio/studio.service.ts` — pass `guideSceneId` from body/node into generate opts
+
+**Interfaces:**
+- Consumes: `getGenerationScene`, `formatFundamentalsBlock`
+- Produces: `buildGuideSystemOverlay(guideSceneId?: string): string | null`; `generatePromptContent(..., opts?: { guideSceneId?: string })`
+
+- [ ] **Step 1: Failing test**
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { buildGuideSystemOverlay } from './generate'
+
+describe('guideScene overlay', () => {
+  it('builds G3 overlay with fundamentals', () => {
+    const overlay = buildGuideSystemOverlay('g3_exact_text')
+    expect(overlay).toBeTruthy()
+    expect(overlay!).toMatch(/exact|tagline|文字/i)
+    expect(overlay!).toContain('-')
+  })
+
+  it('returns null for unknown id', () => {
+    expect(buildGuideSystemOverlay('nope')).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run — FAIL**
+
+- [ ] **Step 3: Implement**
+
+```ts
+export function buildGuideSystemOverlay(guideSceneId?: string): string | null {
+  if (!guideSceneId) return null
+  const scene = getGenerationScene(guideSceneId)
+  if (!scene) return null
+  const fundamentals = formatFundamentalsBlock(scene.fundamentalsRefs)
+  return [scene.systemOverlay, fundamentals].filter(Boolean).join('\n\n')
+}
+
+// messages system:
+const overlay = buildGuideSystemOverlay(opts?.guideSceneId)
+const system = overlay ? `${def.system}\n\n## Image prompting guide\n${overlay}` : def.system
+```
+
+```ts
+export async function generatePromptFromUserInput(prompt, opts) {
+  const scene = opts?.guideSceneId ? getGenerationScene(opts.guideSceneId) : undefined
+  const forced = scene?.expandViaPromptMode
+  const mode =
+    forced && forced in /* PromptModeId set */ 
+      ? (forced as PromptModeId)
+      : (await classifyPromptMode(prompt, opts)).mode
+  return generatePromptContent(prompt, mode, opts)
+}
+```
+
+Studio: when calling `generatePromptFromUserInput`, pass `guideSceneId` from request/node.data.
+
+- [ ] **Step 4: `pnpm --filter @lnkpi/agent test` PASS for overlay tests**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(agent): overlay guide scene rules on prompt generate"
+```
+
+---
+
+### Task 5: Dock apply helpers + Prompt/Image Dock UI
+
+**Files:**
+- Create: `apps/web/src/components/canvas/dock-studio/panels/guideSceneApply.ts`
+- Create: `apps/web/src/components/canvas/dock-studio/panels/guideSceneApply.test.ts`
+- Modify: `apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue`
+- Modify: `apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue`
+
+**Interfaces:**
+
+```ts
+export function applyGuideSceneToPrompt(input: {
+  sceneId: string
+  currentPrompt: string
+}): { prompt: string; guideSceneId: string; didPrefill: boolean; label: string }
+
+export function clearGuideScene(): { guideSceneId: null }
+```
+
+- [ ] **Step 1: Failing tests**
+
+```ts
+it('prefills when prompt empty', () => {
+  const r = applyGuideSceneToPrompt({ sceneId: 'g3_exact_text', currentPrompt: '' })
+  expect(r.didPrefill).toBe(true)
+  expect(r.prompt.length).toBeGreaterThan(10)
+  expect(r.guideSceneId).toBe('g3_exact_text')
+})
+
+it('does not overwrite non-empty prompt', () => {
+  const r = applyGuideSceneToPrompt({ sceneId: 'g3_exact_text', currentPrompt: 'keep me' })
+  expect(r.didPrefill).toBe(false)
+  expect(r.prompt).toBe('keep me')
+  expect(r.guideSceneId).toBe('g3_exact_text')
+})
+```
+
+- [ ] **Step 2: Run web vitest — FAIL**
+
+- [ ] **Step 3: Implement helper + chips**
+
+PromptDockPanel / ImageDockPanel:
+- Chip row from `listGenerationScenes()`
+- Active when `node.data.guideSceneId` matches
+- onSelect → helper → `emit('patch', { prompt, guideSceneId })`
+- Clear sets `guideSceneId: null` without wiping prompt
+
+- [ ] **Step 4: Tests PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(web): Prompt/Image Dock guide scene chips"
+```
+
+---
+
+### Task 6: Refine edit intent chips + gates
+
+**Files:**
+- Create: `apps/web/src/components/canvas/refine/guideEditIntentApply.ts`
+- Create: `apps/web/src/components/canvas/refine/guideEditIntentApply.test.ts`
+- Modify: `apps/web/src/components/canvas/refine/RefineSidePanel.vue`
+
+**Interfaces:**
+
+```ts
+export function editIntentDisabledReason(
+  intentId: string,
+  capabilities: GuideCapabilities,
+): string | null
+
+export function applyGuideEditIntent(input: {
+  intentId: string
+  capabilities: GuideCapabilities
+  refImageCount: number
+}): { ok: true; prompt: string; guideEditIntentId: string; label: string }
+  | { ok: false; reason: string; disabled: boolean }
+```
+
+- [ ] **Step 1: Failing tests**
+
+```ts
+it('disables E5 without transparent capability', () => {
+  expect(
+    editIntentDisabledReason('e5_transparent_cutout', {
+      transparentBackground: false,
+      qualityParam: true,
+      maxRefImages: 4,
+    }),
+  ).toMatch(/透明|transparent/i)
+})
+
+it('fills E3 template when ok', () => {
+  const r = applyGuideEditIntent({
+    intentId: 'e3_identity_clothing',
+    capabilities: { transparentBackground: false, qualityParam: true, maxRefImages: 4 },
+    refImageCount: 2,
+  })
+  expect(r.ok).toBe(true)
+  if (r.ok) expect(r.prompt).toMatch(/clothing|衣服|face|身份/i)
+})
+```
+
+- [ ] **Step 2: Run — FAIL**
+
+- [ ] **Step 3: Implement beside stain preset**
+
+Use `resolveGuideRequest` + intent templates. Chips for `listEditIntents()`; E5 disabled + tooltip; on click fill prompt like `applyStainPreset`. Guard edit submit if still blocked.
+
+- [ ] **Step 4: Tests PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(web): Refine edit intent chips with capability gates"
+```
+
+---
+
+### Task 7: Agent taxonomy hooks
+
+**Files:**
+- Create: `packages/agent/src/prompt-modes/image-prompting-guide-taxonomy.yaml`
+- Create: `services/agent-runtime/skills/atomic-create/assets/image-prompting-guide-taxonomy.yaml`
+- Create: `services/agent-runtime/app/tools/guide_taxonomy.py`
+- Create: `services/agent-runtime/tests/test_guide_taxonomy.py`
+- Modify: `services/agent-runtime/app/graph/nodes/atomic_parse.py`
+- Modify: copy path that persists `promptMode` on nodes to also persist `guideSceneId` / `guideEditIntentId` when present (grep `promptMode` / `prompt_mode` in `agent-canvas-tools.service.ts`)
+
+**Interfaces:**
+- `resolve_guide_scene(utterance: str) -> str | None`
+- `resolve_guide_edit_intent(utterance: str) -> str | None`
+
+- [ ] **Step 1: Failing pytest**
+
+```python
+from app.tools.guide_taxonomy import resolve_guide_edit_intent, resolve_guide_scene
+
+def test_g3_exact_text():
+    assert resolve_guide_scene("广告图，标语必须精确文字 Yours to Create，不要多余字") == "g3_exact_text"
+
+def test_e5_cutout():
+    assert resolve_guide_edit_intent("把产品抠图做成透明底 PNG") == "e5_transparent_cutout"
+
+def test_no_false_positive_on_hello():
+    assert resolve_guide_scene("你好") is None
+    assert resolve_guide_edit_intent("你好") is None
+```
+
+- [ ] **Step 2: Run — FAIL**
+
+Run: `cd services/agent-runtime && python -m pytest tests/test_guide_taxonomy.py -v`
+
+- [ ] **Step 3: Implement yaml + loader + parse hook**
+
+```yaml
+version: 1
+generation_scenes:
+  - id: g3_exact_text
+    patterns: [精确文字, 标语必须, tagline, 不要多余字, render text]
+  - id: g1_style_lighting
+    patterns: [光影, 胶片感, 35mm, candid, 写实摄影]
+edit_intents:
+  - id: e3_identity_clothing
+    patterns: [换装, 只换衣服, 保留脸, 试穿, identity]
+  - id: e4_combine_refs
+    patterns: [合成到场景, 放到场景, 图1图2, combine reference]
+  - id: e5_transparent_cutout
+    patterns: [抠图, 透明底, 去背景, cutout]
+```
+
+Path candidates mirror `prompt_mode_taxonomy.py`.  
+`atomic_parse`: apply guide ids without clearing `prompt_mode`. If both scene and intent match, prefer intent for 换装/抠图/合成.
+
+Wire node persistence wherever `promptMode` is written today.
+
+- [ ] **Step 4: pytest PASS; existing prompt_mode tests green**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(runtime): image prompting guide taxonomy hooks"
+```
+
+---
+
+### Task 8: End-to-end verification + PR
+
+- [ ] **Step 1: Verification matrix**
+
+```bash
+pnpm --filter @lnkpi/shared test
+pnpm --filter @lnkpi/agent test
+pnpm --filter @lnkpi/web exec vitest run src/components/canvas/dock-studio/panels/guideSceneApply.test.ts src/components/canvas/refine/guideEditIntentApply.test.ts
+cd services/agent-runtime && python -m pytest tests/test_guide_taxonomy.py -v
+pnpm build
+```
+
+Expected: all PASS
+
+- [ ] **Step 2: Manual checklist**
+
+- [ ] Prompt Dock G3/G1: empty prefill; non-empty keep text
+- [ ] Refine E3/E4 templates; E5 disabled tooltip
+- [ ] Stain preset still works
+- [ ] Prompt generate works without `guideSceneId`
+
+- [ ] **Step 3: Open PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --base main --title "feat: Image Prompting Guide Catalog (P0)" --body "$(cat <<'EOF'
+## Summary
+- Dual-track imagePromptingGuide catalog (G3/G1 + E3/E4/E5) with fundamentals
+- resolveGuideRequest + profile capabilities (E5 blocked without transparent)
+- Dock scene chips + Refine intent chips
+- Agent taxonomy hooks write guide ids only
+- Image 2.5 model wiring deferred; see design appendix A
+
+## Spec
+- docs/superpowers/specs/2026-09-11-image-prompting-guide-catalog-design.md
+
+## Test plan
+- [ ] shared / agent / web guide unit tests
+- [ ] pytest test_guide_taxonomy.py
+- [ ] pnpm build
+- [ ] Manual Dock + Refine checklist
+EOF
+)"
+```
+
+---
+
+## Self-Review (plan vs spec)
+
+| Spec requirement | Task |
+|------------------|------|
+| Catalog + types + fundamentals | T1 |
+| Param contract + degradation | T2 |
+| P0 G3/G1/E3/E4/E5 | T3 |
+| Prompt expand overlay | T4 |
+| Dock 可选 scene | T5 |
+| Refine intents + E5 disable | T6 |
+| Agent taxonomy 钩子 only | T7 |
+| Image 2.5 附录不接线 | Global Constraints + T8 |
+| 不塞进 PromptModeId | Global Constraints |
+| 非空 prompt 不覆盖 | T5 |
+
+No TBD placeholders. Id naming consistent across tasks.

--- a/docs/superpowers/specs/2026-09-11-image-prompting-guide-catalog-design.md
+++ b/docs/superpowers/specs/2026-09-11-image-prompting-guide-catalog-design.md
@@ -1,0 +1,399 @@
+# Image Prompting Guide Catalog（设计文档）
+
+> 状态：§1–§4 已定稿并写入  
+> 日期：2026-09-11  
+> 范围：将 OpenAI API《Image prompting》指南（生成类场景 + 编辑类 intent）嵌入本项目工作流  
+> 上游参考：https://developers.openai.com/api/docs/guides/image-prompting  
+> 相关既存：`packages/agent/src/prompt-modes/`（7 种 promptMode）、`imageEditProfiles`、RefineSidePanel 去污预设、atomic `prompt-mode-taxonomy.yaml`
+
+## 决策摘要
+
+| 项 | 选择 |
+|---|---|
+| 官方资产范围 | API《Image prompting》生成类 9 + 编辑类 8；非 ChatGPT Poster/Merch 产品 Templates |
+| 本期落地 | **P0**：fundamentals + G3 + G1 + E3 + E4 + E5 |
+| 产品路径 | **Dock 先行**；Agent **仅 taxonomy 钩子**（写 guide id，不强制自动出图/多轮编辑） |
+| 架构 | **方案 2**：双轨 Catalog（generation_scene / edit_intent），与现有 7 个 `promptMode` 并存 |
+| 模型策略 | **本期 B**：仍用 `image2`；参数契约 + capability 降级 |
+| Image 2.5 | **另开专项**接入 Flare/Sunburst；本规格 **附录** 约束验证与迭代门禁 |
+| 不做 | 17 个新 promptMode、假透明底、ChatGPT Templates/Sketch、Agent 全自动多轮编辑流水线 |
+
+---
+
+## §1 架构与数据模型
+
+### 1.1 目标
+
+在不更换 Image 2.5 模型的前提下，把官方指南的 P0 场景嵌进工作流：
+
+1. Catalog（场景/intent 资产）
+2. Dock 可选
+3. 参数契约与降级
+4. Agent taxonomy 钩子
+5. 规格附录指导日后 Image 2.5 验证迭代
+
+### 1.2 双轨 Catalog
+
+新建共享包模块（Web / Server / Agent 共用），建议路径：
+
+`packages/shared/src/imagePromptingGuide/`
+
+```
+catalog.ts
+types.ts
+fundamentals.ts
+scenes/
+  g3-exact-text.ts
+  g1-style-lighting.ts
+intents/
+  e3-identity-clothing.ts
+  e4-combine-refs.ts
+  e5-transparent-cutout.ts
+```
+
+- **不**把编辑 intent 塞进 `PromptModeId`。
+- 生成 scene **可以**引用现有 `promptMode`（如未来 G6 → `storyboard`），但 P0 以独立 scene/intent 为主。
+
+### 1.3 核心类型
+
+```ts
+type GuideKind = 'generation_scene' | 'edit_intent'
+
+interface ParamContract {
+  size?: string
+  quality?: 'auto' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
+  background?: 'auto' | 'opaque' | 'transparent'
+  outputFormat?: 'png' | 'webp' | 'jpeg'
+}
+
+interface CapabilityGate {
+  requiresTransparentBackground?: boolean
+  minRefImages?: number
+  maxRefImages?: number
+  requiresSubjectRef?: boolean
+}
+
+interface GenerationScene {
+  id: 'g3_exact_text' | 'g1_style_lighting' | string
+  kind: 'generation_scene'
+  label: string
+  description: string
+  fundamentalsRefs: string[]
+  promptScaffold: string
+  fewShot?: { user: string; assistant: string }
+  preferredParams: ParamContract
+  capability: CapabilityGate
+  /** null = 仅预填，不改 classify */
+  expandViaPromptMode?: PromptModeId | null
+}
+
+interface EditIntent {
+  id: 'e3_identity_clothing' | 'e4_combine_refs' | 'e5_transparent_cutout' | string
+  kind: 'edit_intent'
+  label: string
+  description: string
+  changePreserveTemplate: string
+  refRoles: Array<{ role: string; required: boolean; hint: string }>
+  preferredParams: ParamContract
+  capability: CapabilityGate
+}
+```
+
+### 1.4 数据流
+
+```
+[Dock 选 scene/intent]
+  → node.data.guideSceneId / guideEditIntentId（编辑会话可只挂会话元数据）
+  → 预填 scaffold 或 change/preserve 模板
+  → resolveGuideRequest(guide, profile, userOverrides)
+       ├─ ok → 合并参数到生成/编辑请求
+       └─ unsupported → UI 禁用 + reason（尤其 E5）
+
+[Prompt 扩写]（generation_scene 且 expandViaPromptMode 有值）
+  → 现有 generatePrompt + scene system 片段 + fundamentals
+
+[Image 生成 / Image Edit]
+  → 仍走 image2 / imageEditProfiles
+  → 仅附加可映射的 preferredParams
+
+[Agent taxonomy 钩子]
+  → utterance → guideSceneId | guideEditIntentId
+  → 本期不强制自动出图 / 连环编辑
+```
+
+### 1.5 P0 收录清单
+
+| ID | 类型 | Dock 入口 |
+|----|------|-----------|
+| `fundamentals` | 共享规则 | 隐式注入，无独立按钮 |
+| `g3_exact_text` | 生成 | Prompt Dock（Image Dock 可镜像） |
+| `g1_style_lighting` | 生成 | 同上 |
+| `e3_identity_clothing` | 编辑 | Refine 侧栏 intent 芯片 |
+| `e4_combine_refs` | 编辑 | 同上 |
+| `e5_transparent_cutout` | 编辑 | 同上；无透明底则禁用 |
+
+### 1.6 本期明确不做
+
+- 接入 `gpt-image-2.5-flare` / `gpt-image-2.5-sunburst`
+- 一次做完 G2–G9 / E1–E8 全量
+- 把 17 个场景都加成新 `promptMode`
+- Agent 全自动多轮编辑流水线
+
+---
+
+## §2 Dock UX 与交互
+
+### 2.1 入口拆分
+
+| 类型 | 入口 | 交互 |
+|------|------|------|
+| 生成 scene（G3 / G1） | Prompt Dock 为主；Image Dock 可「套用场景」 | 轻量选择器，非大向导 |
+| 编辑 intent（E3 / E4 / E5） | RefineSidePanel（对齐现有去污预设） | 点选 → 填入模板 |
+| fundamentals | 无按钮 | 服务端隐式并入 |
+
+### 2.2 生成侧
+
+1. 工具栏增加「场景模板」芯片：`精确文字`、`风格与光线`。
+2. 选中后写入 `guideSceneId`：
+   - prompt 为空 → 填入 `promptScaffold`（可替换占位）
+   - prompt 非空 → **不覆盖**，只挂 sceneId + 提示「已套用场景约束」
+3. 「生成提示词」：
+   - 有 `expandViaPromptMode` → 现有扩写 + scene 片段 + fundamentals
+   - 无 → 仅预填
+4. Image Dock 套用时映射 `preferredParams` → 现有 aspect / resolution；失败则保留用户参数并弱提示。
+
+### 2.3 编辑侧
+
+1. 去污预设旁增加 intent 芯片：`换装保身份` / `多参考合成` / `透明抠图`。
+2. 选中后：填入 `changePreserveTemplate`；展示 `refRoles` 提示；记录 `guideEditIntentId`。
+3. Capability 门禁：
+   - E5 无透明底 → disabled + tooltip 指向 Image 2.5 专项后启用
+   - E3/E4 参考不足 → 可选中，应用时拦截
+4. 本期 intent **不强制** mask；E5 以整图抠图 + `background=transparent` 为主。
+
+### 2.4 状态与兼容
+
+- 已选模板显示可清除标签；清除不自动清空用户 prompt。
+- 降级/禁用一律明示原因；禁止假棋盘格透明。
+- `promptMode` 与 `guideSceneId` 可并存。
+- 三视图 hint、商业分镜预览、去污预设行为不变；intent 与去污并列，后点覆盖 prompt 模板。
+
+### 2.5 刻意不做的 UX
+
+- 多步 Wizard / 全屏模板画廊
+- ChatGPT Poster/Merch Templates
+- 首屏塞满 17 个场景
+
+---
+
+## §3 参数契约、降级与 Agent taxonomy 钩子
+
+### 3.1 参数解析
+
+```ts
+resolveGuideRequest(guideId, currentProfile, userOverrides)
+  → { params, applied: string[], skipped: string[], blocked?: { reason: string } }
+```
+
+优先级：**blocked 门禁 > 用户显式覆盖 > scene preferred > 模型/系统默认**。
+
+| 契约字段 | 本期（image2）行为 |
+|----------|-------------------|
+| size / 画幅 | 映射 aspect + resolution；失败则 skipped |
+| quality | provider 支持则带上；否则 skipped（P0 不用 forceQuality） |
+| background=transparent | capability 探测；不支持则 E5 blocked |
+| outputFormat=png | 与透明底绑定；随 E5 blocked |
+
+### 3.2 降级表
+
+| 情况 | UI | API |
+|------|----|-----|
+| E5 无透明底 | 禁用 + 明确文案 | 不发假透明请求 |
+| size 映射失败 | 弱提示保留当前画幅 | 用用户当前参数 |
+| quality 不支持 | 不阻断 | 省略字段 |
+| E3/E4 缺参考 | 应用时拦截 | 不发请求 |
+| 未知 guide id | 当无模板 | 忽略 |
+
+### 3.3 Capability 探测
+
+在 `imageModelProfiles` / `imageEditProfiles` 增加可选能力位，例如：
+
+```ts
+capabilities: {
+  transparentBackground: false, // 验证 APIMart 后可改 true
+  qualityParam: true,
+  maxRefImages: number,
+}
+```
+
+Catalog 只声明需求；是否满足看 profile。Image 2.5 专项改 profile 即可解锁 UI，无需改 Catalog/Dock。
+
+### 3.4 Agent taxonomy 钩子
+
+新增平行 taxonomy（镜像 `prompt-mode-taxonomy.yaml`），例如 `image-prompting-guide-taxonomy.yaml`，Python 侧 `resolve_guide_scene` / `resolve_guide_edit_intent`。
+
+P0 触发词（示意，实现时保守宁可漏报）：
+
+| ID | 关键词示例 |
+|----|------------|
+| `g3_exact_text` | 精确文字、标语必须、tagline、不要多余字 |
+| `g1_style_lighting` | 光影、胶片感、35mm、candid |
+| `e3_identity_clothing` | 换装、只换衣服、保留脸、试穿 |
+| `e4_combine_refs` | 合成、放到场景、图1图2、combine |
+| `e5_transparent_cutout` | 抠图、透明底、去背景、cutout |
+
+本期行为：
+
+1. 命中则写入 `guideSceneId` / `guideEditIntentId`
+2. 不自动连环出图/多轮编辑
+3. 与 `prompt_mode` 并存：guide 不覆盖 mode
+4. E5 命中但 capability 不足 → 澄清或仅挂 id 显示禁用态
+5. yaml 同步进 atomic-create skill assets
+
+---
+
+## §4 错误处理、测试与分期边界
+
+### 4.1 错误处理原则
+
+- 未知 guide id：静默当未选模板
+- E5 blocked：UI + 请求层双重校验
+- 扩写失败：不因 scene 片段导致整链崩溃；可降级仅 scaffold
+- **不静默改图意**（尤其不假透明、不清空用户 prompt）
+
+### 4.2 测试（本期必做）
+
+1. Catalog：P0 注册完整；`resolveGuideRequest` 三态
+2. Capability：`transparentBackground` false→E5 blocked；true→可 applied
+3. taxonomy：中英命中；与 prompt_mode 并存
+4. Dock：空 prompt 预填；非空不覆盖；清除标签不丢 prompt；Refine 填模板
+5. 回归：7 promptMode、三视图 pipeline、去污预设
+
+不做：全量视觉金样人工打分（留给 Image 2.5 附录流程）。
+
+### 4.3 分期
+
+| 期次 | 内容 |
+|------|------|
+| 本期 | Catalog 骨架 + fundamentals + P0 + Dock + 参数契约/降级 + Agent 钩子 + 本附录 |
+| 下期 A | Catalog 补全其余 G/E；按需映射现有 mode |
+| 下期 B | Image 2.5 模型接入专项（见附录） |
+| 不做 | ChatGPT Templates/Sketch、17 新 promptMode、Agent 全自动多轮编辑 |
+
+### 4.4 文件落点
+
+| 区域 | 路径/职责 |
+|------|-----------|
+| shared | `packages/shared/src/imagePromptingGuide/*` |
+| agent | 扩写叠加 scene；taxonomy yaml |
+| web | Prompt/Image Dock 场景选择；RefineSidePanel intent |
+| agent-runtime | `resolve_guide_*` + skill assets 同步 |
+| docs | 本设计 + 附录 |
+
+### 4.5 成功标准
+
+- Dock 可选 P0，行为符合 §2
+- E5 无透明能力时稳定禁用；有能力时改 profile 即启用
+- Agent 仅挂 id，不改变现有自动出图主路径
+- 附录可直接开 Image 2.5 专项，验收项无需再争论
+
+---
+
+## 附录 A：Image 2.5 模型接入 — 验证与迭代门禁
+
+> 本期不实现模型接线；专项开工时以本附录为验收契约。
+
+### A.1 目标模型
+
+| 模型 | 角色 |
+|------|------|
+| `gpt-image-2.5-flare`（或网关等价） | 速度优先；质量接近/对标 GPT Image 2 |
+| `gpt-image-2.5-sunburst`（或网关等价） | 质量优先 |
+
+参数与 prompt 解耦：`quality` / `size` / `background` 走 API，不塞进自然语言 prompt。
+
+### A.2 基线包（Baseline Pack）
+
+在切换模型前，用 **image2 + 本期 Catalog** 固化基线：
+
+| 场景 | 最少金样数 | 必备输入 |
+|------|------------|----------|
+| G3 精确文字 | 3 | 含引号文案 +「出现一次/禁止多余字」 |
+| G1 风格光线 | 3 | 主体 + 光/镜头/质感 + 排除重修图 |
+| E3 换装保身份 | 3 | 人物图 + ≥1 服装参考 |
+| E4 多参考合成 | 3 | 场景图 + 主体图 + 落点说明 |
+| E5 透明抠图 | 3 | 产品图；断言真实 alpha（非棋盘格像素） |
+
+每条金样记录：prompt、参考图、期望断言、当前 image2 输出（或哈希/URL）、当时 params。
+
+### A.3 验收维度
+
+对比候选模型 vs image2 基线时，至少检查：
+
+1. 指令遵循（改/保边界）
+2. 身份 / 产品几何保真
+3. 文字准确与多余字
+4. 透明通道（E5）：解码后 alpha；发丝/边缘/阴影
+5. 无多余改动（背景、构图、光）
+6. 一致性：同请求重复 N 次的漂移
+7. 延迟与失败率 / 重试成本
+
+### A.4 切换门禁（官方迁移顺序产品化）
+
+1. 固定 prompt、参考图、尺寸、output format，先比模型。
+2. 若 image2 已满足质量 → 先测 **Flare** 是否保质降延迟。
+3. 若 image2 不满足复杂用例 → 先测 **Sunburst** 达标，再回头测 Flare。
+4. 质量达标后再调 `quality` 档位；一次只改一个变量。
+5. 按 **workflow** 灰度（先 P0 edit intents，再 generation scenes）；保留 image2 回滚。
+6. 通过后将 profile `capabilities.transparentBackground`（等）置 true，跑附录回归：E5 从 blocked → enabled。
+
+### A.5 解锁与回滚
+
+- Catalog / Dock **不**硬编码 2.5 model id。
+- 解锁只改 profile capability + 默认 model key。
+- 回滚：默认 profile 回到 image2；E5 若失去透明能力自动回到 disabled。
+
+### A.6 专项交付物清单
+
+- [ ] `studioModelCatalog` + `imageModelProfiles` / `imageEditProfiles` 条目
+- [ ] generation-adapter / image-provider 接线与计费
+- [ ] 基线包目录与自动化/半自动对比记录
+- [ ] capability 解锁 PR + E5 回归绿
+- [ ] 灰度与回滚 runbook（可附在专项 plan）
+
+---
+
+## 官方场景全表（供下期 A 填 Catalog）
+
+### 生成类（9）
+
+1. Control style and lighting → P0 `g1_style_lighting`
+2. Explain a process visually
+3. Render exact text → P0 `g3_exact_text`
+4. Design a reusable logo（强依赖 transparent）
+5. Historical / real-world context
+6. Story → comic strip（可映射 storyboard）
+7. Interface preview
+8. Scientific / educational visuals
+9. Slides / diagrams / charts
+
+### 编辑类（8）
+
+1. Translate while preserving layout
+2. Transfer a visual style
+3. Preserve identity and change clothing → P0 `e3_identity_clothing`
+4. Combine references → P0 `e4_combine_refs`
+5. Transparent product cutout → P0 `e5_transparent_cutout`
+6. Drawing → realistic
+7. Remove an object
+8. Insert a person into a scene
+
+---
+
+## Spec Self-Review
+
+- [x] 无 TBD/TODO 占位要求
+- [x] 生成/编辑双轨与「不塞进 promptMode」一致
+- [x] 本期范围与附录 2.5 专项边界清晰
+- [x] E5 降级与 capability 解锁路径无歧义
+- [x] Agent 钩子「只写 id」无歧义

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -27,9 +27,11 @@ export {
   tryRuleShortcut,
   heuristicMode,
   classifyPromptMode,
+  buildGuideSystemOverlay,
   generatePromptContent,
   generatePromptFromUserInput,
 } from './prompt-modes'
+export type { GeneratePromptOpts } from './prompt-modes'
 export { mergeRefsToPrompt } from './refs/merge-refs'
 export type { MergeTextSource } from './refs/merge-refs'
 export { generateTextWithImages, ECOMMERCE_VISION_SYSTEM, DEFAULT_VISION_USER_PROMPT } from './refs/vision-text'

--- a/packages/agent/src/prompt-modes/generate-guide-overlay.test.ts
+++ b/packages/agent/src/prompt-modes/generate-guide-overlay.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { buildGuideSystemOverlay } from './generate'
+
+describe('guideScene overlay', () => {
+  it('builds G3 overlay with fundamentals', () => {
+    const overlay = buildGuideSystemOverlay('g3_exact_text')
+    expect(overlay).toBeTruthy()
+    expect(overlay!).toMatch(/exact|tagline|文字/i)
+    expect(overlay!).toContain('-')
+  })
+
+  it('returns null for unknown id', () => {
+    expect(buildGuideSystemOverlay('nope')).toBeNull()
+  })
+})

--- a/packages/agent/src/prompt-modes/generate.ts
+++ b/packages/agent/src/prompt-modes/generate.ts
@@ -1,10 +1,26 @@
-import { getPromptMode } from './registry'
+import { formatFundamentalsBlock, getGenerationScene } from '@lnkpi/shared'
+import { getPromptMode, PROMPT_MODE_IDS } from './registry'
 import type { PromptModeId } from './types'
 import { classifyPromptMode } from './classify'
 import { validateCommercialStoryboardOutput } from './modes/commercial-storyboard-validate'
 
 const MODE_TEMPERATURE: Partial<Record<PromptModeId, number>> = {
   commercial_storyboard: 0.35,
+}
+
+export type GeneratePromptOpts = {
+  apiKey?: string
+  baseUrl?: string
+  model?: string
+  guideSceneId?: string
+}
+
+export function buildGuideSystemOverlay(guideSceneId?: string): string | null {
+  if (!guideSceneId) return null
+  const scene = getGenerationScene(guideSceneId)
+  if (!scene) return null
+  const fundamentals = formatFundamentalsBlock(scene.fundamentalsRefs)
+  return [scene.systemOverlay, fundamentals].filter(Boolean).join('\n\n')
 }
 
 async function callChat(
@@ -35,7 +51,7 @@ async function callChat(
 export async function generatePromptContent(
   prompt: string,
   mode: PromptModeId,
-  opts?: { apiKey?: string; baseUrl?: string; model?: string },
+  opts?: GeneratePromptOpts,
 ): Promise<{ mode: PromptModeId; content: string }> {
   const key = opts?.apiKey ?? process.env.OPENAI_API_KEY
   const def = getPromptMode(mode)
@@ -48,8 +64,10 @@ export async function generatePromptContent(
   const model = opts?.model ?? process.env.OPENAI_CHAT_MODEL ?? 'gpt-4o'
   const temperature = MODE_TEMPERATURE[mode] ?? 0.8
   const fewShots = def.fewShots ?? [def.fewShot]
+  const overlay = buildGuideSystemOverlay(opts?.guideSceneId)
+  const system = overlay ? `${def.system}\n\n## Image prompting guide\n${overlay}` : def.system
   const messages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }> = [
-    { role: 'system', content: def.system },
+    { role: 'system', content: system },
   ]
   for (const shot of fewShots) {
     messages.push({ role: 'user', content: shot.user })
@@ -82,8 +100,13 @@ export async function generatePromptContent(
 
 export async function generatePromptFromUserInput(
   prompt: string,
-  opts?: { apiKey?: string; baseUrl?: string; model?: string },
+  opts?: GeneratePromptOpts,
 ): Promise<{ mode: PromptModeId; content: string }> {
-  const { mode } = await classifyPromptMode(prompt, opts)
+  const scene = opts?.guideSceneId ? getGenerationScene(opts.guideSceneId) : undefined
+  const forced = scene?.expandViaPromptMode
+  const mode =
+    forced && PROMPT_MODE_IDS.includes(forced as PromptModeId)
+      ? (forced as PromptModeId)
+      : (await classifyPromptMode(prompt, opts)).mode
   return generatePromptContent(prompt, mode, opts)
 }

--- a/packages/agent/src/prompt-modes/image-prompting-guide-taxonomy.yaml
+++ b/packages/agent/src/prompt-modes/image-prompting-guide-taxonomy.yaml
@@ -1,0 +1,14 @@
+# Image prompting guide taxonomy — mirrors P0 catalog scene/intent ids
+version: 1
+generation_scenes:
+  - id: g3_exact_text
+    patterns: [精确文字, 标语必须, tagline, 不要多余字, render text]
+  - id: g1_style_lighting
+    patterns: [光影, 胶片感, 35mm, candid, 写实摄影]
+edit_intents:
+  - id: e3_identity_clothing
+    patterns: [换装, 只换衣服, 保留脸, 试穿, identity]
+  - id: e4_combine_refs
+    patterns: [合成到场景, 放到场景, 图1图2, combine reference]
+  - id: e5_transparent_cutout
+    patterns: [抠图, 透明底, 去背景, cutout]

--- a/packages/agent/src/prompt-modes/index.ts
+++ b/packages/agent/src/prompt-modes/index.ts
@@ -1,7 +1,12 @@
 export type { PromptModeId, PromptModeDefinition } from './types'
 export { PROMPT_MODES, PROMPT_MODE_IDS, getPromptMode } from './registry'
 export { tryRuleShortcut, heuristicMode, classifyPromptMode } from './classify'
-export { generatePromptContent, generatePromptFromUserInput } from './generate'
+export {
+  buildGuideSystemOverlay,
+  generatePromptContent,
+  generatePromptFromUserInput,
+} from './generate'
+export type { GeneratePromptOpts } from './generate'
 export {
   CHARACTER_TURNAROUND_TEMPLATE,
   CHARACTER_TURNAROUND_STYLE_PRESETS,

--- a/packages/shared/src/imageEditProfiles.test.ts
+++ b/packages/shared/src/imageEditProfiles.test.ts
@@ -14,5 +14,10 @@ describe('resolveImageEditProfile', () => {
     expect(p.size).toBe('auto')
     expect(p.pollIntervalMs).toBe(8000)
     expect(p.maxPollMs).toBe(360000)
+    expect(p.capabilities).toEqual({
+      transparentBackground: false,
+      qualityParam: true,
+      maxRefImages: 4,
+    })
   })
 })

--- a/packages/shared/src/imageEditProfiles.ts
+++ b/packages/shared/src/imageEditProfiles.ts
@@ -1,3 +1,6 @@
+import { defaultGuideCapabilities } from './imagePromptingGuide/resolveGuideRequest'
+import type { GuideCapabilities } from './imagePromptingGuide/types'
+
 export const P1_IMAGE_EDIT_MODEL_KEY = 'image2'
 export const IMAGE_EDIT_GATEWAY_MODEL_ID = 'gpt-image-2-official'
 
@@ -10,6 +13,7 @@ export interface ImageEditModelProfile {
   size: 'auto'
   pollIntervalMs: number
   maxPollMs: number
+  capabilities?: GuideCapabilities
 }
 
 const IMAGE2_EDIT_PROFILE: ImageEditModelProfile = {
@@ -19,6 +23,7 @@ const IMAGE2_EDIT_PROFILE: ImageEditModelProfile = {
   size: 'auto',
   pollIntervalMs: 8000,
   maxPollMs: 360000,
+  capabilities: defaultGuideCapabilities(),
 }
 
 /** P1: ignore unknown keys; always return the Image2 edit profile. */

--- a/packages/shared/src/imageModelProfiles.test.ts
+++ b/packages/shared/src/imageModelProfiles.test.ts
@@ -22,6 +22,11 @@ describe('resolveImageModelProfile', () => {
     expect(p.refWire).toBe('apimart_image_urls')
     expect(p.maxN).toBe(4)
     expect(p.maxRefs).toBe(16)
+    expect(p.capabilities).toEqual({
+      transparentBackground: false,
+      qualityParam: true,
+      maxRefImages: 4,
+    })
   })
 
   it('maps APIMart gemini-3.x-flash aliases to gpt-image-2-official', () => {

--- a/packages/shared/src/imageModelProfiles.ts
+++ b/packages/shared/src/imageModelProfiles.ts
@@ -1,4 +1,6 @@
 import type { ImageResolutionTier } from './imageParams'
+import { defaultGuideCapabilities } from './imagePromptingGuide/resolveGuideRequest'
+import type { GuideCapabilities } from './imagePromptingGuide/types'
 
 export type ImageRefWire = 'none' | 'agnes_extra_body' | 'apimart_image_urls' | 'legacy_prompt_tags'
 export type ImageSizeWire = 'pixel' | 'ratio_resolution'
@@ -17,6 +19,7 @@ export interface ImageModelProfile {
   defaultQuality?: string
   pollIntervalMs: number
   maxPollMs: number
+  capabilities?: GuideCapabilities
 }
 
 const SEEDREAM_GATEWAY = 'doubao-seedream-5-0-pro'
@@ -114,6 +117,7 @@ const APIMART_IMAGE2_PROFILE: Omit<ImageModelProfile, 'gatewayModelId'> = {
   resolutionCase: 'lower',
   defaultQuality: 'high',
   maxPollMs: 360_000,
+  capabilities: defaultGuideCapabilities(),
 }
 
 const APIMART_GENERIC_IMAGE_PROFILE: Omit<ImageModelProfile, 'gatewayModelId'> = {

--- a/packages/shared/src/imagePromptingGuide/catalog.test.ts
+++ b/packages/shared/src/imagePromptingGuide/catalog.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import {
+  FUNDAMENTALS,
+  formatFundamentalsBlock,
+  listEditIntents,
+  listGenerationScenes,
+} from './catalog'
+
+describe('imagePromptingGuide catalog scaffold', () => {
+  it('exposes eight fundamentals', () => {
+    expect(FUNDAMENTALS).toHaveLength(8)
+    expect(FUNDAMENTALS[0]?.id).toBe('define_result')
+  })
+
+  it('lists empty P0 registries until scenes/intents land', () => {
+    expect(listGenerationScenes()).toEqual([])
+    expect(listEditIntents()).toEqual([])
+  })
+
+  it('formats fundamentals block', () => {
+    const block = formatFundamentalsBlock(['define_result', 'exact_text'])
+    expect(block).toContain('Define the result')
+    expect(block).toContain('Specify exact text')
+  })
+})

--- a/packages/shared/src/imagePromptingGuide/catalog.test.ts
+++ b/packages/shared/src/imagePromptingGuide/catalog.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   FUNDAMENTALS,
   formatFundamentalsBlock,
+  getEditIntent,
   listEditIntents,
   listGenerationScenes,
 } from './catalog'
@@ -12,9 +13,23 @@ describe('imagePromptingGuide catalog scaffold', () => {
     expect(FUNDAMENTALS[0]?.id).toBe('define_result')
   })
 
-  it('lists empty P0 registries until scenes/intents land', () => {
-    expect(listGenerationScenes()).toEqual([])
-    expect(listEditIntents()).toEqual([])
+  it('registers P0 generation scenes', () => {
+    expect(listGenerationScenes().map((s) => s.id).sort()).toEqual([
+      'g1_style_lighting',
+      'g3_exact_text',
+    ])
+  })
+
+  it('registers P0 edit intents', () => {
+    expect(listEditIntents().map((i) => i.id).sort()).toEqual([
+      'e3_identity_clothing',
+      'e4_combine_refs',
+      'e5_transparent_cutout',
+    ])
+  })
+
+  it('E5 requires transparent capability', () => {
+    expect(getEditIntent('e5_transparent_cutout')?.capability.requiresTransparentBackground).toBe(true)
   })
 
   it('formats fundamentals block', () => {

--- a/packages/shared/src/imagePromptingGuide/catalog.ts
+++ b/packages/shared/src/imagePromptingGuide/catalog.ts
@@ -1,8 +1,13 @@
 import { FUNDAMENTALS, formatFundamentalsBlock } from './fundamentals'
+import { e3IdentityClothing } from './intents/e3-identity-clothing'
+import { e4CombineRefs } from './intents/e4-combine-refs'
+import { e5TransparentCutout } from './intents/e5-transparent-cutout'
+import { g1StyleLighting } from './scenes/g1-style-lighting'
+import { g3ExactText } from './scenes/g3-exact-text'
 import type { EditIntent, GenerationScene } from './types'
 
-const GENERATION_SCENES: GenerationScene[] = []
-const EDIT_INTENTS: EditIntent[] = []
+const GENERATION_SCENES: GenerationScene[] = [g1StyleLighting, g3ExactText]
+const EDIT_INTENTS: EditIntent[] = [e3IdentityClothing, e4CombineRefs, e5TransparentCutout]
 
 export { FUNDAMENTALS, formatFundamentalsBlock }
 export function listGenerationScenes() { return GENERATION_SCENES }

--- a/packages/shared/src/imagePromptingGuide/catalog.ts
+++ b/packages/shared/src/imagePromptingGuide/catalog.ts
@@ -1,0 +1,15 @@
+import { FUNDAMENTALS, formatFundamentalsBlock } from './fundamentals'
+import type { EditIntent, GenerationScene } from './types'
+
+const GENERATION_SCENES: GenerationScene[] = []
+const EDIT_INTENTS: EditIntent[] = []
+
+export { FUNDAMENTALS, formatFundamentalsBlock }
+export function listGenerationScenes() { return GENERATION_SCENES }
+export function listEditIntents() { return EDIT_INTENTS }
+export function getGenerationScene(id: string) {
+  return GENERATION_SCENES.find((s) => s.id === id)
+}
+export function getEditIntent(id: string) {
+  return EDIT_INTENTS.find((i) => i.id === id)
+}

--- a/packages/shared/src/imagePromptingGuide/fundamentals.ts
+++ b/packages/shared/src/imagePromptingGuide/fundamentals.ts
@@ -1,0 +1,16 @@
+export const FUNDAMENTALS = [
+  { id: 'define_result', enTitle: 'Define the result', guidance: 'Name subject, intended use, composition, and constraints.' },
+  { id: 'maintainable_format', enTitle: 'Choose a maintainable format', guidance: 'Prefer skimmable structure over clever syntax.' },
+  { id: 'visible_details', enTitle: 'Describe visible details', guidance: 'Materials, lighting, colors, medium; say photorealistic explicitly when needed.' },
+  { id: 'people_actions', enTitle: 'Specify people and actions', guidance: 'Body framing, gaze, and interaction with objects.' },
+  { id: 'exact_text', enTitle: 'Specify exact text', guidance: 'Quote required wording; forbid extra text; check spelling.' },
+  { id: 'separate_changes', enTitle: 'Separate changes from constraints', guidance: 'For edits: change only X; list what must stay.' },
+  { id: 'assign_ref_roles', enTitle: 'Assign roles to references', guidance: 'Number each input by purpose: subject, style, clothing, background.' },
+  { id: 'iterate', enTitle: 'Iterate deliberately', guidance: 'One change per turn; restate critical preserve constraints.' },
+] as const
+
+export function formatFundamentalsBlock(ids?: string[]): string {
+  const set = ids?.length ? new Set(ids) : null
+  const items = set ? FUNDAMENTALS.filter((f) => set.has(f.id)) : [...FUNDAMENTALS]
+  return items.map((f) => `- ${f.enTitle}: ${f.guidance}`).join('\n')
+}

--- a/packages/shared/src/imagePromptingGuide/index.ts
+++ b/packages/shared/src/imagePromptingGuide/index.ts
@@ -1,3 +1,4 @@
 export * from './types'
 export * from './fundamentals'
 export * from './catalog'
+export * from './resolveGuideRequest'

--- a/packages/shared/src/imagePromptingGuide/index.ts
+++ b/packages/shared/src/imagePromptingGuide/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './fundamentals'
+export * from './catalog'

--- a/packages/shared/src/imagePromptingGuide/intents/e3-identity-clothing.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e3-identity-clothing.ts
@@ -1,0 +1,20 @@
+import type { EditIntent } from '../types'
+
+/** P0 E3 — Preserve identity and change clothing */
+export const e3IdentityClothing: EditIntent = {
+  id: 'e3_identity_clothing',
+  kind: 'edit_intent',
+  label: '换装保身份',
+  description: 'Change only clothing; preserve face, identity, pose, and background.',
+  changePreserveTemplate: `Edit the image to dress the person using the provided clothing reference(s).
+Change only the clothing. Do not change face, facial features, skin tone, body shape, pose, or identity.
+Preserve exact likeness, expression, hairstyle, and proportions.
+Fit garments naturally to the existing pose with realistic fabric behavior; match lighting and shadows.
+Do not change the background, camera angle, or framing. No accessories, text, logos, or watermarks.`,
+  refRoles: [
+    { role: 'subject', required: true, hint: '人物原图（身份/姿态）' },
+    { role: 'clothing', required: true, hint: '服装参考图' },
+  ],
+  preferredParams: { size: '1024x1536', quality: 'medium' },
+  capability: { minRefImages: 2 },
+}

--- a/packages/shared/src/imagePromptingGuide/intents/e4-combine-refs.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e4-combine-refs.ts
@@ -1,0 +1,18 @@
+import type { EditIntent } from '../types'
+
+/** P0 E4 — Combine references */
+export const e4CombineRefs: EditIntent = {
+  id: 'e4_combine_refs',
+  kind: 'edit_intent',
+  label: '多参考合成',
+  description: 'Place the subject from image 2 into the scene of image 1; change nothing else.',
+  changePreserveTemplate: `Place the subject from image 2 into the setting of image 1.
+Use the same style of lighting, composition, and background as image 1.
+Change nothing else — preserve identity of the subject and the rest of the scene.`,
+  refRoles: [
+    { role: 'scene', required: true, hint: '图1：场景/背景' },
+    { role: 'subject', required: true, hint: '图2：要放入场景的主体' },
+  ],
+  preferredParams: { size: '1024x1536', quality: 'medium' },
+  capability: { minRefImages: 2 },
+}

--- a/packages/shared/src/imagePromptingGuide/intents/e5-transparent-cutout.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e5-transparent-cutout.ts
@@ -1,0 +1,22 @@
+import type { EditIntent } from '../types'
+
+/** P0 E5 — Transparent product cutout */
+export const e5TransparentCutout: EditIntent = {
+  id: 'e5_transparent_cutout',
+  kind: 'edit_intent',
+  label: '透明抠图',
+  description: 'Isolate the product on a fully transparent background; no checkerboard or scenery.',
+  changePreserveTemplate: `Extract the product from the input image and isolate it on a fully transparent background.
+Output: centered product, crisp silhouette, no halos/fringing.
+Preserve product geometry and label legibility exactly.
+Add only light polishing. Do not add a solid backdrop, checkerboard, scenery, or shadow.
+Do not restyle the product; remove the background and preserve clean alpha transparency.`,
+  refRoles: [{ role: 'product', required: true, hint: '产品图' }],
+  preferredParams: {
+    size: '1024x1536',
+    quality: 'medium',
+    background: 'transparent',
+    outputFormat: 'png',
+  },
+  capability: { requiresTransparentBackground: true, minRefImages: 1 },
+}

--- a/packages/shared/src/imagePromptingGuide/resolveGuideRequest.test.ts
+++ b/packages/shared/src/imagePromptingGuide/resolveGuideRequest.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { resolveGuideRequest } from './resolveGuideRequest'
+import type { EditIntent } from './types'
+
+const e5: EditIntent = {
+  id: 'e5_transparent_cutout',
+  kind: 'edit_intent',
+  label: '透明抠图',
+  description: 'x',
+  changePreserveTemplate: 'Extract…',
+  refRoles: [{ role: 'product', required: true, hint: '产品图' }],
+  preferredParams: { background: 'transparent', outputFormat: 'png', quality: 'medium' },
+  capability: { requiresTransparentBackground: true, minRefImages: 1 },
+}
+
+describe('resolveGuideRequest', () => {
+  it('blocks E5 when transparentBackground is false', () => {
+    const r = resolveGuideRequest({
+      guide: e5,
+      capabilities: { transparentBackground: false, qualityParam: true, maxRefImages: 4 },
+      refImageCount: 1,
+    })
+    expect(r.blocked?.reason).toMatch(/transparent/i)
+    expect(r.applied).toEqual([])
+  })
+
+  it('applies transparent when capability true', () => {
+    const r = resolveGuideRequest({
+      guide: e5,
+      capabilities: { transparentBackground: true, qualityParam: true, maxRefImages: 4 },
+      refImageCount: 1,
+    })
+    expect(r.blocked).toBeUndefined()
+    expect(r.params.background).toBe('transparent')
+    expect(r.applied).toContain('background')
+  })
+
+  it('skips quality when qualityParam false', () => {
+    const r = resolveGuideRequest({
+      guide: e5,
+      capabilities: { transparentBackground: true, qualityParam: false, maxRefImages: 4 },
+      refImageCount: 1,
+    })
+    expect(r.skipped).toContain('quality')
+    expect(r.params.quality).toBeUndefined()
+  })
+
+  it('blocks when minRefImages not met', () => {
+    const r = resolveGuideRequest({
+      guide: e5,
+      capabilities: { transparentBackground: true, qualityParam: true, maxRefImages: 4 },
+      refImageCount: 0,
+    })
+    expect(r.blocked?.reason).toMatch(/ref/i)
+  })
+})

--- a/packages/shared/src/imagePromptingGuide/resolveGuideRequest.test.ts
+++ b/packages/shared/src/imagePromptingGuide/resolveGuideRequest.test.ts
@@ -20,7 +20,7 @@ describe('resolveGuideRequest', () => {
       capabilities: { transparentBackground: false, qualityParam: true, maxRefImages: 4 },
       refImageCount: 1,
     })
-    expect(r.blocked?.reason).toMatch(/transparent/i)
+    expect(r.blocked?.reason).toMatch(/透明/)
     expect(r.applied).toEqual([])
   })
 
@@ -51,6 +51,29 @@ describe('resolveGuideRequest', () => {
       capabilities: { transparentBackground: true, qualityParam: true, maxRefImages: 4 },
       refImageCount: 0,
     })
-    expect(r.blocked?.reason).toMatch(/ref/i)
+    expect(r.blocked?.reason).toMatch(/需要至少 1 张参考图/)
+    expect(r.blocked?.reason).toMatch(/产品图/)
+  })
+
+  it('minRef block lists required refRoles for multi-ref intents', () => {
+    const e3: EditIntent = {
+      id: 'e3_identity_clothing',
+      kind: 'edit_intent',
+      label: '换装保身份',
+      description: 'x',
+      changePreserveTemplate: 'Edit…',
+      refRoles: [
+        { role: 'subject', required: true, hint: '人物' },
+        { role: 'clothing', required: true, hint: '服装' },
+      ],
+      preferredParams: {},
+      capability: { minRefImages: 2 },
+    }
+    const r = resolveGuideRequest({
+      guide: e3,
+      capabilities: { transparentBackground: false, qualityParam: true, maxRefImages: 4 },
+      refImageCount: 1,
+    })
+    expect(r.blocked?.reason).toBe('需要至少 2 张参考图：人物 + 服装')
   })
 })

--- a/packages/shared/src/imagePromptingGuide/resolveGuideRequest.ts
+++ b/packages/shared/src/imagePromptingGuide/resolveGuideRequest.ts
@@ -46,15 +46,24 @@ export function resolveGuideRequest(input: GuideResolveInput): GuideResolveResul
   if (guide.capability.requiresTransparentBackground && !capabilities.transparentBackground) {
     return {
       ...empty,
-      blocked: { reason: 'Model does not support transparent background' },
+      blocked: { reason: '当前模型不支持透明背景' },
     }
   }
 
   const minRefs = guide.capability.minRefImages
   if (minRefs != null && (refImageCount ?? 0) < minRefs) {
+    const roleHints =
+      'refRoles' in guide && Array.isArray(guide.refRoles)
+        ? guide.refRoles
+            .filter((r) => r.required)
+            .map((r) => r.hint)
+            .filter(Boolean)
+            .join(' + ')
+        : ''
+    const detail = roleHints ? `：${roleHints}` : ''
     return {
       ...empty,
-      blocked: { reason: `Requires at least ${minRefs} ref image(s)` },
+      blocked: { reason: `需要至少 ${minRefs} 张参考图${detail}` },
     }
   }
 

--- a/packages/shared/src/imagePromptingGuide/resolveGuideRequest.ts
+++ b/packages/shared/src/imagePromptingGuide/resolveGuideRequest.ts
@@ -1,0 +1,81 @@
+import type {
+  EditIntent,
+  GenerationScene,
+  GuideCapabilities,
+  ParamContract,
+} from './types'
+
+export interface GuideResolveInput {
+  guide: GenerationScene | EditIntent
+  capabilities: GuideCapabilities
+  userOverrides?: Partial<ParamContract>
+  refImageCount?: number
+}
+
+export interface GuideResolveResult {
+  params: ParamContract
+  applied: string[]
+  skipped: string[]
+  blocked?: { reason: string }
+}
+
+export function defaultGuideCapabilities(): GuideCapabilities {
+  return {
+    transparentBackground: false,
+    qualityParam: true,
+    maxRefImages: 4,
+  }
+}
+
+const PARAM_KEYS: (keyof ParamContract)[] = ['size', 'quality', 'background', 'outputFormat']
+
+function isParamSupported(
+  key: keyof ParamContract,
+  value: ParamContract[keyof ParamContract],
+  capabilities: GuideCapabilities,
+): boolean {
+  if (key === 'quality') return capabilities.qualityParam
+  if (key === 'background' && value === 'transparent') return capabilities.transparentBackground
+  return true
+}
+
+export function resolveGuideRequest(input: GuideResolveInput): GuideResolveResult {
+  const { guide, capabilities, userOverrides, refImageCount } = input
+  const empty: GuideResolveResult = { params: {}, applied: [], skipped: [] }
+
+  if (guide.capability.requiresTransparentBackground && !capabilities.transparentBackground) {
+    return {
+      ...empty,
+      blocked: { reason: 'Model does not support transparent background' },
+    }
+  }
+
+  const minRefs = guide.capability.minRefImages
+  if (minRefs != null && (refImageCount ?? 0) < minRefs) {
+    return {
+      ...empty,
+      blocked: { reason: `Requires at least ${minRefs} ref image(s)` },
+    }
+  }
+
+  const params: ParamContract = {}
+  const applied: string[] = []
+  const skipped: string[] = []
+
+  for (const key of PARAM_KEYS) {
+    const preferred = guide.preferredParams[key]
+    const override = userOverrides?.[key]
+    const value = override !== undefined ? override : preferred
+    if (value === undefined) continue
+
+    if (!isParamSupported(key, value, capabilities)) {
+      skipped.push(key)
+      continue
+    }
+
+    ;(params as Record<string, unknown>)[key] = value
+    applied.push(key)
+  }
+
+  return { params, applied, skipped }
+}

--- a/packages/shared/src/imagePromptingGuide/scenes/g1-style-lighting.ts
+++ b/packages/shared/src/imagePromptingGuide/scenes/g1-style-lighting.ts
@@ -1,0 +1,20 @@
+import type { GenerationScene } from '../types'
+
+/** P0 G1 — Control style and lighting (OpenAI Image prompting guide) */
+export const g1StyleLighting: GenerationScene = {
+  id: 'g1_style_lighting',
+  kind: 'generation_scene',
+  label: '风格与光线',
+  description: 'Describe subject, framing, light, and texture; avoid heavy retouching.',
+  fundamentalsRefs: ['define_result', 'visible_details', 'people_actions'],
+  promptScaffold: `Create a photorealistic candid photograph of {{SUBJECT}}.
+Describe framing (e.g. medium close-up at eye level), lens cues, and composition.
+Lighting: {{LIGHT}} — soft/natural balance, shallow depth of field if needed.
+Texture: real skin/material detail, subtle grain if film-like; honest and unposed.
+No glamorization, no heavy retouching.`,
+  systemOverlay:
+    'Style & lighting scene: specify subject, framing, light, and texture. Prefer candid honesty; forbid heavy retouching and glamorization.',
+  preferredParams: { size: '1024x1536', quality: 'medium' },
+  capability: {},
+  expandViaPromptMode: 'image_prompt_multi_style',
+}

--- a/packages/shared/src/imagePromptingGuide/scenes/g3-exact-text.ts
+++ b/packages/shared/src/imagePromptingGuide/scenes/g3-exact-text.ts
@@ -1,0 +1,21 @@
+import type { GenerationScene } from '../types'
+
+/** P0 G3 — Render exact text (OpenAI Image prompting guide) */
+export const g3ExactText: GenerationScene = {
+  id: 'g3_exact_text',
+  kind: 'generation_scene',
+  label: '精确文字',
+  description: 'Quote required copy; render the tagline exactly once with no extra text.',
+  fundamentalsRefs: ['define_result', 'exact_text', 'visible_details'],
+  promptScaffold: `Create a polished campaign / fashion ad for a brand.
+The ad features the subject with the tagline "{{TAGLINE}}".
+Make it feel stylish and contemporary for the intended audience.
+Use clean composition, strong color direction, and premium photography cues.
+Render the tagline exactly once, clearly and legibly, integrated into the layout.
+No extra text, no watermarks, no unrelated logos.`,
+  systemOverlay:
+    'Exact text scene: put required wording in quotes; render the tagline exactly once; no extra text, watermarks, or unrelated logos. Check spelling and legibility.',
+  preferredParams: { size: '1024x1536', quality: 'medium' },
+  capability: {},
+  expandViaPromptMode: 'image_prompt_multi_style',
+}

--- a/packages/shared/src/imagePromptingGuide/types.ts
+++ b/packages/shared/src/imagePromptingGuide/types.ts
@@ -1,0 +1,46 @@
+export type GuideKind = 'generation_scene' | 'edit_intent'
+
+export interface ParamContract {
+  size?: string
+  quality?: 'auto' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
+  background?: 'auto' | 'opaque' | 'transparent'
+  outputFormat?: 'png' | 'webp' | 'jpeg'
+}
+
+export interface CapabilityGate {
+  requiresTransparentBackground?: boolean
+  minRefImages?: number
+  maxRefImages?: number
+  requiresSubjectRef?: boolean
+}
+
+export interface GuideCapabilities {
+  transparentBackground: boolean
+  qualityParam: boolean
+  maxRefImages: number
+}
+
+export interface GenerationScene {
+  id: string
+  kind: 'generation_scene'
+  label: string
+  description: string
+  fundamentalsRefs: string[]
+  promptScaffold: string
+  systemOverlay?: string
+  fewShot?: { user: string; assistant: string }
+  preferredParams: ParamContract
+  capability: CapabilityGate
+  expandViaPromptMode?: string | null
+}
+
+export interface EditIntent {
+  id: string
+  kind: 'edit_intent'
+  label: string
+  description: string
+  changePreserveTemplate: string
+  refRoles: Array<{ role: string; required: boolean; hint: string }>
+  preferredParams: ParamContract
+  capability: CapabilityGate
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -29,6 +29,7 @@ export * from './journeyTrace'
 export * from './mediaInfo'
 export * from './videoGeneration/types'
 export { resolveCanonicalVideoRequest } from './videoGeneration/resolveCanonicalVideoRequest'
+export * from './imagePromptingGuide'
 
 export type GenerationType = 'text' | 'image' | 'video'
 

--- a/services/agent-runtime/app/graph/atomic_parse_schema.py
+++ b/services/agent-runtime/app/graph/atomic_parse_schema.py
@@ -28,6 +28,8 @@ class AtomicParseItem(TypedDict, total=False):
     resolutionBump: bool
     promptMode: str
     prompt_mode: str
+    guideSceneId: str
+    guideEditIntentId: str
     videoSettings: dict[str, Any]
     videoMode: str
     referenceImageUrl: str
@@ -102,6 +104,12 @@ def _normalize_item(raw: dict[str, Any]) -> AtomicParseItem | None:
     pm = raw.get("promptMode") or raw.get("prompt_mode")
     if pm:
         item["promptMode"] = str(pm)
+    scene = raw.get("guideSceneId") or raw.get("guide_scene_id")
+    if scene:
+        item["guideSceneId"] = str(scene)
+    edit_intent = raw.get("guideEditIntentId") or raw.get("guide_edit_intent_id")
+    if edit_intent:
+        item["guideEditIntentId"] = str(edit_intent)
     video_settings = _normalize_video_settings(raw.get("videoSettings"))
     if video_settings:
         item["videoSettings"] = video_settings
@@ -256,6 +264,7 @@ def parse_outcome_to_state(
     canvas_context: str | None = None,
     prior_spec: dict[str, Any] | None = None,
     sidebar_attachments: list[dict[str, Any]] | None = None,
+    utterance: str | None = None,
 ) -> dict[str, Any]:
     """Map validated parse outcome to graph state patch."""
     if outcome["kind"] == "clarify":
@@ -266,7 +275,11 @@ def parse_outcome_to_state(
             "clarify_question": outcome["clarify_question"],
         }
 
-    items = outcome["items"]
+    items = [dict(i) for i in outcome["items"]]
+    if utterance:
+        from app.tools.guide_taxonomy import apply_guide_taxonomy_to_items
+
+        items = apply_guide_taxonomy_to_items(items, utterance)
     first = dict(items[0])
     if canvas_context:
         first["canvas_context"] = canvas_context

--- a/services/agent-runtime/app/graph/intent_parse_schema.py
+++ b/services/agent-runtime/app/graph/intent_parse_schema.py
@@ -26,6 +26,8 @@ class IntentParseItem(TypedDict, total=False):
     prompt: str
     confirm_gate: bool
     prompt_mode: str
+    guideSceneId: str
+    guideEditIntentId: str
     pipeline: str
     imageAspect: str
     resolutionBump: bool
@@ -68,6 +70,12 @@ def _normalize_parse_item(raw: dict[str, Any]) -> IntentParseItem | None:
         item["confirm_gate"] = bool(raw["confirm_gate"])
     if raw.get("prompt_mode"):
         item["prompt_mode"] = str(raw["prompt_mode"])
+    scene = raw.get("guideSceneId") or raw.get("guide_scene_id")
+    if scene:
+        item["guideSceneId"] = str(scene)
+    edit_intent = raw.get("guideEditIntentId") or raw.get("guide_edit_intent_id")
+    if edit_intent:
+        item["guideEditIntentId"] = str(edit_intent)
     if raw.get("pipeline"):
         item["pipeline"] = str(raw["pipeline"])
     if raw.get("imageAspect"):

--- a/services/agent-runtime/app/graph/nodes/atomic_create_node.py
+++ b/services/agent-runtime/app/graph/nodes/atomic_create_node.py
@@ -47,6 +47,21 @@ def _atomic_batch_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
                     if item.get("referenceImageUrl")
                     else {}
                 ),
+                **(
+                    {"promptMode": item.get("promptMode") or item.get("prompt_mode")}
+                    if (item.get("promptMode") or item.get("prompt_mode"))
+                    else {}
+                ),
+                **(
+                    {"guideSceneId": item["guideSceneId"]}
+                    if item.get("guideSceneId")
+                    else {}
+                ),
+                **(
+                    {"guideEditIntentId": item["guideEditIntentId"]}
+                    if item.get("guideEditIntentId")
+                    else {}
+                ),
             }
         )
     return batch

--- a/services/agent-runtime/app/graph/nodes/atomic_parse.py
+++ b/services/agent-runtime/app/graph/nodes/atomic_parse.py
@@ -33,6 +33,7 @@ from app.graph.clarify_reply import classify_clarify_reply
 from app.graph.intent_parse_llm import LLM_PARSE_TIMEOUT_SEC, llm_parse_intent
 from app.graph.intent_parse_schema import IntentParseResult, intent_result_to_parse_outcome
 from app.graph.planning_guard import validate_llm_parse
+from app.tools.guide_taxonomy import apply_guide_taxonomy_to_items
 from app.tools.prompt_mode_taxonomy import resolve_prompt_mode
 
 logger = logging.getLogger(__name__)
@@ -103,6 +104,22 @@ def _apply_prompt_mode_to_result(result: IntentParseResult, utterance: str) -> I
     return result
 
 
+def _apply_guide_taxonomy_to_result(result: IntentParseResult, utterance: str) -> IntentParseResult:
+    """Stamp guide scene/edit intent without clearing prompt_mode."""
+    raw_items = [dict(i) for i in (result.get("items") or [])]
+    stamped = apply_guide_taxonomy_to_items(raw_items, utterance)
+    if stamped == raw_items:
+        return result
+    result = dict(result)
+    result["items"] = stamped  # type: ignore[assignment]
+    return result
+
+
+def _apply_taxonomies_to_result(result: IntentParseResult, utterance: str) -> IntentParseResult:
+    """Apply prompt_mode then guide ids; guide never clears prompt_mode."""
+    return _apply_guide_taxonomy_to_result(_apply_prompt_mode_to_result(result, utterance), utterance)
+
+
 def _outcome_label(outcome: ParseOutcome) -> str:
     if outcome["kind"] == "clarify":
         return f"clarify:{outcome.get('reason', '')}"
@@ -138,7 +155,7 @@ async def _structured_llm_outcome(
     if raw is None:
         return None, None, False
 
-    raw = _apply_prompt_mode_to_result(raw, text)
+    raw = _apply_taxonomies_to_result(raw, text)
     guard = validate_llm_parse(raw, text)
     if guard is not None:
         return guard, raw, True
@@ -228,6 +245,7 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
                 canvas_context=parse_ctx,
                 prior_spec=prior_spec,
                 sidebar_attachments=sidebar_attachments,
+                utterance=text,
             )
             patch.pop("pre_parsed_intent", None)
             patch.pop("clarify_context", None)
@@ -239,7 +257,7 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
             question = str(clarify_ctx.get("clarify_question") or state.get("clarify_question") or "")
             classified = classify_clarify_reply(original, question, text, checkpoint=checkpoint)
             if classified != "none":
-                classified = _apply_prompt_mode_to_result(classified, original or text)
+                classified = _apply_taxonomies_to_result(classified, original or text)
                 reason = str(classified.get("reason") or "")
                 validation_u = (
                     classified["items"][0]["prompt"]
@@ -263,6 +281,7 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
                     canvas_context=parse_ctx,
                     prior_spec=prior_spec,
                     sidebar_attachments=sidebar_attachments,
+                    utterance=original or text,
                 )
                 patch.pop("clarify_context", None)
                 return patch
@@ -291,6 +310,7 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
                     canvas_context=parse_ctx,
                     prior_spec=prior_spec,
                     sidebar_attachments=sidebar_attachments,
+                    utterance=parse_utterance,
                 )
                 patch.pop("clarify_context", None)
                 return patch
@@ -318,6 +338,7 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
                 canvas_context=parse_ctx,
                 prior_spec=prior_spec,
                 sidebar_attachments=sidebar_attachments,
+                utterance=text,
             )
 
         canvas_ctx = parse_ctx
@@ -425,6 +446,7 @@ def make_parse_atomic_intent_node(*, nest: Any | None = None, llm: Any | None = 
             canvas_context=canvas_ctx,
             prior_spec=prior_spec,
             sidebar_attachments=sidebar_attachments,
+            utterance=text,
         )
         patch["explore_summary"] = explore_summary_from_packet(context_packet)
         if settings.agent_thinking_ui and outcome.get("kind") == "items":

--- a/services/agent-runtime/app/tools/guide_taxonomy.py
+++ b/services/agent-runtime/app/tools/guide_taxonomy.py
@@ -1,0 +1,105 @@
+"""Load image prompting guide taxonomy and resolve scene/edit intent from utterance."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from app.config import settings
+
+
+def _taxonomy_candidates() -> list[Path]:
+    skill = Path(settings.skills_dir) / "atomic-create"
+    candidates = [
+        skill / "assets" / "image-prompting-guide-taxonomy.yaml",
+    ]
+    here = Path(__file__).resolve()
+    # Monorepo dev fallback (packages/agent shared taxonomy)
+    if len(here.parents) >= 5:
+        candidates.append(
+            here.parents[4]
+            / "packages"
+            / "agent"
+            / "src"
+            / "prompt-modes"
+            / "image-prompting-guide-taxonomy.yaml"
+        )
+    return candidates
+
+
+def _resolve_taxonomy_path() -> Path | None:
+    for path in _taxonomy_candidates():
+        if path.is_file():
+            return path
+    return None
+
+
+@lru_cache(maxsize=1)
+def _load_taxonomy() -> dict[str, list[dict[str, Any]]]:
+    path = _resolve_taxonomy_path()
+    if path is None:
+        return {"generation_scenes": [], "edit_intents": []}
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    scenes = raw.get("generation_scenes") or []
+    intents = raw.get("edit_intents") or []
+    return {
+        "generation_scenes": [s for s in scenes if isinstance(s, dict) and s.get("id")],
+        "edit_intents": [i for i in intents if isinstance(i, dict) and i.get("id")],
+    }
+
+
+def _match_entry(utterance: str, entries: list[dict[str, Any]]) -> str | None:
+    text = (utterance or "").strip()
+    if not text:
+        return None
+    lower = text.lower()
+    for entry in entries:
+        patterns = entry.get("patterns") or []
+        for pat in patterns:
+            p = str(pat)
+            if p.lower() in lower or p in text:
+                return str(entry["id"])
+    return None
+
+
+def resolve_guide_scene(utterance: str) -> str | None:
+    """Heuristic generation scene id from utterance; None if no match."""
+    return _match_entry(utterance, _load_taxonomy()["generation_scenes"])
+
+
+def resolve_guide_edit_intent(utterance: str) -> str | None:
+    """Heuristic edit intent id from utterance; None if no match."""
+    return _match_entry(utterance, _load_taxonomy()["edit_intents"])
+
+
+def apply_guide_taxonomy_to_items(
+    items: list[dict[str, Any]],
+    utterance: str,
+) -> list[dict[str, Any]]:
+    """Stamp guide scene/edit intent onto items without clearing prompt_mode.
+
+    When both match, prefer edit intent (换装/抠图/合成) over generation scene.
+    """
+    scene_id = resolve_guide_scene(utterance)
+    intent_id = resolve_guide_edit_intent(utterance)
+    if not scene_id and not intent_id:
+        return items
+    # Prefer edit intent when both match (换装 / 抠图 / 合成).
+    if intent_id:
+        scene_id = None
+    out: list[dict[str, Any]] = []
+    for item in items:
+        patched = dict(item)
+        target = str(patched.get("target_type") or "")
+        if target in ("prompt", "text", "image"):
+            if intent_id and not patched.get("guideEditIntentId") and not patched.get(
+                "guide_edit_intent_id"
+            ):
+                patched["guideEditIntentId"] = intent_id
+            if scene_id and not patched.get("guideSceneId") and not patched.get("guide_scene_id"):
+                patched["guideSceneId"] = scene_id
+        out.append(patched)
+    return out

--- a/services/agent-runtime/skills/atomic-create/assets/image-prompting-guide-taxonomy.yaml
+++ b/services/agent-runtime/skills/atomic-create/assets/image-prompting-guide-taxonomy.yaml
@@ -1,0 +1,14 @@
+# Image prompting guide taxonomy — mirrors P0 catalog scene/intent ids
+version: 1
+generation_scenes:
+  - id: g3_exact_text
+    patterns: [精确文字, 标语必须, tagline, 不要多余字, render text]
+  - id: g1_style_lighting
+    patterns: [光影, 胶片感, 35mm, candid, 写实摄影]
+edit_intents:
+  - id: e3_identity_clothing
+    patterns: [换装, 只换衣服, 保留脸, 试穿, identity]
+  - id: e4_combine_refs
+    patterns: [合成到场景, 放到场景, 图1图2, combine reference]
+  - id: e5_transparent_cutout
+    patterns: [抠图, 透明底, 去背景, cutout]

--- a/services/agent-runtime/tests/test_guide_taxonomy.py
+++ b/services/agent-runtime/tests/test_guide_taxonomy.py
@@ -1,0 +1,27 @@
+from app.tools.guide_taxonomy import (
+    apply_guide_taxonomy_to_items,
+    resolve_guide_edit_intent,
+    resolve_guide_scene,
+)
+
+
+def test_g3_exact_text():
+    assert resolve_guide_scene("广告图，标语必须精确文字 Yours to Create，不要多余字") == "g3_exact_text"
+
+
+def test_e5_cutout():
+    assert resolve_guide_edit_intent("把产品抠图做成透明底 PNG") == "e5_transparent_cutout"
+
+
+def test_no_false_positive_on_hello():
+    assert resolve_guide_scene("你好") is None
+    assert resolve_guide_edit_intent("你好") is None
+
+
+def test_prefer_edit_intent_when_both_match():
+    items = apply_guide_taxonomy_to_items(
+        [{"target_type": "image", "prompt": "精确文字换装保留脸"}],
+        "精确文字换装保留脸",
+    )
+    assert items[0].get("guideEditIntentId") == "e3_identity_clothing"
+    assert items[0].get("guideSceneId") is None


### PR DESCRIPTION
## Summary
- Dual-track imagePromptingGuide catalog (G3/G1 + E3/E4/E5) with fundamentals
- resolveGuideRequest + profile capabilities (E5 blocked without transparent)
- Dock scene chips + Refine intent chips
- Agent taxonomy hooks write guide ids only
- Image 2.5 model wiring deferred; see design appendix A

## Spec
- docs/superpowers/specs/2026-09-11-image-prompting-guide-catalog-design.md

## Test plan
- [x] shared / agent / web guide unit tests
- [x] pytest test_guide_taxonomy.py
- [x] pnpm build
- [ ] Manual Dock + Refine checklist (empty/non-empty prefill, E3/E4/E5, stain preset, generate without guideSceneId)


Made with [Cursor](https://cursor.com)