### PR TITLE
feat: Image Prompting Guide Catalog fill (minimal picker + 12 scenes)

### DIFF
--- a/.superpowers/sdd/final-fix-report.md
+++ b/.superpowers/sdd/final-fix-report.md
@@ -1,0 +1,24 @@
+# Catalog Fill Final Fix Report
+
+Status: DONE — merge blockers C1、I2、I3 已修复；低成本项 I5 同步完成。
+
+## Changes
+
+- `GuidePickerPopover` 新增 `below-start` / `above-end` placement；Prompt、Image、Refine 三处 picker 均使用向上、右对齐定位。
+- `MentionInput` 关闭 mention 菜单及 `DockRefPreview` 关闭预览时消费 Escape，避免继续关闭父级 dock。
+- 两份 taxonomy YAML 恢复精确/具体意图优先顺序，保持逐字节一致；新增「写实摄影 + 精确文字」解析为 `g3_exact_text` 的回归测试。
+- Prompt dock 仅写入 guide id，因此显式允许透明背景场景；Image dock 继续使用真实模型能力。
+- 可选 I4、I6 未纳入本次合并阻断修复，避免扩大 PR 范围。
+
+## Verification
+
+- `pnpm --filter @lnkpi/shared test` — 24 files / 139 tests passed。
+- 指定 Web Vitest 命令 — 11 files / 44 tests passed。
+- 新增 `MentionInput` 回归测试随扩展 Web 验证通过；扩展合计 12 files / 45 tests passed。
+- `python3 -m pytest tests/test_guide_taxonomy.py -v`（项目 `.venv`）— 18 passed，1 条既有 Pydantic deprecation warning。
+- `cmp` 两份 taxonomy YAML — 返回 0。
+- `git diff --check` — 返回 0。
+- `pnpm build` — 返回 0；仅有既有 Rollup chunk-size / PURE annotation warnings。
+
+Commit: `fix(web): guide picker placement, Esc nesting, taxonomy priority`
+PR: #279（同一分支更新）

--- a/.superpowers/sdd/task-6-report.md
+++ b/.superpowers/sdd/task-6-report.md
@@ -5,3 +5,14 @@ Tests: `guideSceneApply.test.ts` 3/3 通过；`pnpm build` 通过。
 Capabilities: Prompt 使用默认能力；Image 按当前模型 profile 解析，Image2 保持 `transparentBackground: false`。
 Concerns: 无；未修改 RefineSidePanel，未 push。
 Report: `.superpowers/sdd/task-6-report.md`
+
+## Fix: Esc nested focus (spec §1.3)
+
+**Problem:** `GuidePickerPopover` 仅在根元素 `@keydown.escape` 处理 Esc，焦点不在 popover 内时 Esc 会冒泡到 `DockStudioToolbar` 的 window listener，直接关闭整个 dock。
+
+**Fix:**
+- `GuidePickerPopover.vue`：`open=true` 时注册 window **capture-phase** Esc listener，调用 `preventDefault` / `stopPropagation` / `stopImmediatePropagation` 后 emit `close`；`open=false` 与 `onUnmounted` 时注销。
+- `DockStudioToolbar.vue`：`handleDockEscape` 增加 `event.defaultPrevented` 早退作为双保险。
+
+**Tests:** `DockStudioToolbar.test.ts` 4/4、`GuidePickerPopover.test.ts` 2/2 通过（含 defaultPrevented 与无焦点 Esc 场景）。
+Commit: `fix(web): Esc closes guide picker before dock`

--- a/.superpowers/sdd/task-6-report.md
+++ b/.superpowers/sdd/task-6-report.md
@@ -1,56 +1,7 @@
-# Task 6 Report: Refine edit intent chips + gates
-
-**Status:** DONE  
-**Branch:** `feature/image-prompting-guide-catalog-spec`  
-**Commit:** `531a184` — `feat(web): Refine edit intent chips with capability gates`
-
-## What landed
-
-### Helper
-- `guideEditIntentApply.ts`: `editIntentDisabledReason` (E5 without transparent → 中文/transparent reason) + `applyGuideEditIntent` via `resolveGuideRequest` + `changePreserveTemplate`
-- Vitest: E5 disable, E3 fill, E5 block, minRefImages fail
-
-### Refine UI
-- `RefineSidePanel`: chips from `listEditIntents()` beside stain preset; E5 disabled + tooltip from image2 `capabilities.transparentBackground: false`
-- Click fills prompt like stain preset; `runRefine` guards if active intent still capability-blocked
-
-## TDD evidence
-
-| Step | Result |
-|------|--------|
-| RED | import `./guideEditIntentApply` unresolved |
-| GREEN | `guideEditIntentApply.test.ts` 6 pass |
-
-## Self-review
-
-- No Agent taxonomy (Task 7); no Image 2.5 models; no fake transparent backgrounds.
-- Capabilities from `resolveImageEditProfile()` (image2 defaults).
-
-## Concerns
-
-- ~~Chip click uses `Math.max(1, minRefImages)` so E3/E4 templates fill despite Refine still being single-image; submit guard only checks capability disable (not min refs).~~ **Fixed below.**
-- Active intent id is local panel state only (not persisted on node).
-
----
-
-## Review fix (Critical / Important)
-
-**Status:** FIXED  
-**Findings addressed:**
-1. Stop faking `refImageCount` on chip fill — pass real `refineRefImageCount` (1).
-2. Fill path still writes `changePreserveTemplate` when only `minRefImages` fails; capability failures (E5 transparent) still blocked.
-3. `runRefine` submit gate calls `applyGuideEditIntent(..., mode: 'submit')` with real ref count; blocks on min refs or capability and does not send edit.
-
-### Changes
-- `guideEditIntentApply.ts`: `mode: 'fill' | 'submit'` — fill allows template when refs insufficient; submit fails closed.
-- `RefineSidePanel.vue`: chip fill uses real ref count + `mode: 'fill'`; `runRefine` uses `mode: 'submit'` gate.
-- Tests: fill-with-insufficient-refs, submit minRef/capability gates.
-
-### Test evidence
-
-```text
-pnpm --filter @lnkpi/web exec vitest run src/components/canvas/refine/guideEditIntentApply.test.ts
-✓ guideEditIntentApply.test.ts (9 tests) 8ms
-Test Files  1 passed (1)
-Tests  9 passed (9)
-```
+# Task 6 Report
+Status: 完成 Prompt/Image Dock 场景图标选择器接入，移除平铺场景 chips，并隐藏标题栏关闭按钮。
+Commit: `feat(web): Prompt/Image dock scene icon picker`（本提交）
+Tests: `guideSceneApply.test.ts` 3/3 通过；`pnpm build` 通过。
+Capabilities: Prompt 使用默认能力；Image 按当前模型 profile 解析，Image2 保持 `transparentBackground: false`。
+Concerns: 无；未修改 RefineSidePanel，未 push。
+Report: `.superpowers/sdd/task-6-report.md`

--- a/apps/web/src/components/canvas/DockStudioToolbar.test.ts
+++ b/apps/web/src/components/canvas/DockStudioToolbar.test.ts
@@ -41,4 +41,24 @@ describe('DockStudioToolbar', () => {
     expect(wrapper.emitted('close')).toHaveLength(1)
     wrapper.unmount()
   })
+
+  it('does not emit close when Escape was defaultPrevented', () => {
+    const wrapper = shallowMount(DockStudioToolbar, {
+      props: {
+        node: { id: 'text-1', type: 'text', data: {} } as never,
+        upstream: {} as never,
+      },
+    })
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    })
+    event.preventDefault()
+    window.dispatchEvent(event)
+
+    expect(wrapper.emitted('close')).toBeUndefined()
+    wrapper.unmount()
+  })
 })

--- a/apps/web/src/components/canvas/DockStudioToolbar.test.ts
+++ b/apps/web/src/components/canvas/DockStudioToolbar.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mount, shallowMount } from '@vue/test-utils'
+import DockStudioToolbar from './DockStudioToolbar.vue'
+import DockToolbarShell from './dock-studio/shared/DockToolbarShell.vue'
+
+describe('DockToolbarShell', () => {
+  it('shows the close button by default and emits close', async () => {
+    const wrapper = mount(DockToolbarShell)
+
+    await wrapper.get('.bottom-toolbar-close').trigger('click')
+
+    expect(wrapper.emitted('close')).toHaveLength(1)
+  })
+
+  it('renders header-end content and can hide the close button', () => {
+    const wrapper = mount(DockToolbarShell, {
+      props: { showClose: false },
+      slots: { 'header-end': '<button class="scene-picker">场景</button>' },
+    })
+
+    expect(wrapper.find('.scene-picker').exists()).toBe(true)
+    expect(wrapper.find('.bottom-toolbar-close').exists()).toBe(false)
+  })
+})
+
+describe('DockStudioToolbar', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('emits close when Escape is pressed while the dock is visible', () => {
+    const wrapper = shallowMount(DockStudioToolbar, {
+      props: {
+        node: { id: 'text-1', type: 'text', data: {} } as never,
+        upstream: {} as never,
+      },
+    })
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+
+    expect(wrapper.emitted('close')).toHaveLength(1)
+    wrapper.unmount()
+  })
+})

--- a/apps/web/src/components/canvas/DockStudioToolbar.vue
+++ b/apps/web/src/components/canvas/DockStudioToolbar.vue
@@ -56,6 +56,7 @@ const dockLocked = computed(() => {
 })
 
 function handleDockEscape(event: KeyboardEvent) {
+  if (event.defaultPrevented) return
   if (event.key === 'Escape' && visible.value) emit('close')
 }
 

--- a/apps/web/src/components/canvas/DockStudioToolbar.vue
+++ b/apps/web/src/components/canvas/DockStudioToolbar.vue
@@ -4,7 +4,7 @@ import type { UpstreamNodeContext } from '@/composables/useUpstreamNodeContext'
 import type { MentionOption } from '@/components/canvas/MentionInput.vue'
 import DockStudioRouter from '@/components/canvas/dock-studio/DockStudioRouter.vue'
 import { EDITABLE_NODE_TYPES } from '@/composables/useSelectedNodeEditor'
-import { computed } from 'vue'
+import { computed, onMounted, onUnmounted } from 'vue'
 import { isNodeGenerating } from '@/constants/dockStudio'
 import type { CompositionTrack } from '@/utils/compositionUpstream'
 import type { NodeRef } from '@/composables/useNodeRefs'
@@ -53,6 +53,18 @@ const dockLocked = computed(() => {
   if (props.generating) return true
   const status = props.node?.data?.status
   return isNodeGenerating(status) || status === 'uploading'
+})
+
+function handleDockEscape(event: KeyboardEvent) {
+  if (event.key === 'Escape' && visible.value) emit('close')
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', handleDockEscape)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleDockEscape)
 })
 </script>
 

--- a/apps/web/src/components/canvas/MentionInput.test.ts
+++ b/apps/web/src/components/canvas/MentionInput.test.ts
@@ -1,0 +1,27 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import MentionInput from './MentionInput.vue'
+
+describe('MentionInput', () => {
+  it('prevents Escape from closing the parent dock when dismissing mentions', async () => {
+    const wrapper = mount(MentionInput, {
+      props: {
+        modelValue: '@',
+        mentions: [{ id: 'ref-1', label: '参考图' }],
+      },
+    })
+    const textarea = wrapper.get('textarea')
+    await textarea.trigger('input')
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    })
+    textarea.element.dispatchEvent(event)
+    await wrapper.vm.$nextTick()
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(wrapper.find('ul').exists()).toBe(false)
+  })
+})

--- a/apps/web/src/components/canvas/MentionInput.vue
+++ b/apps/web/src/components/canvas/MentionInput.vue
@@ -133,6 +133,8 @@ function onKeydown(e: KeyboardEvent) {
       e.preventDefault()
       insertMention(filteredMentions.value[selectedIndex.value])
     } else if (e.key === 'Escape') {
+      e.preventDefault()
+      e.stopPropagation()
       showMenu.value = false
     }
     return

--- a/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
@@ -17,17 +17,20 @@ import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.
 import DockCreditBadge from '@/components/canvas/dock-studio/shared/DockCreditBadge.vue'
 import DockRefStrip from '@/components/canvas/dock-studio/shared/DockRefStrip.vue'
 import DockTypeIcon from '@/components/canvas/dock-studio/shared/DockTypeIcon.vue'
+import GuidePickerPopover from '@/components/canvas/dock-studio/shared/GuidePickerPopover.vue'
 import type { LocalRefBinding, NodeRef } from '@/composables/useNodeRefs'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
 import { useModelProviderSettings } from '@/composables/useModelProviderSettings'
-import { resolveGenerationModel } from '@/constants/studioModels'
+import { catalogModelKeyFromValue, resolveGenerationModel } from '@/constants/studioModels'
 import { estimateImageCredits } from '@/constants/credits'
 import { persistMediaUrl } from '@/composables/useMediaUpload'
 import {
   TURNAROUND_PIPELINE_DOCK_HINT,
+  defaultGuideCapabilities,
   getGenerationScene,
+  getModelEntry,
   isTurnaroundLikePrompt,
-  listGenerationScenes,
+  resolveImageModelProfile,
 } from '@lnkpi/shared'
 import { CX_IMAGE_EDIT_ENABLED } from '@/utils/refineSession'
 import { applyGuideSceneToPrompt, clearGuideScene } from './guideSceneApply'
@@ -64,6 +67,7 @@ const refUploading = ref(false)
 const refUploadProgress = ref(0)
 const refUploadError = ref('')
 const promptSectionRef = ref<InstanceType<typeof DockPromptSection> | null>(null)
