### PR TITLE
feat(web): place workflow imports in blank space and fit view

### DIFF
--- a/apps/web/src/composables/useWorkflowExchange.test.ts
+++ b/apps/web/src/composables/useWorkflowExchange.test.ts
@@ -30,6 +30,12 @@ vi.mock('./useCanvasMedia', async () => {
 import { buildWorkflowDocument } from '@lnkpi/shared'
 import { exportWorkflowPackage, importWorkflowPackage } from './useWorkflowExchange'
 import { downloadMediaPackage } from './useCanvasMedia'
+import {
+  IMPORT_NODE_ESTIMATE,
+  IMPORT_PLACE_MARGIN,
+  rectsOverlap,
+  unionNodeBBox,
+} from './workflowImportPlacement'
 
 async function zipWithWorkflow(
   doc: ReturnType<typeof buildWorkflowDocument>,
@@ -282,13 +288,95 @@ describe('importWorkflowPackage', () => {
     expect(Object.keys(result.idMap)).toEqual(expect.arrayContaining(['prompt-1', 'image-1']))
     expect(mergedNodes.map((n) => n.id)).toEqual(['prompt-imported-1', 'image-imported-2'])
     expect(mergedNodes.every((n) => !seedNodes.some((s) => s.id === n.id))).toBe(true)
-    expect(mergedNodes[0].position).toEqual({ x: 90, y: 100 })
-    expect(mergedNodes[1].position).toEqual({ x: 180, y: 100 })
+    // Uniform translation: relative delta between roots preserved from file (90px x)
+    expect(mergedNodes[1].position.x - mergedNodes[0].position.x).toBe(90)
+    expect(mergedNodes[1].position.y - mergedNodes[0].position.y).toBe(0)
     expect(mergedEdges).toHaveLength(1)
     expect(mergedEdges[0].source).toBe('prompt-imported-1')
     expect(mergedEdges[0].target).toBe('image-imported-2')
     expect(uploadMediaMock).toHaveBeenCalledOnce()
     expect(mergedNodes[1].data?.url).toBe('https://cdn.example/uploaded.png')
+  })
+
+  it('places import away from overlapping canvas seed with margin', async () => {
+    const doc = buildWorkflowDocument({
+      nodes: [
+        {
+          id: 'prompt-1',
+          type: 'prompt',
+          position: { x: 0, y: 0 },
+          data: { prompt: 'hello' },
+        },
+      ],
+      edges: [],
+      mode: 'full',
+      exportMode: 'lightweight',
+      mediaIndex: [],
+    })
+    const file = new File([JSON.stringify(doc)], 'workflow.json', { type: 'application/json' })
+    const seedNodes = [{ id: 'seed-1', type: 'prompt', position: { x: 0, y: 0 }, data: {} }]
+    const applyMerge = vi.fn()
+    let seq = 0
+
+    await importWorkflowPackage(file, {
+      nodes: seedNodes,
+      edges: [],
+      applyMerge,
+      createId: (type) => `${type}-place-${++seq}`,
+      uploadMedia: uploadMediaMock,
+      getViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+      getContainerSize: () => ({ width: 1000, height: 800 }),
+    })
+
+    expect(applyMerge).toHaveBeenCalledOnce()
+    const [mergedNodes] = applyMerge.mock.calls[0] as [
+      Array<{ id: string; position: { x: number; y: number } }>,
+    ]
+    const seedBBox = unionNodeBBox(seedNodes)!
+    const importBBox = unionNodeBBox(mergedNodes)!
+    expect(rectsOverlap(seedBBox, importBBox, IMPORT_PLACE_MARGIN)).toBe(false)
+    // Not the old fixed +80 path
+    expect(mergedNodes[0].position).not.toEqual({ x: 80, y: 80 })
+  })
+
+  it('calls fitImportedNodes with remapped ids after merge', async () => {
+    const doc = buildWorkflowDocument({
+      nodes: [
+        {
+          id: 'prompt-1',
+          type: 'prompt',
+          position: { x: 0, y: 0 },
+          data: { prompt: 'hello' },
+        },
+        {
+          id: 'image-1',
+          type: 'image',
+          position: { x: 100, y: 0 },
+          data: { url: 'https://cdn.example/a.png' },
+        },
+      ],
+      edges: [],
+      mode: 'full',
+      exportMode: 'lightweight',
+      mediaIndex: [],
+    })
+    const file = new File([JSON.stringify(doc)], 'workflow.json', { type: 'application/json' })
+    const applyMerge = vi.fn()
+    const fitImportedNodes = vi.fn()
+    let seq = 0
+
+    await importWorkflowPackage(file, {
+      nodes: [],
+      edges: [],
+      applyMerge,
+      createId: (type) => `${type}-fit-${++seq}`,
+      uploadMedia: uploadMediaMock,
+      fitImportedNodes,
+    })
+
+    expect(applyMerge).toHaveBeenCalledOnce()
+    expect(fitImportedNodes).toHaveBeenCalledOnce()
+    expect(fitImportedNodes).toHaveBeenCalledWith(['prompt-fit-1', 'image-fit-2'])
   })
 
   it('rejects invalid format without calling applyMerge', async () => {
@@ -332,15 +420,18 @@ describe('importWorkflowPackage', () => {
       mediaIndex: [],
     })
     const file = new File([JSON.stringify(doc)], 'workflow.json', { type: 'application/json' })
+    const seedNodes = [{ id: 'seed-1', type: 'prompt', position: { x: 0, y: 0 }, data: {} }]
     const applyMerge = vi.fn()
     let seq = 0
 
     await importWorkflowPackage(file, {
-      nodes: [],
+      nodes: seedNodes,
       edges: [],
       applyMerge,
       createId: (type) => `${type}-grp-${++seq}`,
       uploadMedia: uploadMediaMock,
+      getViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+      getContainerSize: () => ({ width: 1000, height: 800 }),
     })
 
     expect(applyMerge).toHaveBeenCalledOnce()
@@ -358,7 +449,10 @@ describe('importWorkflowPackage', () => {
     const child = mergedNodes.find((n) => n.id === 'prompt-grp-2')
     expect(parent).toBeDefined()
     expect(child).toBeDefined()
-    expect(parent!.position).toEqual({ x: 120, y: 130 })
+    // Same uniform translation applied to root only
+    const dx = parent!.position.x - 40
+    const dy = parent!.position.y - 50
+    expect(dx !== 0 || dy !== 0).toBe(true)
     expect(child!.position).toEqual({ x: 12, y: 18 })
     expect(child!.parentNode).toBe('group-grp-1')
     expect(child!.extent).toBe('parent')
@@ -366,6 +460,15 @@ describe('importWorkflowPackage', () => {
     expect(parent!.parentNode).toBeUndefined()
     expect(parent!.extent).toBeUndefined()
     expect(parent!.expandParent).toBeUndefined()
+    // Placed root clears seed with margin
+    const seedBBox = unionNodeBBox(seedNodes)!
+    const placedRoot = {
+      x: parent!.position.x,
+      y: parent!.position.y,
+      width: IMPORT_NODE_ESTIMATE.width,
+      height: IMPORT_NODE_ESTIMATE.height,
+    }
+    expect(rectsOverlap(seedBBox, placedRoot, IMPORT_PLACE_MARGIN)).toBe(false)
   })
 
   it('lightweight json keeps existing urls without re-upload', async () => {

--- a/apps/web/src/composables/useWorkflowExchange.test.ts
+++ b/apps/web/src/composables/useWorkflowExchange.test.ts
@@ -376,6 +376,9 @@ describe('importWorkflowPackage', () => {
 
     expect(applyMerge).toHaveBeenCalledOnce()
     expect(fitImportedNodes).toHaveBeenCalledOnce()
+    expect(applyMerge.mock.invocationCallOrder[0]).toBeLessThan(
+      fitImportedNodes.mock.invocationCallOrder[0],
+    )
     expect(fitImportedNodes).toHaveBeenCalledWith(['prompt-fit-1', 'image-fit-2'])
   })
 

--- a/apps/web/src/composables/useWorkflowExchange.ts
+++ b/apps/web/src/composables/useWorkflowExchange.ts
@@ -15,6 +15,7 @@ import {
   triggerBlobDownload,
   type DownloadMediaOptions,
 } from './useCanvasMedia'
+import { computeImportTranslation } from './workflowImportPlacement'
 
 export type WorkflowExportMode = 'full_package' | 'lightweight' | 'media_list_only'
 
@@ -59,6 +60,9 @@ export interface ImportWorkflowPackageContext {
   ) => void | Promise<void>
   createId?: (type: string) => string
   uploadMedia?: (file: File) => Promise<string>
+  getViewport?: () => { x: number; y: number; zoom: number }
+  getContainerSize?: () => { width: number; height: number }
+  fitImportedNodes?: (nodeIds: string[]) => void | Promise<void>
 }
 
 export interface ImportWorkflowPackageResult {
@@ -67,8 +71,6 @@ export interface ImportWorkflowPackageResult {
   mediaOk: number
   mediaFail: number
 }
-
-const IMPORT_POSITION_OFFSET = 80
 
 function defaultCreateIdFactory(existingNodes: WorkflowExportNode[]): (type: string) => string {
   const used = new Set(existingNodes.map((n) => n.id))
@@ -144,7 +146,11 @@ async function uploadZipMedia(
   return { mediaOk, mediaFail }
 }
 
-function toMergeNodes(doc: WorkflowDocument): WorkflowExportNode[] {
+function toMergeNodes(
+  doc: WorkflowDocument,
+  translation: { dx: number; dy: number } = { dx: 0, dy: 0 },
+): WorkflowExportNode[] {
+  const { dx, dy } = translation
   return doc.graph.nodes.map((node) => {
     const parent = node.parentNode ?? node.parentId
     const isChild = parent !== undefined && parent !== ''
@@ -154,8 +160,8 @@ function toMergeNodes(doc: WorkflowDocument): WorkflowExportNode[] {
       position: isChild
         ? { x: node.position.x, y: node.position.y }
         : {
-            x: node.position.x + IMPORT_POSITION_OFFSET,
-            y: node.position.y + IMPORT_POSITION_OFFSET,
+            x: node.position.x + dx,
+            y: node.position.y + dy,
           },
       ...(isChild
         ? { parentNode: parent, extent: 'parent' as const, expandParent: true }
@@ -333,7 +339,13 @@ export async function importWorkflowPackage(
       mediaFail = mediaResult.mediaFail
     }
 
-    const mergeNodes = toMergeNodes(remapped)
+    const { x: dx, y: dy } = computeImportTranslation({
+      importNodes: remapped.graph.nodes,
+      canvasNodes: ctx.nodes,
+      viewport: ctx.getViewport?.(),
+      containerSize: ctx.getContainerSize?.(),
+    })
+    const mergeNodes = toMergeNodes(remapped, { dx, dy })
     const mergeEdges: WorkflowExportEdge[] = remapped.graph.edges.map((e) => ({
       id: e.id,
       source: e.source,
@@ -341,6 +353,7 @@ export async function importWorkflowPackage(
     }))
 
     await ctx.applyMerge(mergeNodes, mergeEdges)
+    await ctx.fitImportedNodes?.(mergeNodes.map((n) => n.id))
     if (mediaFail > 0) {
       ElMessage.warning(
         `已导入工作流：${mergeNodes.length} 个节点（媒体成功 ${mediaOk} / 失败 ${mediaFail}）`,

--- a/apps/web/src/composables/workflowImportPlacement.test.ts
+++ b/apps/web/src/composables/workflowImportPlacement.test.ts
@@ -5,6 +5,7 @@ import {
   unionNodeBBox,
   viewportToFlowRect,
   IMPORT_PLACE_MARGIN,
+  IMPORT_PLACE_STEP,
 } from './workflowImportPlacement'
 
 describe('workflowImportPlacement', () => {
@@ -29,6 +30,46 @@ describe('workflowImportPlacement', () => {
     const a = unionNodeBBox(canvasNodes)!
     const b = unionNodeBBox(placed)!
     expect(rectsOverlap(a, b, IMPORT_PLACE_MARGIN)).toBe(false)
+  })
+
+  it('clamps the free axis into the current viewport, not file coordinates', () => {
+    const canvasNodes = [{ id: 'existing', position: { x: 2000, y: 2000 } }]
+    const importNodes = [{ id: 'imported', position: { x: 0, y: 0 } }]
+    const viewport = { x: -2000, y: -2000, zoom: 1 }
+    const containerSize = { width: 1000, height: 800 }
+    const viewBBox = viewportToFlowRect(viewport, containerSize)
+    expect(viewBBox).toEqual({ x: 2000, y: 2000, width: 1000, height: 800 })
+
+    const { x: dx, y: dy } = computeImportTranslation({
+      importNodes,
+      canvasNodes,
+      viewport,
+      containerSize,
+    })
+    const placed = unionNodeBBox(
+      importNodes.map((n) => ({
+        ...n,
+        position: { x: n.position.x + dx, y: n.position.y + dy },
+      })),
+    )!
+
+    expect(placed.y).not.toBeCloseTo(0)
+    expect(placed.y).toBeGreaterThan(viewBBox.y - IMPORT_PLACE_MARGIN)
+
+    const viewRight = viewBBox.x + viewBBox.width
+    const viewBottom = viewBBox.y + viewBBox.height
+    const insideView =
+      placed.x >= viewBBox.x &&
+      placed.y >= viewBBox.y &&
+      placed.x + placed.width <= viewRight &&
+      placed.y + placed.height <= viewBottom
+    const tightlyRightExterior =
+      placed.x >= viewRight &&
+      placed.x <= viewRight + IMPORT_PLACE_MARGIN + IMPORT_PLACE_STEP &&
+      placed.y >= viewBBox.y &&
+      placed.y + placed.height <= viewBottom
+
+    expect(insideView || tightlyRightExterior).toBe(true)
   })
 
   it('keeps child relative coords out of translation input roots', () => {

--- a/apps/web/src/composables/workflowImportPlacement.test.ts
+++ b/apps/web/src/composables/workflowImportPlacement.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeImportTranslation,
+  rectsOverlap,
+  unionNodeBBox,
+  viewportToFlowRect,
+  IMPORT_PLACE_MARGIN,
+} from './workflowImportPlacement'
+
+describe('workflowImportPlacement', () => {
+  it('viewportToFlowRect matches (-x/zoom, -y/zoom, w/zoom, h/zoom)', () => {
+    const r = viewportToFlowRect({ x: -100, y: -50, zoom: 2 }, { width: 800, height: 600 })
+    expect(r).toEqual({ x: 50, y: 25, width: 400, height: 300 })
+  })
+
+  it('separates import bbox from overlapping canvas with margin', () => {
+    const canvasNodes = [{ id: 'a', position: { x: 0, y: 0 } }]
+    const importNodes = [{ id: 'b', position: { x: 0, y: 0 } }]
+    const { x: dx, y: dy } = computeImportTranslation({
+      importNodes,
+      canvasNodes,
+      viewport: { x: 0, y: 0, zoom: 1 },
+      containerSize: { width: 1000, height: 800 },
+    })
+    const placed = importNodes.map((n) => ({
+      ...n,
+      position: { x: n.position.x + dx, y: n.position.y + dy },
+    }))
+    const a = unionNodeBBox(canvasNodes)!
+    const b = unionNodeBBox(placed)!
+    expect(rectsOverlap(a, b, IMPORT_PLACE_MARGIN)).toBe(false)
+  })
+
+  it('keeps child relative coords out of translation input roots', () => {
+    const nodes = [
+      { id: 'g', type: 'group', position: { x: 10, y: 10 } },
+      { id: 'c', position: { x: 5, y: 5 }, parentNode: 'g' },
+    ]
+    const box = unionNodeBBox(nodes)!
+    expect(box.x).toBe(10)
+    expect(box.y).toBe(10)
+  })
+})

--- a/apps/web/src/composables/workflowImportPlacement.ts
+++ b/apps/web/src/composables/workflowImportPlacement.ts
@@ -76,6 +76,13 @@ function isClear(placed: Rect, canvasBBox: Rect | null, margin: number): boolean
   return !rectsOverlap(placed, canvasBBox, margin)
 }
 
+function centerInView(view: Rect, size: Size): Point {
+  return {
+    x: view.x + view.width / 2 - size.width / 2,
+    y: view.y + view.height / 2 - size.height / 2,
+  }
+}
+
 function tryCandidate(
   importBBox: Rect,
   targetX: number,
@@ -119,20 +126,21 @@ export function computeImportTranslation(input: {
   }
 
   if (viewBBox) {
+    const viewCenter = centerInView(viewBBox, importBBox)
     const rightInteriorX = viewBBox.x + viewBBox.width - importBBox.width - margin
-    const rightInteriorY = importBBox.y
+    const rightInteriorY = viewCenter.y
     candidates.push({ x: rightInteriorX, y: rightInteriorY })
 
     if (canvasBBox) {
-      candidates.push({ x: canvasBBox.x + canvasBBox.width + margin, y: importBBox.y })
+      candidates.push({ x: canvasBBox.x + canvasBBox.width + margin, y: viewCenter.y })
     }
 
-    const belowInteriorX = importBBox.x
+    const belowInteriorX = viewCenter.x
     const belowInteriorY = viewBBox.y + viewBBox.height - importBBox.height - margin
     candidates.push({ x: belowInteriorX, y: belowInteriorY })
 
     if (canvasBBox) {
-      candidates.push({ x: importBBox.x, y: canvasBBox.y + canvasBBox.height + margin })
+      candidates.push({ x: viewCenter.x, y: canvasBBox.y + canvasBBox.height + margin })
     }
 
     const stepBases = [
@@ -148,9 +156,9 @@ export function computeImportTranslation(input: {
     }
 
     const exteriorRightX = viewBBox.x + viewBBox.width + margin
-    candidates.push({ x: exteriorRightX, y: importBBox.y })
+    candidates.push({ x: exteriorRightX, y: viewCenter.y })
     for (let i = 1; i <= MAX_STEP_ATTEMPTS; i++) {
-      candidates.push({ x: exteriorRightX, y: importBBox.y + i * step })
+      candidates.push({ x: exteriorRightX, y: viewCenter.y + i * step })
     }
   }
 

--- a/apps/web/src/composables/workflowImportPlacement.ts
+++ b/apps/web/src/composables/workflowImportPlacement.ts
@@ -1,0 +1,182 @@
+export type Point = { x: number; y: number }
+export type Size = { width: number; height: number }
+export type Rect = { x: number; y: number; width: number; height: number }
+export type NodeLike = {
+  id: string
+  type?: string
+  position: Point
+  parentNode?: string
+  parentId?: string
+}
+
+export const IMPORT_NODE_ESTIMATE = { width: 280, height: 180 } as const
+export const IMPORT_PLACE_MARGIN = 64
+export const IMPORT_PLACE_STEP = 120
+
+const MAX_STEP_ATTEMPTS = 12
+
+export function isRootNode(node: NodeLike, idSet?: Set<string>): boolean {
+  const parentId = node.parentNode ?? node.parentId
+  if (!parentId) return true
+  if (idSet) return !idSet.has(parentId)
+  return false
+}
+
+export function unionNodeBBox(nodes: NodeLike[], estimate: Size = IMPORT_NODE_ESTIMATE): Rect | null {
+  if (nodes.length === 0) return null
+
+  const idSet = new Set(nodes.map((n) => n.id))
+  const roots = nodes.filter((n) => isRootNode(n, idSet))
+  if (roots.length === 0) return null
+
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+
+  for (const node of roots) {
+    const x = node.position.x
+    const y = node.position.y
+    minX = Math.min(minX, x)
+    minY = Math.min(minY, y)
+    maxX = Math.max(maxX, x + estimate.width)
+    maxY = Math.max(maxY, y + estimate.height)
+  }
+
+  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY }
+}
+
+export function rectsOverlap(a: Rect, b: Rect, margin = 0): boolean {
+  const ax = a.x - margin
+  const ay = a.y - margin
+  const aw = a.width + 2 * margin
+  const ah = a.height + 2 * margin
+  return !(ax + aw <= b.x || b.x + b.width <= ax || ay + ah <= b.y || b.y + b.height <= ay)
+}
+
+export function viewportToFlowRect(
+  viewport: { x: number; y: number; zoom: number },
+  container: Size,
+): Rect {
+  const { x, y, zoom } = viewport
+  return {
+    x: -x / zoom,
+    y: -y / zoom,
+    width: container.width / zoom,
+    height: container.height / zoom,
+  }
+}
+
+function placedBBox(importBBox: Rect, dx: number, dy: number): Rect {
+  return { ...importBBox, x: importBBox.x + dx, y: importBBox.y + dy }
+}
+
+function isClear(placed: Rect, canvasBBox: Rect | null, margin: number): boolean {
+  if (!canvasBBox) return true
+  return !rectsOverlap(placed, canvasBBox, margin)
+}
+
+function tryCandidate(
+  importBBox: Rect,
+  targetX: number,
+  targetY: number,
+  canvasBBox: Rect | null,
+  margin: number,
+): Point | null {
+  const dx = targetX - importBBox.x
+  const dy = targetY - importBBox.y
+  const placed = placedBBox(importBBox, dx, dy)
+  if (isClear(placed, canvasBBox, margin)) {
+    return { x: dx, y: dy }
+  }
+  return null
+}
+
+export function computeImportTranslation(input: {
+  importNodes: NodeLike[]
+  canvasNodes: NodeLike[]
+  viewport?: { x: number; y: number; zoom: number }
+  containerSize?: Size
+}): Point {
+  const importBBox = unionNodeBBox(input.importNodes)
+  if (!importBBox) return { x: 0, y: 0 }
+
+  const canvasBBox = unionNodeBBox(input.canvasNodes)
+  const margin = IMPORT_PLACE_MARGIN
+  const step = IMPORT_PLACE_STEP
+  const viewBBox =
+    input.viewport && input.containerSize
+      ? viewportToFlowRect(input.viewport, input.containerSize)
+      : null
+
+  const candidates: Point[] = []
+
+  if (!canvasBBox && viewBBox) {
+    candidates.push({
+      x: viewBBox.x + viewBBox.width / 2 - importBBox.width / 2,
+      y: viewBBox.y + viewBBox.height / 2 - importBBox.height / 2,
+    })
+  }
+
+  if (viewBBox) {
+    const rightInteriorX = viewBBox.x + viewBBox.width - importBBox.width - margin
+    const rightInteriorY = importBBox.y
+    candidates.push({ x: rightInteriorX, y: rightInteriorY })
+
+    if (canvasBBox) {
+      candidates.push({ x: canvasBBox.x + canvasBBox.width + margin, y: importBBox.y })
+    }
+
+    const belowInteriorX = importBBox.x
+    const belowInteriorY = viewBBox.y + viewBBox.height - importBBox.height - margin
+    candidates.push({ x: belowInteriorX, y: belowInteriorY })
+
+    if (canvasBBox) {
+      candidates.push({ x: importBBox.x, y: canvasBBox.y + canvasBBox.height + margin })
+    }
+
+    const stepBases = [
+      { x: rightInteriorX, y: rightInteriorY },
+      { x: belowInteriorX, y: belowInteriorY },
+    ]
+    for (const base of stepBases) {
+      for (let i = 1; i <= MAX_STEP_ATTEMPTS; i++) {
+        candidates.push({ x: base.x + i * step, y: base.y })
+        candidates.push({ x: base.x, y: base.y + i * step })
+        candidates.push({ x: base.x + i * step, y: base.y + i * step })
+      }
+    }
+
+    const exteriorRightX = viewBBox.x + viewBBox.width + margin
+    candidates.push({ x: exteriorRightX, y: importBBox.y })
+    for (let i = 1; i <= MAX_STEP_ATTEMPTS; i++) {
+      candidates.push({ x: exteriorRightX, y: importBBox.y + i * step })
+    }
+  }
+
+  if (!viewBBox && canvasBBox) {
+    candidates.push({ x: canvasBBox.x + canvasBBox.width + margin, y: importBBox.y })
+    candidates.push({ x: importBBox.x, y: canvasBBox.y + canvasBBox.height + margin })
+  }
+
+  if (canvasBBox) {
+    candidates.push({
+      x: canvasBBox.x + canvasBBox.width + margin,
+      y: canvasBBox.y + canvasBBox.height + margin,
+    })
+  }
+
+  for (const target of candidates) {
+    const result = tryCandidate(importBBox, target.x, target.y, canvasBBox, margin)
+    if (result) return result
+  }
+
+  if (canvasBBox) {
+    return {
+      x: canvasBBox.x + canvasBBox.width + margin - importBBox.x,
+      y: canvasBBox.y + canvasBBox.height + margin - importBBox.y,
+    }
+  }
+
+  return { x: 0, y: 0 }
+}

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -2197,6 +2197,15 @@ async function onWorkflowImportSelected(event: Event) {
         nodeCounter++
         return `${type}-${nodeCounter}`
       },
+      getViewport: () => vueFlowRef.value?.getViewport?.() ?? { x: 0, y: 0, zoom: 1 },
+      getContainerSize: () => {
+        const el = vueFlowRef.value?.$el as HTMLElement | undefined
+        const rect = el?.getBoundingClientRect?.()
+        return { width: rect?.width || 1000, height: rect?.height || 800 }
+      },
+      fitImportedNodes: async (ids) => {
+        await vueFlowRef.value?.fitView({ nodes: ids, padding: 0.2, duration: 300 })
+      },
       applyMerge: (mergeNodes, mergeEdges) => {
         for (const n of mergeNodes) {
           nodes.value.push({

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -2204,7 +2204,12 @@ async function onWorkflowImportSelected(event: Event) {
         return { width: rect?.width || 1000, height: rect?.height || 800 }
       },
       fitImportedNodes: async (ids) => {
-        await vueFlowRef.value?.fitView({ nodes: ids, padding: 0.2, duration: 300 })
+        await nextTick()
+        try {
+          await vueFlowRef.value?.fitView({ nodes: ids, padding: 0.2, duration: 300 })
+        } catch {
+          // ignore
+        }
       },
       applyMerge: (mergeNodes, mergeEdges) => {
         for (const n of mergeNodes) {

--- a/docs/superpowers/plans/2026-09-12-workflow-import-placement.md
+++ b/docs/superpowers/plans/2026-09-12-workflow-import-placement.md
@@ -1,0 +1,216 @@
+# Workflow Import Placement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace fixed `(+80,+80)` import offset with blank-space placement (prefer viewport interior, else viewport-right exterior) and `fitView` onto imported nodes after merge.
+
+**Architecture:** Pure geometry helpers (bbox / collide / `computeImportTranslation`) live in `useWorkflowExchange.ts` (or a tiny colocated `workflowImportPlacement.ts` if the composable grows). `importWorkflowPackage` takes optional viewport + fit callbacks from `CanvasPage` via `ImportWorkflowPackageContext`. Root nodes share one `(dx,dy)`; group children keep relative coords.
+
+**Tech Stack:** Vue 3, Vue Flow (`fitView` / `getViewport` on existing `vueFlowRef`), Vitest
+
+**Spec:** [docs/superpowers/specs/2026-09-12-workflow-import-placement-design.md](../specs/2026-09-12-workflow-import-placement-design.md)
+
+## Global Constraints
+
+- Whole-subgraph **uniform translation** only — do not reshuffle topology.
+- Group **children keep relative positions**; keep `extent: 'parent'` / `expandParent: true`.
+- Constants (verbatim from spec): estimate `W=280 H=180`, margin `M=64`, step `STEP=120`, fitView `padding: 0.2`, `duration: 300`.
+- Empty canvas: place near viewport center-right (or origin if no viewport), still call fit when provided.
+- Remove sole reliance on `IMPORT_POSITION_OFFSET = 80` as the placement strategy.
+- Commit per task; PR before claim done: focused web tests + `pnpm build` (or web+shared build) green.
+
+## File map
+
+| File | Role |
+| --- | --- |
+| `apps/web/src/composables/workflowImportPlacement.ts` | Pure: `Rect`, `unionNodeBBox`, `rectsOverlap`, `viewportToFlowRect`, `computeImportTranslation` |
+| `apps/web/src/composables/workflowImportPlacement.test.ts` | Unit tests for translation / non-overlap |
+| `apps/web/src/composables/useWorkflowExchange.ts` | Wire translation into `toMergeNodes` / `importWorkflowPackage`; extend context |
+| `apps/web/src/composables/useWorkflowExchange.test.ts` | Import tests: no overlap vs seed canvas; child relative; fit callback invoked |
+| `apps/web/src/pages/CanvasPage.vue` | Pass `getViewport`, `getContainerSize`, `fitImportedNodes` |
+
+---
+
+### Task 1: Pure placement geometry + tests
+
+**Files:**
+- Create: `apps/web/src/composables/workflowImportPlacement.ts`
+- Create: `apps/web/src/composables/workflowImportPlacement.test.ts`
+
+**Interfaces:**
+
+```typescript
+export type Point = { x: number; y: number }
+export type Size = { width: number; height: number }
+export type Rect = { x: number; y: number; width: number; height: number }
+export type NodeLike = {
+  id: string
+  type?: string
+  position: Point
+  parentNode?: string
+  parentId?: string
+}
+
+export const IMPORT_NODE_ESTIMATE = { width: 280, height: 180 } as const
+export const IMPORT_PLACE_MARGIN = 64
+export const IMPORT_PLACE_STEP = 120
+
+export function isRootNode(node: NodeLike, idSet?: Set<string>): boolean
+export function unionNodeBBox(nodes: NodeLike[], estimate?: Size): Rect | null
+export function rectsOverlap(a: Rect, b: Rect, margin?: number): boolean
+export function viewportToFlowRect(
+  viewport: { x: number; y: number; zoom: number },
+  container: Size,
+): Rect
+export function computeImportTranslation(input: {
+  importNodes: NodeLike[]
+  canvasNodes: NodeLike[]
+  viewport?: { x: number; y: number; zoom: number }
+  containerSize?: Size
+}): Point // { x: dx, y: dy }
+```
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+import { describe, expect, it } from 'vitest'
+import {
+  computeImportTranslation,
+  rectsOverlap,
+  unionNodeBBox,
+  viewportToFlowRect,
+  IMPORT_PLACE_MARGIN,
+} from './workflowImportPlacement'
+
+describe('workflowImportPlacement', () => {
+  it('viewportToFlowRect matches (-x/zoom, -y/zoom, w/zoom, h/zoom)', () => {
+    const r = viewportToFlowRect({ x: -100, y: -50, zoom: 2 }, { width: 800, height: 600 })
+    expect(r).toEqual({ x: 50, y: 25, width: 400, height: 300 })
+  })
+
+  it('separates import bbox from overlapping canvas with margin', () => {
+    const canvasNodes = [{ id: 'a', position: { x: 0, y: 0 } }]
+    const importNodes = [{ id: 'b', position: { x: 0, y: 0 } }]
+    const { x: dx, y: dy } = computeImportTranslation({
+      importNodes,
+      canvasNodes,
+      viewport: { x: 0, y: 0, zoom: 1 },
+      containerSize: { width: 1000, height: 800 },
+    })
+    const placed = importNodes.map((n) => ({
+      ...n,
+      position: { x: n.position.x + dx, y: n.position.y + dy },
+    }))
+    const a = unionNodeBBox(canvasNodes)!
+    const b = unionNodeBBox(placed)!
+    expect(rectsOverlap(a, b, IMPORT_PLACE_MARGIN)).toBe(false)
+  })
+
+  it('keeps child relative coords out of translation input roots', () => {
+    // computeImportTranslation only uses roots; test isRootNode / union ignores children
+    const nodes = [
+      { id: 'g', type: 'group', position: { x: 10, y: 10 } },
+      { id: 'c', position: { x: 5, y: 5 }, parentNode: 'g' },
+    ]
+    const box = unionNodeBBox(nodes)!
+    expect(box.x).toBe(10)
+    expect(box.y).toBe(10)
+  })
+})
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```bash
+pnpm --filter @lnkpi/web exec vitest run src/composables/workflowImportPlacement.test.ts
+```
+
+- [ ] **Step 3: Implement `workflowImportPlacement.ts`** per spec §3 (candidate order: viewport-right interior → below → step → viewport exterior right → canvas bottom-right fallback).
+
+- [ ] **Step 4: Run — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/composables/workflowImportPlacement.ts apps/web/src/composables/workflowImportPlacement.test.ts
+git commit -m "feat(web): blank-space translation for workflow import"
+```
+
+---
+
+### Task 2: Wire import path + CanvasPage fitView
+
+**Files:**
+- Modify: `apps/web/src/composables/useWorkflowExchange.ts`
+- Modify: `apps/web/src/composables/useWorkflowExchange.test.ts`
+- Modify: `apps/web/src/pages/CanvasPage.vue`
+
+**Interfaces:**
+
+```typescript
+export interface ImportWorkflowPackageContext {
+  // existing fields...
+  getViewport?: () => { x: number; y: number; zoom: number }
+  getContainerSize?: () => { width: number; height: number }
+  fitImportedNodes?: (nodeIds: string[]) => void | Promise<void>
+}
+```
+
+- [ ] **Step 1: Failing / extend import tests**
+
+- Seed canvas node at `(0,0)`; import json with root at `(0,0)` → `applyMerge` nodes’ root positions must not overlap seed bbox (± margin).
+- Parent+child import: child `position` unchanged relative to file; parent shifted by same dx/dy as translation.
+- `fitImportedNodes` mock called with remapped ids after merge.
+
+- [ ] **Step 2: Implement**
+
+1. Delete `IMPORT_POSITION_OFFSET`-only path (or keep unused constant removed).
+2. After remap + media upload, `const { x: dx, y: dy } = computeImportTranslation({ importNodes: remapped.graph.nodes, canvasNodes: ctx.nodes, viewport: ctx.getViewport?.(), containerSize: ctx.getContainerSize?.() })`.
+3. `toMergeNodes(doc, { dx, dy })` applies translation to roots only.
+4. `await ctx.applyMerge(...)` then `await ctx.fitImportedNodes?.(mergeNodes.map(n => n.id))`.
+
+- [ ] **Step 3: CanvasPage**
+
+In `onWorkflowImportSelected`, add:
+
+```typescript
+getViewport: () => vueFlowRef.value?.getViewport?.() ?? { x: 0, y: 0, zoom: 1 },
+getContainerSize: () => {
+  const el = vueFlowRef.value?.$el as HTMLElement | undefined
+  const rect = el?.getBoundingClientRect?.()
+  return { width: rect?.width || 1000, height: rect?.height || 800 }
+},
+fitImportedNodes: async (ids) => {
+  await vueFlowRef.value?.fitView({ nodes: ids, padding: 0.2, duration: 300 })
+},
+```
+
+(Match existing `fitView` call sites around `CanvasPage.vue` ~1181/1194.)
+
+- [ ] **Step 4: Tests PASS**
+
+```bash
+pnpm --filter @lnkpi/web exec vitest run src/composables/workflowImportPlacement.test.ts src/composables/useWorkflowExchange.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(web): place workflow imports in blank space and fit view"
+```
+
+---
+
+## Spec coverage
+
+| Spec requirement | Task |
+| --- | --- |
+| Uniform translation | T1+T2 |
+| Viewport-first then exterior | T1 |
+| Margin 64 / step 120 / estimate 280×180 | T1 |
+| Children relative unchanged | T1+T2 |
+| fitView after merge | T2 |
+| No fixed +80-only | T2 |
+
+**Placeholders:** none.  
+**Handoff:** After plan commit, execute via Subagent-Driven (recommended) or Inline.

--- a/docs/superpowers/specs/2026-09-12-workflow-import-placement-design.md
+++ b/docs/superpowers/specs/2026-09-12-workflow-import-placement-design.md
@@ -1,0 +1,99 @@
+# 工作流导入落点（空白区 + 视口对准）设计
+
+> 日期：2026-09-12  
+> 状态：已批准（对话确认方案 **C**）  
+> 产品：超创平台（lnkpi）无限画布  
+> 上级规格：[2026-09-12-canvas-workflow-exchange-design.md](./2026-09-12-canvas-workflow-exchange-design.md)  
+> 背景：W1 导入合并仅对根节点做固定 `(+80,+80)`，易与当前画布/视口重叠遮挡  
+
+## 1. 背景与目标
+
+当前 `importWorkflowPackage` → `toMergeNodes` 对每个**根节点**施加常量 `IMPORT_POSITION_OFFSET = 80`，分组子节点保留相对坐标。规格只保证 ID remap 与合并进当前画布，**未**定义避障与视口行为。
+
+**目标：** 导入子图以**整包统一平移**落到空白区，尽量不遮挡当前视口内容；导入后视口对准新块。
+
+**非目标：**
+
+- 打散或重排导入拓扑（边相对关系须保持）
+- 修改分组子节点相对坐标 / `extent`
+- 新建 session / 替换整布（仍为 merge）
+- 精确像素级与真实 DOM 尺寸碰撞（可用固定估算宽高）
+
+## 2. 产品规则（方案 C）
+
+1. **优先**在当前视口 flow 矩形内找空白（右侧 → 下方）。  
+2. 若与已有内容或视口占用冲突，按步长外推；仍失败则落到**视口右外侧**，再与画布包围盒碰撞外推。  
+3. 合并完成后对**本次导入节点**做短动画 `fitView`（padding ≈ 0.2）。
+
+## 3. 算法
+
+### 3.1 包围盒
+
+- **根节点**：无 `parentNode` / `parentId`（或父 id 不在本子图内）的节点。  
+- **估算尺寸**：默认 `W=280, H=180`（可常量；group 可用更大宽高如 `320×240`，YAGNI 可先统一）。  
+- `importBBox`：导入图根节点 `position` + 估算尺寸的并集。  
+- `canvasBBox`：当前画布根节点同规则；空画布 → 无障碍（可把导入放在视口中心偏右下，或原点附近视口内空白）。  
+- `viewBBox`：由 Vue Flow `getViewport()`（`x,y,zoom`）与画布容器像素尺寸换算：
+
+```text
+flowX = (-viewport.x) / zoom
+flowY = (-viewport.y) / zoom
+flowW = containerWidth / zoom
+flowH = containerHeight / zoom
+```
+
+（以仓库现有 Vue Flow 坐标系为准；实现时对照 `useVueFlow` 文档与现有 `setViewport` 用法校准一次。）
+
+### 3.2 碰撞
+
+矩形轴对齐相交即冲突。Margin `M = 64`：候选放置时，导入 bbox 外扩 M 再与 `canvasBBox` / 已占用区检测。
+
+### 3.3 候选落点顺序
+
+对「导入 bbox 左上角」求 `dx, dy`（整包平移量 = `targetTopLeft - importBBox.topLeft`）：
+
+1. 视口内右侧：`import` 左缘贴 `view` 右缘内侧，或贴 `canvasBBox` 右缘 + M（取更不易撞的一侧试探）。  
+2. 视口内下方：同理。  
+3. 步长外推：`STEP = 120`，沿右/下各尝试有限次（如 12 次）。  
+4. 回退：视口右外侧（`view.right + M`），再相对 `canvasBBox` 右/下外推直至无相交或达上限；上限仍冲突则采用「canvas 右下 + M」的最后候选（最差也比固定 +80 可控）。
+
+空画布：优先视口中心附近偏右（仍做 fitView）。
+
+### 3.4 应用与对准
+
+1. 所有**根节点** `position += (dx, dy)`。  
+2. 子节点坐标不变；`parentNode` / `extent` / `expandParent` 逻辑保持现状。  
+3. `applyMerge` 之后：`fitView({ nodes: importedIds, padding: 0.2, duration: 300 })`（API 名以 `@vue-flow/core` 现用为准）。  
+4. 若 `fitView` 不可用，退化为 `setViewport` 使导入 bbox 中心落入视口中心。
+
+## 4. 接口与文件
+
+| 位置 | 变更 |
+|------|------|
+| `apps/web/src/composables/useWorkflowExchange.ts` | 抽出 `computeImportTranslation` / `placeImportedNodes`；`toMergeNodes` 接受 `(dx,dy)` 或内部调用；删除仅 `+80` 的默认路径 |
+| `ImportWorkflowPackageContext` | 增加可选 `getViewport` / `getContainerSize` / `fitImportedNodes(ids)`，由 `CanvasPage` 注入 |
+| `apps/web/src/pages/CanvasPage.vue` | 导入时注入 viewport + fitView |
+| `useWorkflowExchange.test.ts` | 单测：重叠 canvas 时 dx/dy 使 bbox 分离；空画布；子节点相对坐标不变；可选 mock fit 被调用 |
+
+纯几何函数尽量无 DOM，便于 Vitest。
+
+## 5. 验收
+
+1. 当前画布中心已有节点时导入同源坐标包 → 新块与旧块轴对齐 bbox **不相交**（margin≥64）。  
+2. 导入后视口可见新块主体（fitView / 等效对准）。  
+3. 含 group 的包：子节点相对父仍正确；`extent`/`expandParent` 仍设置。  
+4. 无回归：非法格式仍不 merge；媒体缺失仍 warning + 计数。
+
+## 6. 风险
+
+| 风险 | 缓解 |
+|------|------|
+| 估算尺寸与真实节点差较大 | margin 64 + 步长外推；后续可接 `dimensions` |
+| 坐标系符号搞反 | 单测用固定 viewport 夹具 + 手工一眼冒烟 |
+| 超大导入图视口内永远放不下 | 规则允许落到视口外再 fitView |
+
+## 7. 修订记录
+
+| 日期 | 变更 |
+|------|------|
+| 2026-09-12 | 初稿：对话选定方案 C 后入库 |


### PR DESCRIPTION
## Summary
- 工作流导入落点改为整包统一平移到当前视口空白区（优先右侧/下方，否则视口右外侧外推），移除固定 `(+80,+80)`。
- 纯几何模块 `workflowImportPlacement` + `CanvasPage` 注入 viewport/`fitView`；导入后对准新块（padding 0.2，duration 300）。
- 视口自由轴居中到当前工作区，避免平移画布后仍落在文件原坐标附近。

## Test plan
- [x] `pnpm build`
- [x] `pnpm --filter @lnkpi/web exec vitest run src/composables/workflowImportPlacement.test.ts src/composables/useWorkflowExchange.test.ts`（15/15）
- [ ] 画布已有节点时导入 zip：新块不与现有内容重叠（含 margin），且视口短动画对准导入节点
- [ ] 空画布导入：落在视口内，随后 fitView
- [ ] 画布已平移到远处（如 ~(2000,2000)）再导入：落点在当前视口内或紧贴右侧，而非 y≈0
- [ ] 含 group 的包：子节点相对坐标 / extent 不变


Made with [Cursor](https://cursor.com)