### PR TITLE
feat(web): Dock scene labels + Chinese guide scaffolds

### DIFF
--- a/apps/web/src/components/canvas/dock-studio/DockStudioRouter.vue
+++ b/apps/web/src/components/canvas/dock-studio/DockStudioRouter.vue
@@ -95,7 +95,6 @@ const panelBindings = {
     @remove-ref="panelBindings.removeRef"
     @generate="panelBindings.generate"
     @close="panelBindings.close"
-    @refine="emit('refine')"
   />
   <VideoDockPanel
     v-else-if="node && nodeType === 'video'"

--- a/apps/web/src/components/canvas/dock-studio/panels/AudioDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/AudioDockPanel.vue
@@ -12,7 +12,7 @@ import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGener
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import DockCreditBadge from '@/components/canvas/dock-studio/shared/DockCreditBadge.vue'
 import DockRefStrip from '@/components/canvas/dock-studio/shared/DockRefStrip.vue'
-import type { NodeRef } from '@/composables/useNodeRefs'
+import type { LocalRefBinding, NodeRef } from '@/composables/useNodeRefs'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
 import {
   DEFAULT_AUDIO_EMOTION,
@@ -31,6 +31,7 @@ import {
 import { useModelProviderSettings } from '@/composables/useModelProviderSettings'
 import { isNodeGenerating } from '@/constants/dockStudio'
 import { estimateAudioCredits } from '@/constants/credits'
+import { useDockLocalImageUpload } from '@/components/canvas/dock-studio/shared/useDockLocalImageUpload'
 
 const { getConfig } = useModelProviderSettings()
 
@@ -64,6 +65,16 @@ const modelVoices = computed(() => getModelEntry(catalogModelKeyFromValue(audioM
 
 const speech = useSpeechRecognition()
 const promptSectionRef = ref<InstanceType<typeof DockPromptSection> | null>(null)
+const {
+  inputRef: refInput,
+  uploading: refUploading,
+  uploadError: refUploadError,
+  pick: pickReferenceImage,
+  onFileChange: onRefFileChange,
+} = useDockLocalImageUpload({
+  getExistingLocalRefs: () => (props.node.data?.localRefs as LocalRefBinding[]) ?? [],
+  onPatch: (patch) => emit('patch', patch),
+})
 const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
 const credits = computed(() => estimateAudioCredits())
 
@@ -164,10 +175,16 @@ function onRefMention(refKey: string) {
   <DockToolbarShell type="audio" @close="emit('close')">
     <DockRefStrip
       :refs="refs ?? []"
+      show-add-upload
+      :add-upload-disabled="readonly"
+      :add-upload-busy="refUploading"
       @reorder="onRefReorder"
       @remove="onRefRemove"
       @mention="onRefMention"
+      @add-upload="pickReferenceImage"
     />
+    <input ref="refInput" type="file" accept="image/*" class="hidden" @change="onRefFileChange">
+    <p v-if="refUploadError" class="mx-3 mb-1 text-[10px] text-red-400/90">{{ refUploadError }}</p>
 
     <DockPromptSection
       ref="promptSectionRef"

--- a/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
@@ -104,6 +104,9 @@ const activeGuideSceneId = computed(() => {
   const id = props.node.data?.guideSceneId
   return typeof id === 'string' && id.trim() ? id.trim() : ''
 })
+const activeGuideScene = computed(() =>
+  activeGuideSceneId.value ? getGenerationScene(activeGuideSceneId.value) ?? null : null,
+)
 
 function onSelectGuideScene(sceneId: string) {
   if (readonly.value) return
@@ -314,22 +317,24 @@ function clearReferenceImage() {
       <div class="relative">
         <button
           type="button"
-          class="bottom-toolbar-close relative"
-          :class="activeGuideSceneId ? 'bg-fuchsia-500/15 text-fuchsia-300' : 'text-white/35'"
+          class="dock-guide-scene-btn relative"
+          :class="{ 'is-guide-active': activeGuideSceneId }"
           :disabled="readonly"
           aria-label="场景模板"
+          :title="activeGuideScene?.label ?? '场景模板'"
           :aria-expanded="guidePickerOpen"
           @click="guidePickerOpen = !guidePickerOpen"
         >
-          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
             <rect x="4" y="4" width="6" height="6" rx="1" />
             <rect x="14" y="4" width="6" height="6" rx="1" />
             <rect x="4" y="14" width="6" height="6" rx="1" />
             <rect x="14" y="14" width="6" height="6" rx="1" />
           </svg>
+          <span class="dock-guide-scene-btn__label">{{ activeGuideScene?.label ?? '场景模板' }}</span>
           <span
             v-if="activeGuideSceneId"
-            class="absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-fuchsia-400"
+            class="dock-guide-scene-btn__dot"
             aria-hidden="true"
           />
         </button>

--- a/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/ImageDockPanel.vue
@@ -16,14 +16,12 @@ import DockGenerateButton from '@/components/canvas/dock-studio/shared/DockGener
 import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.vue'
 import DockCreditBadge from '@/components/canvas/dock-studio/shared/DockCreditBadge.vue'
 import DockRefStrip from '@/components/canvas/dock-studio/shared/DockRefStrip.vue'
-import DockTypeIcon from '@/components/canvas/dock-studio/shared/DockTypeIcon.vue'
 import GuidePickerPopover from '@/components/canvas/dock-studio/shared/GuidePickerPopover.vue'
 import type { LocalRefBinding, NodeRef } from '@/composables/useNodeRefs'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
 import { useModelProviderSettings } from '@/composables/useModelProviderSettings'
 import { catalogModelKeyFromValue, resolveGenerationModel } from '@/constants/studioModels'
 import { estimateImageCredits } from '@/constants/credits'
-import { persistMediaUrl } from '@/composables/useMediaUpload'
 import {
   TURNAROUND_PIPELINE_DOCK_HINT,
   defaultGuideCapabilities,
@@ -32,10 +30,10 @@ import {
   isTurnaroundLikePrompt,
   resolveImageModelProfile,
 } from '@lnkpi/shared'
-import { CX_IMAGE_EDIT_ENABLED } from '@/utils/refineSession'
 import { applyGuideSceneToPrompt, clearGuideScene } from './guideSceneApply'
-import { isImageDockReadonly, shouldShowRefineEntry } from './imageDockRefineEntry'
+import { isImageDockReadonly } from './imageDockRefineEntry'
 import { mapPreferredSizeToAspect } from './mapPreferredSizeToAspect'
+import { useDockLocalImageUpload } from '@/components/canvas/dock-studio/shared/useDockLocalImageUpload'
 
 const { getConfig } = useModelProviderSettings()
 
@@ -53,7 +51,6 @@ const emit = defineEmits<{
   generate: []
   close: []
   removeRef: [ref: NodeRef]
-  refine: []
 }>()
 
 const prompt = ref('')
@@ -62,12 +59,25 @@ const imageAspect = ref<ImageAspectRatio>('16:9')
 const imageResolution = ref<ImageResolution>('1K')
 const imageCount = ref<ImageCount>(1)
 const referenceImageUrl = ref('')
-const refInput = ref<HTMLInputElement | null>(null)
-const refUploading = ref(false)
-const refUploadProgress = ref(0)
-const refUploadError = ref('')
 const promptSectionRef = ref<InstanceType<typeof DockPromptSection> | null>(null)
 const guidePickerOpen = ref(false)
+
+const {
+  inputRef: refInput,
+  uploading: refUploading,
+  uploadError: refUploadError,
+  pick: pickReferenceImage,
+  onFileChange: onRefFileChange,
+} = useDockLocalImageUpload({
+  getExistingLocalRefs: () => (props.node.data?.localRefs as LocalRefBinding[]) ?? [],
+  onPatch: (patch) => {
+    if (typeof patch.referenceImageUrl === 'string') {
+      referenceImageUrl.value = patch.referenceImageUrl
+    }
+    emit('patch', patch)
+  },
+  syncReferenceImageUrl: true,
+})
 
 const speech = useSpeechRecognition()
 const readonly = computed(() =>
@@ -78,13 +88,6 @@ const readonly = computed(() =>
   }),
 )
 const credits = computed(() => estimateImageCredits(imageCount.value))
-const showRefineEntry = computed(() =>
-  shouldShowRefineEntry({
-    url: props.node.data?.url,
-    readonly: readonly.value,
-    enabled: CX_IMAGE_EDIT_ENABLED,
-  }),
-)
 
 const showTurnaroundHint = computed(() => {
   const data = props.node.data ?? {}
@@ -253,62 +256,6 @@ function toggleVoice() {
     }
   })
 }
-
-function pickReferenceImage() {
-  refInput.value?.click()
-}
-
-function createLocalRefId(prefix: string) {
-  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
-}
-
-async function onRefFileChange(event: Event) {
-  const input = event.target as HTMLInputElement
-  const file = input.files?.[0]
-  input.value = ''
-  if (!file || !file.type.startsWith('image/')) return
-
-  refUploadError.value = ''
-  refUploadProgress.value = 0
-  refUploading.value = true
-  const blobUrl = URL.createObjectURL(file)
-  referenceImageUrl.value = blobUrl
-
-  try {
-    const url = await persistMediaUrl(file, blobUrl, {
-      onProgress: (p) => {
-        refUploadProgress.value = p
-      },
-    })
-    if (url !== blobUrl) URL.revokeObjectURL(blobUrl)
-
-    referenceImageUrl.value = url
-    const binding: LocalRefBinding = {
-      id: createLocalRefId('upload'),
-      mediaType: 'image',
-      sourceKind: 'upload',
-      label: file.name,
-      url,
-    }
-    const prev = (props.node.data?.localRefs as LocalRefBinding[]) ?? []
-    emit('patch', {
-      localRefs: [...prev, binding],
-      referenceImageUrl: url,
-    })
-  } catch (err) {
-    refUploadError.value = err instanceof Error ? err.message : '参考图上传失败，请重试'
-    URL.revokeObjectURL(blobUrl)
-    referenceImageUrl.value = ''
-  } finally {
-    refUploading.value = false
-    refUploadProgress.value = 0
-  }
-}
-
-function clearReferenceImage() {
-  referenceImageUrl.value = ''
-  syncField('referenceImageUrl', '')
-}
 </script>
 
 <template>
@@ -353,10 +300,16 @@ function clearReferenceImage() {
 
     <DockRefStrip
       :refs="stripRefs"
+      show-add-upload
+      :add-upload-disabled="readonly"
+      :add-upload-busy="refUploading"
       @reorder="onRefReorder"
       @remove="onRefRemove"
       @mention="onRefMention"
+      @add-upload="pickReferenceImage"
     />
+    <input ref="refInput" type="file" accept="image/*" class="hidden" @change="onRefFileChange">
+    <p v-if="refUploadError" class="mx-3 mb-1 text-[10px] text-red-400/90">{{ refUploadError }}</p>
 
     <DockPromptSection
       ref="promptSectionRef"
@@ -389,38 +342,6 @@ function clearReferenceImage() {
         @update:count="imageCount = $event; syncField('imageCount', $event)"
       />
 
-      <div class="flex items-center gap-1.5">
-        <button
-          type="button"
-          class="dock-icon-btn"
-          :disabled="readonly || refUploading"
-          title="参考图"
-          @click="pickReferenceImage"
-        >
-          <DockTypeIcon v-if="!refUploading" icon="image" :size="13" />
-          <span v-else class="whitespace-nowrap text-[9px] text-white/60">
-            {{ refUploadProgress > 0 ? `上传中 ${refUploadProgress}%` : '上传中...' }}
-          </span>
-        </button>
-        <div
-          v-if="effectiveRefUrl"
-          class="relative h-7 w-7 overflow-hidden rounded-md border border-white/15"
-        >
-          <img :src="effectiveRefUrl" alt="" class="h-full w-full object-cover">
-          <button
-            type="button"
-            class="absolute inset-0 flex items-center justify-center bg-black/50 text-[10px] opacity-0 transition hover:opacity-100"
-            @click="clearReferenceImage"
-          >
-            <svg viewBox="0 0 24 24" width="10" height="10" fill="none" stroke="currentColor" stroke-width="2.5">
-              <path d="M18 6 6 18M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
-        <input ref="refInput" type="file" accept="image/*" class="hidden" @change="onRefFileChange">
-        <p v-if="refUploadError" class="text-[10px] text-red-400/90">{{ refUploadError }}</p>
-      </div>
-
       <div class="ml-auto flex items-center gap-2">
         <DockMicButton
           :listening="speech.listening.value"
@@ -428,14 +349,6 @@ function clearReferenceImage() {
           @toggle="toggleVoice"
         />
         <DockCreditBadge :credits="credits" />
-        <button
-          v-if="showRefineEntry"
-          type="button"
-          class="neo-chip rounded-md px-2 py-1 text-[10px]"
-          @click="emit('refine')"
-        >
-          精修这张图
-        </button>
         <DockGenerateButton
           :generating="generating"
           :disabled="!generating && !prompt.trim()"

--- a/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
@@ -23,6 +23,7 @@ import {
   buildPromptNodeCardPreview,
   countMarkdownTableDataRows,
   defaultGuideCapabilities,
+  getGenerationScene,
 } from '@lnkpi/shared'
 import { applyGuideSceneToPrompt, clearGuideScene } from './guideSceneApply'
 
@@ -86,6 +87,9 @@ const activeGuideSceneId = computed(() => {
   const id = props.node.data?.guideSceneId
   return typeof id === 'string' && id.trim() ? id.trim() : ''
 })
+const activeGuideScene = computed(() =>
+  activeGuideSceneId.value ? getGenerationScene(activeGuideSceneId.value) ?? null : null,
+)
 
 function onSelectGuideScene(sceneId: string) {
   if (readonly.value) return
@@ -192,22 +196,24 @@ function onRefMention(refKey: string) {
       <div class="relative">
         <button
           type="button"
-          class="bottom-toolbar-close relative"
-          :class="activeGuideSceneId ? 'bg-fuchsia-500/15 text-fuchsia-300' : 'text-white/35'"
+          class="dock-guide-scene-btn relative"
+          :class="{ 'is-guide-active': activeGuideSceneId }"
           :disabled="readonly"
           aria-label="场景模板"
+          :title="activeGuideScene?.label ?? '场景模板'"
           :aria-expanded="guidePickerOpen"
           @click="guidePickerOpen = !guidePickerOpen"
         >
-          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
             <rect x="4" y="4" width="6" height="6" rx="1" />
             <rect x="14" y="4" width="6" height="6" rx="1" />
             <rect x="4" y="14" width="6" height="6" rx="1" />
             <rect x="14" y="14" width="6" height="6" rx="1" />
           </svg>
+          <span class="dock-guide-scene-btn__label">{{ activeGuideScene?.label ?? '场景模板' }}</span>
           <span
             v-if="activeGuideSceneId"
-            class="absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-fuchsia-400"
+            class="dock-guide-scene-btn__dot"
             aria-hidden="true"
           />
         </button>

--- a/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/PromptDockPanel.vue
@@ -13,7 +13,7 @@ import DockCreditBadge from '@/components/canvas/dock-studio/shared/DockCreditBa
 import DockRefStrip from '@/components/canvas/dock-studio/shared/DockRefStrip.vue'
 import GuidePickerPopover from '@/components/canvas/dock-studio/shared/GuidePickerPopover.vue'
 import { estimateTextCredits } from '@/constants/credits'
-import type { NodeRef } from '@/composables/useNodeRefs'
+import type { LocalRefBinding, NodeRef } from '@/composables/useNodeRefs'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
 import { useModelProviderSettings } from '@/composables/useModelProviderSettings'
 import { resolveGenerationModel } from '@/constants/studioModels'
@@ -26,6 +26,7 @@ import {
   getGenerationScene,
 } from '@lnkpi/shared'
 import { applyGuideSceneToPrompt, clearGuideScene } from './guideSceneApply'
+import { useDockLocalImageUpload } from '@/components/canvas/dock-studio/shared/useDockLocalImageUpload'
 
 const MODE_LABELS = PROMPT_MODE_LABELS
 
@@ -51,6 +52,16 @@ const textModel = ref(getConfig('text').model)
 
 const speech = useSpeechRecognition()
 const promptSectionRef = ref<InstanceType<typeof DockPromptSection> | null>(null)
+const {
+  inputRef: refInput,
+  uploading: refUploading,
+  uploadError: refUploadError,
+  pick: pickReferenceImage,
+  onFileChange: onRefFileChange,
+} = useDockLocalImageUpload({
+  getExistingLocalRefs: () => (props.node.data?.localRefs as LocalRefBinding[]) ?? [],
+  onPatch: (patch) => emit('patch', patch),
+})
 const guidePickerOpen = ref(false)
 const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
 const promptMode = computed(() => {
@@ -167,18 +178,8 @@ function toggleVoice() {
   })
 }
 
-function mergeRefOrder(reorderedTextRefIds: string[]): string[] {
-  const allRefs = props.refs ?? []
-  const textIdSet = new Set(reorderedTextRefIds)
-  const nonTextIds = allRefs.filter((ref) => ref.mediaType !== 'text').map((ref) => ref.refId)
-  const prevOrder = (props.node.data?.refOrder as string[]) ?? allRefs.map((ref) => ref.refId)
-  const preservedNonText = prevOrder.filter((id) => nonTextIds.includes(id) && !textIdSet.has(id))
-  const missingNonText = nonTextIds.filter((id) => !preservedNonText.includes(id))
-  return [...reorderedTextRefIds, ...preservedNonText, ...missingNonText]
-}
-
 function onRefReorder(refIds: string[]) {
-  emit('patch', { refOrder: mergeRefOrder(refIds) })
+  emit('patch', { refOrder: refIds })
 }
 
 function onRefRemove(ref: NodeRef) {
@@ -231,11 +232,17 @@ function onRefMention(refKey: string) {
     </template>
 
     <DockRefStrip
-      :refs="textRefs"
+      :refs="refs ?? []"
+      show-add-upload
+      :add-upload-disabled="readonly"
+      :add-upload-busy="refUploading"
       @reorder="onRefReorder"
       @remove="onRefRemove"
       @mention="onRefMention"
+      @add-upload="pickReferenceImage"
     />
+    <input ref="refInput" type="file" accept="image/*" class="hidden" @change="onRefFileChange">
+    <p v-if="refUploadError" class="mx-3 mb-1 text-[10px] text-red-400/90">{{ refUploadError }}</p>
 
     <DockPromptSection
       ref="promptSectionRef"

--- a/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/TextDockPanel.vue
@@ -11,12 +11,13 @@ import DockMicButton from '@/components/canvas/dock-studio/shared/DockMicButton.
 import DockCreditBadge from '@/components/canvas/dock-studio/shared/DockCreditBadge.vue'
 import DockOptimizePrompt from '@/components/canvas/dock-studio/shared/DockOptimizePrompt.vue'
 import DockRefStrip from '@/components/canvas/dock-studio/shared/DockRefStrip.vue'
-import type { NodeRef } from '@/composables/useNodeRefs'
+import type { LocalRefBinding, NodeRef } from '@/composables/useNodeRefs'
 import { useSpeechRecognition } from '@/composables/useSpeechRecognition'
 import { useModelProviderSettings } from '@/composables/useModelProviderSettings'
 import { resolveGenerationModel, isDeepSeekV4Model } from '@/constants/studioModels'
 import { isNodeGenerating } from '@/constants/dockStudio'
 import { estimateTextCredits } from '@/constants/credits'
+import { useDockLocalImageUpload } from '@/components/canvas/dock-studio/shared/useDockLocalImageUpload'
 
 const { getConfig } = useModelProviderSettings()
 
@@ -45,6 +46,16 @@ const legacySeededForId = ref<string | null>(null)
 
 const speech = useSpeechRecognition()
 const promptSectionRef = ref<InstanceType<typeof DockPromptSection> | null>(null)
+const {
+  inputRef: refInput,
+  uploading: refUploading,
+  uploadError: refUploadError,
+  pick: pickReferenceImage,
+  onFileChange: onRefFileChange,
+} = useDockLocalImageUpload({
+  getExistingLocalRefs: () => (props.node.data?.localRefs as LocalRefBinding[]) ?? [],
+  onPatch: (patch) => emit('patch', patch),
+})
 const readonly = computed(() => isNodeGenerating(props.node.data?.status) || !!props.generating)
 const wordCount = computed(() => prompt.value.replace(/\s/g, '').length)
 const credits = computed(() => estimateTextCredits())
@@ -151,10 +162,16 @@ function onRefMention(refKey: string) {
   <DockToolbarShell type="text" @close="emit('close')">
     <DockRefStrip
       :refs="refs ?? []"
+      show-add-upload
+      :add-upload-disabled="readonly"
+      :add-upload-busy="refUploading"
       @reorder="onRefReorder"
       @remove="onRefRemove"
       @mention="onRefMention"
+      @add-upload="pickReferenceImage"
     />
+    <input ref="refInput" type="file" accept="image/*" class="hidden" @change="onRefFileChange">
+    <p v-if="refUploadError" class="mx-3 mb-1 text-[10px] text-red-400/90">{{ refUploadError }}</p>
 
     <DockPromptSection
       ref="promptSectionRef"

--- a/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
@@ -29,7 +29,7 @@ import { catalogModelKeyFromValue, resolveGenerationModel } from '@/constants/st
 import { DEFAULT_VIDEO_SETTINGS, type VideoSettings } from '@lnkpi/shared'
 import { isNodeGenerating, NODE_GENERATION_STATUS } from '@/constants/dockStudio'
 import { estimateVideoCredits } from '@/constants/credits'
-import { useDockLocalImageUpload } from '@/components/canvas/dock-studio/shared/useDockLocalImageUpload'
+import { useDockLocalImageUpload, createLocalRefId } from '@/components/canvas/dock-studio/shared/useDockLocalImageUpload'
 import { useVideoModelCapabilities } from '@/composables/useVideoModelCapabilities'
 import VideoCapabilityBadges from '@/components/canvas/dock-studio/shared/VideoCapabilityBadges.vue'
 import {

--- a/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
+++ b/apps/web/src/components/canvas/dock-studio/panels/VideoDockPanel.vue
@@ -29,7 +29,7 @@ import { catalogModelKeyFromValue, resolveGenerationModel } from '@/constants/st
 import { DEFAULT_VIDEO_SETTINGS, type VideoSettings } from '@lnkpi/shared'
 import { isNodeGenerating, NODE_GENERATION_STATUS } from '@/constants/dockStudio'
 import { estimateVideoCredits } from '@/constants/credits'
-import { persistMediaUrl } from '@/composables/useMediaUpload'
+import { useDockLocalImageUpload } from '@/components/canvas/dock-studio/shared/useDockLocalImageUpload'
 import { useVideoModelCapabilities } from '@/composables/useVideoModelCapabilities'
 import VideoCapabilityBadges from '@/components/canvas/dock-studio/shared/VideoCapabilityBadges.vue'
 import {
@@ -64,14 +64,28 @@ const videoMode = ref<VideoGenerationMode>('text_to_video')
 const referenceImageUrl = ref('')
 const seed = ref<number | undefined>(undefined)
 const negativePrompt = ref('')
-const refInput = ref<HTMLInputElement | null>(null)
-const refUploading = ref(false)
-const refUploadProgress = ref(0)
-const refUploadError = ref('')
 const refPreflight = ref<MediaRefPreflight | null>(null)
 const refPreflightLoading = ref(false)
 const pendingPreflightToast = ref(false)
 let preflightSeq = 0
+
+const {
+  inputRef: refInput,
+  uploading: refUploading,
+  uploadError: refUploadError,
+  pick: pickReferenceImage,
+  onFileChange: onRefFileChange,
+} = useDockLocalImageUpload({
+  getExistingLocalRefs: () => (props.node.data?.localRefs as LocalRefBinding[]) ?? [],
+  onPatch: (patch) => {
+    if (typeof patch.referenceImageUrl === 'string') {
+      referenceImageUrl.value = patch.referenceImageUrl
+      videoMode.value = 'image_to_video'
+    }
+    emit('patch', { ...patch, videoMode: 'image_to_video' })
+  },
+  syncReferenceImageUrl: true,
+})
 
 const speech = useSpeechRecognition()
 const promptSectionRef = ref<InstanceType<typeof DockPromptSection> | null>(null)
@@ -356,68 +370,6 @@ function toggleVoice() {
   })
 }
 
-function pickReferenceImage() {
-  refInput.value?.click()
-}
-
-function createLocalRefId(prefix: string) {
-  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
-}
-
-async function onRefFileChange(event: Event) {
-  const input = event.target as HTMLInputElement
-  const file = input.files?.[0]
-  input.value = ''
-  if (!file || !file.type.startsWith('image/')) return
-
-  refUploadError.value = ''
-  refUploadProgress.value = 0
-  refUploading.value = true
-  const blobUrl = URL.createObjectURL(file)
-  referenceImageUrl.value = blobUrl
-  videoMode.value = 'image_to_video'
-
-  try {
-    const url = await persistMediaUrl(file, blobUrl, {
-      onProgress: (p) => {
-        refUploadProgress.value = p
-      },
-    })
-    if (url !== blobUrl) URL.revokeObjectURL(blobUrl)
-
-    referenceImageUrl.value = url
-    const binding: LocalRefBinding = {
-      id: createLocalRefId('upload'),
-      mediaType: 'image',
-      sourceKind: 'upload',
-      label: file.name,
-      url,
-    }
-    const prev = (props.node.data?.localRefs as LocalRefBinding[]) ?? []
-    emit('patch', {
-      localRefs: [...prev, binding],
-      videoMode: 'image_to_video',
-    })
-  } catch (err) {
-    refUploadError.value = err instanceof Error ? err.message : '参考图上传失败，请重试'
-    URL.revokeObjectURL(blobUrl)
-    referenceImageUrl.value = ''
-  } finally {
-    refUploading.value = false
-    refUploadProgress.value = 0
-  }
-}
-
-function clearReferenceImage() {
-  referenceImageUrl.value = ''
-  videoMode.value = 'text_to_video'
-  const prev = (props.node.data?.localRefs as LocalRefBinding[]) ?? []
-  emit('patch', {
-    localRefs: prev.filter((r) => r.mediaType !== 'image'),
-    videoMode: 'text_to_video',
-  })
-}
-
 function onRefReorder(refIds: string[]) {
   emit('patch', { refOrder: refIds })
 }
@@ -436,10 +388,16 @@ function onRefMention(refKey: string) {
     <DockRefStrip
       :refs="refs ?? []"
       :video-mode="videoMode"
+      show-add-upload
+      :add-upload-disabled="readonly"
+      :add-upload-busy="refUploading"
       @reorder="onRefReorder"
       @remove="onRefRemove"
       @mention="onRefMention"
+      @add-upload="pickReferenceImage"
     />
+    <input ref="refInput" type="file" accept="image/*" class="hidden" @change="onRefFileChange">
+    <p v-if="refUploadError" class="mx-3 mb-1 text-[10px] text-red-400/90">{{ refUploadError }}</p>
 
     <p
       v-if="unsupportedMediaRefs.showWarning"
@@ -558,40 +516,6 @@ function onRefMention(refKey: string) {
         :model-key="catalogModelKeyFromValue(videoModel)"
         @update:model-value="syncField('videoSettings', $event)"
       />
-
-      <template v-if="videoMode === 'image_to_video'">
-        <div class="flex items-center gap-1.5">
-          <button
-            type="button"
-            class="dock-icon-btn"
-            :disabled="readonly || refUploading"
-            title="参考图"
-            @click="pickReferenceImage"
-          >
-            <DockTypeIcon v-if="!refUploading" icon="image" :size="13" />
-            <span v-else class="whitespace-nowrap text-[9px] text-white/60">
-              {{ refUploadProgress > 0 ? `上传中 ${refUploadProgress}%` : '上传中...' }}
-            </span>
-          </button>
-          <div
-            v-if="effectiveRefUrl"
-            class="relative h-7 w-7 overflow-hidden rounded-md border border-white/15"
-          >
-            <img :src="effectiveRefUrl" alt="" class="h-full w-full object-cover">
-            <button
-              type="button"
-              class="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition hover:opacity-100"
-              @click="clearReferenceImage"
-            >
-              <svg viewBox="0 0 24 24" width="10" height="10" fill="none" stroke="currentColor" stroke-width="2.5">
-                <path d="M18 6 6 18M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
-          <input ref="refInput" type="file" accept="image/*" class="hidden" @change="onRefFileChange">
-          <p v-if="refUploadError" class="text-[10px] text-red-400/90">{{ refUploadError }}</p>
-        </div>
-      </template>
 
       <ElAlert
         v-if="showRefPreflightAlert"

--- a/apps/web/src/components/canvas/dock-studio/panels/guideSceneApply.test.ts
+++ b/apps/web/src/components/canvas/dock-studio/panels/guideSceneApply.test.ts
@@ -5,7 +5,8 @@ describe('applyGuideSceneToPrompt', () => {
   it('prefills when prompt empty', () => {
     const r = applyGuideSceneToPrompt({ sceneId: 'g3_exact_text', currentPrompt: '' })
     expect(r.didPrefill).toBe(true)
-    expect(r.prompt.length).toBeGreaterThan(10)
+    expect(r.prompt).toContain('{{TAGLINE}}')
+    expect(r.prompt).toContain('标语')
     expect(r.guideSceneId).toBe('g3_exact_text')
   })
 

--- a/apps/web/src/components/canvas/dock-studio/shared/DockRefStrip.test.ts
+++ b/apps/web/src/components/canvas/dock-studio/shared/DockRefStrip.test.ts
@@ -27,4 +27,28 @@ describe('DockRefStrip', () => {
     expect(wrapper.text()).toContain('首帧')
     expect(wrapper.text()).toContain('末帧')
   })
+
+  it('hides strip when empty and upload not enabled', () => {
+    const wrapper = mount(DockRefStrip, { props: { refs: [] } })
+    expect(wrapper.find('.dock-ref-strip').exists()).toBe(false)
+  })
+
+  it('shows muted + when upload enabled with no refs', () => {
+    const wrapper = mount(DockRefStrip, {
+      props: { refs: [], showAddUpload: true },
+    })
+    const add = wrapper.find('.dock-ref-strip__add')
+    expect(add.exists()).toBe(true)
+    expect(add.classes()).not.toContain('is-prominent')
+  })
+
+  it('makes + prominent when refs exist and emits addUpload', async () => {
+    const wrapper = mount(DockRefStrip, {
+      props: { refs: [imageRef('I1')], showAddUpload: true },
+    })
+    const add = wrapper.find('.dock-ref-strip__add')
+    expect(add.classes()).toContain('is-prominent')
+    await add.trigger('click')
+    expect(wrapper.emitted('addUpload')).toHaveLength(1)
+  })
 })

--- a/apps/web/src/components/canvas/dock-studio/shared/DockRefStrip.vue
+++ b/apps/web/src/components/canvas/dock-studio/shared/DockRefStrip.vue
@@ -5,10 +5,21 @@ import type { VideoGenerationMode } from '@/composables/useUpstreamNodeContext'
 import DockRefChip from '@/components/canvas/dock-studio/shared/DockRefChip.vue'
 import { resolveRefRoleLabel } from '@/components/canvas/dock-studio/shared/dockRefRoleLabels'
 
-const props = defineProps<{
-  refs: NodeRef[]
-  videoMode?: VideoGenerationMode
-}>()
+const props = withDefaults(
+  defineProps<{
+    refs: NodeRef[]
+    videoMode?: VideoGenerationMode
+    /** Show trailing + for local image upload. */
+    showAddUpload?: boolean
+    addUploadDisabled?: boolean
+    addUploadBusy?: boolean
+  }>(),
+  {
+    showAddUpload: false,
+    addUploadDisabled: false,
+    addUploadBusy: false,
+  },
+)
 
 const roleLabels = computed(() => {
   const mode = props.videoMode ?? 'text_to_video'
@@ -20,10 +31,14 @@ const roleLabels = computed(() => {
   return map
 })
 
+const showStrip = computed(() => props.refs.length > 0 || props.showAddUpload)
+const addUploadProminent = computed(() => props.refs.length > 0)
+
 const emit = defineEmits<{
   reorder: [refIds: string[]]
   remove: [ref: NodeRef]
   mention: [refKey: string]
+  addUpload: []
 }>()
 
 const dragRefId = ref<string | null>(null)
@@ -75,7 +90,7 @@ function onDragEnd() {
 </script>
 
 <template>
-  <div v-if="refs.length" class="dock-ref-strip">
+  <div v-if="showStrip" class="dock-ref-strip">
     <div class="dock-ref-strip__scroll">
       <DockRefChip
         v-for="refItem in refs"
@@ -93,6 +108,19 @@ function onDragEnd() {
         @remove="emit('remove', refItem)"
         @mention="emit('mention', $event)"
       />
+      <button
+        v-if="showAddUpload"
+        type="button"
+        class="dock-ref-strip__add"
+        :class="{ 'is-prominent': addUploadProminent, 'is-busy': addUploadBusy }"
+        :disabled="addUploadDisabled || addUploadBusy"
+        :title="addUploadBusy ? '上传中…' : '上传参考图'"
+        aria-label="上传参考图"
+        @click="emit('addUpload')"
+      >
+        <span v-if="addUploadBusy" class="dock-ref-strip__add-busy">…</span>
+        <span v-else aria-hidden="true">+</span>
+      </button>
     </div>
   </div>
 </template>
@@ -123,5 +151,45 @@ function onDragEnd() {
 .dock-ref-strip__scroll::-webkit-scrollbar-thumb {
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.18);
+}
+
+.dock-ref-strip__add {
+  display: inline-flex;
+  height: 28px;
+  width: 28px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed color-mix(in srgb, var(--neo-border) 80%, transparent);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--neo-text-muted);
+  font-size: 16px;
+  line-height: 1;
+  opacity: 0.45;
+  cursor: pointer;
+  transition: opacity 0.15s ease, border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+}
+
+.dock-ref-strip__add.is-prominent {
+  opacity: 0.85;
+  border-style: solid;
+  border-color: var(--neo-border);
+}
+
+.dock-ref-strip__add:hover:not(:disabled) {
+  opacity: 1;
+  background: var(--neo-hover-bg);
+  color: var(--neo-text-primary);
+}
+
+.dock-ref-strip__add:disabled {
+  cursor: not-allowed;
+  opacity: 0.35;
+}
+
+.dock-ref-strip__add-busy {
+  font-size: 12px;
+  letter-spacing: 0.05em;
 }
 </style>

--- a/apps/web/src/components/canvas/dock-studio/shared/useDockLocalImageUpload.ts
+++ b/apps/web/src/components/canvas/dock-studio/shared/useDockLocalImageUpload.ts
@@ -6,6 +6,8 @@ function createLocalRefId(prefix: string) {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
 }
 
+export { createLocalRefId }
+
 /** Shared Image/Video/Prompt/Text/Audio Dock local reference image upload. */
 export function useDockLocalImageUpload(options: {
   getExistingLocalRefs: () => LocalRefBinding[]

--- a/apps/web/src/components/canvas/dock-studio/shared/useDockLocalImageUpload.ts
+++ b/apps/web/src/components/canvas/dock-studio/shared/useDockLocalImageUpload.ts
@@ -1,0 +1,75 @@
+import { ref } from 'vue'
+import type { LocalRefBinding } from '@/composables/useNodeRefs'
+import { persistMediaUrl } from '@/composables/useMediaUpload'
+
+function createLocalRefId(prefix: string) {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+}
+
+/** Shared Image/Video/Prompt/Text/Audio Dock local reference image upload. */
+export function useDockLocalImageUpload(options: {
+  getExistingLocalRefs: () => LocalRefBinding[]
+  onPatch: (patch: Record<string, unknown>) => void
+  /** Also write legacy referenceImageUrl (Image / Video i2v). */
+  syncReferenceImageUrl?: boolean
+}) {
+  const inputRef = ref<HTMLInputElement | null>(null)
+  const uploading = ref(false)
+  const uploadProgress = ref(0)
+  const uploadError = ref('')
+
+  function pick() {
+    inputRef.value?.click()
+  }
+
+  async function onFileChange(event: Event) {
+    const input = event.target as HTMLInputElement
+    const file = input.files?.[0]
+    input.value = ''
+    if (!file || !file.type.startsWith('image/')) return
+
+    uploadError.value = ''
+    uploadProgress.value = 0
+    uploading.value = true
+    const blobUrl = URL.createObjectURL(file)
+
+    try {
+      const url = await persistMediaUrl(file, blobUrl, {
+        onProgress: (p) => {
+          uploadProgress.value = p
+        },
+      })
+      if (url !== blobUrl) URL.revokeObjectURL(blobUrl)
+
+      const binding: LocalRefBinding = {
+        id: createLocalRefId('upload'),
+        mediaType: 'image',
+        sourceKind: 'upload',
+        label: file.name,
+        url,
+      }
+      const patch: Record<string, unknown> = {
+        localRefs: [...options.getExistingLocalRefs(), binding],
+      }
+      if (options.syncReferenceImageUrl) {
+        patch.referenceImageUrl = url
+      }
+      options.onPatch(patch)
+    } catch (err) {
+      uploadError.value = err instanceof Error ? err.message : '参考图上传失败，请重试'
+      URL.revokeObjectURL(blobUrl)
+    } finally {
+      uploading.value = false
+      uploadProgress.value = 0
+    }
+  }
+
+  return {
+    inputRef,
+    uploading,
+    uploadProgress,
+    uploadError,
+    pick,
+    onFileChange,
+  }
+}

--- a/apps/web/src/styles/neo-node.css
+++ b/apps/web/src/styles/neo-node.css
@@ -1174,6 +1174,55 @@
   color: var(--neo-text-primary);
 }
 
+.dock-guide-scene-btn {
+  position: relative;
+  display: inline-flex;
+  max-width: min(148px, 42vw);
+  height: 26px;
+  align-items: center;
+  gap: 5px;
+  padding: 0 8px 0 6px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--neo-text-muted);
+  font-size: 11px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.dock-guide-scene-btn:hover {
+  background: var(--neo-hover-bg);
+  color: var(--neo-text-primary);
+}
+
+.dock-guide-scene-btn.is-guide-active {
+  border-color: color-mix(in srgb, rgb(232 121 249) 25%, transparent);
+  background: color-mix(in srgb, rgb(217 70 239) 15%, transparent);
+  color: rgb(240 171 252);
+}
+
+.dock-guide-scene-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.dock-guide-scene-btn__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dock-guide-scene-btn__dot {
+  position: absolute;
+  top: 4px;
+  right: 5px;
+  height: 5px;
+  width: 5px;
+  border-radius: 999px;
+  background: rgb(232 121 249);
+}
+
 .bottom-toolbar-actions {
   display: flex;
   flex-wrap: wrap;

--- a/docs/superpowers/plans/2026-09-12-dock-guide-scene-label.md
+++ b/docs/superpowers/plans/2026-09-12-dock-guide-scene-label.md
@@ -1,0 +1,21 @@
+# Dock Scene Label + Chinese Scaffolds Implementation Plan
+
+> **For agentic workers:** Task-by-task; PR scoped to Dock labels + catalog Chinese templates.
+
+**Goal:** Align Dock header with Refine (show scene name); prefill Chinese scaffolds for domestic UX; keep English systemOverlay.
+
+## Task 1: Dock header labels
+
+- [x] `PromptDockPanel.vue` / `ImageDockPanel.vue`: icon + label, chip layout, ellipsis
+- [x] `getGenerationScene` for active label
+
+## Task 2: Chinese scaffolds (G + E)
+
+- [x] Translate all `promptScaffold` and `changePreserveTemplate` to Chinese; keep `{{PLACEHOLDERS}}`
+- [x] Leave `systemOverlay` English
+- [x] Update any tests that assert English scaffold substrings
+
+## Task 3: Verify + PR
+
+- [x] vitest shared catalog + guideSceneApply + guideEditIntentApply
+- [ ] mydev: branch commit PR CI

--- a/docs/superpowers/specs/2026-09-12-dock-guide-scene-label-design.md
+++ b/docs/superpowers/specs/2026-09-12-dock-guide-scene-label-design.md
@@ -1,0 +1,31 @@
+# Dock 场景显性名 + 中文脚手架（方案 A）
+
+> 状态：已批准（2026-09-12）  
+> 范围：Prompt/Image Dock 标题栏标签；Catalog 用户可见脚手架中文化
+
+## 决策
+
+| 项 | 选择 |
+|----|------|
+| Dock 显性 | 标题栏「图标 + 场景名」；未选「场景模板」 |
+| 用户预填 | `promptScaffold` / `changePreserveTemplate` → **中文**（保留 `{{…}}` 占位） |
+| 扩写约束 | `systemOverlay` → **仍英文** |
+| 可选「切换英文」 | **本期不做**（方案 A） |
+
+## Dock UI
+
+- PromptDockPanel / ImageDockPanel：`activeGuideScene?.label ?? '场景模板'`
+- 已选 fuchsia + 小圆点；长名 ellipsis
+- Refine：已有意图名，不改交互；仅受益于中文 `changePreserveTemplate`
+
+## Catalog
+
+- 改写全部 G1–G9 / E1–E8 的用户可见模板为中文
+- 不新增 `promptScaffoldEn` 字段（YAGNI）
+- `applyGuideSceneToPrompt` / `applyGuideEditIntent` 逻辑不变（空框预填、非空只挂 id）
+
+## 不做
+
+- 一键英/中切换、机翻、locale 设置
+- Dock popover portal（仍 above-end）
+- Image 2.5 / preferredParams 全量接线

--- a/packages/shared/src/imagePromptingGuide/intents/e1-translate-layout.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e1-translate-layout.ts
@@ -9,11 +9,11 @@ export const e1TranslateLayout: EditIntent = {
   groupId: 'local_edit',
   groupLabel: '局部手术',
   fundamentalsRefs: ['exact_text', 'separate_changes', 'iterate'],
-  changePreserveTemplate: `Translate the visible text in the input image into {{TARGET_LANGUAGE}}.
-Replace only the original text and render the supplied translation exactly.
-Preserve layout, hierarchy, font character, colors, spacing, imagery, logos, and background.
-Fit translated copy naturally without clipping or overlap.
-Do not add, remove, or redesign any other element.`,
+  changePreserveTemplate: `将输入图中的可见文字翻译为 {{TARGET_LANGUAGE}}。
+仅替换原文，并精确呈现所给译文。
+保留版面、层级、字体气质、颜色、间距、图像、logo 与背景。
+译文自然嵌入，避免裁切或重叠。
+不要增删或重设计其他任何元素。`,
   refRoles: [{ role: 'source', required: true, hint: '待翻译的原版面' }],
   preferredParams: { size: '1536x1024', quality: 'medium' },
   capability: { minRefImages: 1 },

--- a/packages/shared/src/imagePromptingGuide/intents/e2-style-transfer.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e2-style-transfer.ts
@@ -9,11 +9,11 @@ export const e2StyleTransfer: EditIntent = {
   groupId: 'ref_compose',
   groupLabel: '参考合成',
   fundamentalsRefs: ['separate_changes', 'assign_ref_roles', 'iterate'],
-  changePreserveTemplate: `Restyle the content of image 1 using the visual style of image 2.
-Transfer palette, medium, texture, lighting treatment, and mark-making from the style reference.
-Preserve the subject identity, pose, composition, proportions, objects, and scene structure from image 1.
-Do not copy people, objects, text, or composition from image 2.
-Change only the visual style; add no text, logos, or watermarks.`,
+  changePreserveTemplate: `用图 2 的视觉风格重绘图 1 的内容。
+迁移风格参考的配色、介质、质感、光线处理与笔触。
+保留图 1 的主体身份、姿态、构图、比例、物体与场景结构。
+不要从图 2 复制人物、物体、文字或构图。
+只改变视觉风格；不要添加文字、logo 或水印。`,
   refRoles: [
     { role: 'content', required: true, hint: '图1：保留内容与构图的原图' },
     { role: 'style', required: true, hint: '图2：仅提供视觉风格' },

--- a/packages/shared/src/imagePromptingGuide/intents/e3-identity-clothing.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e3-identity-clothing.ts
@@ -9,11 +9,11 @@ export const e3IdentityClothing: EditIntent = {
   groupId: 'identity_product',
   groupLabel: '身份/产品',
   fundamentalsRefs: ['separate_changes', 'assign_ref_roles', 'iterate'],
-  changePreserveTemplate: `Edit the image to dress the person using the provided clothing reference(s).
-Change only the clothing. Do not change face, facial features, skin tone, body shape, pose, or identity.
-Preserve exact likeness, expression, hairstyle, and proportions.
-Fit garments naturally to the existing pose with realistic fabric behavior; match lighting and shadows.
-Do not change the background, camera angle, or framing. No accessories, text, logos, or watermarks.`,
+  changePreserveTemplate: `根据提供的服装参考编辑图像中的人物着装。
+只改服装。不要改变面部、五官、肤色、体型、姿态或身份。
+保留精确相貌、表情、发型与比例。
+服装贴合现有姿态，布料自然，光影匹配。
+不要改变背景、机位或取景。不要添加配饰、文字、logo 或水印。`,
   refRoles: [
     { role: 'subject', required: true, hint: '人物原图（身份/姿态）' },
     { role: 'clothing', required: true, hint: '服装参考图' },

--- a/packages/shared/src/imagePromptingGuide/intents/e4-combine-refs.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e4-combine-refs.ts
@@ -9,9 +9,9 @@ export const e4CombineRefs: EditIntent = {
   groupId: 'ref_compose',
   groupLabel: '参考合成',
   fundamentalsRefs: ['separate_changes', 'assign_ref_roles', 'iterate'],
-  changePreserveTemplate: `Place the subject from image 2 into the setting of image 1.
-Use the same style of lighting, composition, and background as image 1.
-Change nothing else — preserve identity of the subject and the rest of the scene.`,
+  changePreserveTemplate: `将图 2 的主体放入图 1 的场景中。
+光线、构图与背景风格与图 1 一致。
+除此之外不要改动——保留主体身份与场景其余部分。`,
   refRoles: [
     { role: 'scene', required: true, hint: '图1：场景/背景' },
     { role: 'subject', required: true, hint: '图2：要放入场景的主体' },

--- a/packages/shared/src/imagePromptingGuide/intents/e5-transparent-cutout.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e5-transparent-cutout.ts
@@ -9,11 +9,11 @@ export const e5TransparentCutout: EditIntent = {
   groupId: 'identity_product',
   groupLabel: '身份/产品',
   fundamentalsRefs: ['define_result', 'separate_changes', 'iterate'],
-  changePreserveTemplate: `Extract the product from the input image and isolate it on a fully transparent background.
-Output: centered product, crisp silhouette, no halos/fringing.
-Preserve product geometry and label legibility exactly.
-Add only light polishing. Do not add a solid backdrop, checkerboard, scenery, or shadow.
-Do not restyle the product; remove the background and preserve clean alpha transparency.`,
+  changePreserveTemplate: `从输入图中提取产品，并置于完全透明背景。
+输出：产品居中、轮廓干净、无光晕/毛边。
+精确保留产品造型与标签可读性。
+仅可做轻微抛光。不要添加纯色底、棋盘格、场景或投影。
+不要重绘产品；去掉背景并保留干净透明通道。`,
   refRoles: [{ role: 'product', required: true, hint: '产品图' }],
   preferredParams: {
     size: '1024x1536',

--- a/packages/shared/src/imagePromptingGuide/intents/e6-drawing-to-realistic.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e6-drawing-to-realistic.ts
@@ -9,11 +9,11 @@ export const e6DrawingToRealistic: EditIntent = {
   groupId: 'ref_compose',
   groupLabel: '参考合成',
   fundamentalsRefs: ['visible_details', 'separate_changes', 'assign_ref_roles'],
-  changePreserveTemplate: `Convert the input drawing into a photorealistic image.
-Preserve the exact composition, subject placement, pose, perspective, silhouette, and key design features.
-Resolve sketched areas into plausible materials, textures, lighting, and shadows.
-Keep intentional colors and details unless the drawing leaves them unspecified.
-Do not redesign the subject, alter the framing, add objects, text, logos, or watermarks.`,
+  changePreserveTemplate: `将输入草图转为写实照片效果。
+精确保留构图、主体位置、姿态、透视、轮廓与关键设计特征。
+把草图区域落实为合理材质、纹理、光线与阴影。
+草图已标明的颜色与细节应保留；未标明处可合理补全。
+不要重设计主体、改变取景，不要添加物体、文字、logo 或水印。`,
   refRoles: [{ role: 'drawing', required: true, hint: '要转为写实效果的草图/线稿' }],
   preferredParams: { size: '1024x1536', quality: 'medium' },
   capability: { minRefImages: 1 },

--- a/packages/shared/src/imagePromptingGuide/intents/e7-remove-object.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e7-remove-object.ts
@@ -9,11 +9,11 @@ export const e7RemoveObject: EditIntent = {
   groupId: 'local_edit',
   groupLabel: '局部手术',
   fundamentalsRefs: ['define_result', 'separate_changes', 'iterate'],
-  changePreserveTemplate: `Remove {{OBJECT_TO_REMOVE}} from the input image.
-Reconstruct the newly revealed area so it matches the surrounding background, texture, lighting, perspective, and depth.
-Remove related shadows or reflections only when they belong to the removed object.
-Preserve every other person, object, color, detail, camera angle, and crop exactly.
-Do not add replacement objects, text, logos, or watermarks.`,
+  changePreserveTemplate: `从输入图中移除 {{OBJECT_TO_REMOVE}}。
+重建露出区域，使其与周围背景、纹理、光线、透视与纵深一致。
+仅当阴影/倒影属于被移除物体时一并去掉。
+其余人物、物体、颜色、细节、机位与裁切保持不变。
+不要用其他物体替换，不要添加文字、logo 或水印。`,
   refRoles: [{ role: 'source', required: true, hint: '包含待移除物体的原图' }],
   preferredParams: { size: '1024x1536', quality: 'medium' },
   capability: { minRefImages: 1 },

--- a/packages/shared/src/imagePromptingGuide/intents/e8-insert-person.ts
+++ b/packages/shared/src/imagePromptingGuide/intents/e8-insert-person.ts
@@ -9,11 +9,11 @@ export const e8InsertPerson: EditIntent = {
   groupId: 'identity_product',
   groupLabel: '身份/产品',
   fundamentalsRefs: ['people_actions', 'separate_changes', 'assign_ref_roles'],
-  changePreserveTemplate: `Insert the person from image 2 naturally into the scene in image 1 at {{PLACEMENT}}.
-Preserve the person's exact identity, facial features, hairstyle, body proportions, and clothing.
-Match the scene's perspective, scale, lighting, color, focus, contact shadows, and occlusion.
-Preserve the existing background, people, objects, camera angle, and framing.
-Do not alter the person's identity or add text, logos, or watermarks.`,
+  changePreserveTemplate: `将图 2 中的人物自然放入图 1 场景的 {{PLACEMENT}}。
+保留人物精确身份、五官、发型、体型比例与服装。
+匹配场景的透视、尺度、光线、色彩、景深、接触阴影与遮挡。
+保留原有背景、人物、物体、机位与取景。
+不要改变人物身份，不要添加文字、logo 或水印。`,
   refRoles: [
     { role: 'scene', required: true, hint: '图1：目标场景' },
     { role: 'subject', required: true, hint: '图2：要放入场景的人物' },

--- a/packages/shared/src/imagePromptingGuide/scenes/g1-style-lighting.ts
+++ b/packages/shared/src/imagePromptingGuide/scenes/g1-style-lighting.ts
@@ -9,11 +9,11 @@ export const g1StyleLighting: GenerationScene = {
   groupId: 'photo_ad',
   groupLabel: '摄影/广告',
   fundamentalsRefs: ['define_result', 'visible_details', 'people_actions'],
-  promptScaffold: `Create a photorealistic candid photograph of {{SUBJECT}}.
-Describe framing (e.g. medium close-up at eye level), lens cues, and composition.
-Lighting: {{LIGHT}} — soft/natural balance, shallow depth of field if needed.
-Texture: real skin/material detail, subtle grain if film-like; honest and unposed.
-No glamorization, no heavy retouching.`,
+  promptScaffold: `创作一张关于 {{SUBJECT}} 的写实抓拍照片。
+写明取景（如平视中近景）、镜头感与构图。
+光线：{{LIGHT}} — 柔和自然、层次清楚，需要时可浅景深。
+质感：真实皮肤/材质细节，若偏胶片可带轻微颗粒；自然、不摆拍。
+不要过度美化，不要重度修图。`,
   systemOverlay:
     'Style & lighting scene: specify subject, framing, light, and texture. Prefer candid honesty; forbid heavy retouching and glamorization.',
   preferredParams: { size: '1024x1536', quality: 'medium' },

--- a/packages/shared/src/imagePromptingGuide/scenes/g2-process-infographic.ts
+++ b/packages/shared/src/imagePromptingGuide/scenes/g2-process-infographic.ts
@@ -9,11 +9,11 @@ export const g2ProcessInfographic: GenerationScene = {
   groupId: 'info_design',
   groupLabel: '信息设计',
   fundamentalsRefs: ['define_result', 'maintainable_format', 'exact_text'],
-  promptScaffold: `Create a clean process infographic explaining {{PROCESS}}.
-Show the steps in an obvious reading order with numbered stages and concise labels.
-Use consistent icons, spacing, connectors, and a restrained color palette.
-Render all supplied wording exactly and keep the hierarchy legible.
-Do not add unsupported steps, decorative copy, logos, or watermarks.`,
+  promptScaffold: `创作一张清晰的流程信息图，说明 {{PROCESS}}。
+按阅读顺序展示步骤，带编号阶段与简短标签。
+图标、间距、连接线风格统一，配色克制。
+所给文案须精确呈现，层级易读。
+不要添加未给出的步骤、装饰性废话、logo 或水印。`,
   preferredParams: { size: '1536x1024', quality: 'medium' },
   capability: {},
 }

--- a/packages/shared/src/imagePromptingGuide/scenes/g3-exact-text.ts
+++ b/packages/shared/src/imagePromptingGuide/scenes/g3-exact-text.ts
@@ -9,12 +9,12 @@ export const g3ExactText: GenerationScene = {
   groupId: 'photo_ad',
   groupLabel: '摄影/广告',
   fundamentalsRefs: ['define_result', 'exact_text', 'visible_details'],
-  promptScaffold: `Create a polished campaign / fashion ad for a brand.
-The ad features the subject with the tagline "{{TAGLINE}}".
-Make it feel stylish and contemporary for the intended audience.
-Use clean composition, strong color direction, and premium photography cues.
-Render the tagline exactly once, clearly and legibly, integrated into the layout.
-No extra text, no watermarks, no unrelated logos.`,
+  promptScaffold: `创作一张精致的品牌/时尚广告图。
+画面主体搭配标语「{{TAGLINE}}」。
+风格时尚、当代，面向目标受众。
+构图干净，色彩方向明确，摄影质感高级。
+标语只出现一次，清晰可读并融入版面。
+不要多余文字、水印或无关 logo。`,
   systemOverlay:
     'Exact text scene: put required wording in quotes; render the tagline exactly once; no extra text, watermarks, or unrelated logos. Check spelling and legibility.',
   preferredParams: { size: '1024x1536', quality: 'medium' },

--- a/packages/shared/src/imagePromptingGuide/scenes/g4-reusable-logo.ts
+++ b/packages/shared/src/imagePromptingGuide/scenes/g4-reusable-logo.ts
@@ -9,11 +9,11 @@ export const g4ReusableLogo: GenerationScene = {
   groupId: 'brand_ui',
   groupLabel: '品牌/UI',
   fundamentalsRefs: ['define_result', 'visible_details', 'exact_text'],
-  promptScaffold: `Create a distinctive, reusable logo for {{BRAND}}.
-Use a simple silhouette, balanced geometry, and a limited color palette that works at small sizes.
-If lettering is requested, render "{{LOGOTYPE}}" exactly once and keep it legible.
-Isolate the logo on a fully transparent background with crisp, clean edges.
-Do not add mockups, scenery, shadows, extra text, or watermarks.`,
+  promptScaffold: `为 {{BRAND}} 创作一个可复用、辨识度高的 logo。
+造型简洁、几何平衡，小尺寸仍清晰，配色克制。
+若需要字标，将「{{LOGOTYPE}}」精确呈现一次并保持可读。
+logo 置于完全透明背景，边缘干净利落。
+不要样机、场景、投影、多余文字或水印。`,
   preferredParams: {
     size: '1024x1024',
     quality: 'medium',

--- a/packages/shared/src/imagePromptingGuide/scenes/g5-historical-context.ts
+++ b/packages/shared/src/imagePromptingGuide/scenes/g5-historical-context.ts
@@ -9,10 +9,10 @@ export const g5HistoricalContext: GenerationScene = {
   groupId: 'narrative',
   groupLabel: '叙事',
   fundamentalsRefs: ['define_result', 'visible_details', 'people_actions'],
-  promptScaffold: `Create a historically grounded scene set in {{TIME_AND_PLACE}}.
-Depict {{SUBJECT_AND_ACTION}} with period-appropriate clothing, architecture, objects, and materials.
-Use a coherent composition and lighting appropriate to the setting and intended medium.
-Avoid modern objects, anachronistic styling, unsupported symbols, text, logos, or watermarks.`,
+  promptScaffold: `创作一张有历史依据的场景，设定在 {{TIME_AND_PLACE}}。
+表现 {{SUBJECT_AND_ACTION}}，服饰、建筑、器物与材质符合时代。
+构图与光线贴合场景与目标媒介。
+避免现代物品、时代错乱造型、无依据符号，以及多余文字、logo、水印。`,
   preferredParams: { size: '1536x1024', quality: 'medium' },
   capability: {},
 }

--- a/packages/shared/src/imagePromptingGuide/scenes/g6-comic-strip.ts
+++ b/packages/shared/src/imagePromptingGuide/scenes/g6-comic-strip.ts
@@ -9,11 +9,11 @@ export const g6ComicStrip: GenerationScene = {
   groupId: 'narrative',
   groupLabel: '叙事',
   fundamentalsRefs: ['define_result', 'maintainable_format', 'people_actions', 'exact_text'],
-  promptScaffold: `Create a {{PANEL_COUNT}}-panel comic strip about {{STORY}}.
-Keep characters, clothing, props, and setting visually consistent across panels.
-Give each panel a distinct story beat, clear action, and an obvious reading order.
-Render supplied dialogue exactly in readable speech balloons.
-Do not add extra panels, dialogue, logos, or watermarks.`,
+  promptScaffold: `创作一套 {{PANEL_COUNT}} 格漫画，讲述 {{STORY}}。
+人物、服装、道具与场景在各格保持视觉一致。
+每格有独立情节推进、清晰动作与明确阅读顺序。
+所给对白须精确写入可读气泡。
+不要额外分格、对白、logo 或水印。`,
   preferredParams: { size: '1536x1024', quality: 'medium' },
   capability: {},
   expandViaPromptMode: 'storyboard',

--- a/packages/shared/src/imagePromptingGuide/scenes/g7-interface-preview.ts
+++ b/packages/shared/src/imagePromptingGuide/scenes/g7-interface-preview.ts
@@ -9,11 +9,11 @@ export const g7InterfacePreview: GenerationScene = {
   groupId: 'brand_ui',
   groupLabel: '品牌/UI',
   fundamentalsRefs: ['define_result', 'maintainable_format', 'exact_text'],
-  promptScaffold: `Create a polished interface preview for {{PRODUCT_AND_SCREEN}}.
-Show a clear information hierarchy, consistent components, practical spacing, and accessible contrast.
-Use realistic content and render all supplied labels exactly.
-Present the interface from a straightforward viewing angle without obscuring important controls.
-Do not add illegible filler text, unrelated branding, or watermarks.`,
+  promptScaffold: `为 {{PRODUCT_AND_SCREEN}} 创作一张精致的界面预览。
+信息层级清楚，组件一致，间距实用，对比度可读。
+内容贴近真实，所给文案标签须精确呈现。
+取景正面清晰，勿遮挡关键控件。
+不要难辨认的填充字、无关品牌或水印。`,
   preferredParams: { size: '1536x1024', quality: 'medium' },
   capability: {},
 }

--- a/packages/shared/src/imagePromptingGuide/scenes/g8-scientific-visual.ts
+++ b/packages/shared/src/imagePromptingGuide/scenes/g8-scientific-visual.ts
@@ -9,11 +9,11 @@ export const g8ScientificVisual: GenerationScene = {
   groupId: 'info_design',
   groupLabel: '信息设计',
   fundamentalsRefs: ['define_result', 'visible_details', 'exact_text'],
-  promptScaffold: `Create an educational scientific visual explaining {{CONCEPT}} for {{AUDIENCE}}.
-Show the relevant structures, relationships, scale cues, and process accurately.
-Use a clean composition, restrained colors, and clear callouts.
-Render supplied labels exactly and keep annotation lines unambiguous.
-Do not invent unsupported anatomy, data, labels, logos, or watermarks.`,
+  promptScaffold: `创作一张面向 {{AUDIENCE}} 的科学教育图，讲解 {{CONCEPT}}。
+准确呈现相关结构、关系、比例线索与过程。
+构图干净、配色克制、标注清楚。
+所给标签须精确呈现，指示线指向明确、不歧义。
+不要杜撰结构、数据、标签，以及 logo 或水印。`,
   preferredParams: { size: '1536x1024', quality: 'medium' },
   capability: {},
 }

--- a/packages/shared/src/imagePromptingGuide/scenes/g9-slides-charts.ts
+++ b/packages/shared/src/imagePromptingGuide/scenes/g9-slides-charts.ts
@@ -9,11 +9,11 @@ export const g9SlidesCharts: GenerationScene = {
   groupId: 'info_design',
   groupLabel: '信息设计',
   fundamentalsRefs: ['define_result', 'maintainable_format', 'exact_text'],
-  promptScaffold: `Create a presentation slide about {{TOPIC}} using the supplied data.
-Choose a chart form that represents the values faithfully and label units, categories, and legend clearly.
-Use one strong takeaway, concise supporting copy, and a professional visual hierarchy.
-Render titles, labels, and values exactly as provided.
-Do not invent data, distort axes, add unrelated copy, logos, or watermarks.`,
+  promptScaffold: `用所给数据创作一张关于 {{TOPIC}} 的演示幻灯片。
+选择忠实呈现数值的图表类型，并清楚标注单位、类别与图例。
+突出一条核心结论，辅以简短说明，视觉层级专业。
+标题、标签与数值须按提供内容精确呈现。
+不要编造数据、扭曲坐标轴，不要加无关文案、logo 或水印。`,
   preferredParams: { size: '1536x1024', quality: 'medium' },
   capability: {},
 }


### PR DESCRIPTION
## Summary
- Prompt/Image Dock header: icon + **场景模板** / active scene Chinese label (ellipsis), fuchsia when active.
- Catalog G1–G9 / E1–E8: Chinese user-facing scaffolds; English \`systemOverlay\` unchanged (方案 A).
- Spec/plan: \`docs/superpowers/specs/2026-09-12-dock-guide-scene-label-design.md\`

## Test plan
- [x] \`pnpm --filter @lnkpi/shared test\`
- [x] guideSceneApply + guideEditIntentApply vitest
- [ ] Prompt Dock: select G3 → header shows「精确文字」; empty prompt prefills Chinese with \`{{TAGLINE}}\`
- [ ] Image Dock: same label behavior
- [ ] Clear scene →「场景模板」; non-empty prompt still not overwritten


Made with [Cursor](https://cursor.com)