### PR TITLE
fix: asset library short label + local uploads persist

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -4,7 +4,11 @@ AGENT_RUNTIME_SERVICE_TOKEN="dev-token"
 # When set and GET {url}/health is ok, chat streams via LangGraph runtime; else CanvasAgent
 AGENT_RUNTIME_URL="http://127.0.0.1:8000"
 
-# Object storage (COS / S3-compatible) — Wave A A3 media persist
+# Object storage — Wave A A3 media persist
+# When OBJECT_STORAGE_ENDPOINT/BUCKET/ACCESS_KEY/SECRET_KEY are all set → COS/S3.
+# When unset → LocalFilesystemStorageAdapter writes to uploads/ (CVM disk / docker volume).
+# OBJECT_STORAGE_DRIVER=none → force 503 (disable persist-remote rehost).
+# OBJECT_STORAGE_DRIVER=
 OBJECT_STORAGE_ENDPOINT=
 OBJECT_STORAGE_BUCKET=
 OBJECT_STORAGE_ACCESS_KEY=
@@ -12,3 +16,5 @@ OBJECT_STORAGE_SECRET_KEY=
 OBJECT_STORAGE_REGION=ap-guangzhou
 OBJECT_STORAGE_PUBLIC_BASE_URL=
 OBJECT_STORAGE_FORCE_PATH_STYLE=true
+# Optional override for local uploads root (default: <cwd>/uploads)
+# UPLOADS_ROOT=

--- a/apps/server/src/assets/assets.controller.ts
+++ b/apps/server/src/assets/assets.controller.ts
@@ -11,6 +11,7 @@ import {
   Req,
   UseGuards,
 } from '@nestjs/common'
+import { Transform } from 'class-transformer'
 import { IsBoolean, IsIn, IsOptional, IsString, MaxLength } from 'class-validator'
 import { Request } from 'express'
 import { AuthGuard } from '../auth/auth.guard'
