### PR TITLE
fix(agent): trigger browser download on export_media_package

### DIFF
--- a/apps/server/src/agent/agent-canvas-tools.service.test.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.test.ts
@@ -1729,6 +1729,7 @@ describe('AgentCanvasToolsService', () => {
       expect(result.manifest.count).toBe(0)
       expect(result.manifest.items).toEqual([])
       expect(result.manifest.exportedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+      expect(result.canvasCommands).toEqual([{ type: 'export_pack', nodeIds: [] }])
     })
 
     it('skips nodes without url and builds stream-download downloadPath', async () => {
@@ -1763,6 +1764,7 @@ describe('AgentCanvasToolsService', () => {
       })
       expect(result.manifest.items[0].downloadPath).toMatch(/^\/api\/media\/stream-download\?/)
       expect(result.manifest.items[0].downloadPath).toContain('sessionId=s1')
+      expect(result.canvasCommands).toEqual([{ type: 'export_pack', nodeIds: ['img-1'] }])
     })
   })
 })

--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -1803,6 +1803,8 @@ export class AgentCanvasToolsService {
       count: number
       items: Array<{ nodeId: string; url: string; fileName: string; downloadPath: string }>
     }
+    /** Client command: browser triggers authenticated downloadMediaPackage (same path as UI). */
+    canvasCommands: Array<{ type: 'export_pack'; nodeIds: string[] }>
   }> {
     await this.loadOwnedSession(input.sessionId, input.userId)
     const { canvas } = await this.loadSession(input.sessionId)
@@ -1826,12 +1828,14 @@ export class AgentCanvasToolsService {
         downloadPath: `/api/media/stream-download?${params.toString()}`,
       })
     }
+    const exportedNodeIds = items.map((item) => item.nodeId)
     return {
       manifest: {
         exportedAt: new Date().toISOString(),
         count: items.length,
         items,
       },
+      canvasCommands: [{ type: 'export_pack', nodeIds: exportedNodeIds }],
     }
   }
 

--- a/apps/web/src/components/agent/AgentSideRail.vue
+++ b/apps/web/src/components/agent/AgentSideRail.vue
@@ -1774,6 +1774,9 @@ function handleEvent(event: { type: string; data: unknown }) {
         onFocusNode(cmd.nodeId)
       } else if (cmd.type === 'focus_nodes' && cmd.nodeIds?.length) {
         onFocusAll(cmd.nodeIds)
+      } else if (cmd.type === 'export_pack') {
+        // Agent export_media_package → same local download path as UI chip
+        onExportPack(Array.isArray(cmd.nodeIds) ? cmd.nodeIds : [])
       } else if (cmd.type === 'undo') {
         emit('undo')
       } else if (cmd.type === 'redo') {

--- a/services/agent-runtime/app/tools/definitions.py
+++ b/services/agent-runtime/app/tools/definitions.py
@@ -632,7 +632,12 @@ def _all_tool_specs(client: NestCanvasClient) -> list[tuple[str, StructuredTool]
             StructuredTool.from_function(
                 coroutine=export_media_package,
                 name="export_media_package",
-                description="Export downloadable URLs for node media",
+                description=(
+                    "Export selected canvas media to the user's browser downloads. "
+                    "Returns a manifest and triggers client-side authenticated downloads "
+                    "(do not claim files are already saved until the browser downloads; "
+                    "do not paste stream-download markdown links as a substitute)."
+                ),
                 args_schema=ExportMediaInput,
             ),
         ),

--- a/services/agent-runtime/tests/test_canvas_commands.py
+++ b/services/agent-runtime/tests/test_canvas_commands.py
@@ -9,6 +9,16 @@ def test_extract_canvas_commands_from_harness_result():
     assert extract_canvas_commands(result) == [{"type": "focus_node", "nodeId": "n1"}]
 
 
+def test_extract_export_pack_canvas_command():
+    result = {
+        "manifest": {"count": 2, "items": []},
+        "canvasCommands": [{"type": "export_pack", "nodeIds": ["img-1", "vid-2"]}],
+    }
+    assert extract_canvas_commands(result) == [
+        {"type": "export_pack", "nodeIds": ["img-1", "vid-2"]},
+    ]
+
+
 def test_extract_ignores_invalid():
     assert extract_canvas_commands("x") == []
     assert extract_canvas_commands({"canvasCommands": [{"bad": 1}]}) == []


### PR DESCRIPTION
## Summary
- Root cause: Agent `export_media_package` returned manifest/`downloadPath` only; the model said「已导出」and pasted markdown links that lack Bearer auth, so the browser never saved files.
- Nest now returns `canvasCommands: [{ type: 'export_pack', nodeIds }]` (same pattern as `focus_node`).
- Web `AgentSideRail` handles `export_pack` → `onExportPack` → `downloadMediaPackage` (人机同路径).
- Tool description updated so the agent does not claim files are already on disk or paste stream-download links as a substitute.

## Test plan
- [x] `pnpm --filter @lnkpi/server exec vitest run … -t exportMediaPackage`
- [x] `services/agent-runtime/.venv/bin/pytest tests/test_canvas_commands.py`
- [ ] Production: Agent chat「请帮我把当前画布打包导出」→ browser downloads JSON + media (same as UI chip)
- [ ] Empty selection still toasts via existing empty-pack path


Made with [Cursor](https://cursor.com)