+const guidePickerOpen = ref(false)
 
 const speech = useSpeechRecognition()
 const readonly = computed(() =>
@@ -88,7 +92,14 @@ const showTurnaroundHint = computed(() => {
   return isTurnaroundLikePrompt(prompt.value)
 })
 
-const guideScenes = listGenerationScenes()
+const guideCapabilities = computed(() => {
+  const modelKey = catalogModelKeyFromValue(imageModel.value)
+  const gatewayModelId = getModelEntry(modelKey)?.gatewayModelId ?? modelKey
+  return (
+    resolveImageModelProfile(modelKey, gatewayModelId).capabilities ??
+    defaultGuideCapabilities()
+  )
+})
 const activeGuideSceneId = computed(() => {
   const id = props.node.data?.guideSceneId
   return typeof id === 'string' && id.trim() ? id.trim() : ''
@@ -118,6 +129,16 @@ function onSelectGuideScene(sceneId: string) {
 function onClearGuideScene() {
   if (readonly.value) return
   emit('patch', clearGuideScene())
+}
+
+function selectGuideScene(sceneId: string) {
+  onSelectGuideScene(sceneId)
+  guidePickerOpen.value = false
+}
+
+function clearSelectedGuideScene() {
+  onClearGuideScene()
+  guidePickerOpen.value = false
 }
 
 const effectiveRefUrl = computed(() => {
@@ -288,7 +309,42 @@ function clearReferenceImage() {
 </script>
 
 <template>
-  <DockToolbarShell type="image" @close="emit('close')">
+  <DockToolbarShell type="image" :show-close="false" @close="emit('close')">
+    <template #header-end>
+      <div class="relative">
+        <button
+          type="button"
+          class="bottom-toolbar-close relative"
+          :class="activeGuideSceneId ? 'bg-fuchsia-500/15 text-fuchsia-300' : 'text-white/35'"
+          :disabled="readonly"
+          aria-label="场景模板"
+          :aria-expanded="guidePickerOpen"
+          @click="guidePickerOpen = !guidePickerOpen"
+        >
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8">
+            <rect x="4" y="4" width="6" height="6" rx="1" />
+            <rect x="14" y="4" width="6" height="6" rx="1" />
+            <rect x="4" y="14" width="6" height="6" rx="1" />
+            <rect x="14" y="14" width="6" height="6" rx="1" />
+          </svg>
+          <span
+            v-if="activeGuideSceneId"
+            class="absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-fuchsia-400"
+            aria-hidden="true"
+          />
+        </button>
+        <GuidePickerPopover
+          mode="generation_scene"
+          :active-id="activeGuideSceneId || null"
+          :capabilities="guideCapabilities"
+          :open="guidePickerOpen"
+          @select="selectGuideScene"
+          @clear="clearSelectedGuideScene"
+          @close="guidePickerOpen = false"
+        />
+      </div>
+    </template>
+
     <DockRefStrip
       :refs="stripRefs"
       @reorder="onRefReorder"
@@ -304,30 +360,6 @@ function clearReferenceImage() {
       @update:model-value="onPromptInput"
       @submit="onGenerate"
     />
-
-    <div class="mx-3 mb-2 flex flex-wrap items-center gap-1.5">
-      <button
-        v-for="scene in guideScenes"
-        :key="scene.id"
-        type="button"
-        class="neo-chip rounded-md px-2 py-1 text-[10px]"
-        :class="activeGuideSceneId === scene.id ? 'border-indigo-400/50 bg-indigo-500/20 text-indigo-200' : ''"
-        :disabled="readonly"
-        :title="scene.description"
-        @click="onSelectGuideScene(scene.id)"
-      >
-        {{ scene.label }}
-      </button>
-      <button
-        v-if="activeGuideSceneId"
-        type="button"
-        class="neo-chip rounded-md px-2 py-1 text-[10px] text-white/55"
-        :disabled="readonly"
-        @click="onClearGuideScene"
-      >
-        清除场景
-      </button>
-    </div>
 
     <p
       v-if="showTurnaroundHint"

--- a/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
@@ -338,6 +338,7 @@ function clearReferenceImage() {
           :active-id="activeGuideSceneId || null"
           :capabilities="guideCapabilities"
           :open="guidePickerOpen"
+          placement="above-end"
           @select="selectGuideScene"
           @clear="clearSelectedGuideScene"
           @close="guidePickerOpen = false"

--- a/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
@@ -11,6 +11,7 @@ import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGener
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import DockCreditBadge from '@/components/canvas/dock-studio/shared/DockCreditBadge.vue'
 import DockRefStrip from '@/components/canvas/dock-studio/shared/DockRefStrip.vue'
+import GuidePickerPopover from '@/components/canvas/dock-studio/shared/GuidePickerPopover.vue'
 import { estimateTextCredits } from '@/constants/credits'
 import type { NodeRef } from '@/composables/useNodeRefs'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
@@ -21,7 +22,7 @@ import {
   PROMPT_MODE_LABELS,
   buildPromptNodeCardPreview,
   countMarkdownTableDataRows,
-  listGenerationScenes,
+  defaultGuideCapabilities,
 } from '@lnkpi/shared'
 import { applyGuideSceneToPrompt, clearGuideScene } from './guideSceneApply'
 
@@ -49,6 +50,7 @@ const textModel = ref(getConfig('text').model)
 
 const speech = useSpeechRecognition()
 const promptSectionRef = ref<InstanceType<typeof DockPromptSection> | null>(null)
+const guidePickerOpen = ref(false)
 const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
 const promptMode = computed(() => {
   const mode = props.node.data?.promptMode
@@ -75,7 +77,7 @@ const tableRowCount = computed(() =>
 )
 
 const textRefs = computed(() => (props.refs ?? []).filter((ref) => ref.mediaType === 'text'))
-const guideScenes = listGenerationScenes()
+const guideCapabilities = defaultGuideCapabilities()
 const activeGuideSceneId = computed(() => {
   const id = props.node.data?.guideSceneId
   return typeof id === 'string' && id.trim() ? id.trim() : ''
@@ -94,6 +96,16 @@ function onSelectGuideScene(sceneId: string) {
 function onClearGuideScene() {
   if (readonly.value) return
   emit('patch', clearGuideScene())
+}
+
+function selectGuideScene(sceneId: string) {
+  onSelectGuideScene(sceneId)
+  guidePickerOpen.value = false
+}
+
+function clearSelectedGuideScene() {
+  onClearGuideScene()
+  guidePickerOpen.value = false
 }
 
 function syncFromNode() {
@@ -171,7 +183,42 @@ function onRefMention(refKey: string) {
 </script>
 
 <template>
-  <DockToolbarShell type="prompt" @close="emit('close')">
+  <DockToolbarShell type="prompt" :show-close="false" @close="emit('close')">
+    <template #header-end>
+      <div class="relative">
+        <button
+          type="button"
+          class="bottom-toolbar-close relative"
+          :class="activeGuideSceneId ? 'bg-fuchsia-500/15 text-fuchsia-300' : 'text-white/35'"
+          :disabled="readonly"
+          aria-label="场景模板"
+          :aria-expanded="guidePickerOpen"
+          @click="guidePickerOpen = !guidePickerOpen"
+        >
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8">
+            <rect x="4" y="4" width="6" height="6" rx="1" />
+            <rect x="14" y="4" width="6" height="6" rx="1" />
+            <rect x="4" y="14" width="6" height="6" rx="1" />
+            <rect x="14" y="14" width="6" height="6" rx="1" />
+          </svg>
+          <span
+            v-if="activeGuideSceneId"
+            class="absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-fuchsia-400"
+            aria-hidden="true"
+          />
+        </button>
+        <GuidePickerPopover
+          mode="generation_scene"
+          :active-id="activeGuideSceneId || null"
+          :capabilities="guideCapabilities"
+          :open="guidePickerOpen"
+          @select="selectGuideScene"
+          @clear="clearSelectedGuideScene"
+          @close="guidePickerOpen = false"
+        />
+      </div>
+    </template>
+
     <DockRefStrip
       :refs="textRefs"
       @reorder="onRefReorder"
@@ -187,30 +234,6 @@ function onRefMention(refKey: string) {
       @update:model-value="onPromptInput"
       @submit="onGenerate"
     />
-
-    <div class="mx-3 mb-2 flex flex-wrap items-center gap-1.5">
-      <button
-        v-for="scene in guideScenes"
-        :key="scene.id"
-        type="button"
-        class="neo-chip rounded-md px-2 py-1 text-[10px]"
-        :class="activeGuideSceneId === scene.id ? 'border-fuchsia-400/50 bg-fuchsia-500/20 text-fuchsia-200' : ''"
-        :disabled="readonly"
-        :title="scene.description"
-        @click="onSelectGuideScene(scene.id)"
-      >
-        {{ scene.label }}
-      </button>
-      <button
-        v-if="activeGuideSceneId"
-        type="button"
-        class="neo-chip rounded-md px-2 py-1 text-[10px] text-white/55"
-        :disabled="readonly"
-        @click="onClearGuideScene"
-      >
-        清除场景
-      </button>
-    </div>
 
     <section
       v-if="generatedContent"

--- a/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
@@ -77,7 +77,11 @@ const tableRowCount = computed(() =>
 )
 
 const textRefs = computed(() => (props.refs ?? []).filter((ref) => ref.mediaType === 'text'))
-const guideCapabilities = defaultGuideCapabilities()
+// Prompt dock only stamps guide ids; it does not generate images itself.
+const guideCapabilities = {
+  ...defaultGuideCapabilities(),
+  transparentBackground: true,
+}
 const activeGuideSceneId = computed(() => {
   const id = props.node.data?.guideSceneId
   return typeof id === 'string' && id.trim() ? id.trim() : ''
@@ -212,6 +216,7 @@ function onRefMention(refKey: string) {
           :active-id="activeGuideSceneId || null"
           :capabilities="guideCapabilities"
           :open="guidePickerOpen"
+          placement="above-end"
           @select="selectGuideScene"
           @clear="clearSelectedGuideScene"
           @close="guidePickerOpen = false"

--- a/apps/web/src/components/canvas/dock-studio/shared/DockRefPreview.test.ts
+++ b/apps/web/src/components/canvas/dock-studio/shared/DockRefPreview.test.ts
@@ -1,0 +1,33 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import DockRefPreview from './DockRefPreview.vue'
+
+describe('DockRefPreview', () => {
+  it('prevents Escape from closing the parent dock when closing the preview', () => {
+    const wrapper = mount(DockRefPreview, {
+      props: {
+        refItem: {
+          refId: 'ref-1',
+          refKey: 'T1',
+          mediaType: 'text',
+          sourceKind: 'edge',
+          label: '文本引用',
+          preview: '示例',
+          payload: { text: '示例' },
+        },
+        x: 20,
+        y: 20,
+      },
+    })
+    const event = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    })
+
+    document.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(wrapper.emitted('close')).toHaveLength(1)
+  })
+})

--- a/apps/web/src/components/canvas/dock-studio/shared/DockRefPreview.vue
+++ b/apps/web/src/components/canvas/dock-studio/shared/DockRefPreview.vue
@@ -36,7 +36,10 @@ const style = computed(() => {
 })
 
 function onKey(e: KeyboardEvent) {
-  if (e.key === 'Escape') emit('close')
+  if (e.key !== 'Escape') return
+  e.preventDefault()
+  e.stopPropagation()
+  emit('close')
 }
 
 onMounted(() => document.addEventListener('keydown', onKey))

--- a/apps/web/src/components/canvas/dock-studio/shared/DockToolbarShell.vue
+++ b/apps/web/src/components/canvas/dock-studio/shared/DockToolbarShell.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue'
 import DockTypeIcon from './DockTypeIcon.vue'
 import { DOCK_TYPE_LABELS, dockTypeToIcon } from './dockIcons'
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   /** Node type key, e.g. text / image / video / audio */
   type?: string
   /** @deprecated Prefer `type` — kept for legacy panels */
@@ -12,7 +12,10 @@ const props = defineProps<{
   title?: string
   titlePlaceholder?: string
   readonly?: boolean
-}>()
+  showClose?: boolean
+}>(), {
+  showClose: true,
+})
 
 const emit = defineEmits<{
   close: []
@@ -46,11 +49,20 @@ const tooltip = computed(() => {
           @input="emit('update:title', ($event.target as HTMLInputElement).value)"
         >
       </div>
-      <button type="button" class="bottom-toolbar-close" aria-label="关闭" @click="emit('close')">
-        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M18 6 6 18M6 6l12 12" />
-        </svg>
-      </button>
+      <div class="bottom-toolbar-header-end flex items-center gap-1">
+        <slot name="header-end" />
+        <button
+          v-if="showClose"
+          type="button"
+          class="bottom-toolbar-close"
+          aria-label="关闭"
+          @click="emit('close')"
+        >
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M18 6 6 18M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
     </div>
     <slot />
   </div>

--- a/apps/web/src/components/canvas/dock-studio/shared/GuidePickerPopover.test.ts
+++ b/apps/web/src/components/canvas/dock-studio/shared/GuidePickerPopover.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import GuidePickerPopover from './GuidePickerPopover.vue'
+
+const defaultProps = {
+  mode: 'generation_scene' as const,
+  activeId: null,
+  capabilities: {
+    transparentBackground: true,
+    qualityParam: true,
+    maxRefImages: 4,
+  },
+  open: true,
+}
+
+describe('GuidePickerPopover', () => {
+  it('emits close on window Escape even without focus inside', async () => {
+    const wrapper = mount(GuidePickerPopover, { props: defaultProps })
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+
+    expect(wrapper.emitted('close')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('defaultPrevents Escape so dock handlers can bail', async () => {
+    mount(GuidePickerPopover, { props: defaultProps })
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    })
+    window.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+  })
+})

--- a/apps/web/src/components/canvas/dock-studio/shared/GuidePickerPopover.test.ts
+++ b/apps/web/src/components/canvas/dock-studio/shared/GuidePickerPopover.test.ts
@@ -14,6 +14,15 @@ const defaultProps = {
 }
 
 describe('GuidePickerPopover', () => {
+  it('applies above-end placement for bottom dock popovers', () => {
+    const wrapper = mount(GuidePickerPopover, {
+      props: { ...defaultProps, placement: 'above-end' },
+    })
+
+    expect(wrapper.classes()).toContain('guide-picker-popover--above-end')
+    wrapper.unmount()
+  })
+
   it('emits close on window Escape even without focus inside', async () => {
     const wrapper = mount(GuidePickerPopover, { props: defaultProps })
 

--- a/apps/web/src/components/canvas/dock-studio/shared/GuidePickerPopover.vue
+++ b/apps/web/src/components/canvas/dock-studio/shared/GuidePickerPopover.vue
@@ -1,0 +1,340 @@
+<script setup lang="ts">
+import {
+  GUIDE_GROUP_ORDER,
+  listEditIntents,
+  listGenerationScenes,
+  type EditIntent,
+  type GenerationScene,
+  type GuideCapabilities,
+  type GuideKind,
+} from '@lnkpi/shared'
+import { computed, nextTick, ref, watch } from 'vue'
+import { guidePickerDisabledReason } from './guidePickerDisable'
+import { filterGuideItems, groupGuideItems } from './guidePickerFilter'
+
+type GuideItem = GenerationScene | EditIntent
+
+const props = withDefaults(
+  defineProps<{
+    mode: GuideKind
+    activeId: string | null
+    capabilities: GuideCapabilities
+    open: boolean
+    refImageCount?: number
+  }>(),
+  {
+    refImageCount: 0,
+  },
+)
+
+const emit = defineEmits<{
+  select: [id: string]
+  clear: []
+  close: []
+}>()
+
+const query = ref('')
+const searchInput = ref<HTMLInputElement | null>(null)
+
+const items = computed<GuideItem[]>(() =>
+  props.mode === 'generation_scene'
+    ? listGenerationScenes()
+    : listEditIntents(),
+)
+
+const groups = computed(() =>
+  groupGuideItems(
+    filterGuideItems(items.value, query.value),
+    GUIDE_GROUP_ORDER,
+  ),
+)
+
+const searchPlaceholder = computed(() =>
+  props.mode === 'generation_scene' ? '搜索场景…' : '搜索编辑意图…',
+)
+
+const clearLabel = computed(() =>
+  props.mode === 'generation_scene' ? '清除场景' : '清除意图',
+)
+
+watch(
+  () => props.open,
+  (open) => {
+    if (!open) return
+    query.value = ''
+    void nextTick(() => searchInput.value?.focus())
+  },
+  { immediate: true },
+)
+
+function disabledReason(id: string): string | null {
+  return guidePickerDisabledReason(props.mode, id, props.capabilities)
+}
+
+function selectItem(item: GuideItem) {
+  if (disabledReason(item.id)) return
+  emit('select', item.id)
+  emit('close')
+}
+
+function onEscape(event: KeyboardEvent) {
+  event.stopPropagation()
+  emit('close')
+}
+</script>
+
+<template>
+  <section
+    v-if="open"
+    class="guide-picker-popover neo-popover"
+    role="dialog"
+    :aria-label="mode === 'generation_scene' ? '选择生成场景' : '选择编辑意图'"
+    @keydown.escape.prevent="onEscape"
+  >
+    <div class="guide-picker-popover__search">
+      <span aria-hidden="true" class="guide-picker-popover__search-icon">⌕</span>
+      <input
+        ref="searchInput"
+        v-model="query"
+        type="search"
+        class="guide-picker-popover__input"
+        :placeholder="searchPlaceholder"
+        autocomplete="off"
+      />
+    </div>
+
+    <div class="guide-picker-popover__list">
+      <template v-if="groups.length">
+        <section
+          v-for="group in groups"
+          :key="group.groupId"
+          class="guide-picker-popover__group"
+        >
+          <h3 class="guide-picker-popover__group-label">
+            {{ group.groupLabel }}
+          </h3>
+          <button
+            v-for="item in group.items"
+            :key="item.id"
+            type="button"
+            class="guide-picker-popover__item neo-popover-item"
+            :class="{ 'is-active': activeId === item.id }"
+            :disabled="Boolean(disabledReason(item.id))"
+            :title="disabledReason(item.id) || item.description"
+            :aria-current="activeId === item.id ? 'true' : undefined"
+            @click="selectItem(item)"
+          >
+            <span class="guide-picker-popover__item-copy">
+              <span class="guide-picker-popover__item-label">
+                {{ item.label }}
+              </span>
+              <span class="guide-picker-popover__item-description">
+                {{ item.description }}
+              </span>
+            </span>
+            <span
+              v-if="disabledReason(item.id)"
+              class="guide-picker-popover__disabled"
+            >
+              不可用
+            </span>
+            <span
+              v-else-if="activeId === item.id"
+              class="guide-picker-popover__active-mark"
+              aria-hidden="true"
+            >
+              ✓
+            </span>
+          </button>
+        </section>
+      </template>
+      <p v-else class="guide-picker-popover__empty">没有匹配结果</p>
+    </div>
+
+    <footer v-if="activeId" class="guide-picker-popover__footer">
+      <button
+        type="button"
+        class="guide-picker-popover__clear"
+        @click="emit('clear')"
+      >
+        {{ clearLabel }}
+      </button>
+    </footer>
+  </section>
+</template>
+
+<style scoped>
+.guide-picker-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: 50;
+  width: min(288px, calc(100vw - 24px));
+  overflow: hidden;
+  border-radius: 16px;
+}
+
+.guide-picker-popover__search {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: 8px;
+  padding: 0 10px;
+  border: 1px solid var(--neo-border);
+  border-radius: 10px;
+  background: var(--neo-hover-bg);
+  color: var(--neo-text-muted);
+}
+
+.guide-picker-popover__search:focus-within {
+  border-color: var(--neo-border-strong);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--neo-hi-text) 10%, transparent);
+}
+
+.guide-picker-popover__search-icon {
+  flex-shrink: 0;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.guide-picker-popover__input {
+  min-width: 0;
+  width: 100%;
+  height: 34px;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--neo-text-primary);
+  font-size: 12px;
+}
+
+.guide-picker-popover__input::placeholder {
+  color: var(--neo-text-muted);
+}
+
+.guide-picker-popover__input::-webkit-search-cancel-button {
+  opacity: 0.6;
+}
+
+.guide-picker-popover__list {
+  max-height: 280px;
+  overflow-y: auto;
+  padding: 0 6px 6px;
+}
+
+.guide-picker-popover__group + .guide-picker-popover__group {
+  margin-top: 5px;
+}
+
+.guide-picker-popover__group-label {
+  margin: 0;
+  padding: 7px 8px 4px;
+  color: var(--neo-text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.guide-picker-popover__item {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 8px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.guide-picker-popover__item.is-active {
+  border-color: color-mix(in srgb, var(--neo-hi-text) 18%, transparent);
+  background: var(--neo-hi-bg);
+  color: var(--neo-hi-text);
+  box-shadow: var(--neo-hi-shadow);
+}
+
+.guide-picker-popover__item:disabled {
+  opacity: 0.42;
+  cursor: not-allowed;
+}
+
+.guide-picker-popover__item:disabled:hover {
+  background: transparent;
+  color: var(--neo-text-secondary);
+}
+
+.guide-picker-popover__item-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.guide-picker-popover__item-label {
+  overflow: hidden;
+  color: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.guide-picker-popover__item-description {
+  overflow: hidden;
+  color: var(--neo-text-muted);
+  font-size: 10px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.guide-picker-popover__disabled,
+.guide-picker-popover__active-mark {
+  flex-shrink: 0;
+  font-size: 10px;
+}
+
+.guide-picker-popover__disabled {
+  color: var(--neo-text-muted);
+}
+
+.guide-picker-popover__active-mark {
+  color: var(--neo-hi-text);
+  font-weight: 700;
+}
+
+.guide-picker-popover__empty {
+  margin: 0;
+  padding: 24px 8px;
+  color: var(--neo-text-muted);
+  font-size: 12px;
+  text-align: center;
+}
+
+.guide-picker-popover__footer {
+  padding: 7px 8px;
+  border-top: 1px solid var(--neo-border);
+}
+
+.guide-picker-popover__clear {
+  width: 100%;
+  padding: 7px 8px;
+  border: 0;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--neo-text-secondary);
+  font-size: 11px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.guide-picker-popover__clear:hover {
+  background: var(--neo-hover-bg);
+  color: var(--neo-text-primary);
+}
+</style>

--- a/apps/web/src/components/canvas/dock-studio/shared/GuidePickerPopover.vue
+++ b/apps/web/src/components/canvas/dock-studio/shared/GuidePickerPopover.vue
@@ -21,9 +21,11 @@ const props = withDefaults(
     capabilities: GuideCapabilities
     open: boolean
     refImageCount?: number
+    placement?: 'below-start' | 'above-end'
   }>(),
   {
     refImageCount: 0,
+    placement: 'below-start',
   },
 )
 
@@ -103,6 +105,7 @@ function onEscape(event: KeyboardEvent) {
   <section
     v-if="open"
     class="guide-picker-popover neo-popover"
+    :class="`guide-picker-popover--${placement}`"
     role="dialog"
     :aria-label="mode === 'generation_scene' ? '选择生成场景' : '选择编辑意图'"
     @keydown.escape.prevent="onEscape"
@@ -188,6 +191,13 @@ function onEscape(event: KeyboardEvent) {
   width: min(288px, calc(100vw - 24px));
   overflow: hidden;
   border-radius: 16px;
+}
+
+.guide-picker-popover--above-end {
+  top: auto;
+  right: 0;
+  bottom: calc(100% + 8px);
+  left: auto;
 }
 
 .guide-picker-popover__search {

--- a/apps/web/src/components/canvas/dock-studio/shared/GuidePickerPopover.vue
+++ b/apps/web/src/components/canvas/dock-studio/shared/GuidePickerPopover.vue
@@ -8,7 +8,7 @@ import {
   type GuideCapabilities,
   type GuideKind,
 } from '@lnkpi/shared'
-import { computed, nextTick, ref, watch } from 'vue'
+import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
 import { guidePickerDisabledReason } from './guidePickerDisable'
 import { filterGuideItems, groupGuideItems } from './guidePickerFilter'
 
@@ -57,15 +57,31 @@ const clearLabel = computed(() =>
   props.mode === 'generation_scene' ? '清除场景' : '清除意图',
 )
 
+function handleWindowEscape(event: KeyboardEvent) {
+  if (event.key !== 'Escape') return
+  event.preventDefault()
+  event.stopPropagation()
+  event.stopImmediatePropagation()
+  emit('close')
+}
+
 watch(
   () => props.open,
-  (open) => {
+  (open, _prev, onCleanup) => {
     if (!open) return
     query.value = ''
     void nextTick(() => searchInput.value?.focus())
+    window.addEventListener('keydown', handleWindowEscape, { capture: true })
+    onCleanup(() => {
+      window.removeEventListener('keydown', handleWindowEscape, { capture: true })
+    })
   },
   { immediate: true },
 )
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleWindowEscape, { capture: true })
+})
 
 function disabledReason(id: string): string | null {
   return guidePickerDisabledReason(props.mode, id, props.capabilities)

--- a/apps/web/src/components/canvas/dock-studio/shared/guidePickerDisable.test.ts
+++ b/apps/web/src/components/canvas/dock-studio/shared/guidePickerDisable.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { guidePickerDisabledReason } from './guidePickerDisable'
+
+const capabilities = {
+  transparentBackground: false,
+  qualityParam: true,
+  maxRefImages: 4,
+}
+
+describe('guidePickerDisabledReason', () => {
+  it('disables transparent generation scenes when unsupported', () => {
+    expect(
+      guidePickerDisabledReason('generation_scene', 'g4_reusable_logo', capabilities),
+    ).toMatch(/透明背景/)
+  })
+
+  it('uses the edit intent capability gate for E5', () => {
+    expect(
+      guidePickerDisabledReason('edit_intent', 'e5_transparent_cutout', capabilities),
+    ).toMatch(/透明|transparent/i)
+  })
+})

--- a/apps/web/src/components/canvas/dock-studio/shared/guidePickerDisable.ts
+++ b/apps/web/src/components/canvas/dock-studio/shared/guidePickerDisable.ts
@@ -1,0 +1,28 @@
+import {
+  getGenerationScene,
+  type GuideCapabilities,
+  type GuideKind,
+} from '@lnkpi/shared'
+import { editIntentDisabledReason } from '@/components/canvas/refine/guideEditIntentApply'
+
+const TRANSPARENT_BACKGROUND_REASON = '当前模型不支持透明背景'
+
+export function guidePickerDisabledReason(
+  mode: GuideKind,
+  id: string,
+  capabilities: GuideCapabilities,
+): string | null {
+  if (mode === 'edit_intent') {
+    return editIntentDisabledReason(id, capabilities)
+  }
+
+  const scene = getGenerationScene(id)
+  if (
+    scene?.capability.requiresTransparentBackground &&
+    !capabilities.transparentBackground
+  ) {
+    return TRANSPARENT_BACKGROUND_REASON
+  }
+
+  return null
+}

--- a/apps/web/src/components/canvas/dock-studio/shared/guidePickerFilter.test.ts
+++ b/apps/web/src/components/canvas/dock-studio/shared/guidePickerFilter.test.ts
@@ -1,0 +1,100 @@
+import { GUIDE_GROUP_ORDER, listGenerationScenes } from '@lnkpi/shared'
+import { describe, expect, it } from 'vitest'
+import { filterGuideItems, groupGuideItems } from './guidePickerFilter'
+
+type GuideItem = {
+  id: string
+  label: string
+  description: string
+  groupId?: string
+}
+
+const sampleItems: GuideItem[] = [
+  {
+    id: 'g1_style_lighting',
+    label: '风格与光照',
+    description: 'Adjust mood and lighting on a subject.',
+    groupId: 'photo_ad',
+  },
+  {
+    id: 'g4_reusable_logo',
+    label: '可复用 Logo',
+    description: 'Create a simple, reusable logo mark with a clean transparent background.',
+    groupId: 'brand_ui',
+  },
+  {
+    id: 'g2_process_infographic',
+    label: '流程信息图',
+    description: 'Explain a process with labeled steps.',
+    groupId: 'info_design',
+  },
+  {
+    id: 'legacy_item',
+    label: 'Legacy',
+    description: 'Item without a group.',
+  },
+]
+
+describe('filterGuideItems', () => {
+  it('returns all items when query is empty', () => {
+    expect(filterGuideItems(sampleItems, '')).toEqual(sampleItems)
+  })
+
+  it('returns all items when query is whitespace only', () => {
+    expect(filterGuideItems(sampleItems, '   \t  ')).toEqual(sampleItems)
+  })
+
+  it('matches logo against id, label, or description (case-insensitive)', () => {
+    const scenes = listGenerationScenes()
+    const matches = filterGuideItems(scenes, 'logo')
+    expect(matches.some((item) => item.id === 'g4_reusable_logo')).toBe(true)
+    expect(matches.every((item) => {
+      const haystack = `${item.id} ${item.label} ${item.description}`.toLowerCase()
+      return haystack.includes('logo')
+    })).toBe(true)
+  })
+
+  it('matches against groupId when present', () => {
+    const matches = filterGuideItems(sampleItems, 'brand_ui')
+    expect(matches.map((item) => item.id)).toEqual(['g4_reusable_logo'])
+  })
+
+  it('is case-insensitive', () => {
+    const matches = filterGuideItems(sampleItems, 'LOGO')
+    expect(matches.map((item) => item.id)).toEqual(['g4_reusable_logo'])
+  })
+})
+
+describe('groupGuideItems', () => {
+  it('clusters items by groupId following order and skips empty groups', () => {
+    const grouped = groupGuideItems(sampleItems, GUIDE_GROUP_ORDER)
+
+    expect(grouped.map((g) => g.groupId)).toEqual(['photo_ad', 'info_design', 'brand_ui', 'ungrouped'])
+    expect(grouped[0]?.groupLabel).toBe('摄影/广告')
+    expect(grouped[0]?.items.map((item) => item.id)).toEqual(['g1_style_lighting'])
+    expect(grouped[1]?.groupLabel).toBe('信息设计')
+    expect(grouped[2]?.groupLabel).toBe('品牌/UI')
+    expect(grouped[2]?.items.map((item) => item.id)).toEqual(['g4_reusable_logo'])
+  })
+
+  it('places items without groupId in a final ungrouped bucket labeled 其他', () => {
+    const grouped = groupGuideItems(sampleItems, GUIDE_GROUP_ORDER)
+    const ungrouped = grouped.find((g) => g.groupId === 'ungrouped')
+
+    expect(ungrouped?.groupLabel).toBe('其他')
+    expect(ungrouped?.items.map((item) => item.id)).toEqual(['legacy_item'])
+  })
+
+  it('preserves item order within each group', () => {
+    const items: GuideItem[] = [
+      { id: 'a', label: 'A', description: 'first', groupId: 'photo_ad' },
+      { id: 'b', label: 'B', description: 'second', groupId: 'photo_ad' },
+      { id: 'c', label: 'C', description: 'third', groupId: 'brand_ui' },
+    ]
+
+    const grouped = groupGuideItems(items, GUIDE_GROUP_ORDER)
+    const photoAd = grouped.find((g) => g.groupId === 'photo_ad')
+
+    expect(photoAd?.items.map((item) => item.id)).toEqual(['a', 'b'])
+  })
+})

--- a/apps/web/src/components/canvas/dock-studio/shared/guidePickerFilter.ts
+++ b/apps/web/src/components/canvas/dock-studio/shared/guidePickerFilter.ts
@@ -1,0 +1,64 @@
+import { guideGroupLabel } from '@lnkpi/shared'
+import type { GuideGroupId } from '@lnkpi/shared'
+
+const UNGROUPED_GROUP_ID = 'ungrouped'
+const UNGROUPED_GROUP_LABEL = '其他'
+
+export function filterGuideItems<
+  T extends { id: string; label: string; description: string; groupId?: string },
+>(items: T[], query: string): T[] {
+  const normalized = query.trim().toLowerCase()
+  if (!normalized) {
+    return items
+  }
+
+  return items.filter((item) => {
+    const fields = [item.id, item.label, item.description]
+    if (item.groupId) {
+      fields.push(item.groupId)
+    }
+    return fields.some((field) => field.toLowerCase().includes(normalized))
+  })
+}
+
+export function groupGuideItems<T extends { groupId?: string }>(
+  items: T[],
+  order: string[],
+): Array<{ groupId: string; groupLabel: string; items: T[] }> {
+  const byGroup = new Map<string, T[]>()
+  const ungrouped: T[] = []
+
+  for (const item of items) {
+    if (!item.groupId) {
+      ungrouped.push(item)
+      continue
+    }
+    const bucket = byGroup.get(item.groupId) ?? []
+    bucket.push(item)
+    byGroup.set(item.groupId, bucket)
+  }
+
+  const grouped: Array<{ groupId: string; groupLabel: string; items: T[] }> = []
+
+  for (const groupId of order) {
+    const groupItems = byGroup.get(groupId)
+    if (!groupItems?.length) {
+      continue
+    }
+    grouped.push({
+      groupId,
+      groupLabel: guideGroupLabel(groupId as GuideGroupId),
+      items: groupItems,
+    })
+  }
+
+  if (ungrouped.length > 0) {
+    grouped.push({
+      groupId: UNGROUPED_GROUP_ID,
+      groupLabel: UNGROUPED_GROUP_LABEL,
+      items: ungrouped,
+    })
+  }
+
+  return grouped
+}

--- a/apps/web/src/components/canvas/refine/RefineSidePanel.vue
+++ b/apps/web/src/components/canvas/refine/RefineSidePanel.vue
@@ -3,12 +3,12 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { ElMessage } from 'element-plus'
 import {
   getEditIntent,
-  listEditIntents,
   resolveImageEditProfile,
   type ImageVersionEntry,
 } from '@lnkpi/shared'
 import DockCreditBadge from '@/components/canvas/dock-studio/shared/DockCreditBadge.vue'
 import DockTypeIcon from '@/components/canvas/dock-studio/shared/DockTypeIcon.vue'
+import GuidePickerPopover from '@/components/canvas/dock-studio/shared/GuidePickerPopover.vue'
 import { persistMediaUrl } from '@/composables/useMediaUpload'
 import { estimateImageCredits } from '@/constants/credits'
 import { studioApi } from '@/services/studio-api'
@@ -59,7 +59,7 @@ const editor = useCanvasEditorStore()
 const promptRef = ref<HTMLTextAreaElement | null>(null)
 const prompt = ref('')
 const activeGuideEditIntentId = ref<string | null>(null)
-const editIntents = listEditIntents()
+const editIntentPickerOpen = ref(false)
 const guideCapabilities =
   resolveImageEditProfile().capabilities ?? {
     transparentBackground: false,
@@ -189,12 +189,6 @@ function editIntentChipDisabled(intentId: string): boolean {
   return busy.value || !!editIntentDisabledReason(intentId, guideCapabilities)
 }
 
-function editIntentChipTitle(intentId: string): string {
-  const disabled = editIntentDisabledReason(intentId, guideCapabilities)
-  if (disabled) return disabled
-  return getEditIntent(intentId)?.description ?? ''
-}
-
 function applyEditIntent(intentId: string) {
   if (editIntentChipDisabled(intentId)) return
   const result = applyGuideEditIntent({
@@ -209,6 +203,11 @@ function applyEditIntent(intentId: string) {
   }
   activeGuideEditIntentId.value = result.guideEditIntentId
   prompt.value = result.prompt
+}
+
+function clearEditIntent() {
+  activeGuideEditIntentId.value = null
+  editIntentPickerOpen.value = false
 }
 
 function focusReplacePrompt() {
@@ -530,6 +529,41 @@ onBeforeUnmount(() => {
           <span v-if="!collapsed" class="refine-side__title">精修</span>
         </div>
         <div v-if="!collapsed" class="flex items-center gap-1">
+          <div class="relative">
+            <button
+              type="button"
+              class="refine-side__icon-btn relative"
+              :class="{ 'is-guide-active': activeGuideEditIntentId }"
+              :disabled="busy"
+              aria-label="编辑意图"
+              title="编辑意图"
+              :aria-expanded="editIntentPickerOpen"
+              @click="editIntentPickerOpen = !editIntentPickerOpen"
+            >
+              <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8">
+                <rect x="4" y="4" width="6" height="6" rx="1" />
+                <rect x="14" y="4" width="6" height="6" rx="1" />
+                <rect x="4" y="14" width="6" height="6" rx="1" />
+                <rect x="14" y="14" width="6" height="6" rx="1" />
+              </svg>
+              <span
+                v-if="activeGuideEditIntentId"
+                class="absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-fuchsia-400"
+                aria-hidden="true"
+              />
+            </button>
+            <GuidePickerPopover
+              class="refine-side__guide-picker"
+              mode="edit_intent"
+              :active-id="activeGuideEditIntentId"
+              :capabilities="guideCapabilities"
+              :open="editIntentPickerOpen"
+              :ref-image-count="refineRefImageCount"
+              @select="applyEditIntent"
+              @clear="clearEditIntent"
+              @close="editIntentPickerOpen = false"
+            />
+          </div>
           <button
             v-if="!isNarrow"
             type="button"
@@ -731,18 +765,6 @@ onBeforeUnmount(() => {
         <div class="refine-dock__chips">
           <button type="button" class="refine-dock__chip" :disabled="busy" @click="applyStainPreset">去除污渍瑕疵</button>
           <button type="button" class="refine-dock__chip" :disabled="busy" @click="focusReplacePrompt">替换选区内容</button>
-          <button
-            v-for="intent in editIntents"
-            :key="intent.id"
-            type="button"
-            class="refine-dock__chip"
-            :class="{ 'is-active': activeGuideEditIntentId === intent.id }"
-            :disabled="editIntentChipDisabled(intent.id)"
-            :title="editIntentChipTitle(intent.id)"
-            @click="applyEditIntent(intent.id)"
-          >
-            {{ intent.label }}
-          </button>
         </div>
 
         <p v-if="activeRefRoleHints" class="refine-dock__hint">
@@ -921,6 +943,17 @@ onBeforeUnmount(() => {
   border-color: var(--neo-border-strong);
   color: var(--neo-text-primary);
   background: var(--neo-hover-bg);
+}
+
+.refine-side__icon-btn.is-guide-active {
+  border-color: color-mix(in srgb, rgb(232 121 249) 25%, transparent);
+  background: color-mix(in srgb, rgb(217 70 239) 15%, transparent);
+  color: rgb(240 171 252);
+}
+
+.refine-side__guide-picker {
+  right: 0;
+  left: auto;
 }
 
 .refine-side__icon-btn:disabled {

--- a/apps/web/src/components/canvas/refine/RefineSidePanel.vue
+++ b/apps/web/src/components/canvas/refine/RefineSidePanel.vue
@@ -559,6 +559,7 @@ onBeforeUnmount(() => {
               :capabilities="guideCapabilities"
               :open="editIntentPickerOpen"
               :ref-image-count="refineRefImageCount"
+              placement="above-end"
               @select="applyEditIntent"
               @clear="clearEditIntent"
               @close="editIntentPickerOpen = false"

--- a/deploy/prod-image-prompting-guide-verify.py
+++ b/deploy/prod-image-prompting-guide-verify.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Production smoke for Image Prompting Guide Catalog Fill (#278).
+
+Checks:
+  1. Auth + session
+  2. POST /studio/prompt/generate with guideSceneId=g3_exact_text
+  3. Existing g3/e5 agent atomic utterances stamp guide ids on nodes
+  4. Catalog-fill g6/e7 utterances stamp the new guide ids on nodes
+
+Usage:
+  python3 deploy/prod-image-prompting-guide-verify.py
+  BASE_URL=http://119.29.173.89:8888 PHONE=17279698608 CODE=123456 \\
+    python3 deploy/prod-image-prompting-guide-verify.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import uuid
+from http.client import IncompleteRead
+from typing import Any
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+BASE = os.environ.get("BASE_URL", "http://119.29.173.89:8888").rstrip("/")
+API = f"{BASE}/api"
+PHONE = os.environ.get("PHONE", "17279698608")
+CODE = os.environ.get("CODE", "123456")
+SSE_TIMEOUT_SEC = float(os.environ.get("SSE_TIMEOUT_SEC", "240"))
+
+PASS = FAIL = 0
+
+
+def record(case: str, ok: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if ok:
+        PASS += 1
+        icon = "✅"
+    else:
+        FAIL += 1
+        icon = "❌"
+    line = f"{icon} {case}"
+    if detail:
+        line += f" — {detail[:260]}"
+    print(line)
+
+
+def http(m: str, p: str, b: dict | None = None, t: str | None = None) -> Any:
+    h = {"Content-Type": "application/json", "Accept": "application/json"}
+    if t:
+        h["Authorization"] = f"Bearer {t}"
+    r = Request(
+        f"{API}{p}",
+        data=None if b is None else json.dumps(b).encode(),
+        headers=h,
+        method=m,
+    )
+    with urlopen(r, timeout=180) as resp:
+        return json.loads(resp.read())
+
+
+def sse_collect(t: str, sid: str, msg: str, tid: str, *, timeout: float) -> tuple[list[dict], str, set[str], str]:
+    body: dict[str, Any] = {"sessionId": sid, "message": msg, "threadId": tid}
+    h = {
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+        "Authorization": f"Bearer {t}",
+        "Idempotency-Key": f"ik_{uuid.uuid4().hex}",
+    }
+    r = Request(f"{API}/agent/chat/conversation", data=json.dumps(body).encode(), headers=h, method="POST")
+    events: list[dict] = []
+    types: set[str] = set()
+    parts: list[str] = []
+    end = time.time() + timeout
+    exit_reason = "timeout"
+    with urlopen(r, timeout=timeout) as resp:
+        buf = ""
+        try:
+            while time.time() < end:
+                try:
+                    chunk = resp.read(4096)
+                except IncompleteRead as exc:
+                    if exc.partial:
+                        buf += exc.partial.decode(errors="replace")
+                    exit_reason = "eof"
+                    break
+                if not chunk:
+                    exit_reason = "eof"
+                    break
+                buf += chunk.decode(errors="replace")
+                while "\n\n" in buf:
+                    block, buf = buf.split("\n\n", 1)
+                    for line in block.splitlines():
+                        if not line.startswith("data:"):
+                            continue
+                        pl = line[5:].strip()
+                        if pl == "[DONE]":
+                            return events, "".join(parts), types, "done_marker"
+                        try:
+                            ev = json.loads(pl)
+                        except json.JSONDecodeError:
+                            continue
+                        events.append(ev)
+                        et = str(ev.get("type") or "")
+                        types.add(et)
+                        if et == "text_delta":
+                            parts.append(str((ev.get("data") or {}).get("text") or ""))
+                        if et == "done":
+                            return events, "".join(parts), types, "done"
+                        if et == "error":
+                            return events, "".join(parts), types, "error"
+        except IncompleteRead:
+            exit_reason = "eof"
+    return events, "".join(parts), types, exit_reason
+
+
+def latest_nodes(tok: str, sid: str) -> list[dict[str, Any]]:
+    sess = http("GET", f"/sessions/{sid}", t=tok)["data"]
+    canvas = sess.get("canvasData") or {}
+    return list(canvas.get("nodes") or [])
+
+
+def verify_prompt_api_accepts_guide_scene(tok: str) -> None:
+    """DTO acceptance smoke: empty prompt must 400 quickly even with guideSceneId present."""
+    t0 = time.time()
+    try:
+        http(
+            "POST",
+            "/studio/prompt/generate",
+            {"prompt": "", "guideSceneId": "g3_exact_text"},
+            t=tok,
+        )
+        record("studio accepts guideSceneId field", False, "expected 400 for empty prompt")
+    except Exception as exc:  # noqa: BLE001
+        msg = str(exc)
+        ok = "400" in msg or "Bad Request" in msg
+        record(
+            "studio accepts guideSceneId field",
+            ok,
+            f"{type(exc).__name__}: {msg[:120]} sec={time.time() - t0:.1f}",
+        )
+
+
+def _node_guide_ids(node: dict[str, Any]) -> tuple[str, str]:
+    data = node.get("data") or {}
+    scene = str(data.get("guideSceneId") or data.get("guide_scene_id") or "").strip()
+    intent = str(data.get("guideEditIntentId") or data.get("guide_edit_intent_id") or "").strip()
+    return scene, intent
+
+
+def verify_agent_taxonomy_stamp(tok: str, label: str, utterance: str, expect_scene: str | None, expect_intent: str | None) -> None:
+    sid = http("POST", "/sessions", {"title": f"guide-{label}-{int(time.time())}"}, t=tok)["data"]["id"]
+    tid = f"{sid}:{uuid.uuid4()}"
+    _, text, types, exit_reason = sse_collect(tok, sid, utterance, tid, timeout=SSE_TIMEOUT_SEC)
+    nodes = latest_nodes(tok, sid)
+    found_scene = ""
+    found_intent = ""
+    for n in nodes:
+        s, i = _node_guide_ids(n)
+        if s:
+            found_scene = s
+        if i:
+            found_intent = i
+
+    if expect_scene:
+        record(
+            f"agent stamp scene ({label})",
+            found_scene == expect_scene,
+            f"got={found_scene or '-'} exit={exit_reason} types={sorted(types)[:6]} text={text[:80]!r}",
+        )
+    if expect_intent:
+        record(
+            f"agent stamp intent ({label})",
+            found_intent == expect_intent,
+            f"got={found_intent or '-'} exit={exit_reason} nodes={len(nodes)} text={text[:80]!r}",
+        )
+
+
+def main() -> int:
+    print(f"BASE_URL={BASE}")
+    print("Deploy target: Image Prompting Guide Catalog Fill (#278)\n")
+    try:
+        http("POST", "/auth/send-code", {"phone": PHONE})
+        tok = http("POST", "/auth/login", {"phone": PHONE, "code": CODE})["data"]["token"]
+        record("auth login", True)
+    except Exception as exc:  # noqa: BLE001
+        record("auth login", False, str(exc))
+        print(f"\nPASS={PASS} FAIL={FAIL}")
+        return 1
+
+    verify_prompt_api_accepts_guide_scene(tok)
+
+    # Atomic create utterances (must include 帮我生成…) so runtime stamps guide ids on nodes
+    verify_agent_taxonomy_stamp(
+        tok,
+        "g3",
+        "帮我生成一个广告提示词，标语必须精确文字 Yours to Create，不要多余字",
+        expect_scene="g3_exact_text",
+        expect_intent=None,
+    )
+    verify_agent_taxonomy_stamp(
+        tok,
+        "e5",
+        "帮我生成一张产品抠图透明底 PNG",
+        expect_scene=None,
+        expect_intent="e5_transparent_cutout",
+    )
+    verify_agent_taxonomy_stamp(
+        tok,
+        "g6",
+        "帮我生成一组漫画分格，讲述机器人在雨夜寻找家的故事",
+        expect_scene="g6_comic_strip",
+        expect_intent=None,
+    )
+    verify_agent_taxonomy_stamp(
+        tok,
+        "e7",
+        "帮我生成一张去物体并自然补全背景的图片",
+        expect_scene=None,
+        expect_intent="e7_remove_object",
+    )
+
+    print(f"\nPASS={PASS} FAIL={FAIL}")
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/superpowers/plans/2026-09-11-image-prompting-guide-catalog-fill.md
+++ b/docs/superpowers/plans/2026-09-11-image-prompting-guide-catalog-fill.md
@@ -1,0 +1,252 @@
+# Image Prompting Guide Catalog Fill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver minimal Dock/Refine scene-icon + searchable dropdown UX and register the remaining 12 official Image Prompting Guide scenes/intents on top of P0 Catalog.
+
+**Architecture:** Extend `@lnkpi/shared` `imagePromptingGuide` with `groupId`/`groupLabel` and full G2/G4–G9 + E1/E2/E6–E8 assets. Add shared `GuidePickerPopover.vue`. Replace `DockToolbarShell` close `×` with a header-end slot used for scene/intent icons; Esc closes dock (nested: close popover first). Prompt/Image use generation mode; Refine uses edit-intent mode while keeping stain/replace chips. Sync taxonomy yaml + Python resolver.
+
+**Tech Stack:** TypeScript (`@lnkpi/shared`), Vue 3 + Vitest (`apps/web`), Python taxonomy (`services/agent-runtime`), Nest unchanged except no new PromptModeId.
+
+**Spec:** [2026-09-11-image-prompting-guide-catalog-fill-design.md](../specs/2026-09-11-image-prompting-guide-catalog-fill-design.md)
+
+## Global Constraints
+
+- Branch: `feature/image-prompting-guide-catalog-fill` — **禁止直推 main**
+- 一次做满剩余 12 个 id；下拉搜索为主交互；**场景图标替换 `×`**；关闭仅 **空白 + Esc**
+- 仍用 `image2`；G4/E5（及任何 `requiresTransparentBackground`）无透明底时列表禁用
+- 不把 G/E 塞进 `PromptModeId`；不接 Image 2.5；不恢复主栏芯片墙
+- Refine 保留「去除污渍瑕疵」「替换选区内容」快捷芯片
+- 本地：`pnpm --filter @lnkpi/shared test`、相关 web vitest、`pytest tests/test_guide_taxonomy.py`；PR 前 `pnpm build`
+- Squash merge
+
+## File map
+
+| File | Role |
+|------|------|
+| `packages/shared/src/imagePromptingGuide/types.ts` | Add `groupId` / `groupLabel` |
+| `packages/shared/src/imagePromptingGuide/scenes/g2-*.ts` … `g9-*.ts` | New generation scenes |
+| `packages/shared/src/imagePromptingGuide/intents/e1-*.ts` … | New edit intents |
+| `packages/shared/src/imagePromptingGuide/catalog.ts` + `catalog.test.ts` | Register all 9+8 |
+| `packages/shared/src/imagePromptingGuide/guideGroups.ts` | Group order + labels helper |
+| `apps/web/.../GuidePickerPopover.vue` (+ optional `.test.ts` for filter helper) | Searchable grouped popover |
+| `apps/web/.../guidePickerFilter.ts` (+ test) | Pure filter/group logic |
+| `apps/web/.../DockToolbarShell.vue` | `headerEnd` slot; optional hide default close |
+| `PromptDockPanel.vue` / `ImageDockPanel.vue` | Remove chip row; scene icon + popover |
+| `RefineSidePanel.vue` | Edit-intent icon + popover |
+| `CanvasPage.vue` (or dock host) | Esc closes selected dock when open |
+| `image-prompting-guide-taxonomy.yaml` ×2 | New patterns |
+| `guide_taxonomy.py` + `test_guide_taxonomy.py` | New id coverage |
+| `deploy/prod-image-prompting-guide-verify.py` | Extend stamp cases |
+
+---
+
+### Task 1: Types + group helper + existing assets annotated
+
+**Files:**
+- Modify: `packages/shared/src/imagePromptingGuide/types.ts`
+- Create: `packages/shared/src/imagePromptingGuide/guideGroups.ts`
+- Create: `packages/shared/src/imagePromptingGuide/guideGroups.test.ts`
+- Modify: existing `g1`/`g3`/`e3`/`e4`/`e5` assets to set `groupId`/`groupLabel`
+
+**Interfaces:**
+- Produces:
+
+```ts
+export type GuideGroupId =
+  | 'photo_ad' | 'info_design' | 'brand_ui' | 'narrative'
+  | 'local_edit' | 'identity_product' | 'ref_compose'
+
+export const GUIDE_GROUP_ORDER: GuideGroupId[]
+export function guideGroupLabel(id: GuideGroupId): string
+```
+
+- [ ] **Step 1: Failing test** — `guideGroupLabel('photo_ad') === '摄影/广告'`; order length 7
+- [ ] **Step 2: Run — FAIL**
+- [ ] **Step 3: Implement types + guideGroups; annotate P0 assets**
+- [ ] **Step 4: PASS**
+- [ ] **Step 5: Commit** `feat(shared): add guide group metadata`
+
+---
+
+### Task 2: Register remaining 12 catalog assets
+
+**Files:**
+- Create scenes: `g2-process-infographic.ts`, `g4-reusable-logo.ts`, `g5-historical-context.ts`, `g6-comic-strip.ts`, `g7-interface-preview.ts`, `g8-scientific-visual.ts`, `g9-slides-charts.ts`
+- Create intents: `e1-translate-layout.ts`, `e2-style-transfer.ts`, `e6-drawing-to-realistic.ts`, `e7-remove-object.ts`, `e8-insert-person.ts`
+- Modify: `catalog.ts`, `catalog.test.ts`
+
+**Interfaces:**
+- Stable ids exactly as spec tables
+- G4 + E5: `requiresTransparentBackground: true`
+- G6: `expandViaPromptMode: 'storyboard'`
+- Each asset: non-empty `promptScaffold` or `changePreserveTemplate`, `groupId`, `fundamentalsRefs`
+
+- [ ] **Step 1: Update catalog.test.ts** to expect sorted 9 generation + 8 edit ids; assert G4/E5 transparent gate; G6 expandVia
+- [ ] **Step 2: Run — FAIL**
+- [ ] **Step 3: Implement assets + register**
+- [ ] **Step 4: `pnpm --filter @lnkpi/shared test` PASS**
+- [ ] **Step 5: Commit** `feat(shared): fill remaining image prompting guide catalog`
+
+---
+
+### Task 3: `guidePickerFilter` pure helper
+
+**Files:**
+- Create: `apps/web/src/components/canvas/dock-studio/shared/guidePickerFilter.ts`
+- Create: `apps/web/src/components/canvas/dock-studio/shared/guidePickerFilter.test.ts`
+
+**Interfaces:**
+
+```ts
+export function filterGuideItems<T extends { id: string; label: string; description: string; groupId?: string }>(
+  items: T[],
+  query: string,
+): T[]
+
+export function groupGuideItems<T extends { groupId?: string }>(
+  items: T[],
+  order: string[],
+): Array<{ groupId: string; groupLabel: string; items: T[] }>
+```
+
+- [ ] **Step 1: Tests** — empty query returns all; query `logo` matches g4; grouping preserves order
+- [ ] **Step 2: FAIL → implement → PASS**
+- [ ] **Step 5: Commit** `feat(web): guide picker filter helpers`
+
+---
+
+### Task 4: `GuidePickerPopover.vue`
+
+**Files:**
+- Create: `apps/web/src/components/canvas/dock-studio/shared/GuidePickerPopover.vue`
+
+**Behavior:**
+- Props: `mode: 'generation_scene' | 'edit_intent'`, `activeId: string | null`, `capabilities` (for disable), `open`, anchor
+- Emits: `select(id)`, `clear`, `close`
+- Search input; grouped sections; disabled rows call `editIntentDisabledReason` / scene capability via `resolveGuideRequest` with `refImageCount` optional
+- Esc while open emits `close` (popover only)
+- 「清除场景」/「清除意图」 when `activeId` set
+
+- [ ] **Step 1: Minimal component + story-less smoke** — if no component test harness, extract disable helper and unit-test it; mount optional
+- [ ] **Step 2–4: Implement neo dark styles** matching `neo-chip` / refine dock tokens
+- [ ] **Step 5: Commit** `feat(web): GuidePickerPopover searchable dropdown`
+
+---
+
+### Task 5: DockToolbarShell header slot + Esc close
+
+**Files:**
+- Modify: `DockToolbarShell.vue` — replace hard-coded close with:
+
+```vue
+<slot name="header-end">
+  <!-- default empty: no × -->
+</slot>
+```
+
+- For panels that still need close elsewhere: none for Prompt/Image per spec
+- Modify: `CanvasPage.vue` (or wherever dock selection lives) — `keydown Escape` closes dock if open and popover not handling; verify blank-click path still works
+- Grep all `DockToolbarShell` usages: Video/Text/etc. must still close — **pass `header-end` close button for non-guide docks** OR keep prop `showClose?: boolean` default true for backward compat, Prompt/Image set `showClose=false` and provide scene slot
+
+**Recommended compat:**
+
+```ts
+showClose?: boolean // default true
+```
+
+Prompt/Image: `:show-close="false"` + `#header-end` scene button. Other docks unchanged.
+
+- [ ] **Step 1: Test or manual checklist** for Text dock still has ×
+- [ ] **Step 2: Implement shell + Esc**
+- [ ] **Step 5: Commit** `feat(web): dock header-end slot and Esc close`
+
+---
+
+### Task 6: Wire Prompt + Image Dock
+
+**Files:**
+- Modify: `PromptDockPanel.vue` — remove chip `v-for` row; add scene icon in `header-end`; wire popover + existing `applyGuideSceneToPrompt` / clear / toast
+- Modify: `ImageDockPanel.vue` — same; keep aspect mapping from Task prior if present
+
+- [ ] **Step 1: Ensure guideSceneApply tests still pass**
+- [ ] **Step 2: Implement UI wiring**
+- [ ] **Step 5: Commit** `feat(web): Prompt/Image dock scene icon picker`
+
+---
+
+### Task 7: Wire Refine edit-intent picker
+
+**Files:**
+- Modify: `RefineSidePanel.vue` — keep stain/replace chips; remove E* from flat chip `v-for` (or keep none of E*); add edit-intent header icon + `GuidePickerPopover` mode=`edit_intent`; selecting calls `applyEditIntent`
+
+- [ ] **Step 1: guideEditIntentApply tests still PASS**
+- [ ] **Step 2: Implement**
+- [ ] **Step 5: Commit** `feat(web): Refine edit-intent dropdown picker`
+
+---
+
+### Task 8: Taxonomy sync
+
+**Files:**
+- Modify: `packages/agent/src/prompt-modes/image-prompting-guide-taxonomy.yaml`
+- Modify: `services/agent-runtime/skills/atomic-create/assets/image-prompting-guide-taxonomy.yaml`
+- Modify: `services/agent-runtime/tests/test_guide_taxonomy.py` — add cases for e.g. `g6` 漫画分格, `e7` 去掉物体 / 去物体, `g4` logo 透明
+
+- [ ] **Step 1: Failing pytest for new patterns**
+- [ ] **Step 2: Update yaml → PASS**
+- [ ] **Step 5: Commit** `feat(runtime): expand image prompting guide taxonomy`
+
+---
+
+### Task 9: Verify + PR
+
+- [ ] **Step 1: Matrix**
+
+```bash
+pnpm --filter @lnkpi/shared test
+pnpm --filter @lnkpi/web exec vitest run src/components/canvas/dock-studio/shared/guidePickerFilter.test.ts src/components/canvas/dock-studio/panels/guideSceneApply.test.ts src/components/canvas/refine/guideEditIntentApply.test.ts
+cd services/agent-runtime && python -m pytest tests/test_guide_taxonomy.py -v
+pnpm build
+```
+
+- [ ] **Step 2: Extend** `deploy/prod-image-prompting-guide-verify.py` with one new scene + one new intent utterance (atomic `帮我生成…`)
+- [ ] **Step 3: Push + PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --base main --title "feat: Image Prompting Guide Catalog fill (minimal picker + 12 scenes)" --body "$(cat <<'EOF'
+## Summary
+- Full catalog G1–G9 + E1–E8 with group metadata
+- Minimal dock: scene icon replaces ×; searchable GuidePickerPopover
+- Refine: edit-intent dropdown; stain/replace chips kept
+- Taxonomy + prod verify extended
+- Image 2.5 still deferred
+
+## Spec
+- docs/superpowers/specs/2026-09-11-image-prompting-guide-catalog-fill-design.md
+
+## Test plan
+- [ ] shared/web/pytest matrix above
+- [ ] Manual: Prompt/Image icon picker, Esc/blank close, Refine intent disable E5
+- [ ] Prod smoke after deploy
+EOF
+)"
+```
+
+---
+
+## Self-Review (plan vs spec)
+
+| Spec item | Task |
+|-----------|------|
+| groupId metadata | T1 |
+| 12 new assets + full registry | T2 |
+| Dropdown search filter | T3–T4 |
+| × → scene icon; Esc/blank | T5–T6 |
+| Refine intent dropdown; stain chips | T7 |
+| Taxonomy | T8 |
+| Prod verify extend | T9 |
+| No Image 2.5 / no PromptModeId | Global Constraints |
+
+No TBD placeholders. Id list matches spec tables.

--- a/docs/superpowers/specs/2026-09-11-image-prompting-guide-catalog-fill-design.md
+++ b/docs/superpowers/specs/2026-09-11-image-prompting-guide-catalog-fill-design.md
@@ -1,0 +1,135 @@
+# Image Prompting Guide Catalog 补全（设计文档）
+
+> 状态：§1–§2 已定稿并写入  
+> 日期：2026-09-11  
+> 父规格：[2026-09-11-image-prompting-guide-catalog-design.md](./2026-09-11-image-prompting-guide-catalog-design.md)（P0 已合并 #278）  
+> 范围：一次交付「极简 Dock 入口 + 全量剩余 12 个官方场景/意图」；仍不接 Image 2.5 模型
+
+## 决策摘要
+
+| 项 | 选择 |
+|---|---|
+| 补全范围 | **A**：一次做满剩余 12 个（G2/G4–G9 + E1/E2/E6–E8） |
+| 选择器形态 | **C 下拉搜索**（非扁平芯片、非分组折叠主交互） |
+| Dock 极简入口 | 右上角 **场景模板图标替换 `×`**；关闭仅靠 **点空白 + Esc** |
+| 实现路径 | **方案 2**：共享 `GuidePickerPopover` + 一次注册全量 Catalog |
+| 三入口统一 | Prompt / Image Dock → 生成场景；Refine → 编辑意图下拉；去污/替换选区仍为快捷芯片 |
+| 模型 | 仍 `image2`；G4/E5 透明底 capability 不足则列表禁用 |
+| 不做 | Image 2.5 接线、ChatGPT Templates/Sketch、把 G/E 塞进 `PromptModeId` |
+
+---
+
+## §1 交互与壳层
+
+### 1.1 Prompt / Image Dock
+
+1. `DockToolbarShell` 右上角：以 **场景模板** 图标按钮替换关闭 `×`。
+2. 未选场景：图标 muted；已选 `guideSceneId`：fuchsia 高亮 + 小圆点（验收态）。
+3. 点击图标：锚定弹出 `GuidePickerPopover`（搜索框 + 分组列表 +「清除场景」）。
+4. 选中行为沿用既有 `applyGuideSceneToPrompt`：空 prompt 预填 scaffold；非空只挂 id + toast「已套用约束，未改写原文」。
+5. **关闭 Dock**：点击画布空白关闭（沿用 `CanvasPage` 现有逻辑）；**Esc 关闭**（若现状缺失则本期补齐）。不再提供 `×`。
+
+### 1.2 Refine 侧栏
+
+1. 保留快捷芯片：`去除污渍瑕疵`、`替换选区内容`。
+2. 新增右上（或标题栏对称位置）**编辑意图** 图标 → 同一 `GuidePickerPopover`（mode=`edit_intent`）。
+3. 列表含全部 E1–E8；capability / minRef 规则沿用 `applyGuideEditIntent`（fill 可填模板，submit 拦截）。
+4. E5（及任何 `requiresTransparentBackground`）无透明底能力时禁用 + 中文原因。
+
+### 1.3 关闭与可达性（已选 A 的约束）
+
+- 产品明确接受：无 `×`，依赖空白点击 + Esc。
+- 实现必须保证：Desktop 空白关闭路径可用；Esc 在 Dock / Refine 打开时关闭面板；下拉打开时 Esc 先关下拉再关 Dock（标准嵌套焦点）。
+
+---
+
+## §2 Catalog / taxonomy / 落点
+
+### 2.1 生成场景（Prompt / Image 共用下拉）
+
+| ID | 标签 | 分组 | 状态 |
+|----|------|------|------|
+| `g1_style_lighting` | 风格与光线 | 摄影/广告 | 已有 |
+| `g3_exact_text` | 精确文字 | 摄影/广告 | 已有 |
+| `g2_process_infographic` | 流程信息图 | 信息设计 | 新增 |
+| `g8_scientific_visual` | 科学教育图 | 信息设计 | 新增 |
+| `g9_slides_charts` | 幻灯片/图表 | 信息设计 | 新增 |
+| `g4_reusable_logo` | 可复用 Logo | 品牌/UI | 新增；透明底 gate |
+| `g7_interface_preview` | 界面预览 | 品牌/UI | 新增 |
+| `g5_historical_context` | 历史语境 | 叙事 | 新增 |
+| `g6_comic_strip` | 故事漫画分格 | 叙事 | 新增；`expandViaPromptMode: storyboard` |
+
+分组仅用于下拉分区标题与搜索过滤，不作为主栏芯片。
+
+### 2.2 编辑意图（Refine 下拉）
+
+| ID | 标签 | 分组 | 状态 |
+|----|------|------|------|
+| `e1_translate_layout` | 版面翻译 | 局部手术 | 新增 |
+| `e7_remove_object` | 去物体 | 局部手术 | 新增 |
+| `e3_identity_clothing` | 换装保身份 | 身份/产品 | 已有 |
+| `e5_transparent_cutout` | 透明抠图 | 身份/产品 | 已有；透明底 gate |
+| `e8_insert_person` | 人物入景 | 身份/产品 | 新增 |
+| `e2_style_transfer` | 风格迁移 | 参考合成 | 新增 |
+| `e4_combine_refs` | 多参考合成 | 参考合成 | 已有 |
+| `e6_drawing_to_realistic` | 草图转写实 | 参考合成 | 新增 |
+
+### 2.3 类型扩展
+
+在既有 `GenerationScene` / `EditIntent` 上增加可选：
+
+```ts
+groupId?: 'photo_ad' | 'info_design' | 'brand_ui' | 'narrative'
+  | 'local_edit' | 'identity_product' | 'ref_compose'
+groupLabel?: string
+```
+
+`GuidePickerPopover` 按 `groupId` 聚类；搜索匹配 `label` / `description` / taxonomy 关键词。
+
+### 2.4 组件与文件
+
+| 路径 | 职责 |
+|------|------|
+| `apps/web/.../GuidePickerPopover.vue` | 搜索下拉、分组、禁用、清除 |
+| `apps/web/.../DockToolbarShell.vue` | 场景入口 slot；移除默认 `×`（由调用方决定） |
+| `PromptDockPanel.vue` / `ImageDockPanel.vue` | 去掉芯片行；接场景图标 + popover |
+| `RefineSidePanel.vue` | 编辑意图图标 + popover；保留去污/替换芯片 |
+| `packages/shared/src/imagePromptingGuide/scenes/*` | 新增 G2/G4–G9 |
+| `packages/shared/src/imagePromptingGuide/intents/*` | 新增 E1/E2/E6–E8 |
+| `catalog.ts` + tests | 注册全量 id |
+| `image-prompting-guide-taxonomy.yaml`（agent + skill assets） | 关键词补齐 |
+| `guide_taxonomy.py` / tests | 解析新 id |
+
+### 2.5 Agent
+
+继续 **仅 taxonomy 钩子** 写 `guideSceneId` / `guideEditIntentId`；不强制自动多轮编辑。双命中时仍优先 edit intent（换装/抠图/合成等）。
+
+### 2.6 测试与验收
+
+1. Catalog：9 生成 + 8 编辑 id 齐全；G4/E5 `requiresTransparentBackground`。  
+2. Popover：搜索过滤；禁用项不可选；清除清空 guide id。  
+3. Dock：无 `×`；Esc / 空白关闭；图标高亮随 `guideSceneId`。  
+4. Refine：去污芯片仍在；E* 经下拉；submit 门禁回归。  
+5. taxonomy：新关键词命中测试。  
+6. 生产：扩展 `deploy/prod-image-prompting-guide-verify.py` 覆盖至少 1 个新 scene + 1 个新 intent stamp。
+
+### 2.7 明确不做
+
+- Image 2.5 Flare/Sunburst 接线与透明底解锁（仍走父规格附录 A）  
+- ChatGPT Poster/Merch / Sketch  
+- 主栏恢复扁平芯片墙  
+- 新增 `PromptModeId` 枚举项承载 G/E
+
+---
+
+## Spec Self-Review
+
+- [x] 无 TBD 占位需求  
+- [x] 与父规格双轨 Catalog / capability 一致  
+- [x] 关闭策略（无 ×）与 Esc/空白要求写死  
+- [x] 全量 id 列表无歧义  
+- [x] 范围可单 PR 交付（UI 壳 + 12 资产 + taxonomy）
+
+## 关系
+
+本规格是父规格「下期 A：Catalog 补全」的落地设计；「下期 B：Image 2.5」仍独立专项。

--- a/packages/agent/src/prompt-modes/image-prompting-guide-taxonomy.yaml
+++ b/packages/agent/src/prompt-modes/image-prompting-guide-taxonomy.yaml
@@ -1,12 +1,12 @@
 # Image prompting guide taxonomy — mirrors catalog scene/intent ids
 version: 1
 generation_scenes:
+  - id: g3_exact_text
+    patterns: [精确文字, 标语必须, tagline, 不要多余字, render text]
   - id: g1_style_lighting
     patterns: [光影, 胶片感, 35mm, candid, 写实摄影]
   - id: g2_process_infographic
     patterns: [流程信息图, 流程图, 步骤信息图, process infographic]
-  - id: g3_exact_text
-    patterns: [精确文字, 标语必须, tagline, 不要多余字, render text]
   - id: g4_reusable_logo
     patterns: [可复用 logo, 可复用logo, logo 透明, logo透明, reusable logo]
   - id: g5_historical_context
@@ -20,16 +20,16 @@ generation_scenes:
   - id: g9_slides_charts
     patterns: [幻灯片图表, 幻灯片, 演示图表, 数据图表, presentation slide]
 edit_intents:
-  - id: e1_translate_layout
-    patterns: [版面翻译, 翻译版面, 保持版式翻译, translate layout]
-  - id: e2_style_transfer
-    patterns: [风格迁移, 风格转换, 参考图风格, style transfer]
   - id: e3_identity_clothing
     patterns: [换装, 只换衣服, 保留脸, 试穿, identity]
   - id: e4_combine_refs
     patterns: [合成到场景, 放到场景, 图1图2, combine reference]
   - id: e5_transparent_cutout
     patterns: [抠图, 透明底, 去背景, cutout]
+  - id: e1_translate_layout
+    patterns: [版面翻译, 翻译版面, 保持版式翻译, translate layout]
+  - id: e2_style_transfer
+    patterns: [风格迁移, 风格转换, 参考图风格, style transfer]
   - id: e6_drawing_to_realistic
     patterns: [草图转写实, 线稿转写实, 草图写实化, drawing to realistic]
   - id: e7_remove_object

--- a/packages/agent/src/prompt-modes/image-prompting-guide-taxonomy.yaml
+++ b/packages/agent/src/prompt-modes/image-prompting-guide-taxonomy.yaml
@@ -1,14 +1,38 @@
-# Image prompting guide taxonomy — mirrors P0 catalog scene/intent ids
+# Image prompting guide taxonomy — mirrors catalog scene/intent ids
 version: 1
 generation_scenes:
-  - id: g3_exact_text
-    patterns: [精确文字, 标语必须, tagline, 不要多余字, render text]
   - id: g1_style_lighting
     patterns: [光影, 胶片感, 35mm, candid, 写实摄影]
+  - id: g2_process_infographic
+    patterns: [流程信息图, 流程图, 步骤信息图, process infographic]
+  - id: g3_exact_text
+    patterns: [精确文字, 标语必须, tagline, 不要多余字, render text]
+  - id: g4_reusable_logo
+    patterns: [可复用 logo, 可复用logo, logo 透明, logo透明, reusable logo]
+  - id: g5_historical_context
+    patterns: [历史语境, 历史场景, 时代还原, historical scene, period-appropriate]
+  - id: g6_comic_strip
+    patterns: [漫画分格, 故事漫画, 连环漫画, comic strip]
+  - id: g7_interface_preview
+    patterns: [界面预览, 产品界面, UI 预览, ui preview, interface preview]
+  - id: g8_scientific_visual
+    patterns: [科学教育图, 科学示意图, 科普图, scientific visual]
+  - id: g9_slides_charts
+    patterns: [幻灯片图表, 幻灯片, 演示图表, 数据图表, presentation slide]
 edit_intents:
+  - id: e1_translate_layout
+    patterns: [版面翻译, 翻译版面, 保持版式翻译, translate layout]
+  - id: e2_style_transfer
+    patterns: [风格迁移, 风格转换, 参考图风格, style transfer]
   - id: e3_identity_clothing
     patterns: [换装, 只换衣服, 保留脸, 试穿, identity]
   - id: e4_combine_refs
     patterns: [合成到场景, 放到场景, 图1图2, combine reference]
   - id: e5_transparent_cutout
     patterns: [抠图, 透明底, 去背景, cutout]
+  - id: e6_drawing_to_realistic
+    patterns: [草图转写实, 线稿转写实, 草图写实化, drawing to realistic]
+  - id: e7_remove_object
+    patterns: [去物体, 去掉物体, 移除物体, 删除物体, remove object]
+  - id: e8_insert_person
+    patterns: [人物入景, 人物放入场景, 把人放入场景, insert person]

--- a/packages/shared/src/imagePromptingGuide/catalog.test.ts
+++ b/packages/shared/src/imagePromptingGuide/catalog.test.ts
@@ -3,6 +3,7 @@ import {
   FUNDAMENTALS,
   formatFundamentalsBlock,
   getEditIntent,
+  getGenerationScene,
   listEditIntents,
   listGenerationScenes,
 } from './catalog'
@@ -13,23 +14,40 @@ describe('imagePromptingGuide catalog scaffold', () => {
     expect(FUNDAMENTALS[0]?.id).toBe('define_result')
   })
 
-  it('registers P0 generation scenes', () => {
+  it('registers all generation scenes', () => {
     expect(listGenerationScenes().map((s) => s.id).sort()).toEqual([
       'g1_style_lighting',
+      'g2_process_infographic',
       'g3_exact_text',
+      'g4_reusable_logo',
+      'g5_historical_context',
+      'g6_comic_strip',
+      'g7_interface_preview',
+      'g8_scientific_visual',
+      'g9_slides_charts',
     ])
   })
 
-  it('registers P0 edit intents', () => {
+  it('registers all edit intents', () => {
     expect(listEditIntents().map((i) => i.id).sort()).toEqual([
+      'e1_translate_layout',
+      'e2_style_transfer',
       'e3_identity_clothing',
       'e4_combine_refs',
       'e5_transparent_cutout',
+      'e6_drawing_to_realistic',
+      'e7_remove_object',
+      'e8_insert_person',
     ])
   })
 
-  it('E5 requires transparent capability', () => {
+  it('marks transparent-background assets', () => {
+    expect(getGenerationScene('g4_reusable_logo')?.capability.requiresTransparentBackground).toBe(true)
     expect(getEditIntent('e5_transparent_cutout')?.capability.requiresTransparentBackground).toBe(true)
+  })
+
+  it('expands G6 through storyboard mode', () => {
+    expect(getGenerationScene('g6_comic_strip')?.expandViaPromptMode).toBe('storyboard')
   })
 
   it('formats fundamentals block', () => {

--- a/packages/shared/src/imagePromptingGuide/catalog.ts
+++ b/packages/shared/src/imagePromptingGuide/catalog.ts
@@ -1,13 +1,44 @@
 import { FUNDAMENTALS, formatFundamentalsBlock } from './fundamentals'
+import { e1TranslateLayout } from './intents/e1-translate-layout'
+import { e2StyleTransfer } from './intents/e2-style-transfer'
 import { e3IdentityClothing } from './intents/e3-identity-clothing'
 import { e4CombineRefs } from './intents/e4-combine-refs'
 import { e5TransparentCutout } from './intents/e5-transparent-cutout'
+import { e6DrawingToRealistic } from './intents/e6-drawing-to-realistic'
+import { e7RemoveObject } from './intents/e7-remove-object'
+import { e8InsertPerson } from './intents/e8-insert-person'
 import { g1StyleLighting } from './scenes/g1-style-lighting'
+import { g2ProcessInfographic } from './scenes/g2-process-infographic'
 import { g3ExactText } from './scenes/g3-exact-text'
+import { g4ReusableLogo } from './scenes/g4-reusable-logo'
+import { g5HistoricalContext } from './scenes/g5-historical-context'
+import { g6ComicStrip } from './scenes/g6-comic-strip'
+import { g7InterfacePreview } from './scenes/g7-interface-preview'
+import { g8ScientificVisual } from './scenes/g8-scientific-visual'
+import { g9SlidesCharts } from './scenes/g9-slides-charts'
 import type { EditIntent, GenerationScene } from './types'
 
-const GENERATION_SCENES: GenerationScene[] = [g1StyleLighting, g3ExactText]
-const EDIT_INTENTS: EditIntent[] = [e3IdentityClothing, e4CombineRefs, e5TransparentCutout]
+const GENERATION_SCENES: GenerationScene[] = [
+  g1StyleLighting,
+  g2ProcessInfographic,
+  g3ExactText,
+  g4ReusableLogo,
+  g5HistoricalContext,
+  g6ComicStrip,
+  g7InterfacePreview,
+  g8ScientificVisual,
+  g9SlidesCharts,
+]
+const EDIT_INTENTS: EditIntent[] = [
+  e1TranslateLayout,
+  e2StyleTransfer,
+  e3IdentityClothing,
+  e4CombineRefs,
+  e5TransparentCutout,
+  e6DrawingToRealistic,
+  e7RemoveObject,
+  e8InsertPerson,
+]
 
 export { FUNDAMENTALS, formatFundamentalsBlock }
 export function listGenerationScenes() { return GENERATION_SCENES }

--- a/packages/shared/src/imagePromptingGuide/guideGroups.test.ts
+++ b/packages/shared/src/imagePromptingGuide/guideGroups.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { GUIDE_GROUP_ORDER, guideGroupLabel } from './guideGroups'
+
+describe('guideGroups', () => {
+  it('maps photo_ad to 摄影/广告', () => {
+    expect(guideGroupLabel('photo_ad')).toBe('摄影/广告')
+  })
+
+  it('defines all seven groups in order', () => {
+    expect(GUIDE_GROUP_ORDER).toHaveLength(7)
+    expect(GUIDE_GROUP_ORDER).toEqual([
+      'photo_ad',
+      'info_design',
+      'brand_ui',
+      'narrative',
+      'local_edit',
+      'identity_product',
+      'ref_compose',
+    ])
+  })
+})

--- a/packages/shared/src/imagePromptingGuide/guideGroups.ts
+++ b/packages/shared/src/imagePromptingGuide/guideGroups.ts
@@ -1,0 +1,25 @@
+import type { GuideGroupId } from './types'
+
+export const GUIDE_GROUP_ORDER: GuideGroupId[] = [
+  'photo_ad',
+  'info_design',
+  'brand_ui',
+  'narrative',
+  'local_edit',
+  'identity_product',
+  'ref_compose',
+]
+
+const GROUP_LABELS: Record<GuideGroupId, string> = {
+  photo_ad: '摄影/广告',
+  info_design: '信息设计',
+  brand_ui: '品牌/UI',
+  narrative: '叙事',
+  local_edit: '局部手术',
+  identity_product: '身份/产品',
+  ref_compose: '参考合成',
+}
+
+export function guideGroupLabel(id: GuideGroupId): string {
+  return GROUP_LABELS[id]
+}

--- a/packages/shared/src/imagePromptingGuide/index.ts
+++ b/packages/shared/src/imagePromptingGuide/index.ts
@@ -1,4 +1,5 @@
 export * from './types'
 export * from './fundamentals'
+export * from './guideGroups'
 export * from './catalog'
 export * from './resolveGuideRequest'

--- a/packages/shared/src/imagePromptingGuide/intents/e1-translate-layout.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e1-translate-layout.ts
@@ -1,0 +1,20 @@
+import type { EditIntent } from '../types'
+
+/** E1 — Translate layout */
+export const e1TranslateLayout: EditIntent = {
+  id: 'e1_translate_layout',
+  kind: 'edit_intent',
+  label: '版面翻译',
+  description: 'Translate visible copy while preserving the original layout and visual design.',
+  groupId: 'local_edit',
+  groupLabel: '局部手术',
+  fundamentalsRefs: ['exact_text', 'separate_changes', 'iterate'],
+  changePreserveTemplate: `Translate the visible text in the input image into {{TARGET_LANGUAGE}}.
+Replace only the original text and render the supplied translation exactly.
+Preserve layout, hierarchy, font character, colors, spacing, imagery, logos, and background.
+Fit translated copy naturally without clipping or overlap.
+Do not add, remove, or redesign any other element.`,
+  refRoles: [{ role: 'source', required: true, hint: '待翻译的原版面' }],
+  preferredParams: { size: '1536x1024', quality: 'medium' },
+  capability: { minRefImages: 1 },
+}

--- a/packages/shared/src/imagePromptingGuide/intents/e2-style-transfer.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e2-style-transfer.ts
@@ -1,0 +1,23 @@
+import type { EditIntent } from '../types'
+
+/** E2 — Style transfer */
+export const e2StyleTransfer: EditIntent = {
+  id: 'e2_style_transfer',
+  kind: 'edit_intent',
+  label: '风格迁移',
+  description: 'Apply the visual language of a style reference while preserving source content.',
+  groupId: 'ref_compose',
+  groupLabel: '参考合成',
+  fundamentalsRefs: ['separate_changes', 'assign_ref_roles', 'iterate'],
+  changePreserveTemplate: `Restyle the content of image 1 using the visual style of image 2.
+Transfer palette, medium, texture, lighting treatment, and mark-making from the style reference.
+Preserve the subject identity, pose, composition, proportions, objects, and scene structure from image 1.
+Do not copy people, objects, text, or composition from image 2.
+Change only the visual style; add no text, logos, or watermarks.`,
+  refRoles: [
+    { role: 'content', required: true, hint: '图1：保留内容与构图的原图' },
+    { role: 'style', required: true, hint: '图2：仅提供视觉风格' },
+  ],
+  preferredParams: { size: '1024x1536', quality: 'medium' },
+  capability: { minRefImages: 2 },
+}

--- a/packages/shared/src/imagePromptingGuide/intents/e3-identity-clothing.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e3-identity-clothing.ts
@@ -8,6 +8,7 @@ export const e3IdentityClothing: EditIntent = {
   description: 'Change only clothing; preserve face, identity, pose, and background.',
   groupId: 'identity_product',
   groupLabel: '身份/产品',
+  fundamentalsRefs: ['separate_changes', 'assign_ref_roles', 'iterate'],
   changePreserveTemplate: `Edit the image to dress the person using the provided clothing reference(s).
 Change only the clothing. Do not change face, facial features, skin tone, body shape, pose, or identity.
 Preserve exact likeness, expression, hairstyle, and proportions.

--- a/packages/shared/src/imagePromptingGuide/intents/e3-identity-clothing.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e3-identity-clothing.ts
@@ -6,6 +6,8 @@ export const e3IdentityClothing: EditIntent = {
   kind: 'edit_intent',
   label: '换装保身份',
   description: 'Change only clothing; preserve face, identity, pose, and background.',
+  groupId: 'identity_product',
+  groupLabel: '身份/产品',
   changePreserveTemplate: `Edit the image to dress the person using the provided clothing reference(s).
 Change only the clothing. Do not change face, facial features, skin tone, body shape, pose, or identity.
 Preserve exact likeness, expression, hairstyle, and proportions.

--- a/packages/shared/src/imagePromptingGuide/intents/e4-combine-refs.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e4-combine-refs.ts
@@ -8,6 +8,7 @@ export const e4CombineRefs: EditIntent = {
   description: 'Place the subject from image 2 into the scene of image 1; change nothing else.',
   groupId: 'ref_compose',
   groupLabel: '参考合成',
+  fundamentalsRefs: ['separate_changes', 'assign_ref_roles', 'iterate'],
   changePreserveTemplate: `Place the subject from image 2 into the setting of image 1.
 Use the same style of lighting, composition, and background as image 1.
 Change nothing else — preserve identity of the subject and the rest of the scene.`,

--- a/packages/shared/src/imagePromptingGuide/intents/e4-combine-refs.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e4-combine-refs.ts
@@ -6,6 +6,8 @@ export const e4CombineRefs: EditIntent = {
   kind: 'edit_intent',
   label: '多参考合成',
   description: 'Place the subject from image 2 into the scene of image 1; change nothing else.',
+  groupId: 'ref_compose',
+  groupLabel: '参考合成',
   changePreserveTemplate: `Place the subject from image 2 into the setting of image 1.
 Use the same style of lighting, composition, and background as image 1.
 Change nothing else — preserve identity of the subject and the rest of the scene.`,

--- a/packages/shared/src/imagePromptingGuide/intents/e5-transparent-cutout.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e5-transparent-cutout.ts
@@ -8,6 +8,7 @@ export const e5TransparentCutout: EditIntent = {
   description: 'Isolate the product on a fully transparent background; no checkerboard or scenery.',
   groupId: 'identity_product',
   groupLabel: '身份/产品',
+  fundamentalsRefs: ['define_result', 'separate_changes', 'iterate'],
   changePreserveTemplate: `Extract the product from the input image and isolate it on a fully transparent background.
 Output: centered product, crisp silhouette, no halos/fringing.
 Preserve product geometry and label legibility exactly.

--- a/packages/shared/src/imagePromptingGuide/intents/e5-transparent-cutout.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e5-transparent-cutout.ts
@@ -6,6 +6,8 @@ export const e5TransparentCutout: EditIntent = {
   kind: 'edit_intent',
   label: '透明抠图',
   description: 'Isolate the product on a fully transparent background; no checkerboard or scenery.',
+  groupId: 'identity_product',
+  groupLabel: '身份/产品',
   changePreserveTemplate: `Extract the product from the input image and isolate it on a fully transparent background.
 Output: centered product, crisp silhouette, no halos/fringing.
 Preserve product geometry and label legibility exactly.

--- a/packages/shared/src/imagePromptingGuide/intents/e6-drawing-to-realistic.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e6-drawing-to-realistic.ts
@@ -1,0 +1,20 @@
+import type { EditIntent } from '../types'
+
+/** E6 — Drawing to realistic */
+export const e6DrawingToRealistic: EditIntent = {
+  id: 'e6_drawing_to_realistic',
+  kind: 'edit_intent',
+  label: '草图转写实',
+  description: 'Convert a drawing into a realistic image while preserving its structure and intent.',
+  groupId: 'ref_compose',
+  groupLabel: '参考合成',
+  fundamentalsRefs: ['visible_details', 'separate_changes', 'assign_ref_roles'],
+  changePreserveTemplate: `Convert the input drawing into a photorealistic image.
+Preserve the exact composition, subject placement, pose, perspective, silhouette, and key design features.
+Resolve sketched areas into plausible materials, textures, lighting, and shadows.
+Keep intentional colors and details unless the drawing leaves them unspecified.
+Do not redesign the subject, alter the framing, add objects, text, logos, or watermarks.`,
+  refRoles: [{ role: 'drawing', required: true, hint: '要转为写实效果的草图/线稿' }],
+  preferredParams: { size: '1024x1536', quality: 'medium' },
+  capability: { minRefImages: 1 },
+}

--- a/packages/shared/src/imagePromptingGuide/intents/e7-remove-object.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e7-remove-object.ts
@@ -1,0 +1,20 @@
+import type { EditIntent } from '../types'
+
+/** E7 — Remove object */
+export const e7RemoveObject: EditIntent = {
+  id: 'e7_remove_object',
+  kind: 'edit_intent',
+  label: '去物体',
+  description: 'Remove a specified object and reconstruct the revealed background naturally.',
+  groupId: 'local_edit',
+  groupLabel: '局部手术',
+  fundamentalsRefs: ['define_result', 'separate_changes', 'iterate'],
+  changePreserveTemplate: `Remove {{OBJECT_TO_REMOVE}} from the input image.
+Reconstruct the newly revealed area so it matches the surrounding background, texture, lighting, perspective, and depth.
+Remove related shadows or reflections only when they belong to the removed object.
+Preserve every other person, object, color, detail, camera angle, and crop exactly.
+Do not add replacement objects, text, logos, or watermarks.`,
+  refRoles: [{ role: 'source', required: true, hint: '包含待移除物体的原图' }],
+  preferredParams: { size: '1024x1536', quality: 'medium' },
+  capability: { minRefImages: 1 },
+}

--- a/packages/shared/src/imagePromptingGuide/intents/e8-insert-person.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e8-insert-person.ts
@@ -1,0 +1,23 @@
+import type { EditIntent } from '../types'
+
+/** E8 — Insert person */
+export const e8InsertPerson: EditIntent = {
+  id: 'e8_insert_person',
+  kind: 'edit_intent',
+  label: '人物入景',
+  description: 'Insert a referenced person into a scene while preserving identity and scene continuity.',
+  groupId: 'identity_product',
+  groupLabel: '身份/产品',
+  fundamentalsRefs: ['people_actions', 'separate_changes', 'assign_ref_roles'],
+  changePreserveTemplate: `Insert the person from image 2 naturally into the scene in image 1 at {{PLACEMENT}}.
+Preserve the person's exact identity, facial features, hairstyle, body proportions, and clothing.
+Match the scene's perspective, scale, lighting, color, focus, contact shadows, and occlusion.
+Preserve the existing background, people, objects, camera angle, and framing.
+Do not alter the person's identity or add text, logos, or watermarks.`,
+  refRoles: [
+    { role: 'scene', required: true, hint: '图1：目标场景' },
+    { role: 'subject', required: true, hint: '图2：要放入场景的人物' },
+  ],
+  preferredParams: { size: '1024x1536', quality: 'medium' },
+  capability: { minRefImages: 2, requiresSubjectRef: true },
+}

--- a/packages/shared/src/imagePromptingGuide/resolveGuideRequest.test.ts
+++ b/packages/shared/src/imagePromptingGuide/resolveGuideRequest.test.ts
@@ -7,6 +7,7 @@ const e5: EditIntent = {
   kind: 'edit_intent',
   label: '透明抠图',
   description: 'x',
+  fundamentalsRefs: ['separate_changes'],
   changePreserveTemplate: 'Extract…',
   refRoles: [{ role: 'product', required: true, hint: '产品图' }],
   preferredParams: { background: 'transparent', outputFormat: 'png', quality: 'medium' },
@@ -61,6 +62,7 @@ describe('resolveGuideRequest', () => {
       kind: 'edit_intent',
       label: '换装保身份',
       description: 'x',
+      fundamentalsRefs: ['separate_changes'],
       changePreserveTemplate: 'Edit…',
       refRoles: [
         { role: 'subject', required: true, hint: '人物' },

--- a/packages/shared/src/imagePromptingGuide/scenes/g1-style-lighting.ts
+++ b/packages/shared/src/imagePromptingGuide/scenes/g1-style-lighting.ts
@@ -6,6 +6,8 @@ export const g1StyleLighting: GenerationScene = {
   kind: 'generation_scene',
   label: '风格与光线',
   description: 'Describe subject, framing, light, and texture; avoid heavy retouching.',
+  groupId: 'photo_ad',
+  groupLabel: '摄影/广告',
   fundamentalsRefs: ['define_result', 'visible_details', 'people_actions'],
   promptScaffold: `Create a photorealistic candid photograph of {{SUBJECT}}.
 Describe framing (e.g. medium close-up at eye level), lens cues, and composition.

--- a/packages/shared/src/imagePromptingGuide/scenes/g2-process-infographic.ts
+++ b/packages/shared/src/imagePromptingGuide/scenes/g2-process-infographic.ts
@@ -1,0 +1,19 @@
+import type { GenerationScene } from '../types'
+
+/** G2 — Process infographic */
+export const g2ProcessInfographic: GenerationScene = {
+  id: 'g2_process_infographic',
+  kind: 'generation_scene',
+  label: '流程信息图',
+  description: 'Turn a sequence into a clear, ordered infographic with concise labels.',
+  groupId: 'info_design',
+  groupLabel: '信息设计',
+  fundamentalsRefs: ['define_result', 'maintainable_format', 'exact_text'],
+  promptScaffold: `Create a clean process infographic explaining {{PROCESS}}.
+Show the steps in an obvious reading order with numbered stages and concise labels.
+Use consistent icons, spacing, connectors, and a restrained color palette.
+Render all supplied wording exactly and keep the hierarchy legible.
+Do not add unsupported steps, decorative copy, logos, or watermarks.`,
+  preferredParams: { size: '1536x1024', quality: 'medium' },
+  capability: {},
+}

--- a/packages/shared/src/imagePromptingGuide/scenes/g3-exact-text.ts
+++ b/packages/shared/src/imagePromptingGuide/scenes/g3-exact-text.ts
@@ -6,6 +6,8 @@ export const g3ExactText: GenerationScene = {
   kind: 'generation_scene',
   label: '精确文字',
   description: 'Quote required copy; render the tagline exactly once with no extra text.',
+  groupId: 'photo_ad',
+  groupLabel: '摄影/广告',
   fundamentalsRefs: ['define_result', 'exact_text', 'visible_details'],
   promptScaffold: `Create a polished campaign / fashion ad for a brand.
 The ad features the subject with the tagline "{{TAGLINE}}".

--- a/packages/shared/src/imagePromptingGuide/scenes/g4-reusable-logo.ts
+++ b/packages/shared/src/imagePromptingGuide/scenes/g4-reusable-logo.ts
@@ -1,0 +1,24 @@
+import type { GenerationScene } from '../types'
+
+/** G4 — Reusable logo */
+export const g4ReusableLogo: GenerationScene = {
+  id: 'g4_reusable_logo',
+  kind: 'generation_scene',
+  label: '可复用 Logo',
+  description: 'Create a simple, reusable logo mark with a clean transparent background.',
+  groupId: 'brand_ui',
+  groupLabel: '品牌/UI',
+  fundamentalsRefs: ['define_result', 'visible_details', 'exact_text'],
+  promptScaffold: `Create a distinctive, reusable logo for {{BRAND}}.
+Use a simple silhouette, balanced geometry, and a limited color palette that works at small sizes.
+If lettering is requested, render "{{LOGOTYPE}}" exactly once and keep it legible.
+Isolate the logo on a fully transparent background with crisp, clean edges.
+Do not add mockups, scenery, shadows, extra text, or watermarks.`,
+  preferredParams: {
+    size: '1024x1024',
+    quality: 'medium',
+    background: 'transparent',
+    outputFormat: 'png',
+  },
+  capability: { requiresTransparentBackground: true },
+}

--- a/packages/shared/src/imagePromptingGuide/scenes/g5-historical-context.ts
+++ b/packages/shared/src/imagePromptingGuide/scenes/g5-historical-context.ts
@@ -1,0 +1,18 @@
+import type { GenerationScene } from '../types'
+
+/** G5 — Historical context */
+export const g5HistoricalContext: GenerationScene = {
+  id: 'g5_historical_context',
+  kind: 'generation_scene',
+  label: '历史语境',
+  description: 'Reconstruct a historically grounded scene with period-appropriate visual details.',
+  groupId: 'narrative',
+  groupLabel: '叙事',
+  fundamentalsRefs: ['define_result', 'visible_details', 'people_actions'],
+  promptScaffold: `Create a historically grounded scene set in {{TIME_AND_PLACE}}.
+Depict {{SUBJECT_AND_ACTION}} with period-appropriate clothing, architecture, objects, and materials.
+Use a coherent composition and lighting appropriate to the setting and intended medium.
+Avoid modern objects, anachronistic styling, unsupported symbols, text, logos, or watermarks.`,
+  preferredParams: { size: '1536x1024', quality: 'medium' },
+  capability: {},
+}

--- a/packages/shared/src/imagePromptingGuide/scenes/g6-comic-strip.ts
+++ b/packages/shared/src/imagePromptingGuide/scenes/g6-comic-strip.ts
@@ -1,0 +1,20 @@
+import type { GenerationScene } from '../types'
+
+/** G6 — Comic strip */
+export const g6ComicStrip: GenerationScene = {
+  id: 'g6_comic_strip',
+  kind: 'generation_scene',
+  label: '故事漫画分格',
+  description: 'Tell a coherent short story through ordered comic panels.',
+  groupId: 'narrative',
+  groupLabel: '叙事',
+  fundamentalsRefs: ['define_result', 'maintainable_format', 'people_actions', 'exact_text'],
+  promptScaffold: `Create a {{PANEL_COUNT}}-panel comic strip about {{STORY}}.
+Keep characters, clothing, props, and setting visually consistent across panels.
+Give each panel a distinct story beat, clear action, and an obvious reading order.
+Render supplied dialogue exactly in readable speech balloons.
+Do not add extra panels, dialogue, logos, or watermarks.`,
+  preferredParams: { size: '1536x1024', quality: 'medium' },
+  capability: {},
+  expandViaPromptMode: 'storyboard',
+}

--- a/packages/shared/src/imagePromptingGuide/scenes/g7-interface-preview.ts
+++ b/packages/shared/src/imagePromptingGuide/scenes/g7-interface-preview.ts
@@ -1,0 +1,19 @@
+import type { GenerationScene } from '../types'
+
+/** G7 — Interface preview */
+export const g7InterfacePreview: GenerationScene = {
+  id: 'g7_interface_preview',
+  kind: 'generation_scene',
+  label: '界面预览',
+  description: 'Visualize a polished product interface with a clear hierarchy and realistic content.',
+  groupId: 'brand_ui',
+  groupLabel: '品牌/UI',
+  fundamentalsRefs: ['define_result', 'maintainable_format', 'exact_text'],
+  promptScaffold: `Create a polished interface preview for {{PRODUCT_AND_SCREEN}}.
+Show a clear information hierarchy, consistent components, practical spacing, and accessible contrast.
+Use realistic content and render all supplied labels exactly.
+Present the interface from a straightforward viewing angle without obscuring important controls.
+Do not add illegible filler text, unrelated branding, or watermarks.`,
+  preferredParams: { size: '1536x1024', quality: 'medium' },
+  capability: {},
+}

--- a/packages/shared/src/imagePromptingGuide/scenes/g8-scientific-visual.ts
+++ b/packages/shared/src/imagePromptingGuide/scenes/g8-scientific-visual.ts
@@ -1,0 +1,19 @@
+import type { GenerationScene } from '../types'
+
+/** G8 — Scientific visual */
+export const g8ScientificVisual: GenerationScene = {
+  id: 'g8_scientific_visual',
+  kind: 'generation_scene',
+  label: '科学教育图',
+  description: 'Explain a scientific concept with accurate structure and readable annotations.',
+  groupId: 'info_design',
+  groupLabel: '信息设计',
+  fundamentalsRefs: ['define_result', 'visible_details', 'exact_text'],
+  promptScaffold: `Create an educational scientific visual explaining {{CONCEPT}} for {{AUDIENCE}}.
+Show the relevant structures, relationships, scale cues, and process accurately.
+Use a clean composition, restrained colors, and clear callouts.
+Render supplied labels exactly and keep annotation lines unambiguous.
+Do not invent unsupported anatomy, data, labels, logos, or watermarks.`,
+  preferredParams: { size: '1536x1024', quality: 'medium' },
+  capability: {},
+}

--- a/packages/shared/src/imagePromptingGuide/scenes/g9-slides-charts.ts
+++ b/packages/shared/src/imagePromptingGuide/scenes/g9-slides-charts.ts
@@ -1,0 +1,19 @@
+import type { GenerationScene } from '../types'
+
+/** G9 — Slides and charts */
+export const g9SlidesCharts: GenerationScene = {
+  id: 'g9_slides_charts',
+  kind: 'generation_scene',
+  label: '幻灯片/图表',
+  description: 'Present supplied data in a clear slide with an appropriate chart and concise hierarchy.',
+  groupId: 'info_design',
+  groupLabel: '信息设计',
+  fundamentalsRefs: ['define_result', 'maintainable_format', 'exact_text'],
+  promptScaffold: `Create a presentation slide about {{TOPIC}} using the supplied data.
+Choose a chart form that represents the values faithfully and label units, categories, and legend clearly.
+Use one strong takeaway, concise supporting copy, and a professional visual hierarchy.
+Render titles, labels, and values exactly as provided.
+Do not invent data, distort axes, add unrelated copy, logos, or watermarks.`,
+  preferredParams: { size: '1536x1024', quality: 'medium' },
+  capability: {},
+}

--- a/packages/shared/src/imagePromptingGuide/types.ts
+++ b/packages/shared/src/imagePromptingGuide/types.ts
@@ -52,6 +52,7 @@ export interface EditIntent {
   description: string
   groupId?: GuideGroupId
   groupLabel?: string
+  fundamentalsRefs: string[]
   changePreserveTemplate: string
   refRoles: Array<{ role: string; required: boolean; hint: string }>
   preferredParams: ParamContract

--- a/packages/shared/src/imagePromptingGuide/types.ts
+++ b/packages/shared/src/imagePromptingGuide/types.ts
@@ -1,5 +1,14 @@
 export type GuideKind = 'generation_scene' | 'edit_intent'
 
+export type GuideGroupId =
+  | 'photo_ad'
+  | 'info_design'
+  | 'brand_ui'
+  | 'narrative'
+  | 'local_edit'
+  | 'identity_product'
+  | 'ref_compose'
+
 export interface ParamContract {
   size?: string
   quality?: 'auto' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
@@ -25,6 +34,8 @@ export interface GenerationScene {
   kind: 'generation_scene'
   label: string
   description: string
+  groupId?: GuideGroupId
+  groupLabel?: string
   fundamentalsRefs: string[]
   promptScaffold: string
   systemOverlay?: string
@@ -39,6 +50,8 @@ export interface EditIntent {
   kind: 'edit_intent'
   label: string
   description: string
+  groupId?: GuideGroupId
+  groupLabel?: string
   changePreserveTemplate: string
   refRoles: Array<{ role: string; required: boolean; hint: string }>
   preferredParams: ParamContract

--- a/services/agent-runtime/skills/atomic-create/assets/image-prompting-guide-taxonomy.yaml
+++ b/services/agent-runtime/skills/atomic-create/assets/image-prompting-guide-taxonomy.yaml
@@ -1,12 +1,12 @@
 # Image prompting guide taxonomy — mirrors catalog scene/intent ids
 version: 1
 generation_scenes:
+  - id: g3_exact_text
+    patterns: [精确文字, 标语必须, tagline, 不要多余字, render text]
   - id: g1_style_lighting
     patterns: [光影, 胶片感, 35mm, candid, 写实摄影]
   - id: g2_process_infographic
     patterns: [流程信息图, 流程图, 步骤信息图, process infographic]
-  - id: g3_exact_text
-    patterns: [精确文字, 标语必须, tagline, 不要多余字, render text]
   - id: g4_reusable_logo
     patterns: [可复用 logo, 可复用logo, logo 透明, logo透明, reusable logo]
   - id: g5_historical_context
@@ -20,16 +20,16 @@ generation_scenes:
   - id: g9_slides_charts
     patterns: [幻灯片图表, 幻灯片, 演示图表, 数据图表, presentation slide]
 edit_intents:
-  - id: e1_translate_layout
-    patterns: [版面翻译, 翻译版面, 保持版式翻译, translate layout]
-  - id: e2_style_transfer
-    patterns: [风格迁移, 风格转换, 参考图风格, style transfer]
   - id: e3_identity_clothing
     patterns: [换装, 只换衣服, 保留脸, 试穿, identity]
   - id: e4_combine_refs
     patterns: [合成到场景, 放到场景, 图1图2, combine reference]
   - id: e5_transparent_cutout
     patterns: [抠图, 透明底, 去背景, cutout]
+  - id: e1_translate_layout
+    patterns: [版面翻译, 翻译版面, 保持版式翻译, translate layout]
+  - id: e2_style_transfer
+    patterns: [风格迁移, 风格转换, 参考图风格, style transfer]
   - id: e6_drawing_to_realistic
     patterns: [草图转写实, 线稿转写实, 草图写实化, drawing to realistic]
   - id: e7_remove_object

--- a/services/agent-runtime/skills/atomic-create/assets/image-prompting-guide-taxonomy.yaml
+++ b/services/agent-runtime/skills/atomic-create/assets/image-prompting-guide-taxonomy.yaml
@@ -1,14 +1,38 @@
-# Image prompting guide taxonomy — mirrors P0 catalog scene/intent ids
+# Image prompting guide taxonomy — mirrors catalog scene/intent ids
 version: 1
 generation_scenes:
-  - id: g3_exact_text
-    patterns: [精确文字, 标语必须, tagline, 不要多余字, render text]
   - id: g1_style_lighting
     patterns: [光影, 胶片感, 35mm, candid, 写实摄影]
+  - id: g2_process_infographic
+    patterns: [流程信息图, 流程图, 步骤信息图, process infographic]
+  - id: g3_exact_text
+    patterns: [精确文字, 标语必须, tagline, 不要多余字, render text]
+  - id: g4_reusable_logo
+    patterns: [可复用 logo, 可复用logo, logo 透明, logo透明, reusable logo]
+  - id: g5_historical_context
+    patterns: [历史语境, 历史场景, 时代还原, historical scene, period-appropriate]
+  - id: g6_comic_strip
+    patterns: [漫画分格, 故事漫画, 连环漫画, comic strip]
+  - id: g7_interface_preview
+    patterns: [界面预览, 产品界面, UI 预览, ui preview, interface preview]
+  - id: g8_scientific_visual
+    patterns: [科学教育图, 科学示意图, 科普图, scientific visual]
+  - id: g9_slides_charts
+    patterns: [幻灯片图表, 幻灯片, 演示图表, 数据图表, presentation slide]
 edit_intents:
+  - id: e1_translate_layout
+    patterns: [版面翻译, 翻译版面, 保持版式翻译, translate layout]
+  - id: e2_style_transfer
+    patterns: [风格迁移, 风格转换, 参考图风格, style transfer]
   - id: e3_identity_clothing
     patterns: [换装, 只换衣服, 保留脸, 试穿, identity]
   - id: e4_combine_refs
     patterns: [合成到场景, 放到场景, 图1图2, combine reference]
   - id: e5_transparent_cutout
     patterns: [抠图, 透明底, 去背景, cutout]
+  - id: e6_drawing_to_realistic
+    patterns: [草图转写实, 线稿转写实, 草图写实化, drawing to realistic]
+  - id: e7_remove_object
+    patterns: [去物体, 去掉物体, 移除物体, 删除物体, remove object]
+  - id: e8_insert_person
+    patterns: [人物入景, 人物放入场景, 把人放入场景, insert person]

--- a/services/agent-runtime/tests/test_guide_taxonomy.py
+++ b/services/agent-runtime/tests/test_guide_taxonomy.py
@@ -11,6 +11,10 @@ def test_g3_exact_text():
     assert resolve_guide_scene("广告图，标语必须精确文字 Yours to Create，不要多余字") == "g3_exact_text"
 
 
+def test_exact_text_takes_priority_over_style_lighting():
+    assert resolve_guide_scene("写实摄影广告图，包含精确文字") == "g3_exact_text"
+
+
 def test_e5_cutout():
     assert resolve_guide_edit_intent("把产品抠图做成透明底 PNG") == "e5_transparent_cutout"
 

--- a/services/agent-runtime/tests/test_guide_taxonomy.py
+++ b/services/agent-runtime/tests/test_guide_taxonomy.py
@@ -1,3 +1,5 @@
+import pytest
+
 from app.tools.guide_taxonomy import (
     apply_guide_taxonomy_to_items,
     resolve_guide_edit_intent,
@@ -11,6 +13,37 @@ def test_g3_exact_text():
 
 def test_e5_cutout():
     assert resolve_guide_edit_intent("把产品抠图做成透明底 PNG") == "e5_transparent_cutout"
+
+
+@pytest.mark.parametrize(
+    ("utterance", "expected"),
+    [
+        ("把步骤整理成流程信息图", "g2_process_infographic"),
+        ("设计一个 logo 透明底版本", "g4_reusable_logo"),
+        ("重现有时代细节的历史语境", "g5_historical_context"),
+        ("用漫画分格讲一个故事", "g6_comic_strip"),
+        ("制作移动应用的界面预览", "g7_interface_preview"),
+        ("绘制清晰的科学教育图", "g8_scientific_visual"),
+        ("根据这些数据制作幻灯片图表", "g9_slides_charts"),
+    ],
+)
+def test_resolve_new_generation_scenes(utterance, expected):
+    assert resolve_guide_scene(utterance) == expected
+
+
+@pytest.mark.parametrize(
+    ("utterance", "expected"),
+    [
+        ("保持设计不变，只做版面翻译", "e1_translate_layout"),
+        ("参考第二张图进行风格迁移", "e2_style_transfer"),
+        ("把这张草图转写实", "e6_drawing_to_realistic"),
+        ("去物体并自然补全背景", "e7_remove_object"),
+        ("去掉物体并保留其他内容", "e7_remove_object"),
+        ("把参考人物入景到街道照片", "e8_insert_person"),
+    ],
+)
+def test_resolve_new_edit_intents(utterance, expected):
+    assert resolve_guide_edit_intent(utterance) == expected
 
 
 def test_no_false_positive_on_hello():


### PR DESCRIPTION
## Summary
- Full catalog G1–G9 + E1–E8 with group metadata
- Minimal dock: scene icon replaces ×; searchable GuidePickerPopover
- Refine: edit-intent dropdown; stain/replace chips kept
- Taxonomy + prod verify extended
- Image 2.5 still deferred

## Spec
- docs/superpowers/specs/2026-09-11-image-prompting-guide-catalog-fill-design.md
- docs/superpowers/plans/2026-09-11-image-prompting-guide-catalog-fill.md

## Test plan
- [ ] shared/web/pytest matrix (see Task 9 report)
- [ ] Manual: Prompt/Image icon picker, Esc/blank close, Refine intent disable E5
- [ ] Prod smoke after deploy

Made with [Cursor](https://cursor.com)