@@ -43,6 +44,9 @@ class PersistRemoteDto {
   kind!: 'image' | 'video' | 'audio'
 
   @IsOptional()
+  @Transform(({ value }) =>
+    typeof value === 'string' && value.length > 128 ? value.slice(0, 128) : value,
+  )
   @IsString()
   @MaxLength(128)
   label?: string
@@ -81,6 +85,9 @@ class SaveUserAssetDto {
   url!: string
 
   @IsOptional()
+  @Transform(({ value }) =>
+    typeof value === 'string' && value.length > 128 ? value.slice(0, 128) : value,
+  )
   @IsString()
   @MaxLength(128)
   label?: string

--- a/apps/server/src/assets/persist-remote.service.ts
+++ b/apps/server/src/assets/persist-remote.service.ts
@@ -230,7 +230,7 @@ export class PersistRemoteService {
   private assertStorageConfigured(): void {
     if (this.storage instanceof UnconfiguredStorageAdapter) {
       throw new ServiceUnavailableException(
-        '对象存储未配置，无法持久化收藏。请配置 OBJECT_STORAGE_* 或稍后重试',
+        '存储未启用（OBJECT_STORAGE_DRIVER=none），无法持久化收藏',
       )
     }
   }

--- a/apps/server/src/storage/local-filesystem.storage-adapter.test.ts
+++ b/apps/server/src/storage/local-filesystem.storage-adapter.test.ts
@@ -1,0 +1,60 @@
+import { BadRequestException } from '@nestjs/common'
+import { mkdtemp, readFile, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { Readable } from 'stream'
+import {
+  LocalFilesystemStorageAdapter,
+  resolveUploadTarget,
+} from './local-filesystem.storage-adapter'
+
+describe('resolveUploadTarget', () => {
+  it('maps users/{id}/assets/{year}/{file} to flat upload target', () => {
+    expect(resolveUploadTarget('users/u1/assets/2026/abc.png')).toEqual({
+      userId: 'u1',
+      fileName: 'abc.png',
+    })
+  })
+
+  it('rejects path traversal / malformed keys', () => {
+    expect(() => resolveUploadTarget('../etc/passwd')).toThrow(BadRequestException)
+    expect(() => resolveUploadTarget('users/u1/assets/2026/../x.png')).toThrow(BadRequestException)
+  })
+})
+
+describe('LocalFilesystemStorageAdapter', () => {
+  let rootDir = ''
+
+  beforeEach(async () => {
+    rootDir = await mkdtemp(join(tmpdir(), 'lnkpi-local-storage-'))
+  })
+
+  afterEach(async () => {
+    await rm(rootDir, { recursive: true, force: true })
+  })
+
+  it('writes stream under uploads/{userId}/{file} and returns /api/uploads url', async () => {
+    const adapter = new LocalFilesystemStorageAdapter({ rootDir })
+    const { publicUrl } = await adapter.putStream({
+      key: 'users/u1/assets/2026/deadbeef.png',
+      body: Readable.from([Buffer.from('png-bytes')]),
+      contentType: 'image/png',
+    })
+    expect(publicUrl).toBe('/api/uploads/u1/deadbeef.png')
+    const written = await readFile(join(rootDir, 'u1', 'deadbeef.png'))
+    expect(written.toString()).toBe('png-bytes')
+  })
+
+  it('prefixes API_PUBLIC_URL when configured', async () => {
+    const adapter = new LocalFilesystemStorageAdapter({
+      rootDir,
+      publicBaseUrl: 'http://119.29.173.89:8888',
+    })
+    const { publicUrl } = await adapter.putStream({
+      key: 'users/u2/assets/2026/aa.bin',
+      body: Readable.from([Buffer.from('x')]),
+      contentType: 'application/octet-stream',
+    })
+    expect(publicUrl).toBe('http://119.29.173.89:8888/api/uploads/u2/aa.bin')
+  })
+})

--- a/apps/server/src/storage/local-filesystem.storage-adapter.ts
+++ b/apps/server/src/storage/local-filesystem.storage-adapter.ts
@@ -1,0 +1,52 @@
+import { BadRequestException } from '@nestjs/common'
+import { createWriteStream } from 'fs'
+import { mkdir } from 'fs/promises'
+import { join } from 'path'
+import { pipeline } from 'stream/promises'
+import type { StorageAdapter, StoragePutInput } from './storage.adapter'
+
+export type LocalFilesystemStorageConfig = {
+  /** Absolute or cwd-relative uploads root (same as Nest static `/api/uploads/`). */
+  rootDir: string
+  /** Optional `API_PUBLIC_URL` so returned URLs are absolute for clients. */
+  publicBaseUrl?: string
+}
+
+/**
+ * Persist streams onto the CVM (or local) uploads volume.
+ * Public URL shape matches existing upload refs: `/api/uploads/{userId}/{fileName}`.
+ */
+export class LocalFilesystemStorageAdapter implements StorageAdapter {
+  constructor(private readonly config: LocalFilesystemStorageConfig) {}
+
+  async putStream(input: StoragePutInput): Promise<{ publicUrl: string }> {
+    const { userId, fileName } = resolveUploadTarget(input.key)
+    const userDir = join(this.config.rootDir, userId)
+    await mkdir(userDir, { recursive: true })
+    const absPath = join(userDir, fileName)
+    if (!absPath.startsWith(userDir)) {
+      throw new BadRequestException('非法存储路径')
+    }
+    await pipeline(input.body, createWriteStream(absPath))
+    const relativeUrl = `/api/uploads/${userId}/${fileName}`
+    const base = this.config.publicBaseUrl?.replace(/\/$/, '')
+    return { publicUrl: base ? `${base}${relativeUrl}` : relativeUrl }
+  }
+}
+
+/** Map persist key `users/{userId}/assets/{year}/{uuid}.ext` → flat upload path. */
+export function resolveUploadTarget(key: string): { userId: string; fileName: string } {
+  const parts = key.split('/').filter(Boolean)
+  if (parts[0] !== 'users' || !parts[1] || parts.length < 3) {
+    throw new BadRequestException('非法存储 key')
+  }
+  if (parts.some((p) => p === '..' || p.includes('\\') || p.includes('\0'))) {
+    throw new BadRequestException('非法存储 key')
+  }
+  const userId = parts[1]
+  const fileName = parts[parts.length - 1]
+  if (!userId || !fileName || fileName.includes('/')) {
+    throw new BadRequestException('非法存储 key')
+  }
+  return { userId, fileName }
+}

--- a/apps/server/src/storage/storage.adapter.test.ts
+++ b/apps/server/src/storage/storage.adapter.test.ts
@@ -1,5 +1,6 @@
 import { ServiceUnavailableException } from '@nestjs/common'
 import { createStorageAdapterFromEnv } from './storage.module'
+import { LocalFilesystemStorageAdapter } from './local-filesystem.storage-adapter'
 import { UnconfiguredStorageAdapter } from './unconfigured.storage-adapter'
 import { Readable } from 'stream'
 
@@ -10,16 +11,25 @@ describe('StorageAdapter factory', () => {
     process.env = { ...prev }
   })
 
-  it('returns UnconfiguredStorageAdapter when env missing', () => {
+  it('returns LocalFilesystemStorageAdapter when COS env missing', () => {
     delete process.env.OBJECT_STORAGE_ENDPOINT
     delete process.env.OBJECT_STORAGE_BUCKET
     delete process.env.OBJECT_STORAGE_ACCESS_KEY
     delete process.env.OBJECT_STORAGE_SECRET_KEY
+    delete process.env.OBJECT_STORAGE_DRIVER
+    const adapter = createStorageAdapterFromEnv()
+    expect(adapter).toBeInstanceOf(LocalFilesystemStorageAdapter)
+  })
+
+  it('returns UnconfiguredStorageAdapter when DRIVER=none', () => {
+    process.env.OBJECT_STORAGE_DRIVER = 'none'
+    delete process.env.OBJECT_STORAGE_ENDPOINT
     const adapter = createStorageAdapterFromEnv()
     expect(adapter).toBeInstanceOf(UnconfiguredStorageAdapter)
   })
 
   it('returns S3CompatibleStorageAdapter when env complete', () => {
+    delete process.env.OBJECT_STORAGE_DRIVER
     process.env.OBJECT_STORAGE_ENDPOINT = 'https://cos.example'
     process.env.OBJECT_STORAGE_BUCKET = 'b'
     process.env.OBJECT_STORAGE_ACCESS_KEY = 'ak'

--- a/apps/server/src/storage/storage.module.ts
+++ b/apps/server/src/storage/storage.module.ts
@@ -1,31 +1,49 @@
 import { Global, Module } from '@nestjs/common'
+import { join } from 'path'
+import { LocalFilesystemStorageAdapter } from './local-filesystem.storage-adapter'
 import { S3CompatibleStorageAdapter } from './s3-compatible.storage-adapter'
 import { STORAGE_ADAPTER, type StorageAdapter } from './storage.adapter'
 import { UnconfiguredStorageAdapter } from './unconfigured.storage-adapter'
 
+/**
+ * Prefer COS/S3 when OBJECT_STORAGE_* is complete; otherwise persist to local uploads/
+ * (CVM disk / docker volume). Set OBJECT_STORAGE_DRIVER=none to force 503 (tests / lock-down).
+ */
 export function createStorageAdapterFromEnv(): StorageAdapter {
+  const driver = process.env.OBJECT_STORAGE_DRIVER?.trim().toLowerCase()
+  if (driver === 'none') {
+    return new UnconfiguredStorageAdapter()
+  }
+
   const endpoint = process.env.OBJECT_STORAGE_ENDPOINT?.trim()
   const bucket = process.env.OBJECT_STORAGE_BUCKET?.trim()
   const accessKey = process.env.OBJECT_STORAGE_ACCESS_KEY?.trim()
   const secretKey = process.env.OBJECT_STORAGE_SECRET_KEY?.trim()
-  if (!endpoint || !bucket || !accessKey || !secretKey) {
-    return new UnconfiguredStorageAdapter()
+  if (endpoint && bucket && accessKey && secretKey) {
+    const region = process.env.OBJECT_STORAGE_REGION?.trim()
+    const publicBaseUrl = process.env.OBJECT_STORAGE_PUBLIC_BASE_URL?.trim()
+    const forcePathStyleRaw = process.env.OBJECT_STORAGE_FORCE_PATH_STYLE?.trim()
+    const forcePathStyle =
+      forcePathStyleRaw === undefined || forcePathStyleRaw === ''
+        ? undefined
+        : forcePathStyleRaw === 'true'
+    return new S3CompatibleStorageAdapter({
+      endpoint,
+      bucket,
+      accessKeyId: accessKey,
+      secretAccessKey: secretKey,
+      ...(region ? { region } : {}),
+      ...(publicBaseUrl ? { publicBaseUrl } : {}),
+      ...(forcePathStyle !== undefined ? { forcePathStyle } : {}),
+    })
   }
-  const region = process.env.OBJECT_STORAGE_REGION?.trim()
-  const publicBaseUrl = process.env.OBJECT_STORAGE_PUBLIC_BASE_URL?.trim()
-  const forcePathStyleRaw = process.env.OBJECT_STORAGE_FORCE_PATH_STYLE?.trim()
-  const forcePathStyle =
-    forcePathStyleRaw === undefined || forcePathStyleRaw === ''
-      ? undefined
-      : forcePathStyleRaw === 'true'
-  return new S3CompatibleStorageAdapter({
-    endpoint,
-    bucket,
-    accessKeyId: accessKey,
-    secretAccessKey: secretKey,
-    ...(region ? { region } : {}),
+
+  const rootDir =
+    process.env.UPLOADS_ROOT?.trim() || join(process.cwd(), 'uploads')
+  const publicBaseUrl = process.env.API_PUBLIC_URL?.replace(/\/$/, '') || undefined
+  return new LocalFilesystemStorageAdapter({
+    rootDir,
     ...(publicBaseUrl ? { publicBaseUrl } : {}),
-    ...(forcePathStyle !== undefined ? { forcePathStyle } : {}),
   })
 }
 

--- a/apps/server/src/storage/unconfigured.storage-adapter.ts
+++ b/apps/server/src/storage/unconfigured.storage-adapter.ts
@@ -4,7 +4,7 @@ import type { StorageAdapter, StoragePutInput } from './storage.adapter'
 export class UnconfiguredStorageAdapter implements StorageAdapter {
   async putStream(_input: StoragePutInput): Promise<{ publicUrl: string }> {
     throw new ServiceUnavailableException(
-      '对象存储未配置，无法持久化收藏。请配置 OBJECT_STORAGE_* 或稍后重试',
+      '存储未启用（OBJECT_STORAGE_DRIVER=none），无法持久化收藏',
     )
   }
 }

--- a/apps/web/src/components/canvas/CanvasNodeAudio.vue
+++ b/apps/web/src/components/canvas/CanvasNodeAudio.vue
@@ -89,7 +89,8 @@ function saveToLibrary() {
   void saveAssetToLibrary({
     kind: 'audio',
     url,
-    label: props.data.label ?? props.data.prompt ?? '',
+    label: props.data.label,
+    prompt: props.data.prompt,
     sourceNodeId: props.id,
     sessionId: sessionId.value,
   })

--- a/apps/web/src/components/canvas/CanvasNodeImage.vue
+++ b/apps/web/src/components/canvas/CanvasNodeImage.vue
@@ -111,7 +111,8 @@ function saveToLibrary() {
   void saveAssetToLibrary({
     kind: 'image',
     url,
-    label: props.data.label ?? props.data.prompt ?? '',
+    label: props.data.label,
+    prompt: props.data.prompt,
     sourceNodeId: props.id,
     sessionId: sessionId.value,
     generationRecordId: props.data.generationRecordId,

--- a/apps/web/src/composables/useAssetLibrary.test.ts
+++ b/apps/web/src/composables/useAssetLibrary.test.ts
@@ -1,6 +1,10 @@
 import type { AxiosResponse } from 'axios'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
-import { saveAssetToLibrary } from './useAssetLibrary'
+import {
+  ASSET_LIBRARY_LABEL_MAX,
+  resolveAssetLibraryLabel,
+  saveAssetToLibrary,
+} from './useAssetLibrary'
 import { assetsApi } from '@/services/assets-api'
 
 vi.mock('@/services/assets-api', () => ({
@@ -21,6 +25,27 @@ vi.mock('element-plus', () => ({
 function mockAxiosResponse<T>(data: T): AxiosResponse<T> {
   return { data, status: 200, statusText: 'OK', headers: {}, config: {} as AxiosResponse<T>['config'] }
 }
+
+describe('resolveAssetLibraryLabel', () => {
+  it('prefers short label over prompt', () => {
+    expect(
+      resolveAssetLibraryLabel({ kind: 'image', label: '产品图', prompt: '很长的提示词'.repeat(20) }),
+    ).toBe('产品图')
+  })
+
+  it('falls back to prompt then kind default', () => {
+    expect(resolveAssetLibraryLabel({ kind: 'image', prompt: '  抠图  ' })).toBe('抠图')
+    expect(resolveAssetLibraryLabel({ kind: 'video' })).toBe('视频')
+    expect(resolveAssetLibraryLabel({ kind: 'audio', label: '' })).toBe('音频')
+  })
+
+  it('truncates to 128 chars (not filename semantics)', () => {
+    const long = '为这个图片创作广告图'.repeat(20)
+    const resolved = resolveAssetLibraryLabel({ kind: 'image', prompt: long })
+    expect(resolved.length).toBe(ASSET_LIBRARY_LABEL_MAX)
+    expect(resolved).toBe(long.slice(0, ASSET_LIBRARY_LABEL_MAX))
+  })
+})
 
 describe('saveAssetToLibrary', () => {
   beforeEach(() => {
@@ -54,7 +79,29 @@ describe('saveAssetToLibrary', () => {
       mockAxiosResponse({ code: 0, data: {} }) as never,
     )
     await saveAssetToLibrary({ kind: 'image', url: '/api/uploads/u/a.png' })
-    expect(assetsApi.saveMine).toHaveBeenCalledWith({ kind: 'image', url: '/api/uploads/u/a.png' })
+    expect(assetsApi.saveMine).toHaveBeenCalledWith({
+      kind: 'image',
+      url: '/api/uploads/u/a.png',
+      label: '图片',
+    })
     expect(assetsApi.persistRemote).not.toHaveBeenCalled()
+  })
+
+  it('truncates long prompt used as title before saveMine', async () => {
+    vi.mocked(assetsApi.saveMine).mockResolvedValue(
+      mockAxiosResponse({ code: 0, data: {} }) as never,
+    )
+    const longPrompt = '为这个图片创作精致品牌广告推广图画面'.repeat(10)
+    expect(longPrompt.length).toBeGreaterThan(ASSET_LIBRARY_LABEL_MAX)
+    await saveAssetToLibrary({
+      kind: 'image',
+      url: '/api/uploads/u/a.png',
+      prompt: longPrompt,
+    })
+    expect(assetsApi.saveMine).toHaveBeenCalledWith({
+      kind: 'image',
+      url: '/api/uploads/u/a.png',
+      label: longPrompt.slice(0, ASSET_LIBRARY_LABEL_MAX),
+    })
   })
 })

--- a/apps/web/src/composables/useAssetLibrary.ts
+++ b/apps/web/src/composables/useAssetLibrary.ts
@@ -83,7 +83,9 @@ export async function saveAssetToLibrary(payload: SaveAssetToLibraryInput) {
   } catch (e: unknown) {
     const status = (e as { response?: { status?: number } })?.response?.status
     if (status === 503) {
-      ElMessage.error('对象存储未配置，无法持久化收藏。请配置 OBJECT_STORAGE_* 或稍后重试')
+      ElMessage.error(
+        '媒体持久化不可用（存储未启用）。请检查服务端 uploads 或 OBJECT_STORAGE_* 配置后重试',
+      )
     } else {
       ElMessage.error('保存失败，请稍后重试')
     }

--- a/apps/web/src/composables/useAssetLibrary.ts
+++ b/apps/web/src/composables/useAssetLibrary.ts
@@ -3,6 +3,9 @@ import { ElMessage } from 'element-plus'
 import { assetsApi, type SaveUserAssetPayload } from '@/services/assets-api'
 import { isUpstreamMediaUrl } from '@/composables/useCanvasMedia'
 
+/** 与服务端 PersistRemoteDto / SaveUserAssetDto `@MaxLength(128)` 对齐：资产库标题，不是文件名 */
+export const ASSET_LIBRARY_LABEL_MAX = 128
+
 /** 资产库版本号：保存/删除成功后自增，资产库面板据此重新拉取 */
 export const assetLibraryVersion = ref(0)
 
@@ -10,8 +13,41 @@ export function bumpAssetLibrary() {
   assetLibraryVersion.value += 1
 }
 
+function defaultAssetLibraryLabel(kind: SaveUserAssetPayload['kind']): string {
+  switch (kind) {
+    case 'video':
+      return '视频'
+    case 'audio':
+      return '音频'
+    default:
+      return '图片'
+  }
+}
+
+/**
+ * 资产库展示标题：优先短 label，其次 prompt，再默认「图片/视频/音频」；超长截断到 128。
+ * 完整提示词应留在 generation metadata，不要整段塞进 label。
+ */
+export function resolveAssetLibraryLabel(opts: {
+  kind: SaveUserAssetPayload['kind']
+  label?: string | null
+  prompt?: string | null
+}): string {
+  const preferred =
+    (typeof opts.label === 'string' && opts.label.trim()) ||
+    (typeof opts.prompt === 'string' && opts.prompt.trim()) ||
+    defaultAssetLibraryLabel(opts.kind)
+  if (preferred.length <= ASSET_LIBRARY_LABEL_MAX) return preferred
+  return preferred.slice(0, ASSET_LIBRARY_LABEL_MAX)
+}
+
+export type SaveAssetToLibraryInput = SaveUserAssetPayload & {
+  /** Dock 提示词；仅在没有短 label 时作标题后备，会截断 */
+  prompt?: string | null
+}
+
 /** 把节点媒体保存进全局资产库（需登录；同一 URL 幂等） */
-export async function saveAssetToLibrary(payload: SaveUserAssetPayload) {
+export async function saveAssetToLibrary(payload: SaveAssetToLibraryInput) {
   if (!localStorage.getItem('token')) {
     ElMessage.warning('登录后才能保存到资产库')
     return false
@@ -20,19 +56,26 @@ export async function saveAssetToLibrary(payload: SaveUserAssetPayload) {
     ElMessage.warning('该文件尚未上传成功，无法保存到资产库')
     return false
   }
+  const { prompt: _prompt, ...rest } = payload
+  const label = resolveAssetLibraryLabel({
+    kind: payload.kind,
+    label: payload.label,
+    prompt: payload.prompt,
+  })
+  const normalized: SaveUserAssetPayload = { ...rest, label }
   try {
-    if (isUpstreamMediaUrl(payload.url)) {
+    if (isUpstreamMediaUrl(normalized.url)) {
       await assetsApi.persistRemote({
-        url: payload.url,
-        kind: payload.kind,
-        label: payload.label,
-        sourceNodeId: payload.sourceNodeId,
-        sessionId: payload.sessionId,
-        replaceNodeUrl: payload.replaceNodeUrl,
-        generationRecordId: payload.generationRecordId,
+        url: normalized.url,
+        kind: normalized.kind,
+        label: normalized.label,
+        sourceNodeId: normalized.sourceNodeId,
+        sessionId: normalized.sessionId,
+        replaceNodeUrl: normalized.replaceNodeUrl,
+        generationRecordId: normalized.generationRecordId,
       })
     } else {
-      await assetsApi.saveMine(payload)
+      await assetsApi.saveMine(normalized)
     }
     bumpAssetLibrary()
     ElMessage.success('已存入资产库')

--- a/deploy/.env.production.example
+++ b/deploy/.env.production.example
@@ -42,6 +42,17 @@ APIMART_BASE_URL=https://api.apimart.ai/v1
 # NODE_USE_ENV_PROXY=1
 # NO_PROXY=localhost,127.0.0.1,lnkpi-api,lnkpi-agent-runtime,postgres,redis
 
+# --- 媒体持久化（Wave A A3）---
+# 四项均配置 → 腾讯云 COS / S3；留空 → 写入本机 uploads 卷（docker volume lnkpi-uploads）
+# OBJECT_STORAGE_DRIVER=none → 关闭 persist-remote（503）
+# OBJECT_STORAGE_ENDPOINT=
+# OBJECT_STORAGE_BUCKET=
+# OBJECT_STORAGE_ACCESS_KEY=
+# OBJECT_STORAGE_SECRET_KEY=
+# OBJECT_STORAGE_REGION=ap-guangzhou
+# OBJECT_STORAGE_PUBLIC_BASE_URL=
+# OBJECT_STORAGE_FORCE_PATH_STYLE=true
+
 # --- Agent Runtime（LangGraph；详见 deploy/AGENT_RUNTIME_PRODUCTION.md）---
 # 服务互信（不是出图 BYOK Key）。两边 token 必须相同。
 AGENT_RUNTIME_SERVICE_TOKEN=


### PR DESCRIPTION
## Summary
- Truncate asset-library titles to 128 chars (prefer label → prompt → default), with server-side clip as defense.
- When `OBJECT_STORAGE_*` is unset, persist-remote rehosts upstream media to local `uploads/` (docker volume); COS still used when fully configured; `OBJECT_STORAGE_DRIVER=none` keeps the 503 lock-down.

## Test plan
- [ ] `pnpm --filter @lnkpi/server exec vitest run src/storage src/assets/persist-remote.service.test.ts`
- [ ] `pnpm --filter @lnkpi/web exec vitest run src/composables/useAssetLibrary.test.ts`
- [ ] Without COS env: save Agnes-generated image to asset library → 200, URL under `/api/uploads/...`
- [ ] With long Dock prompt: saved asset label ≤ 128 on `/assets/mine`
- [ ] `OBJECT_STORAGE_DRIVER=none`: persist-remote still returns 503


Made with [Cursor](https://cursor.com)