### PR TITLE
fix(web): fit viewport after workflow import when nodes unmeasured

### DIFF
--- a/apps/web/src/composables/fitImportedViewport.test.ts
+++ b/apps/web/src/composables/fitImportedViewport.test.ts
@@ -27,14 +27,15 @@ describe('fitImportedViewport', () => {
     expect(updateNodeInternals).toHaveBeenCalledWith(['a', 'b'])
     expect(fitView).toHaveBeenCalled()
     expect(fitBounds).toHaveBeenCalledOnce()
-    const [bounds, opts] = fitBounds.mock.calls[0]
-    expect(bounds).toEqual({
-      x: 2000,
-      y: 2100,
-      width: 400 + IMPORT_NODE_ESTIMATE.width,
-      height: IMPORT_NODE_ESTIMATE.height,
-    })
-    expect(opts).toMatchObject({ padding: 0.2, duration: 300 })
+    expect(fitBounds).toHaveBeenCalledWith(
+      {
+        x: 2000,
+        y: 2100,
+        width: 400 + IMPORT_NODE_ESTIMATE.width,
+        height: IMPORT_NODE_ESTIMATE.height,
+      },
+      expect.objectContaining({ padding: 0.2, duration: 300 }),
+    )
     expect(result).toBe('fitBounds')
   })
 

