### PR TITLE
fix(server): DirectUploadService Nest DI crash (#293)

### DIFF
--- a/apps/server/src/upload/direct-upload.module.di.test.ts
+++ b/apps/server/src/upload/direct-upload.module.di.test.ts
@@ -1,0 +1,18 @@
+import 'reflect-metadata'
+import { describe, expect, it } from 'vitest'
+import { Test } from '@nestjs/testing'
+import { DirectUploadService } from './direct-upload.service'
+import { STORAGE_ADAPTER } from '../storage/storage.adapter'
+
+describe('DirectUploadService Nest DI', () => {
+  it('resolves with only STORAGE_ADAPTER (no optional Function param)', async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        DirectUploadService,
+        { provide: STORAGE_ADAPTER, useValue: {} },
+      ],
+    }).compile()
+    expect(moduleRef.get(DirectUploadService)).toBeInstanceOf(DirectUploadService)
+    await moduleRef.close()
+  })
+})

--- a/apps/server/src/upload/direct-upload.service.test.ts
+++ b/apps/server/src/upload/direct-upload.service.test.ts
@@ -2,16 +2,20 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { BadRequestException } from '@nestjs/common'
 import { DirectUploadService } from './direct-upload.service'
 
+vi.mock('../storage/object-storage-env', () => ({
+  isObjectStorageConfigured: vi.fn(() => true),
+}))
+
+import { isObjectStorageConfigured } from '../storage/object-storage-env'
+
 describe('DirectUploadService', () => {
   const presignPut = vi.fn()
   let svc: DirectUploadService
 
   beforeEach(() => {
     presignPut.mockReset()
-    svc = new DirectUploadService(
-      { presignPut } as any,
-      () => true, // isConfigured
-    )
+    vi.mocked(isObjectStorageConfigured).mockReturnValue(true)
+    svc = new DirectUploadService({ presignPut } as any)
   })
 
   it('rejects oversize', async () => {
@@ -25,7 +29,8 @@ describe('DirectUploadService', () => {
   })
 
   it('returns local when storage not configured', async () => {
-    svc = new DirectUploadService({} as any, () => false)
+    vi.mocked(isObjectStorageConfigured).mockReturnValue(false)
+    svc = new DirectUploadService({} as any)
     await expect(
       svc.createCredential('u1', { fileName: 'a.png', mimeType: 'image/png', size: 10 }),
     ).resolves.toEqual({ mode: 'local' })

--- a/apps/server/src/upload/direct-upload.service.ts
+++ b/apps/server/src/upload/direct-upload.service.ts
@@ -20,14 +20,9 @@ export type DirectUploadCredential =
 
 @Injectable()
 export class DirectUploadService {
-  private readonly isConfigured: () => boolean
-
   constructor(
     @Inject(STORAGE_ADAPTER) private readonly adapter: StorageAdapter,
-    isConfigured?: () => boolean,
-  ) {
-    this.isConfigured = isConfigured ?? isObjectStorageConfigured
-  }
+  ) {}
 
   async createCredential(
     userId: string,
@@ -40,7 +35,7 @@ export class DirectUploadService {
       )
     }
 
-    if (!this.isConfigured() || !this.adapter.presignPut) {
+    if (!isObjectStorageConfigured() || !this.adapter.presignPut) {
       return { mode: 'local' }
     }
 


### PR DESCRIPTION
## Summary
- Remove optional `isConfigured?: () => boolean` ctor arg from `DirectUploadService` so Nest no longer tries to inject `Function` at index `[1]`.
- Call `isObjectStorageConfigured()` directly; update unit tests and add a Nest TestingModule DI smoke test.

Closes prod crash-loop from #293 (`Nest can't resolve dependencies of the DirectUploadService (Symbol(STORAGE_ADAPTER), ?)`).

## Test plan
- [x] `vitest` `direct-upload.service.test.ts` + `direct-upload.module.di.test.ts`
- [x] `pnpm --filter @lnkpi/server` prisma generate + build
- [ ] CI green
- [ ] After deploy: `lnkpi-api` healthy (no DI crash)


Made with [Cursor](https://cursor.com)