### PR TITLE
fix(web): portal Refine edit-intent picker (overflow clip)

### DIFF
--- a/apps/web/src/components/canvas/dock-studio/shared/GuidePickerPopover.test.ts
+++ b/apps/web/src/components/canvas/dock-studio/shared/GuidePickerPopover.test.ts
@@ -17,32 +17,81 @@ describe('GuidePickerPopover', () => {
   it('applies above-end placement for bottom dock popovers', () => {
     const wrapper = mount(GuidePickerPopover, {
       props: { ...defaultProps, placement: 'above-end' },
+      attachTo: document.body,
     })
 
-    expect(wrapper.classes()).toContain('guide-picker-popover--above-end')
+    expect(wrapper.find('.guide-picker-popover--above-end').exists()).toBe(true)
     wrapper.unmount()
   })
 
   it('applies below-end placement for top-of-panel pickers (Refine)', () => {
     const wrapper = mount(GuidePickerPopover, {
       props: { ...defaultProps, mode: 'edit_intent', placement: 'below-end' },
+      attachTo: document.body,
     })
 
-    expect(wrapper.classes()).toContain('guide-picker-popover--below-end')
+    expect(wrapper.find('.guide-picker-popover--below-end').exists()).toBe(true)
     wrapper.unmount()
   })
 
+  it('portals to body with fixed coords so overflow parents cannot clip', async () => {
+    const anchor = document.createElement('button')
+    anchor.getBoundingClientRect = () =>
+      ({
+        top: 120,
+        bottom: 148,
+        left: 400,
+        right: 520,
+        width: 120,
+        height: 28,
+        x: 400,
+        y: 120,
+        toJSON: () => ({}),
+      }) as DOMRect
+    document.body.appendChild(anchor)
+
+    const wrapper = mount(GuidePickerPopover, {
+      props: {
+        ...defaultProps,
+        mode: 'edit_intent',
+        placement: 'below-end',
+        portal: true,
+        anchorEl: anchor,
+      },
+      attachTo: document.body,
+    })
+
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+
+    const panel = document.body.querySelector('.guide-picker-popover--portal') as HTMLElement | null
+    expect(panel).toBeTruthy()
+    expect(panel?.style.position).toBe('fixed')
+    expect(panel?.style.top).toBe('156px')
+    expect(Number.parseFloat(panel?.style.left || '0')).toBeGreaterThanOrEqual(12)
+    expect(document.body.contains(panel)).toBe(true)
+
+    wrapper.unmount()
+    anchor.remove()
+  })
+
   it('emits close on window Escape even without focus inside', async () => {
-    const wrapper = mount(GuidePickerPopover, { props: defaultProps })
+    const wrapper = mount(GuidePickerPopover, {
+      props: defaultProps,
+      attachTo: document.body,
+    })
 
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
 
-    expect(wrapper.emitted('close')).toHaveLength(1)
+    expect(wrapper.emitted('close') ?? []).toHaveLength(1)
     wrapper.unmount()
   })
 
   it('defaultPrevents Escape so dock handlers can bail', async () => {
-    mount(GuidePickerPopover, { props: defaultProps })
+    const wrapper = mount(GuidePickerPopover, {
+      props: defaultProps,
+      attachTo: document.body,
+    })
 
     const event = new KeyboardEvent('keydown', {
       key: 'Escape',
@@ -52,5 +101,6 @@ describe('GuidePickerPopover', () => {
     window.dispatchEvent(event)
 
     expect(event.defaultPrevented).toBe(true)
+    wrapper.unmount()
   })
 })

--- a/apps/web/src/components/canvas/dock-studio/shared/GuidePickerPopover.vue
+++ b/apps/web/src/components/canvas/dock-studio/shared/GuidePickerPopover.vue
@@ -8,7 +8,7 @@ import {
   type GuideCapabilities,
   type GuideKind,
 } from '@lnkpi/shared'
-import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
+import { computed, nextTick, onUnmounted, ref, watch, type CSSProperties } from 'vue'
 import { guidePickerDisabledReason } from './guidePickerDisable'
 import { filterGuideItems, groupGuideItems } from './guidePickerFilter'
 
@@ -22,10 +22,16 @@ const props = withDefaults(
     open: boolean
     refImageCount?: number
     placement?: 'below-start' | 'below-end' | 'above-end'
+    /** Escape overflow:auto ancestors (e.g. Refine side panel body). */
+    portal?: boolean
+    /** Required when portal=true — position relative to this element. */
+    anchorEl?: HTMLElement | null
   }>(),
   {
     refImageCount: 0,
     placement: 'below-start',
+    portal: false,
+    anchorEl: null,
   },
 )
 
@@ -37,6 +43,8 @@ const emit = defineEmits<{
 
 const query = ref('')
 const searchInput = ref<HTMLInputElement | null>(null)
+const panelRef = ref<HTMLElement | null>(null)
+const portalStyle = ref<CSSProperties>({})
 
 const items = computed<GuideItem[]>(() =>
   props.mode === 'generation_scene'
@@ -59,6 +67,55 @@ const clearLabel = computed(() =>
   props.mode === 'generation_scene' ? '清除场景' : '清除意图',
 )
 
+const POPOVER_WIDTH = 288
+const VIEW_MARGIN = 12
+const GAP = 8
+const EST_HEIGHT = 340
+
+function clamp(n: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, n))
+}
+
+function updatePortalPosition() {
+  if (!props.portal || !props.anchorEl || typeof window === 'undefined') return
+  const rect = props.anchorEl.getBoundingClientRect()
+  const width = Math.min(POPOVER_WIDTH, window.innerWidth - VIEW_MARGIN * 2)
+  const measured = panelRef.value?.getBoundingClientRect().height
+  const height = measured && measured > 0 ? measured : EST_HEIGHT
+
+  let top: number
+  const preferBelow = props.placement !== 'above-end'
+  const spaceBelow = window.innerHeight - rect.bottom - GAP - VIEW_MARGIN
+  const spaceAbove = rect.top - GAP - VIEW_MARGIN
+  const placeBelow = preferBelow
+    ? spaceBelow >= Math.min(height, 200) || spaceBelow >= spaceAbove
+    : spaceAbove < Math.min(height, 200) && spaceBelow > spaceAbove
+
+  if (placeBelow) {
+    top = rect.bottom + GAP
+  } else {
+    top = rect.top - height - GAP
+  }
+
+  let left =
+    props.placement === 'below-start'
+      ? rect.left
+      : rect.right - width
+
+  left = clamp(left, VIEW_MARGIN, window.innerWidth - width - VIEW_MARGIN)
+  top = clamp(top, VIEW_MARGIN, window.innerHeight - VIEW_MARGIN)
+
+  portalStyle.value = {
+    position: 'fixed',
+    top: `${top}px`,
+    left: `${left}px`,
+    width: `${width}px`,
+    zIndex: 120,
+    right: 'auto',
+    bottom: 'auto',
+  }
+}
+
 function handleWindowEscape(event: KeyboardEvent) {
   if (event.key !== 'Escape') return
   event.preventDefault()
@@ -67,22 +124,45 @@ function handleWindowEscape(event: KeyboardEvent) {
   emit('close')
 }
 
+function onViewportChange() {
+  updatePortalPosition()
+}
+
 watch(
   () => props.open,
   (open, _prev, onCleanup) => {
     if (!open) return
     query.value = ''
-    void nextTick(() => searchInput.value?.focus())
+    void nextTick(() => {
+      searchInput.value?.focus()
+      updatePortalPosition()
+      void nextTick(() => updatePortalPosition())
+    })
     window.addEventListener('keydown', handleWindowEscape, { capture: true })
+    if (props.portal) {
+      window.addEventListener('resize', onViewportChange)
+      window.addEventListener('scroll', onViewportChange, true)
+    }
     onCleanup(() => {
       window.removeEventListener('keydown', handleWindowEscape, { capture: true })
+      window.removeEventListener('resize', onViewportChange)
+      window.removeEventListener('scroll', onViewportChange, true)
     })
   },
   { immediate: true },
 )
 
+watch(
+  () => [props.anchorEl, props.placement, props.portal] as const,
+  () => {
+    if (props.open) updatePortalPosition()
+  },
+)
+
 onUnmounted(() => {
   window.removeEventListener('keydown', handleWindowEscape, { capture: true })
+  window.removeEventListener('resize', onViewportChange)
+  window.removeEventListener('scroll', onViewportChange, true)
 })
 
 function disabledReason(id: string): string | null {
@@ -102,84 +182,91 @@ function onEscape(event: KeyboardEvent) {
 </script>
 
 <template>
-  <section
-    v-if="open"
-    class="guide-picker-popover neo-popover"
-    :class="`guide-picker-popover--${placement}`"
-    role="dialog"
-    :aria-label="mode === 'generation_scene' ? '选择生成场景' : '选择编辑意图'"
-    @keydown.escape.prevent="onEscape"
-  >
-    <div class="guide-picker-popover__search">
-      <span aria-hidden="true" class="guide-picker-popover__search-icon">⌕</span>
-      <input
-        ref="searchInput"
-        v-model="query"
-        type="search"
-        class="guide-picker-popover__input"
-        :placeholder="searchPlaceholder"
-        autocomplete="off"
-      />
-    </div>
+  <Teleport to="body" :disabled="!portal">
+    <section
+      v-if="open"
+      ref="panelRef"
+      class="guide-picker-popover neo-popover"
+      :class="[
+        `guide-picker-popover--${placement}`,
+        { 'guide-picker-popover--portal': portal },
+      ]"
+      :style="portal ? portalStyle : undefined"
+      role="dialog"
+      :aria-label="mode === 'generation_scene' ? '选择生成场景' : '选择编辑意图'"
+      @keydown.escape.prevent="onEscape"
+    >
+      <div class="guide-picker-popover__search">
+        <span aria-hidden="true" class="guide-picker-popover__search-icon">⌕</span>
+        <input
+          ref="searchInput"
+          v-model="query"
+          type="search"
+          class="guide-picker-popover__input"
+          :placeholder="searchPlaceholder"
+          autocomplete="off"
+        />
+      </div>
 
-    <div class="guide-picker-popover__list">
-      <template v-if="groups.length">
-        <section
-          v-for="group in groups"
-          :key="group.groupId"
-          class="guide-picker-popover__group"
-        >
-          <h3 class="guide-picker-popover__group-label">
-            {{ group.groupLabel }}
-          </h3>
-          <button
-            v-for="item in group.items"
-            :key="item.id"
-            type="button"
-            class="guide-picker-popover__item neo-popover-item"
-            :class="{ 'is-active': activeId === item.id }"
-            :disabled="Boolean(disabledReason(item.id))"
-            :title="disabledReason(item.id) || item.description"
-            :aria-current="activeId === item.id ? 'true' : undefined"
-            @click="selectItem(item)"
+      <div class="guide-picker-popover__list">
+        <template v-if="groups.length">
+          <section
+            v-for="group in groups"
+            :key="group.groupId"
+            class="guide-picker-popover__group"
           >
-            <span class="guide-picker-popover__item-copy">
-              <span class="guide-picker-popover__item-label">
-                {{ item.label }}
-              </span>
-              <span class="guide-picker-popover__item-description">
-                {{ item.description }}
-              </span>
-            </span>
-            <span
-              v-if="disabledReason(item.id)"
-              class="guide-picker-popover__disabled"
+            <h3 class="guide-picker-popover__group-label">
+              {{ group.groupLabel }}
+            </h3>
+            <button
+              v-for="item in group.items"
+              :key="item.id"
+              type="button"
+              class="guide-picker-popover__item neo-popover-item"
+              :class="{ 'is-active': activeId === item.id }"
+              :disabled="Boolean(disabledReason(item.id))"
+              :title="disabledReason(item.id) || item.description"
+              :aria-current="activeId === item.id ? 'true' : undefined"
+              @click="selectItem(item)"
             >
-              不可用
-            </span>
-            <span
-              v-else-if="activeId === item.id"
-              class="guide-picker-popover__active-mark"
-              aria-hidden="true"
-            >
-              ✓
-            </span>
-          </button>
-        </section>
-      </template>
-      <p v-else class="guide-picker-popover__empty">没有匹配结果</p>
-    </div>
+              <span class="guide-picker-popover__item-copy">
+                <span class="guide-picker-popover__item-label">
+                  {{ item.label }}
+                </span>
+                <span class="guide-picker-popover__item-description">
+                  {{ item.description }}
+                </span>
+              </span>
+              <span
+                v-if="disabledReason(item.id)"
+                class="guide-picker-popover__disabled"
+              >
+                不可用
+              </span>
+              <span
+                v-else-if="activeId === item.id"
+                class="guide-picker-popover__active-mark"
+                aria-hidden="true"
+              >
+                ✓
+              </span>
+            </button>
+          </section>
+        </template>
+        <p v-else class="guide-picker-popover__empty">没有匹配结果</p>
+      </div>
 
-    <footer v-if="activeId" class="guide-picker-popover__footer">
-      <button
-        type="button"
-        class="guide-picker-popover__clear"
-        @click="emit('clear')"
-      >
-        {{ clearLabel }}
-      </button>
-    </footer>
-  </section>
+      <footer v-if="activeId" class="guide-picker-popover__footer">
+        <button
+          type="button"
+          class="guide-picker-popover__clear"
+          @click="emit('clear')"
+        >
+          {{ clearLabel }}
+        </button>
+      </footer>
+    </section>
+  </Teleport>
 </template>
 
 <style scoped>
@@ -203,6 +290,14 @@ function onEscape(event: KeyboardEvent) {
   top: auto;
   right: 0;
   bottom: calc(100% + 8px);
+  left: auto;
+}
+
+.guide-picker-popover--portal {
+  /* Inline style supplies fixed top/left/width; reset absolute placement. */
+  top: auto;
+  right: auto;
+  bottom: auto;
   left: auto;
 }
 

--- a/apps/web/src/components/canvas/refine/RefineSidePanel.vue
+++ b/apps/web/src/components/canvas/refine/RefineSidePanel.vue
@@ -57,6 +57,7 @@ const emit = defineEmits<{
 
 const editor = useCanvasEditorStore()
 const promptRef = ref<HTMLTextAreaElement | null>(null)
+const editIntentAnchorRef = ref<HTMLElement | null>(null)
 const prompt = ref('')
 const activeGuideEditIntentId = ref<string | null>(null)
 const editIntentPickerOpen = ref(false)
@@ -726,6 +727,7 @@ onBeforeUnmount(() => {
           <button type="button" class="refine-dock__chip" :disabled="busy" @click="applyStainPreset">清除瑕疵</button>
           <div class="relative">
             <button
+              ref="editIntentAnchorRef"
               type="button"
               class="refine-dock__chip refine-dock__chip--intent"
               :class="{ 'is-guide-active': activeGuideEditIntentId }"
@@ -749,13 +751,14 @@ onBeforeUnmount(() => {
               />
             </button>
             <GuidePickerPopover
-              class="refine-side__guide-picker"
               mode="edit_intent"
               :active-id="activeGuideEditIntentId"
               :capabilities="guideCapabilities"
               :open="editIntentPickerOpen"
               :ref-image-count="refineRefImageCount"
               placement="below-end"
+              portal
+              :anchor-el="editIntentAnchorRef"
               @select="applyEditIntent"
               @clear="clearEditIntent"
               @close="editIntentPickerOpen = false"
@@ -945,11 +948,6 @@ onBeforeUnmount(() => {
   border-color: color-mix(in srgb, rgb(232 121 249) 25%, transparent);
   background: color-mix(in srgb, rgb(217 70 239) 15%, transparent);
   color: rgb(240 171 252);
-}
-
-.refine-side__guide-picker {
-  right: 0;
-  left: auto;
 }
 
 .refine-side__icon-btn:disabled {


### PR DESCRIPTION
## Summary
- Root cause: Refine \`GuidePickerPopover\` was \`position: absolute\` inside \`.refine-side__body { overflow: auto }\`, so the dropdown was clipped.
- Fix: optional \`portal\` + \`anchorEl\` — Teleport to \`body\` with fixed coords (viewport clamp / flip). Refine chips use \`portal\`.

## Test plan
- [x] \`vitest\` GuidePickerPopover (incl. portal fixed coords)
- [ ] Prod Refine → open 编辑意图 → full list visible, not clipped by panel
- [ ] Esc still closes picker first


Made with [Cursor](https://cursor.com)