--- a/apps/web/src/composables/fitImportedViewport.test.ts
+++ b/apps/web/src/composables/fitImportedViewport.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fitImportedViewport } from './fitImportedViewport'
+import { IMPORT_NODE_ESTIMATE } from './workflowImportPlacement'
+
+describe('fitImportedViewport', () => {
+  it('falls back to fitBounds with estimated bbox when fitView skips unmeasured nodes', async () => {
+    const fitView = vi.fn(async () => false)
+    const fitBounds = vi.fn(async () => true)
+    const updateNodeInternals = vi.fn()
+
+    const nodes = [
+      { id: 'a', position: { x: 2000, y: 2100 } },
+      { id: 'b', position: { x: 2400, y: 2100 } },
+    ]
+
+    const result = await fitImportedViewport({
+      ids: ['a', 'b'],
+      nodes,
+      getMeasuredNode: () => undefined,
+      fitView,
+      fitBounds,
+      updateNodeInternals,
+      wait: async () => {},
+      maxAttempts: 2,
+    })
+
+    expect(updateNodeInternals).toHaveBeenCalledWith(['a', 'b'])
+    expect(fitView).toHaveBeenCalled()
+    expect(fitBounds).toHaveBeenCalledOnce()
+    const [bounds, opts] = fitBounds.mock.calls[0]
+    expect(bounds).toEqual({
+      x: 2000,
+      y: 2100,
+      width: 400 + IMPORT_NODE_ESTIMATE.width,
+      height: IMPORT_NODE_ESTIMATE.height,
+    })
+    expect(opts).toMatchObject({ padding: 0.2, duration: 300 })
+    expect(result).toBe('fitBounds')
+  })
+
+  it('uses fitView once imported nodes have dimensions', async () => {
+    const fitView = vi.fn(async () => true)
+    const fitBounds = vi.fn(async () => true)
+    let attempt = 0
+
+    const result = await fitImportedViewport({
+      ids: ['a'],
+      nodes: [{ id: 'a', position: { x: 10, y: 20 } }],
+      getMeasuredNode: (id) => {
+        attempt += 1
+        if (attempt < 2) return { id, dimensions: { width: 0, height: 0 } }
+        return { id, dimensions: { width: 280, height: 180 } }
+      },
+      fitView,
+      fitBounds,
+      wait: async () => {},
+      maxAttempts: 5,
+    })
+
+    expect(result).toBe('fitView')
+    expect(fitView).toHaveBeenCalled()
+    expect(fitBounds).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/composables/fitImportedViewport.ts
+++ b/apps/web/src/composables/fitImportedViewport.ts
@@ -1,0 +1,85 @@
+import {
+  IMPORT_NODE_ESTIMATE,
+  type NodeLike,
+  type Rect,
+  type Size,
+  unionNodeBBox,
+} from './workflowImportPlacement'
+
+export type MeasuredNode = {
+  id: string
+  dimensions?: { width: number; height: number }
+}
+
+export type FitImportedViewportDeps = {
+  ids: string[]
+  nodes: NodeLike[]
+  getMeasuredNode: (id: string) => MeasuredNode | undefined
+  fitView: (opts: {
+    nodes: string[]
+    padding: number
+    duration: number
+  }) => Promise<boolean | void>
+  fitBounds: (
+    bounds: Rect,
+    opts: { padding: number; duration: number },
+  ) => Promise<unknown>
+  updateNodeInternals?: (ids: string[]) => void
+  wait?: () => Promise<void>
+  maxAttempts?: number
+  estimate?: Size
+  padding?: number
+  duration?: number
+}
+
+function hasDimensions(node: MeasuredNode | undefined): boolean {
+  return Boolean(node?.dimensions?.width && node?.dimensions?.height)
+}
+
+async function defaultWait() {
+  await new Promise<void>((resolve) => {
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => resolve())
+    } else {
+      setTimeout(resolve, 0)
+    }
+  })
+}
+
+/**
+ * Vue Flow's fitView skips nodes without measured dimensions.
+ * After a fresh import, one nextTick is often too early — wait briefly,
+ * then fall back to fitBounds using estimated sizes from positions.
+ */
+export async function fitImportedViewport(
+  deps: FitImportedViewportDeps,
+): Promise<'fitView' | 'fitBounds' | 'none'> {
+  const ids = deps.ids.filter(Boolean)
+  if (!ids.length) return 'none'
+
+  const padding = deps.padding ?? 0.2
+  const duration = deps.duration ?? 300
+  const maxAttempts = deps.maxAttempts ?? 12
+  const wait = deps.wait ?? defaultWait
+  const estimate = deps.estimate ?? IMPORT_NODE_ESTIMATE
+
+  deps.updateNodeInternals?.(ids)
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    await wait()
+    const measured = ids.some((id) => hasDimensions(deps.getMeasuredNode(id)))
+    if (!measured && attempt < maxAttempts - 1) continue
+
+    const ok = await deps.fitView({ nodes: ids, padding, duration })
+    if (ok !== false) return 'fitView'
+    if (measured) break
+  }
+
+  const idSet = new Set(ids)
+  const scoped = deps.nodes.filter((n) => idSet.has(n.id))
+  const bounds = unionNodeBBox(scoped, estimate)
+  if (!bounds) return 'none'
+
+  await deps.fitBounds(bounds, { padding, duration })
+  return 'fitBounds'
+}

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -104,6 +104,7 @@ import {
   importWorkflowPackage,
   type WorkflowExportMode,
 } from '@/composables/useWorkflowExchange'
+import { fitImportedViewport } from '@/composables/fitImportedViewport'
 import { fileToPersistedPayload, inferMediaInputKind } from '@/composables/useMediaUpload'
 import { useDebouncedNodePatch } from '@/composables/useDebouncedNodePatch'
 import {
@@ -2206,7 +2207,28 @@ async function onWorkflowImportSelected(event: Event) {
       fitImportedNodes: async (ids) => {
         await nextTick()
         try {
-          await vueFlowRef.value?.fitView({ nodes: ids, padding: 0.2, duration: 300 })
+          const flow = vueFlowRef.value as {
+            findNode?: (id: string) => { id: string; dimensions?: { width: number; height: number } } | undefined
+            fitView?: (opts: { nodes: string[]; padding: number; duration: number }) => Promise<boolean | void>
+            fitBounds?: (
+              bounds: { x: number; y: number; width: number; height: number },
+              opts: { padding: number; duration: number },
+            ) => Promise<unknown>
+            updateNodeInternals?: (ids?: string[] | string) => void
+          } | null
+          if (!flow?.fitView || !flow.fitBounds) return
+          await fitImportedViewport({
+            ids,
+            nodes: nodes.value.map((n) => ({
+              id: n.id,
+              position: n.position,
+              parentNode: (n as { parentNode?: string }).parentNode,
+            })),
+            getMeasuredNode: (id) => flow.findNode?.(id),
+            fitView: (opts) => flow.fitView!(opts),
+            fitBounds: (bounds, opts) => flow.fitBounds!(bounds, opts),
+            updateNodeInternals: (nodeIds) => flow.updateNodeInternals?.(nodeIds),
+          })
         } catch {
           // ignore
         }


### PR DESCRIPTION
## Summary
- 根因：Vue Flow `fitView({ nodes })` 会跳过尚无 `dimensions` 的节点；导入后仅 `nextTick` 时新节点通常未测量，导致视口不动。
- 新增 `fitImportedViewport`：`updateNodeInternals` + 短暂等待后重试 `fitView`；仍失败则用估算 bbox 走 `fitBounds`。
- `CanvasPage` 导入路径接入该 helper。

## Test plan
- [x] `pnpm --filter @lnkpi/web exec vitest run src/composables/fitImportedViewport.test.ts`（及相关 placement/exchange）
- [x] `pnpm --filter @lnkpi/web build`（含 vue-tsc）
- [ ] 生产/预览：已有节点画布导入 zip 后，视口应对准导入块（短动画）
- [ ] 空画布导入：视口仍对准新块
- [ ] 非法 zip：仍不 merge，无 fit


Made with [Cursor](https://cursor.com)