### PR TITLE
fix(web): Refine chips — 清除瑕疵 + edit intent below

### DIFF
--- a/apps/web/src/components/canvas/dock-studio/shared/GuidePickerPopover.test.ts
+++ b/apps/web/src/components/canvas/dock-studio/shared/GuidePickerPopover.test.ts
@@ -23,6 +23,15 @@ describe('GuidePickerPopover', () => {
     wrapper.unmount()
   })
 
+  it('applies below-end placement for top-of-panel pickers (Refine)', () => {
+    const wrapper = mount(GuidePickerPopover, {
+      props: { ...defaultProps, mode: 'edit_intent', placement: 'below-end' },
+    })
+
+    expect(wrapper.classes()).toContain('guide-picker-popover--below-end')
+    wrapper.unmount()
+  })
+
   it('emits close on window Escape even without focus inside', async () => {
     const wrapper = mount(GuidePickerPopover, { props: defaultProps })
 

--- a/apps/web/src/components/canvas/dock-studio/shared/GuidePickerPopover.vue
+++ b/apps/web/src/components/canvas/dock-studio/shared/GuidePickerPopover.vue
@@ -21,7 +21,7 @@ const props = withDefaults(
     capabilities: GuideCapabilities
     open: boolean
     refImageCount?: number
-    placement?: 'below-start' | 'above-end'
+    placement?: 'below-start' | 'below-end' | 'above-end'
   }>(),
   {
     refImageCount: 0,
@@ -191,6 +191,12 @@ function onEscape(event: KeyboardEvent) {
   width: min(288px, calc(100vw - 24px));
   overflow: hidden;
   border-radius: 16px;
+}
+
+.guide-picker-popover--below-end {
+  top: calc(100% + 8px);
+  right: 0;
+  left: auto;
 }
 
 .guide-picker-popover--above-end {

--- a/apps/web/src/components/canvas/refine/RefineSidePanel.vue
+++ b/apps/web/src/components/canvas/refine/RefineSidePanel.vue
@@ -210,11 +210,6 @@ function clearEditIntent() {
   editIntentPickerOpen.value = false
 }
 
-function focusReplacePrompt() {
-  activeGuideEditIntentId.value = null
-  promptRef.value?.focus()
-}
-
 function onLoupeZoomInput(event: Event) {
   const target = event.target
   if (!(target instanceof HTMLInputElement)) return
@@ -529,42 +524,6 @@ onBeforeUnmount(() => {
           <span v-if="!collapsed" class="refine-side__title">精修</span>
         </div>
         <div v-if="!collapsed" class="flex items-center gap-1">
-          <div class="relative">
-            <button
-              type="button"
-              class="refine-side__icon-btn relative"
-              :class="{ 'is-guide-active': activeGuideEditIntentId }"
-              :disabled="busy"
-              aria-label="编辑意图"
-              title="编辑意图"
-              :aria-expanded="editIntentPickerOpen"
-              @click="editIntentPickerOpen = !editIntentPickerOpen"
-            >
-              <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8">
-                <rect x="4" y="4" width="6" height="6" rx="1" />
-                <rect x="14" y="4" width="6" height="6" rx="1" />
-                <rect x="4" y="14" width="6" height="6" rx="1" />
-                <rect x="14" y="14" width="6" height="6" rx="1" />
-              </svg>
-              <span
-                v-if="activeGuideEditIntentId"
-                class="absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-fuchsia-400"
-                aria-hidden="true"
-              />
-            </button>
-            <GuidePickerPopover
-              class="refine-side__guide-picker"
-              mode="edit_intent"
-              :active-id="activeGuideEditIntentId"
-              :capabilities="guideCapabilities"
-              :open="editIntentPickerOpen"
-              :ref-image-count="refineRefImageCount"
-              placement="below-end"
-              @select="applyEditIntent"
-              @clear="clearEditIntent"
-              @close="editIntentPickerOpen = false"
-            />
-          </div>
           <button
             v-if="!isNarrow"
             type="button"
@@ -764,8 +723,44 @@ onBeforeUnmount(() => {
         </div>
 
         <div class="refine-dock__chips">
-          <button type="button" class="refine-dock__chip" :disabled="busy" @click="applyStainPreset">去除污渍瑕疵</button>
-          <button type="button" class="refine-dock__chip" :disabled="busy" @click="focusReplacePrompt">替换选区内容</button>
+          <button type="button" class="refine-dock__chip" :disabled="busy" @click="applyStainPreset">清除瑕疵</button>
+          <div class="relative">
+            <button
+              type="button"
+              class="refine-dock__chip refine-dock__chip--intent"
+              :class="{ 'is-guide-active': activeGuideEditIntentId }"
+              :disabled="busy"
+              aria-label="编辑意图"
+              title="编辑意图"
+              :aria-expanded="editIntentPickerOpen"
+              @click="editIntentPickerOpen = !editIntentPickerOpen"
+            >
+              <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                <rect x="4" y="4" width="6" height="6" rx="1" />
+                <rect x="14" y="4" width="6" height="6" rx="1" />
+                <rect x="4" y="14" width="6" height="6" rx="1" />
+                <rect x="14" y="14" width="6" height="6" rx="1" />
+              </svg>
+              <span>{{ activeEditIntent?.label ?? '编辑意图' }}</span>
+              <span
+                v-if="activeGuideEditIntentId"
+                class="refine-dock__intent-dot"
+                aria-hidden="true"
+              />
+            </button>
+            <GuidePickerPopover
+              class="refine-side__guide-picker"
+              mode="edit_intent"
+              :active-id="activeGuideEditIntentId"
+              :capabilities="guideCapabilities"
+              :open="editIntentPickerOpen"
+              :ref-image-count="refineRefImageCount"
+              placement="below-end"
+              @select="applyEditIntent"
+              @clear="clearEditIntent"
+              @close="editIntentPickerOpen = false"
+            />
+          </div>
         </div>
 
         <p v-if="activeRefRoleHints" class="refine-dock__hint">
@@ -1044,6 +1039,36 @@ onBeforeUnmount(() => {
 .refine-dock__tool:hover {
   border-color: var(--neo-border-strong);
   color: var(--neo-text-primary);
+}
+
+.refine-dock__chip--intent {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  max-width: 100%;
+}
+
+.refine-dock__chip--intent > span:not(.refine-dock__intent-dot) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.refine-dock__chip.is-guide-active {
+  border-color: color-mix(in srgb, rgb(232 121 249) 25%, transparent);
+  background: color-mix(in srgb, rgb(217 70 239) 15%, transparent);
+  color: rgb(240 171 252);
+}
+
+.refine-dock__intent-dot {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  height: 5px;
+  width: 5px;
+  border-radius: 999px;
+  background: rgb(232 121 249);
 }
 
 .refine-dock__tool:disabled,

--- a/apps/web/src/components/canvas/refine/RefineSidePanel.vue
+++ b/apps/web/src/components/canvas/refine/RefineSidePanel.vue
@@ -559,7 +559,7 @@ onBeforeUnmount(() => {
               :capabilities="guideCapabilities"
               :open="editIntentPickerOpen"
               :ref-image-count="refineRefImageCount"
-              placement="above-end"
+              placement="below-end"
               @select="applyEditIntent"
               @clear="clearEditIntent"
               @close="editIntentPickerOpen = false"

--- a/docs/superpowers/plans/2026-09-12-canvas-workflow-exchange.md
+++ b/docs/superpowers/plans/2026-09-12-canvas-workflow-exchange.md
@@ -1,0 +1,303 @@
+# Canvas Workflow Exchange Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Upgrade「导出打包」to a round-trippable workflow package (`workflow.json` + `media/` zip by default), add merge-into-current-canvas import, then publish W2 schema docs/validation for external agents.
+
+**Architecture:** Shared Zod schema + `remapWorkflowIds` in `@lnkpi/shared`. Browser builds zip via `jszip` after `stream-download` fetches (no CVM temp zip). Import parses zip/json, remaps IDs, uploads media, merges into `Session.canvasData`. Agent keeps `canvasCommands.export_pack` (extended params). W2 reuses the same schema.
+
+**Tech Stack:** Vue 3, Zod, Vitest, `jszip`, existing `useCanvasMedia` / `stream-download`, Nest Agent tools (param pass-through)
+
+**Spec:** [docs/superpowers/specs/2026-09-12-canvas-workflow-exchange-design.md](../specs/2026-09-12-canvas-workflow-exchange-design.md)
+
+## Global Constraints
+
+- Default export = **full_package** zip (`workflow.json` + `media/`); **lightweight** JSON-only is optional.
+- Old「仅媒体清单」remains as **advanced** option only.
+- Import merges into **current** canvas; **always remap** IDs (never overwrite same ids).
+- Scope: multi-select → subgraph; else full canvas.
+- Do **not** build zip on CVM disk; browser-side pack only.
+- Reuse existing refs fields in `data` (localRefs / mentionedKeys); do not invent a second refs syntax.
+- `format` must be `"lnkpi.workflow"`, `version` `"1.0.0"`.
+- Implement **W1 before W2**; W2 tasks must not start until W1 export+import green.
+- Commit per task; PR before claim done: `pnpm build` + focused tests.
+
+## File map
+
+| File | Role |
+| --- | --- |
+| `packages/shared/src/canvas/workflowExchange.ts` | Zod schema, types, `inferMediaRole`, `buildWorkflowDocument`, `remapWorkflowIds`, `validateWorkflow` |
+| `packages/shared/src/canvas/workflowExchange.test.ts` | Unit tests |
+| `packages/shared/src/index.ts` | Re-export |
+| `apps/web/package.json` | Add `jszip` (+ `@types/jszip` if needed) |
+| `apps/web/src/composables/useWorkflowExchange.ts` | Export zip/json + import merge orchestration |
+| `apps/web/src/composables/useWorkflowExchange.test.ts` | Front unit tests (jszip mock) |
+| `apps/web/src/composables/useCanvasMedia.ts` | Keep media-list helper; call sites migrate default to workflow export |
+| `apps/web/src/pages/CanvasPage.vue` | Wire export modes + import file picker |
+| `apps/web/src/components/agent/AgentSideRail.vue` | Pass through export_pack options if present |
+| `apps/server/.../agent-canvas-tools.service.ts` | Optional: exportMediaPackage still returns canvasCommands; may add `exportMode`/`scope` on command |
+| `docs/superpowers/specs/...` / `docs/workflow/` | W2 agent guide + golden sample |
+| `services/agent-runtime/.../definitions.py` | Tool description update for workflow pack |
+
+---
+
+## Phase W1
+
+### Task 1: Shared schema + remap + validate
+
+**Files:**
+- Create: `packages/shared/src/canvas/workflowExchange.ts`
+- Create: `packages/shared/src/canvas/workflowExchange.test.ts`
+- Modify: `packages/shared/src/index.ts`
+
+**Interfaces:**
+- Produces:
+  - `WORKFLOW_FORMAT = 'lnkpi.workflow'`
+  - `WORKFLOW_VERSION = '1.0.0'`
+  - `WorkflowDocument` (zod infer)
+  - `validateWorkflow(input: unknown): WorkflowDocument` (throws / returns `{ ok, data, error }`)
+  - `inferMediaRole(data: Record<string, unknown>): 'generated' | 'uploaded' | 'none'`
+  - `buildWorkflowDocument(input: { nodes; edges; mode; exportMode; sourceSessionId?; mediaIndex? }): WorkflowDocument`
+  - `remapWorkflowIds(doc: WorkflowDocument, createId: (type: string) => string): { document: WorkflowDocument; idMap: Record<string, string> }`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+import { describe, expect, it } from 'vitest'
+import {
+  buildWorkflowDocument,
+  remapWorkflowIds,
+  validateWorkflow,
+  inferMediaRole,
+} from './workflowExchange'
+
+describe('workflowExchange', () => {
+  it('validateWorkflow accepts minimal doc', () => {
+    const doc = buildWorkflowDocument({
+      nodes: [{ id: 'image-1', type: 'image', position: { x: 0, y: 0 }, data: { prompt: 'p', url: 'https://x/a.png' } }],
+      edges: [],
+      mode: 'full',
+      exportMode: 'lightweight',
+    })
+    expect(doc.format).toBe('lnkpi.workflow')
+    expect(doc.version).toBe('1.0.0')
+    expect(validateWorkflow(doc).nodes[0].mediaRole).toMatch(/generated|uploaded|none/)
+  })
+
+  it('remapWorkflowIds rewrites edges and localRefs node ids', () => {
+    const doc = buildWorkflowDocument({
+      nodes: [
+        { id: 'image-1', type: 'image', position: { x: 0, y: 0 }, data: { url: 'https://x/a.png', localRefs: [{ nodeId: 'image-2' }] } },
+        { id: 'image-2', type: 'image', position: { x: 1, y: 0 }, data: { url: 'https://x/b.png' } },
+      ],
+      edges: [{ id: 'e1', source: 'image-2', target: 'image-1' }],
+      mode: 'full',
+      exportMode: 'full_package',
+      mediaIndex: [{ nodeId: 'image-1', kind: 'image', fileName: 'a.png', path: 'media/a.png' }],
+    })
+    let n = 0
+    const { document, idMap } = remapWorkflowIds(doc, (type) => `${type}-new-${++n}`)
+    expect(idMap['image-1']).toMatch(/^image-new-/)
+    expect(document.graph.edges[0].source).toBe(idMap['image-2'])
+    expect(document.graph.edges[0].target).toBe(idMap['image-1'])
+    expect((document.graph.nodes[0].data.localRefs as Array<{ nodeId: string }>)[0].nodeId).toBe(idMap['image-2'])
+    expect(document.mediaIndex[0].nodeId).toBe(idMap['image-1'])
+  })
+
+  it('inferMediaRole detects upload vs generated', () => {
+    expect(inferMediaRole({ url: 'https://x/a.png', imageVersions: [{ source: 'upload' }] })).toBe('uploaded')
+    expect(inferMediaRole({ url: 'https://x/a.png', generationRecordId: 'g1' })).toBe('generated')
+    expect(inferMediaRole({})).toBe('none')
+  })
+})
+```
+
+Adjust `localRefs` shape to match real `LocalRefBinding` in repo (read `packages/shared` / node data before coding).
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+```bash
+pnpm --filter @lnkpi/shared exec vitest run src/canvas/workflowExchange.test.ts
+```
+
+- [ ] **Step 3: Implement `workflowExchange.ts`**
+
+Include Zod schemas for top-level + graph + mediaIndex; `buildWorkflowDocument` sets `exportedAt: new Date().toISOString()` and assigns `mediaRole` per node; `remapWorkflowIds` walks nodes/edges/mediaIndex and recursively replaces known id strings inside `data.localRefs` / `mentionedKeys` only when they are node ids (document exact rules in code comments).
+
+- [ ] **Step 4: Re-export from `packages/shared/src/index.ts`**
+
+```typescript
+export * from './canvas/workflowExchange'
+```
+
+- [ ] **Step 5: Run tests — expect PASS**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/shared/src/canvas/workflowExchange.ts packages/shared/src/canvas/workflowExchange.test.ts packages/shared/src/index.ts
+git commit -m "feat(shared): lnkpi.workflow schema and id remap"
+```
+
+---
+
+### Task 2: Browser export — workflow zip / lightweight / advanced media-list
+
+**Files:**
+- Modify: `apps/web/package.json` (add `jszip`)
+- Create: `apps/web/src/composables/useWorkflowExchange.ts`
+- Create: `apps/web/src/composables/useWorkflowExchange.test.ts`
+- Modify: `apps/web/src/composables/useCanvasMedia.ts` (keep `downloadMediaPackage` for advanced)
+- Modify: `apps/web/src/pages/CanvasPage.vue`
+
+**Interfaces:**
+- Consumes: `buildWorkflowDocument`, `downloadMediaFile` / stream-download
+- Produces:
+  - `exportWorkflowPackage(opts: { nodes; edges; selectedIds; sessionId?; exportMode: 'full_package' | 'lightweight' | 'media_list_only' }): Promise<{ ok: boolean; mediaOk: number; mediaFail: number }>`
+
+- [ ] **Step 1: Add dependency**
+
+```bash
+pnpm --filter @lnkpi/web add jszip
+```
+
+- [ ] **Step 2: Failing test — full_package builds zip with workflow.json**
+
+Mock `downloadMediaFile` / fetch to return a tiny blob; assert JSZip contains `workflow.json` and `media/...`.
+
+- [ ] **Step 3: Implement `exportWorkflowPackage`**
+
+Logic:
+1. If `exportMode === 'media_list_only'` → call existing `downloadMediaPackage` and return.
+2. Resolve node set: `selectedIds.length ? selectedIds : all node ids`; include edges with both ends in set; expand group children like `duplicateSubgraph` if needed.
+3. `buildWorkflowDocument({ mode: selectedIds.length ? 'subgraph' : 'full', exportMode: full|light, ... })`.
+4. Lightweight: download `workflow.json` blob only.
+5. Full: for each media node, `downloadMediaFile` → arrayBuffer → zip.file(`media/${fileName}`); write `workflow.json`; trigger zip download as `lnkpi-workflow-${Date.now()}.zip`.
+6. Toast success/fail counts.
+
+- [ ] **Step 4: Wire CanvasPage**
+
+- Default `handlePackageDownload` / `handleExportPack` → `exportWorkflowPackage({ exportMode: 'full_package', ... })`.
+- Add advanced UI (menu item or modifier): `media_list_only` and `lightweight` (minimal: two extra actions in existing download menu if present; else temporary `window` confirm is **not** allowed — use existing canvas toolbar download menu patterns).
+
+Search CanvasPage for `@download` / download menu and extend labels:
+- 「导出工作流」→ full_package (default)
+- 「导出工作流（仅 JSON）」→ lightweight  
+- 「仅导出媒体清单」→ media_list_only
+
+- [ ] **Step 5: Tests PASS + commit**
+
+```bash
+pnpm --filter @lnkpi/web exec vitest run src/composables/useWorkflowExchange.test.ts src/composables/useCanvasMedia.test.ts
+git add apps/web/package.json apps/web/pnpm-lock.yaml pnpm-lock.yaml apps/web/src/composables/useWorkflowExchange.ts apps/web/src/composables/useWorkflowExchange.test.ts apps/web/src/pages/CanvasPage.vue
+git commit -m "feat(web): export canvas workflow zip package"
+```
+
+(Only stage lockfile paths that actually change.)
+
+---
+
+### Task 3: Browser import — merge into current canvas
+
+**Files:**
+- Modify: `apps/web/src/composables/useWorkflowExchange.ts`
+- Modify: `apps/web/src/composables/useWorkflowExchange.test.ts`
+- Modify: `apps/web/src/pages/CanvasPage.vue`
+- Possibly: upload helper already used by canvas file drop (`createFileNodeAt` / upload API)
+
+**Interfaces:**
+- Produces:
+  - `importWorkflowPackage(file: File, ctx: { nodes; edges; sessionId; applyMerge: (nodes, edges) => void | Promise<void> }): Promise<{ addedNodes: number; idMap: Record<string, string> }>`
+
+- [ ] **Step 1: Failing tests**
+
+- Zip with two nodes + one edge → after import, `applyMerge` receives remapped nodes/edges; no id collision with seed canvas ids.
+- Invalid format → throws / returns error, no merge.
+
+- [ ] **Step 2: Implement import**
+
+1. If `.json`, parse text; if `.zip`, JSZip.loadAsync → read `workflow.json` + `media/*`.
+2. `validateWorkflow`.
+3. `remapWorkflowIds` with canvas id factory (reuse `createNodeId` style from CanvasPage / shared).
+4. For each mediaIndex path, read zip file → upload via existing upload API → set `data.url` on remapped node.
+5. Offset positions (+80,+80) so imports are visible.
+6. `applyMerge` appends nodes/edges and `persistUserEdit` / equivalent.
+
+- [ ] **Step 3: UI**
+
+Hidden `<input type="file" accept=".zip,.json">` + toolbar/menu「导入工作流」.
+
+- [ ] **Step 4: Tests PASS + commit**
+
+```bash
+git commit -m "feat(web): import workflow package into current canvas"
+```
+
+---
+
+### Task 4: Agent path — export_pack triggers workflow export
+
+**Files:**
+- Modify: `apps/web/src/components/agent/AgentSideRail.vue` (`canvas_command` `export_pack`)
+- Modify: `apps/web/src/pages/CanvasPage.vue` `handleExportPack`
+- Modify: `apps/server/src/agent/agent-canvas-tools.service.ts` (canvasCommands payload may include `exportMode?: 'full_package'`)
+- Modify: `services/agent-runtime/app/tools/definitions.py` description
+- Test: extend server test for canvasCommands shape; web handler smoke if easy
+
+**Interfaces:**
+- `canvasCommands: [{ type: 'export_pack', nodeIds: string[], exportMode?: 'full_package' | 'lightweight' }]`
+- Empty `nodeIds` from Nest means「整布」for Agent export of all media nodes — **CanvasPage**: if `nodeIds.length === 0`, treat as full canvas; if non-empty, use as selection scope.
+
+- [ ] **Step 1: Update Nest command** default `exportMode: 'full_package'` on `canvasCommands[0]`.
+
+- [ ] **Step 2: SideRail/CanvasPage** call `exportWorkflowPackage` instead of `downloadMediaPackage`.
+
+- [ ] **Step 3: Tool description** — say browser downloads workflow zip (graph+media), not markdown links.
+
+- [ ] **Step 4: Tests + commit**
+
+```bash
+git commit -m "feat(agent): export_pack downloads workflow package"
+```
+
+---
+
+## Phase W2 (after W1 merged)
+
+### Task 5: Docs, validate CLI surface, golden sample
+
+**Files:**
+- Create: `docs/workflow/README.md` (Agent learning guide)
+- Create: `docs/workflow/examples/minimal-workflow.json`
+- Optionally: `packages/shared` already exports `validateWorkflow` — document usage
+- Add test that loads golden sample through `validateWorkflow`
+
+- [ ] **Step 1: Write golden JSON** matching schema (2 nodes + 1 edge, lightweight).
+
+- [ ] **Step 2: README sections:** schema fields, how to generate, import steps, validation snippet.
+
+- [ ] **Step 3: Test loads example + commit**
+
+```bash
+git commit -m "docs(workflow): agent guide and golden workflow sample"
+```
+
+---
+
+## Spec coverage (self-review)
+
+| Spec requirement | Task |
+| --- | --- |
+| full_package zip default | T2 |
+| lightweight optional | T2 |
+| media_list advanced | T2 |
+| subgraph vs full scope | T2 |
+| schema + mediaRole | T1 |
+| remap import merge | T1+T3 |
+| Agent same path | T4 |
+| A2.1 zip folded in | T2 |
+| W2 docs/validate/golden | T5 |
+| No CVM zip | T2 (browser only) |
+
+**Placeholders:** none intentional.  
+**Type names:** `exportMode` / `mode` / `mediaRole` / `remapWorkflowIds` consistent across tasks.

--- a/docs/superpowers/specs/2026-09-12-canvas-workflow-exchange-design.md
+++ b/docs/superpowers/specs/2026-09-12-canvas-workflow-exchange-design.md
@@ -1,0 +1,182 @@
+# 画布工作流交换（导出 / 导入）设计
+
+> 日期：2026-09-12  
+> 状态：已批准（对话确认 §1–§3）  
+> 产品：超创平台（lnkpi）无限画布  
+> 方案：**浏览器侧组包**（JSZip / 流式 zip）；导入合并进当前画布  
+> 相关：Wave A A2 导出打包、A2.1 真 zip、A3 媒体持久化  
+
+## 1. 背景与目标
+
+当前「导出打包」产出的 JSON 仅为**媒体清单**（nodeId / url / fileName），不含拓扑、连线、提示词、芯片 refs，也无法再导入画布。
+
+用户需要：
+
+1. **W1 往返交换：** 导出可二次编辑的工作流包（图结构 + 媒体）；导入合并进当前画布。  
+2. **W2 Agent 学习契约：** 同一 schema 供 WorkBuddy / Codex 等学习后生成可导入 JSON，还原拓扑。
+
+**北极星：** 导出 →（可选外部 Agent 改写）→ 导入后，拓扑与提示词可用，媒体可预览/再生成。
+
+## 2. 已确认决策
+
+| 项 | 选择 |
+|----|------|
+| 规格范围 | **D**：W1+W2 同规格描述；实现顺序 **W1 → W2** |
+| 导入落点 | **B**：合并进**当前**画布；ID 冲突则整图重映射 |
+| 媒体 | **B 默认**：JSON + `media/` 同包；**轻量可选**：仅 JSON + URL |
+| 导出范围 | **C**：默认整布；有多选则导出选中子图（含其间边） |
+| 与现有导出 | **A**：升级现有「导出打包」为工作流包；旧「仅媒体清单」降为高级选项 |
+| 组包位置 | 浏览器侧（方案 1）；不在 CVM 落大临时 zip |
+
+## 3. 包格式
+
+### 3.1 默认：`full_package`
+
+```text
+lnkpi-workflow-<timestamp>.zip
+├── workflow.json
+├── media/
+│   └── <stableFileName>
+└── README.md                 # W1 可占位；W2 写完整 Agent 指引
+```
+
+### 3.2 轻量：`lightweight`
+
+仅下载 `lnkpi-workflow-<timestamp>.json`（内容即 `workflow.json`），媒体以 URL 字段保留。
+
+## 4. `workflow.json` Schema（`lnkpi.workflow` v1）
+
+### 4.1 顶层
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `format` | `"lnkpi.workflow"` | 固定 |
+| `version` | `"1.0.0"` | semver |
+| `exportedAt` | ISO string | |
+| `sourceSessionId` | string? | |
+| `mode` | `"full"` \| `"subgraph"` | 整布 / 选中子图 |
+| `exportMode` | `"full_package"` \| `"lightweight"` | |
+| `graph` | object | `nodes`, `edges` |
+| `mediaIndex` | array | 媒体索引 |
+
+### 4.2 `graph.nodes[]`
+
+| 字段 | 说明 |
+|------|------|
+| `id`, `type`, `position` | 与 `CanvasNode` 对齐 |
+| `parentId?` | 分组 |
+| `data` | 原样保留业务字段：`title`, `prompt`/`content`, `status`, `localRefs`, `mentionedKeys`, `url`, 版本信息等（**不新造第二套 refs 语法**） |
+| `mediaRole` | `"generated"` \| `"uploaded"` \| `"none"`（由 url / `imageVersions.source` / 上传标记推断） |
+
+### 4.3 `graph.edges[]`
+
+`id`, `source`, `target`（与现有 `CanvasEdge` 对齐）。
+
+### 4.4 `mediaIndex[]`
+
+| 字段 | 说明 |
+|------|------|
+| `nodeId` | |
+| `kind` | `image` \| `video` \| `audio` \| … |
+| `fileName` | |
+| `path?` | 包内相对路径，如 `media/xxx.png`（full_package） |
+| `url?` | 导出时 upstream / 本站 URL（lightweight 或回退） |
+| `persistedUrl?` | 若 A3 已 persist（可选增强） |
+| `error?` | 拉取失败时记录 |
+
+校验：Zod，置于 `packages/shared`；导出前与导入前各校验一次。
+
+## 5. 数据流
+
+### 5.1 导出
+
+```text
+UI「导出打包」或 Agent export（canvasCommands.export_pack）
+  → scope = multiSelect ? subgraph : full
+  → exportMode = full_package | lightweight（高级）
+  → 序列化 graph + mediaRole + mediaIndex
+  → full_package: stream-download 拉媒体 → JSZip → .zip
+  → lightweight: 仅 workflow.json
+  → 本机下载
+```
+
+部分媒体失败：仍出包；`mediaIndex[].error` + toast「成功 x / 失败 y」。
+
+### 5.2 导入
+
+```text
+选择 .zip 或 workflow.json
+  → 校验 format/version
+  → 解析 graph + media/
+  → remapWorkflowIds（节点、边、data 内 node 引用）
+  → 媒体优先包内文件 → 上传/挂到节点 url
+  → 合并进当前 Session.canvasData 并 persist
+```
+
+冲突策略：**始终重映射 ID**，不覆盖当前画布同名节点。
+
+## 6. 入口与人机同路径
+
+| 入口 | 行为 |
+|------|------|
+| 完成态「导出打包」/ 画布菜单 | 默认工作流包 |
+| 高级选项 | 仅媒体清单（A2 旧行为）；轻量 workflow JSON |
+| 画布「导入工作流」 | 新 UI |
+| Agent | 导出：扩展现有 `export_pack`（可带 `mode`/`scope`/`exportMode`）；导入：W1 可后置 `import_workflow` tool，须走同一解析/remap 服务 |
+
+## 7. 与 Wave A 关系
+
+| 能力 | 关系 |
+|------|------|
+| A2 媒体清单 | 降为高级选项 |
+| A2.1 真 zip | **并入 W1 默认包**，不再空转单独战役 |
+| A3 COS | 可选：有 persist 则写入 `persistedUrl`；未配置不挡导出 |
+
+## 8. 非目标
+
+- 跨账号模板市场 / 公开工作流商店  
+- 自动角色 LoRA / 一致性训练  
+- worldModel / 3D  
+- 默认生成即全量 rehost  
+- 服务端 CVM 落大临时 zip  
+
+## 9. 验收
+
+### 9.1 W1
+
+1. 默认导出 zip：含 `workflow.json`；有媒体时含 `media/` 文件。  
+2. 轻量模式仅 JSON，含拓扑与 prompt/refs。  
+3. 多选→子图；无选中→整布。  
+4. 导入 zip/json → 合并当前画布；新 ID；边与 refs 不断。  
+5. 导入后节点可继续编辑/再生成。  
+6. Agent 导出触发本机工作流包下载。  
+7. 「仅媒体清单」高级入口仍可用。
+
+### 9.2 W2
+
+1. 文档：schema + 示例 +「如何生成可导入 JSON」。  
+2. 共享 `validateWorkflow`；非法包拒绝导入。  
+3. 至少一个「示例 JSON → 导入成功」黄金用例。
+
+## 10. 风险与缓解
+
+| 风险 | 缓解 |
+|------|------|
+| 大包浏览器 OOM | 单文件上限对齐 stream-download；超限跳过并记 error |
+| refs 重映射漏改 | 集中 `remapWorkflowIds`；单测覆盖 localRefs / edges |
+| 旧清单习惯 | 高级保留；默认文案改为「导出工作流」 |
+| 外部 Agent 乱生成 | W2 强校验；导入失败可读 |
+
+## 11. 实现切片（plan 拆 Task）
+
+1. Shared Zod schema + `remapWorkflowIds` 纯函数 + 单测  
+2. 前端导出：JSZip 升级现有导出入口（默认包 + 轻量 + 高级清单）  
+3. 前端导入：文件选择 → 校验 → 合并 persist  
+4. Agent/Nest：`export_pack` 参数扩展；可选 `import_workflow`  
+5. W2：README/docs + validate + 金样  
+
+## 12. 文档
+
+- 本文件：设计规格  
+- 实现计划：`docs/superpowers/plans/2026-09-12-canvas-workflow-exchange.md`（规格审阅通过后 writing-plans）  
+- Wave A 纲领：可增补「工作流交换」为交付增强（不回退 A2 媒体导出可用性）


### PR DESCRIPTION
## Summary
- Fix edit-intent popover clipped at panel top by using `placement=\"below-end\"`.
- Chip row: keep stain preset as **清除瑕疵**, remove **替换选区内容**, move **编辑意图** picker next to it (shows active intent label).

## Test plan
- [ ] Open Refine → chips show `[清除瑕疵] [编辑意图]`; no replace chip
- [ ] Click 编辑意图 → picker opens below chips (not clipped)
- [ ] Select an intent → chip label updates; clear works
- [ ] 清除瑕疵 fills STAIN preset and clears active intent