### PR TITLE
feat: A1 image upscale (fal Real-ESRGAN)

### DIFF
--- a/apps/server/src/agent/agent-canvas-tools.controller.ts
+++ b/apps/server/src/agent/agent-canvas-tools.controller.ts
@@ -563,6 +563,30 @@ class ApplyLayoutOpsDto {
   ops!: Array<Record<string, unknown>>
 }
 
+class UpscaleImageDto {
+  @IsString()
+  sessionId!: string
+
+  @IsString()
+  userId!: string
+
+  @IsOptional()
+  @IsString()
+  nodeId?: string
+
+  @IsOptional()
+  @IsString()
+  imageUrl?: string
+
+  @IsOptional()
+  @IsIn([2, 4])
+  scale?: 2 | 4
+
+  @IsOptional()
+  @IsString()
+  provider?: string
+}
+
 class SaveAgentMessageDto {
   @IsString()
   sessionId!: string
@@ -975,6 +999,12 @@ export class AgentCanvasToolsController {
   @Post('get-image-edit-capabilities')
   async getImageEditCapabilities(@Body() dto: SessionNodeDto) {
     const data = await this.tools.getImageEditCapabilities(dto)
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('upscale-image')
+  async upscaleImage(@Body() dto: UpscaleImageDto) {
+    const data = await this.tools.upscaleImage(dto)
     return { code: 0, message: 'ok', data }
   }
 

--- a/apps/server/src/agent/agent-canvas-tools.service.test.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.test.ts
@@ -6,6 +6,7 @@ import { IMPORT_PLACE_MARGIN, rectsOverlap, unionNodeBBox, type CanvasData } fro
 import { PrismaService } from '../prisma/prisma.service'
 import { PersistRemoteService } from '../assets/persist-remote.service'
 import { StudioService } from '../studio/studio.service'
+import { UpscaleService } from '../studio/upscale.service'
 import { VideoGenerationOrchestrator } from '../studio/video-generation.orchestrator'
 import { MaterialService } from '../canvas/material.service'
 import { AgentCanvasToolsService } from './agent-canvas-tools.service'
@@ -36,6 +37,7 @@ describe('AgentCanvasToolsService', () => {
   const confirmPlatformFallbackMaterial = vi.fn()
   const materialFindFirst = vi.fn()
   const persistRemote = vi.fn()
+  const upscale = vi.fn()
 
   const defaultPrefs = {
     userId: 'u1',
@@ -127,6 +129,12 @@ describe('AgentCanvasToolsService', () => {
     })
     cancelPlatformFallbackMaterial.mockResolvedValue({ id: 'mat-1', status: 'failed' })
     materialFindFirst.mockResolvedValue(null)
+    upscale.mockResolvedValue({
+      url: 'https://cdn.example/upscaled.png',
+      scale: 2,
+      providerId: 'fal',
+      recordId: 'up-1',
+    })
     listGenerations.mockResolvedValue([
       {
         id: 'g1',
@@ -200,6 +208,10 @@ describe('AgentCanvasToolsService', () => {
         {
           provide: PersistRemoteService,
           useValue: { persistRemote },
+        },
+        {
+          provide: UpscaleService,
+          useValue: { upscale },
         },
       ],
     }).compile()
@@ -1464,6 +1476,31 @@ describe('AgentCanvasToolsService', () => {
       const copy = canvas.nodes.find((node) => node.id === result.nodeIds[0])
       expect(copy?.data?.generationRecordId).toBeUndefined()
       expect(copy?.data?.url).toBe('https://cdn.example/gen.png')
+    })
+
+    it('upscaleImage calls UpscaleService with mapped providerId', async () => {
+      const result = await svc.upscaleImage({
+        sessionId: 's1',
+        userId: 'u1',
+        nodeId: 'img-1',
+        imageUrl: 'https://cdn.example/src.png',
+        scale: 2,
+        provider: 'fal',
+      })
+      expect(upscale).toHaveBeenCalledWith({
+        userId: 'u1',
+        sessionId: 's1',
+        nodeId: 'img-1',
+        imageUrl: 'https://cdn.example/src.png',
+        scale: 2,
+        providerId: 'fal',
+      })
+      expect(result).toEqual({
+        url: 'https://cdn.example/upscaled.png',
+        scale: 2,
+        providerId: 'fal',
+        recordId: 'up-1',
+      })
     })
 
     it('getImageEditCapabilities reports only inpaint when image has url', async () => {

--- a/apps/server/src/agent/agent-canvas-tools.service.ts
+++ b/apps/server/src/agent/agent-canvas-tools.service.ts
@@ -26,6 +26,7 @@ import { PUBLIC_ASSETS } from '../assets/public-assets.data'
 import { MaterialService } from '../canvas/material.service'
 import { sanitizeAgentMessageContent } from './agentMessageSanitize'
 import { StudioService, type StudioRefInput } from '../studio/studio.service'
+import { UpscaleService } from '../studio/upscale.service'
 import { VideoGenerationOrchestrator } from '../studio/video-generation.orchestrator'
 import {
   applyLayoutOps,
@@ -381,6 +382,7 @@ export class AgentCanvasToolsService {
     @Inject(MaterialService) private readonly material: MaterialService,
     @Inject(VideoGenerationOrchestrator) private readonly videoOrchestrator: VideoGenerationOrchestrator,
     @Inject(PersistRemoteService) private readonly persistRemote: PersistRemoteService,
+    @Inject(UpscaleService) private readonly upscaleService: UpscaleService,
   ) {}
 
   private async loadAccountGenPrefs(userId: string): Promise<AccountGenPrefs> {
@@ -2177,6 +2179,24 @@ export class AgentCanvasToolsService {
       hasUrl: Boolean(url),
       supportedModes: canEdit ? ['inpaint'] : [],
     }
+  }
+
+  async upscaleImage(input: {
+    sessionId: string
+    userId: string
+    nodeId?: string
+    imageUrl?: string
+    scale?: 2 | 4
+    provider?: string
+  }) {
+    return this.upscaleService.upscale({
+      userId: input.userId,
+      sessionId: input.sessionId,
+      nodeId: input.nodeId,
+      imageUrl: input.imageUrl,
+      scale: input.scale,
+      providerId: input.provider,
+    })
   }
 
   async getAgentMessages(input: {

--- a/apps/server/src/agent/agent-canvas-tools.sidebar.test.ts
+++ b/apps/server/src/agent/agent-canvas-tools.sidebar.test.ts
@@ -5,6 +5,7 @@ import type { CanvasData, SidebarAttachment } from '@lnkpi/shared'
 import { PrismaService } from '../prisma/prisma.service'
 import { PersistRemoteService } from '../assets/persist-remote.service'
 import { StudioService } from '../studio/studio.service'
+import { UpscaleService } from '../studio/upscale.service'
 import { VideoGenerationOrchestrator } from '../studio/video-generation.orchestrator'
 import { MaterialService } from '../canvas/material.service'
 import { AgentCanvasToolsService } from './agent-canvas-tools.service'
@@ -76,6 +77,10 @@ describe('AgentCanvasToolsService.applySidebarAttachments', () => {
         {
           provide: PersistRemoteService,
           useValue: { persistRemote: vi.fn() },
+        },
+        {
+          provide: UpscaleService,
+          useValue: { upscale: vi.fn() },
         },
         VideoGenerationOrchestrator,
       ],

--- a/apps/server/src/agent/agent.service.capabilities.test.ts
+++ b/apps/server/src/agent/agent.service.capabilities.test.ts
@@ -10,6 +10,8 @@ const OBJECT_STORAGE_ENV_KEYS = [
   'OBJECT_STORAGE_SECRET_KEY',
 ] as const
 
+const CAPABILITY_ENV_KEYS = [...OBJECT_STORAGE_ENV_KEYS, 'FAL_KEY'] as const
+
 function createAgentService() {
   return new AgentService(
     {} as never,
@@ -20,17 +22,17 @@ function createAgentService() {
 }
 
 describe('AgentService getCapabilities', () => {
-  const savedEnv: Partial<Record<(typeof OBJECT_STORAGE_ENV_KEYS)[number], string | undefined>> = {}
+  const savedEnv: Partial<Record<(typeof CAPABILITY_ENV_KEYS)[number], string | undefined>> = {}
 
   beforeEach(() => {
-    for (const key of OBJECT_STORAGE_ENV_KEYS) {
+    for (const key of CAPABILITY_ENV_KEYS) {
       savedEnv[key] = process.env[key]
       delete process.env[key]
     }
   })
 
   afterEach(() => {
-    for (const key of OBJECT_STORAGE_ENV_KEYS) {
+    for (const key of CAPABILITY_ENV_KEYS) {
       if (savedEnv[key] === undefined) {
         delete process.env[key]
       } else {
@@ -70,5 +72,16 @@ describe('AgentService getCapabilities', () => {
 
     const svc = createAgentService()
     expect(svc.getCapabilities().stsDirectUpload).toBe(false)
+  })
+
+  it('returns imageUpscale false when no upscale providers are registered', () => {
+    const svc = createAgentService()
+    expect(svc.getCapabilities().imageUpscale).toBe(false)
+  })
+
+  it('returns imageUpscale true when FAL_KEY registers upscale providers', () => {
+    process.env.FAL_KEY = 'fal-test-key'
+    const svc = createAgentService()
+    expect(svc.getCapabilities().imageUpscale).toBe(true)
   })
 })

--- a/apps/server/src/agent/agent.service.ts
+++ b/apps/server/src/agent/agent.service.ts
@@ -4,7 +4,7 @@ import {
   Injectable,
   ServiceUnavailableException,
 } from '@nestjs/common'
-import { applyCanvasActions, type AgentStreamEvent } from '@lnkpi/agent'
+import { applyCanvasActions, createUpscaleProviders, type AgentStreamEvent } from '@lnkpi/agent'
 import type {
   AgentMessageMetadata,
   CanvasAction,
@@ -81,6 +81,8 @@ export class AgentService {
       image: IMAGE_MODELS,
       video: VIDEO_MODELS,
       stsDirectUpload: isObjectStorageConfigured(),
+      imageUpscale:
+        createUpscaleProviders({ falApiKey: process.env.FAL_KEY }).length > 0,
     }
   }
 

--- a/apps/server/src/canvas/canvas.controller.ts
+++ b/apps/server/src/canvas/canvas.controller.ts
@@ -9,6 +9,7 @@ import type {
 } from '@lnkpi/shared'
 import { AuthGuard } from '../auth/auth.guard'
 import { createCancelFlag } from '../points/charge-session'
+import { UpscaleService } from '../studio/upscale.service'
 import { CanvasService } from './canvas.service'
 import { MaterialService } from './material.service'
 import { SceneComposerService } from './scene-composer.service'
@@ -99,6 +100,27 @@ class GenerateImageDto {
   @IsArray()
   @IsString({ each: true })
   mentionedKeys?: string[]
+}
+
+class UpscaleImageDto {
+  @IsString()
+  sessionId!: string
+
+  @IsOptional()
+  @IsString()
+  nodeId?: string
+
+  @IsOptional()
+  @IsString()
+  imageUrl?: string
+
+  @IsOptional()
+  @IsIn([2, 4])
+  scale?: 2 | 4
+
+  @IsOptional()
+  @IsString()
+  provider?: string
 }
 
 class GenerateVideoDto {
@@ -360,6 +382,7 @@ export class CanvasController {
     @Inject(MaterialService) private readonly materialService: MaterialService,
     @Inject(SceneComposerService) private readonly sceneComposerService: SceneComposerService,
     @Inject(VideoCompositionService) private readonly videoCompositionService: VideoCompositionService,
+    @Inject(UpscaleService) private readonly upscaleService: UpscaleService,
   ) {}
 
   @Get('list')
@@ -430,6 +453,20 @@ export class CanvasController {
       count: dto.count,
       refs: dto.refs,
       mentionedKeys: dto.mentionedKeys,
+    })
+    return { code: 0, message: 'ok', data }
+  }
+
+  @Post('material/upscale-image')
+  @UseGuards(AuthGuard)
+  async upscaleImage(@Req() req: { user: { sub: string } }, @Body() dto: UpscaleImageDto) {
+    const data = await this.upscaleService.upscale({
+      userId: req.user.sub,
+      sessionId: dto.sessionId,
+      nodeId: dto.nodeId,
+      imageUrl: dto.imageUrl,
+      scale: dto.scale,
+      providerId: dto.provider,
     })
     return { code: 0, message: 'ok', data }
   }

--- a/apps/server/src/canvas/canvas.module.ts
+++ b/apps/server/src/canvas/canvas.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common'
 import { PointsModule } from '../points/points.module'
 import { ProviderModule } from '../provider/provider.module'
+import { StudioModule } from '../studio/studio.module'
 import { UploadModule } from '../upload/upload.module'
 import { MediaProbeModule } from '../media/media-probe.module'
 import { CanvasController } from './canvas.controller'
@@ -11,7 +12,7 @@ import { ShotService } from './shot.service'
 import { VideoCompositionService } from './video-composition.service'
 
 @Module({
-  imports: [UploadModule, PointsModule, ProviderModule, MediaProbeModule],
+  imports: [UploadModule, PointsModule, ProviderModule, MediaProbeModule, StudioModule],
   controllers: [CanvasController],
   providers: [
     CanvasService,

--- a/apps/server/src/canvas/canvas.upscale.controller.test.ts
+++ b/apps/server/src/canvas/canvas.upscale.controller.test.ts
@@ -1,0 +1,52 @@
+import 'reflect-metadata'
+import { describe, expect, it, vi } from 'vitest'
+import { CanvasController } from './canvas.controller'
+
+describe('CanvasController material/upscale-image', () => {
+  it('calls UpscaleService with session fields and maps provider → providerId', async () => {
+    const upscale = vi.fn(async () => ({
+      url: 'https://cdn/upscaled.png',
+      scale: 2 as const,
+      providerId: 'fal',
+      recordId: 'rec-1',
+    }))
+    const controller = new CanvasController(
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      { upscale } as never,
+    )
+
+    const result = await controller.upscaleImage(
+      { user: { sub: 'user-1' } },
+      {
+        sessionId: 's1',
+        nodeId: 'img-1',
+        imageUrl: 'https://cdn/src.png',
+        scale: 2,
+        provider: 'fal',
+      },
+    )
+
+    expect(upscale).toHaveBeenCalledWith({
+      userId: 'user-1',
+      sessionId: 's1',
+      nodeId: 'img-1',
+      imageUrl: 'https://cdn/src.png',
+      scale: 2,
+      providerId: 'fal',
+    })
+    expect(result).toEqual({
+      code: 0,
+      message: 'ok',
+      data: {
+        url: 'https://cdn/upscaled.png',
+        scale: 2,
+        providerId: 'fal',
+        recordId: 'rec-1',
+      },
+    })
+  })
+})

--- a/apps/server/src/points/reason-map.test.ts
+++ b/apps/server/src/points/reason-map.test.ts
@@ -10,6 +10,22 @@ describe('mapReasonToPointFields', () => {
     })
   })
 
+  it('maps 图像放大 to consume/image/success', () => {
+    expect(mapReasonToPointFields('图像放大', -10)).toEqual({
+      kind: 'consume',
+      category: 'image',
+      status: 'success',
+    })
+  })
+
+  it('maps 图像放大-失败退款', () => {
+    expect(mapReasonToPointFields('图像放大-失败退款', 10)).toEqual({
+      kind: 'refund',
+      category: 'image',
+      status: 'failed_refund',
+    })
+  })
+
   it('maps 文本生成-失败退款', () => {
     expect(mapReasonToPointFields('文本生成-失败退款', 5)).toEqual({
       kind: 'refund',

--- a/apps/server/src/points/reason-map.ts
+++ b/apps/server/src/points/reason-map.ts
@@ -2,7 +2,7 @@ import type { PointCategory, PointKind, PointTxStatus } from './point-tx.types'
 
 const CATEGORY_BY_LABEL: Array<{ match: RegExp; category: PointCategory }> = [
   { match: /文本生成|提示词模式生成/, category: 'text' },
-  { match: /图像生成|图像变体|图像精修/, category: 'image' },
+  { match: /图像生成|图像变体|图像精修|图像放大/, category: 'image' },
   { match: /视频生成/, category: 'video' },
   { match: /音频/, category: 'audio' },
 ]

--- a/apps/server/src/studio/studio.module.ts
+++ b/apps/server/src/studio/studio.module.ts
@@ -3,15 +3,24 @@ import { MediaProbeModule } from '../media/media-probe.module'
 import { PointsModule } from '../points/points.module'
 import { PrismaModule } from '../prisma/prisma.module'
 import { ProviderModule } from '../provider/provider.module'
+import { SessionsModule } from '../sessions/sessions.module'
 import { UploadModule } from '../upload/upload.module'
 import { StudioController } from './studio.controller'
 import { StudioService } from './studio.service'
+import { UpscaleService } from './upscale.service'
 import { VideoGenerationOrchestrator } from './video-generation.orchestrator'
 
 @Module({
-  imports: [MediaProbeModule, PointsModule, ProviderModule, PrismaModule, UploadModule],
+  imports: [
+    MediaProbeModule,
+    PointsModule,
+    ProviderModule,
+    PrismaModule,
+    SessionsModule,
+    UploadModule,
+  ],
   controllers: [StudioController],
-  providers: [StudioService, VideoGenerationOrchestrator],
-  exports: [StudioService, VideoGenerationOrchestrator],
+  providers: [StudioService, UpscaleService, VideoGenerationOrchestrator],
+  exports: [StudioService, UpscaleService, VideoGenerationOrchestrator],
 })
 export class StudioModule {}

--- a/apps/server/src/studio/studio.service.ts
+++ b/apps/server/src/studio/studio.service.ts
@@ -177,7 +177,7 @@ function parseMeta(raw: string | null | undefined): Record<string, unknown> {
 
 function studioPointCategory(type: string): PointCategory {
   if (type === 'text' || type === 'prompt') return 'text'
-  if (type === 'image' || type === 'image_edit') return 'image'
+  if (type === 'image' || type === 'image_edit' || type === 'image_upscale') return 'image'
   if (type === 'audio' || type === 'video') return type
   return 'other'
 }
@@ -2110,7 +2110,9 @@ export class StudioService {
           ? '图像生成'
           : record.type === 'image_edit'
             ? '图像精修'
-            : '生成'
+            : record.type === 'image_upscale'
+              ? '图像放大'
+              : '生成'
     let updatedMeta: Record<string, unknown> = { ...meta, cancelled: true }
     if (cost > 0 && !alreadyRefunded(meta)) {
       await this.points.refund(

--- a/apps/server/src/studio/upscale.service.test.ts
+++ b/apps/server/src/studio/upscale.service.test.ts
@@ -1,0 +1,209 @@
+import 'reflect-metadata'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Test } from '@nestjs/testing'
+import {
+  BadRequestException,
+  NotFoundException,
+  NotImplementedException,
+} from '@nestjs/common'
+import { createUpscaleProviders } from '@lnkpi/agent'
+import { PointsService } from '../points/points.service'
+import { PrismaService } from '../prisma/prisma.service'
+import { SessionsService } from '../sessions/sessions.service'
+import { UPSCALE_POINT_COST, UpscaleService } from './upscale.service'
+
+const upscaleFn = vi.fn()
+const supportsScale = vi.fn((scale: 2 | 4) => scale === 2 || scale === 4)
+
+vi.mock('@lnkpi/agent', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@lnkpi/agent')>()
+  return {
+    ...actual,
+    createUpscaleProviders: vi.fn(() => [
+      {
+        id: 'fal',
+        supportsScale,
+        upscale: upscaleFn,
+      },
+    ]),
+  }
+})
+
+vi.mock('../media/upstream-ref-inline', () => ({
+  inlineUpstreamReferenceImages: vi.fn(async (urls: string[]) => urls),
+}))
+
+describe('UpscaleService', () => {
+  let svc: UpscaleService
+  let pointsConsume: ReturnType<typeof vi.fn>
+  let pointsRefund: ReturnType<typeof vi.fn>
+  let generationCreate: ReturnType<typeof vi.fn>
+  let generationUpdate: ReturnType<typeof vi.fn>
+  let findOne: ReturnType<typeof vi.fn>
+  let stored: Record<string, unknown>
+
+  const baseInput = {
+    userId: 'u1',
+    sessionId: 's1',
+    imageUrl: 'https://cdn/base.png',
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    stored = {}
+    pointsConsume = vi.fn(async () => {})
+    pointsRefund = vi.fn(async () => {})
+    supportsScale.mockImplementation((scale: 2 | 4) => scale === 2 || scale === 4)
+    upscaleFn.mockResolvedValue({
+      url: 'https://cdn/upscaled.png',
+      providerId: 'fal',
+      modelId: 'fal-ai/esrgan',
+    })
+    vi.mocked(createUpscaleProviders).mockReturnValue([
+      {
+        id: 'fal',
+        supportsScale,
+        upscale: upscaleFn,
+      },
+    ])
+    findOne = vi.fn(async () => ({
+      id: 's1',
+      userId: 'u1',
+      canvasData: {
+        nodes: [
+          {
+            id: 'n1',
+            type: 'image',
+            data: { url: 'https://cdn/from-node.png' },
+          },
+        ],
+        edges: [],
+      },
+    }))
+    generationCreate = vi.fn(async (args: { data: Record<string, unknown> }) => {
+      stored = { id: 'g-up', createdAt: new Date(), ...args.data }
+      return stored
+    })
+    generationUpdate = vi.fn(async (args: { where: { id: string }; data: Record<string, unknown> }) => {
+      stored = { ...stored, ...args.data, id: args.where.id }
+      return stored
+    })
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        UpscaleService,
+        {
+          provide: PointsService,
+          useValue: { consume: pointsConsume, refund: pointsRefund },
+        },
+        {
+          provide: PrismaService,
+          useValue: {
+            generationRecord: {
+              create: generationCreate,
+              update: generationUpdate,
+              findFirst: vi.fn(async () => stored),
+            },
+          },
+        },
+        {
+          provide: SessionsService,
+          useValue: { findOne },
+        },
+      ],
+    }).compile()
+
+    svc = moduleRef.get(UpscaleService)
+  })
+
+  it('throws NotImplemented when no providers registered', async () => {
+    vi.mocked(createUpscaleProviders).mockReturnValueOnce([])
+
+    await expect(svc.upscale(baseInput)).rejects.toBeInstanceOf(NotImplementedException)
+    expect(pointsConsume).not.toHaveBeenCalled()
+    expect(generationCreate).not.toHaveBeenCalled()
+  })
+
+  it('throws BadRequest when provider does not support scale=4', async () => {
+    supportsScale.mockReturnValue(false)
+
+    await expect(svc.upscale({ ...baseInput, scale: 4 })).rejects.toBeInstanceOf(BadRequestException)
+    expect(pointsConsume).not.toHaveBeenCalled()
+  })
+
+  it('propagates 积分不足 from consume and does not create record', async () => {
+    pointsConsume.mockRejectedValueOnce(new BadRequestException('积分不足'))
+
+    await expect(svc.upscale(baseInput)).rejects.toMatchObject({
+      message: expect.stringContaining('积分不足'),
+    })
+    expect(generationCreate).not.toHaveBeenCalled()
+    expect(upscaleFn).not.toHaveBeenCalled()
+  })
+
+  it('resolves imageUrl from nodeId via session canvasData', async () => {
+    const out = await svc.upscale({
+      userId: 'u1',
+      sessionId: 's1',
+      nodeId: 'n1',
+    })
+
+    expect(findOne).toHaveBeenCalledWith('s1', 'u1')
+    expect(upscaleFn).toHaveBeenCalledWith(
+      expect.objectContaining({ imageUrl: 'https://cdn/from-node.png', scale: 2 }),
+    )
+    expect(out.url).toBe('https://cdn/upscaled.png')
+  })
+
+  it('throws when nodeId missing from canvas', async () => {
+    await expect(
+      svc.upscale({ userId: 'u1', sessionId: 's1', nodeId: 'missing' }),
+    ).rejects.toBeInstanceOf(NotFoundException)
+    expect(pointsConsume).not.toHaveBeenCalled()
+  })
+
+  it('consumes points, writes image_upscale record, returns result on success', async () => {
+    const out = await svc.upscale({ ...baseInput, scale: 2 })
+
+    expect(createUpscaleProviders).toHaveBeenCalledWith(
+      expect.objectContaining({ falApiKey: process.env.FAL_KEY }),
+    )
+    expect(pointsConsume).toHaveBeenCalledWith(
+      'u1',
+      UPSCALE_POINT_COST,
+      '图像放大',
+      expect.objectContaining({ kind: 'consume', category: 'image', status: 'success' }),
+    )
+    expect(generationCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: 'image_upscale',
+          status: 'generating',
+          sessionId: 's1',
+        }),
+      }),
+    )
+    expect(stored.status).toBe('completed')
+    expect(stored.url).toBe('https://cdn/upscaled.png')
+    expect(out).toEqual({
+      url: 'https://cdn/upscaled.png',
+      scale: 2,
+      providerId: 'fal',
+      recordId: 'g-up',
+    })
+  })
+
+  it('refunds points and marks record failed when provider throws', async () => {
+    upscaleFn.mockRejectedValueOnce(new Error('upstream 502'))
+
+    await expect(svc.upscale(baseInput)).rejects.toBeInstanceOf(BadRequestException)
+    expect(pointsRefund).toHaveBeenCalledWith(
+      'u1',
+      UPSCALE_POINT_COST,
+      '图像放大-失败退款',
+      expect.objectContaining({ kind: 'refund', category: 'image', status: 'failed_refund' }),
+    )
+    expect(stored.status).toBe('failed')
+    expect(stored.type).toBe('image_upscale')
+  })
+})

--- a/apps/server/src/studio/upscale.service.ts
+++ b/apps/server/src/studio/upscale.service.ts
@@ -1,0 +1,217 @@
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  NotFoundException,
+  NotImplementedException,
+} from '@nestjs/common'
+import { createUpscaleProviders, type UpscaleProvider } from '@lnkpi/agent'
+import { applyChargeMeta, applyRefundMeta } from '../points/charge-session'
+import { PointsService } from '../points/points.service'
+import { consumeMeta, refundMeta } from '../points/point-tx.types'
+import { PrismaService } from '../prisma/prisma.service'
+import { SessionsService } from '../sessions/sessions.service'
+import { inlineUpstreamReferenceImages } from '../media/upstream-ref-inline'
+
+/** Same tier as single 图像生成 consume in StudioService. */
+export const UPSCALE_POINT_COST = 10
+
+export const UPSCALE_CHARGE_REASON = '图像放大'
+
+export type UpscaleServiceInput = {
+  userId: string
+  sessionId: string
+  nodeId?: string
+  imageUrl?: string
+  scale?: 2 | 4
+  providerId?: string
+}
+
+export type UpscaleServiceResult = {
+  url: string
+  scale: 2 | 4
+  providerId: string
+  recordId: string
+}
+
+type CanvasNodeLike = {
+  id: string
+  data?: Record<string, unknown> | null
+}
+
+function parseMeta(raw: string | null | undefined): Record<string, unknown> {
+  if (!raw) return {}
+  try {
+    return JSON.parse(raw) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+@Injectable()
+export class UpscaleService {
+  constructor(
+    @Inject(PrismaService) private readonly prisma: PrismaService,
+    @Inject(PointsService) private readonly points: PointsService,
+    @Inject(SessionsService) private readonly sessions: SessionsService,
+  ) {}
+
+  async upscale(input: UpscaleServiceInput): Promise<UpscaleServiceResult> {
+    const scale: 2 | 4 = input.scale ?? 2
+    if (scale !== 2 && scale !== 4) {
+      throw new BadRequestException('scale 仅支持 2 或 4')
+    }
+
+    const session = await this.sessions.findOne(input.sessionId, input.userId)
+    const imageUrl = this.resolveImageUrl(input, session.canvasData)
+
+    const providers = createUpscaleProviders({
+      falApiKey: process.env.FAL_KEY,
+    })
+    if (!providers.length) {
+      throw new NotImplementedException('图像放大暂不可用')
+    }
+
+    const provider = this.pickProvider(providers, input.providerId)
+    if (!provider.supportsScale(scale)) {
+      throw new BadRequestException(`当前通道不支持 ${scale}× 放大`)
+    }
+
+    await this.points.consume(
+      input.userId,
+      UPSCALE_POINT_COST,
+      UPSCALE_CHARGE_REASON,
+      consumeMeta('image', { model: provider.id, generationId: null }),
+    )
+
+    const chargeMeta = applyChargeMeta(
+      {
+        chargeReason: UPSCALE_CHARGE_REASON,
+        scale,
+        providerId: provider.id,
+        sourceImageUrl: imageUrl,
+      },
+      UPSCALE_POINT_COST,
+    )
+
+    const record = await this.prisma.generationRecord.create({
+      data: {
+        userId: input.userId,
+        type: 'image_upscale',
+        prompt: `upscale ${scale}x`,
+        model: provider.id,
+        status: 'generating',
+        metadata: JSON.stringify(chargeMeta),
+        sessionId: input.sessionId,
+        ...(input.nodeId ? { nodeId: input.nodeId } : {}),
+      },
+    })
+
+    try {
+      const [inlined] = await inlineUpstreamReferenceImages([imageUrl])
+      const result = await provider.upscale({
+        imageUrl: inlined ?? imageUrl,
+        scale,
+      })
+
+      const existing = await this.prisma.generationRecord.findFirst({ where: { id: record.id } })
+      const meta = parseMeta(existing?.metadata)
+      await this.prisma.generationRecord.update({
+        where: { id: record.id },
+        data: {
+          url: result.url,
+          status: 'completed',
+          metadata: JSON.stringify({
+            ...meta,
+            scale,
+            providerId: result.providerId,
+            modelId: result.modelId,
+            chargeReason: UPSCALE_CHARGE_REASON,
+            sourceImageUrl: imageUrl,
+          }),
+        },
+      })
+
+      return {
+        url: result.url,
+        scale,
+        providerId: result.providerId,
+        recordId: record.id,
+      }
+    } catch (err) {
+      await this.points.refund(
+        input.userId,
+        UPSCALE_POINT_COST,
+        `${UPSCALE_CHARGE_REASON}-失败退款`,
+        refundMeta('image', 'failed_refund', {
+          model: provider.id,
+          generationId: record.id,
+        }),
+      )
+      const existing = await this.prisma.generationRecord.findFirst({ where: { id: record.id } })
+      const meta = parseMeta(existing?.metadata)
+      await this.prisma.generationRecord.update({
+        where: { id: record.id },
+        data: {
+          status: 'failed',
+          metadata: JSON.stringify(
+            applyRefundMeta(
+              {
+                ...meta,
+                errorRaw: err instanceof Error ? err.message.slice(0, 8000) : String(err),
+              },
+              UPSCALE_POINT_COST,
+              'platform_failed',
+            ),
+          ),
+        },
+      })
+      const message = err instanceof Error ? err.message : '图像放大失败'
+      throw new BadRequestException({
+        message,
+        refundedPoints: UPSCALE_POINT_COST,
+        taskId: record.id,
+      })
+    }
+  }
+
+  private pickProvider(providers: UpscaleProvider[], providerId?: string): UpscaleProvider {
+    if (!providerId?.trim()) return providers[0]!
+    const found = providers.find((p) => p.id === providerId.trim())
+    if (!found) {
+      throw new BadRequestException(`指定 provider 不可用: ${providerId}`)
+    }
+    return found
+  }
+
+  /**
+   * Prefer server-resolved node URL when nodeId is present (same field as
+   * AgentCanvasToolsService.getGenerationStatus / getNode data.url).
+   */
+  private resolveImageUrl(
+    input: UpscaleServiceInput,
+    canvasData: unknown,
+  ): string {
+    if (input.nodeId) {
+      const nodes = (canvasData as { nodes?: CanvasNodeLike[] } | undefined)?.nodes
+      const node = Array.isArray(nodes)
+        ? nodes.find((n) => n.id === input.nodeId)
+        : undefined
+      if (!node) throw new NotFoundException('节点不存在')
+      const url =
+        typeof node.data?.url === 'string' && node.data.url.trim()
+          ? node.data.url.trim()
+          : ''
+      if (!url) {
+        throw new BadRequestException('节点没有可放大的图片')
+      }
+      return url
+    }
+
+    const imageUrl = input.imageUrl?.trim()
+    if (!imageUrl) {
+      throw new BadRequestException('需要 imageUrl 或可解析的 nodeId')
+    }
+    return imageUrl
+  }
+}

--- a/apps/server/src/video-reference.controller.test.ts
+++ b/apps/server/src/video-reference.controller.test.ts
@@ -43,6 +43,7 @@ describe('video generate controllers', () => {
       { generateVideo } as never,
       {} as never,
       {} as never,
+      {} as never,
     )
 
     await controller.generateVideo(

--- a/apps/web/src/components/canvas/CanvasContextMenu.test.ts
+++ b/apps/web/src/components/canvas/CanvasContextMenu.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import CanvasContextMenu from './CanvasContextMenu.vue'
+
+describe('CanvasContextMenu upscale', () => {
+  it('lists 放大 before 编辑图像 and disables when imageUpscale is false', async () => {
+    const wrapper = mount(CanvasContextMenu, {
+      props: {
+        x: 10,
+        y: 20,
+        nodeId: 'img-1',
+        nodeType: 'image',
+        hasUrl: true,
+        imageUpscale: false,
+      },
+    })
+
+    const labels = wrapper.findAll('button').map((b) => b.text())
+    expect(labels[0]).toBe('放大')
+    expect(labels[1]).toBe('编辑图像')
+
+    const upscale = wrapper.findAll('button')[0]
+    expect(upscale.attributes('disabled')).toBeDefined()
+    expect(upscale.attributes('title')).toContain('未启用')
+
+    await upscale.trigger('click')
+    expect(wrapper.emitted('action')).toBeUndefined()
+    wrapper.unmount()
+  })
+
+  it('emits upscale-image when capability is on', async () => {
+    const wrapper = mount(CanvasContextMenu, {
+      props: {
+        x: 10,
+        y: 20,
+        nodeId: 'img-1',
+        nodeType: 'image',
+        hasUrl: true,
+        imageUpscale: true,
+      },
+    })
+
+    await wrapper.findAll('button')[0].trigger('click')
+    expect(wrapper.emitted('action')?.[0]?.[0]).toBe('upscale-image')
+    wrapper.unmount()
+  })
+})

--- a/apps/web/src/components/canvas/CanvasContextMenu.vue
+++ b/apps/web/src/components/canvas/CanvasContextMenu.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from 'vue'
 import { CX_IMAGE_EDIT_ENABLED, canOpenRefineForNode } from '@/utils/refineSession'
 
-const { x, y, nodeId, nodeType, hasUrl, mediaKind, mimeType } = defineProps<{
+const props = defineProps<{
   x: number
   y: number
   nodeId?: string
@@ -11,6 +11,8 @@ const { x, y, nodeId, nodeType, hasUrl, mediaKind, mimeType } = defineProps<{
   mediaKind?: string
   mimeType?: string
   multiSelectedCount?: number
+  /** capabilities.imageUpscale；false 时「放大」disabled + tooltip */
+  imageUpscale?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -21,20 +23,36 @@ const emit = defineEmits<{
 const visible = ref(true)
 
 const showUpstreamDuplicate = computed(
-  () => nodeType !== 'group' && Boolean(nodeId),
+  () => props.nodeType !== 'group' && Boolean(props.nodeId),
 )
 
 const showEditImage = computed(
   () =>
     CX_IMAGE_EDIT_ENABLED &&
-    Boolean(hasUrl) &&
-    canOpenRefineForNode({ type: nodeType, mediaKind, mimeType }),
+    Boolean(props.hasUrl) &&
+    canOpenRefineForNode({
+      type: props.nodeType,
+      mediaKind: props.mediaKind,
+      mimeType: props.mimeType,
+    }),
+)
+
+const showUpscale = computed(() => showEditImage.value)
+
+const upscaleDisabled = computed(() => !props.imageUpscale)
+const upscaleTitle = computed(() =>
+  props.imageUpscale ? '放大 2×' : '当前环境未启用图像放大',
 )
 
 function run(action: string, payload?: string) {
   emit('action', action, payload)
   visible.value = false
   emit('close')
+}
+
+function runUpscale() {
+  if (upscaleDisabled.value) return
+  run('upscale-image')
 }
 </script>
 
@@ -45,6 +63,17 @@ function run(action: string, payload?: string) {
     :style="{ left: `${x}px`, top: `${y}px` }"
     @click.stop
   >
+    <button
+      v-if="showUpscale"
+      class="neo-popover-item block w-full px-4 py-2 text-left text-xs"
+      :disabled="upscaleDisabled"
+      :title="upscaleTitle"
+      :class="{ 'opacity-45 cursor-not-allowed': upscaleDisabled }"
+      @click="runUpscale"
+    >
+      放大
+    </button>
+
     <button
       v-if="showEditImage"
       class="neo-popover-item block w-full px-4 py-2 text-left text-xs"

--- a/apps/web/src/components/canvas/SelectionActionBar.test.ts
+++ b/apps/web/src/components/canvas/SelectionActionBar.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import SelectionActionBar from './SelectionActionBar.vue'
+
+vi.mock('@vue-flow/core', () => ({
+  useVueFlow: () => ({
+    viewport: ref({ x: 0, y: 0, zoom: 1 }),
+    nodes: ref([]),
+    findNode: () => undefined,
+  }),
+}))
+
+describe('SelectionActionBar', () => {
+  const node = {
+    id: 'img-1',
+    type: 'image',
+    position: { x: 100, y: 80 },
+    data: { url: 'https://cdn/a.png' },
+  }
+
+  it('renders 放大 and 编辑; disables upscale with tooltip when capability off', async () => {
+    const wrapper = mount(SelectionActionBar, {
+      props: {
+        node: node as never,
+        imageUpscale: false,
+        loading: false,
+      },
+    })
+
+    const buttons = wrapper.findAll('button')
+    expect(buttons.map((b) => b.text())).toEqual(['放大', '编辑'])
+
+    const upscale = buttons[0]
+    expect(upscale.attributes('disabled')).toBeDefined()
+    expect(upscale.attributes('title')).toContain('未启用')
+
+    await upscale.trigger('click')
+    expect(wrapper.emitted('upscale')).toBeUndefined()
+
+    await buttons[1].trigger('click')
+    expect(wrapper.emitted('edit')).toHaveLength(1)
+    wrapper.unmount()
+  })
+
+  it('emits upscale when enabled; shows loading label', async () => {
+    const wrapper = mount(SelectionActionBar, {
+      props: {
+        node: node as never,
+        imageUpscale: true,
+        loading: false,
+      },
+    })
+
+    await wrapper.get('button.accent').trigger('click')
+    expect(wrapper.emitted('upscale')).toHaveLength(1)
+
+    await wrapper.setProps({ loading: true })
+    expect(wrapper.get('button.accent').text()).toContain('放大中')
+    expect(wrapper.get('button.accent').attributes('disabled')).toBeDefined()
+    wrapper.unmount()
+  })
+})

--- a/apps/web/src/components/canvas/SelectionActionBar.vue
+++ b/apps/web/src/components/canvas/SelectionActionBar.vue
@@ -1,0 +1,147 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useVueFlow } from '@vue-flow/core'
+import { getAbsolutePosition, getNodeSize, type FlowNode } from '@/composables/useCanvasGrouping'
+
+/**
+ * 挂载方式：节点坐标系（与 NodeEditorToolbarOverlay 同模式）。
+ * 随 VueFlow viewport 缩放/平移，避免屏幕坐标贴 bbox 在缩放时错位。
+ */
+const props = defineProps<{
+  node: FlowNode
+  imageUpscale: boolean
+  loading?: boolean
+}>()
+
+const emit = defineEmits<{
+  upscale: []
+  edit: []
+}>()
+
+const { viewport, nodes: flowNodes, findNode } = useVueFlow()
+
+const flowPos = ref<{ x: number; y: number } | null>(null)
+const barWidth = 168
+
+function updatePosition() {
+  const allNodes = flowNodes.value as unknown as FlowNode[]
+  const flowNode = findNode(props.node.id) as FlowNode | undefined
+  const type = String(props.node.type ?? '')
+  const sizeNode = flowNode ?? ({ ...props.node, type } as FlowNode)
+  const abs = getAbsolutePosition(sizeNode, allNodes)
+  const { w } = getNodeSize(sizeNode)
+  flowPos.value = {
+    x: abs.x + w / 2,
+    y: abs.y - 44,
+  }
+}
+
+let raf = 0
+function scheduleUpdate() {
+  cancelAnimationFrame(raf)
+  raf = requestAnimationFrame(updatePosition)
+}
+
+watch(
+  () => props.node?.id,
+  () => {
+    updatePosition()
+  },
+  { immediate: true },
+)
+watch(viewport, scheduleUpdate, { deep: true })
+watch(flowNodes, scheduleUpdate, { deep: true })
+
+onMounted(() => {
+  scheduleUpdate()
+  window.addEventListener('resize', scheduleUpdate)
+})
+
+onUnmounted(() => {
+  cancelAnimationFrame(raf)
+  window.removeEventListener('resize', scheduleUpdate)
+})
+
+const transformStyle = computed(() => ({
+  transform: `translate(${viewport.value.x}px, ${viewport.value.y}px) scale(${viewport.value.zoom})`,
+  transformOrigin: '0 0',
+}))
+
+const barStyle = computed(() => {
+  if (!flowPos.value) return { display: 'none' }
+  return {
+    left: `${flowPos.value.x}px`,
+    top: `${flowPos.value.y}px`,
+    width: `${barWidth}px`,
+    transform: 'translate(-50%, 0)',
+  }
+})
+
+const upscaleDisabled = computed(() => !props.imageUpscale || Boolean(props.loading))
+const upscaleTitle = computed(() => {
+  if (props.loading) return '放大中…'
+  if (!props.imageUpscale) return '当前环境未启用图像放大'
+  return '放大 2×'
+})
+
+function onUpscale() {
+  if (upscaleDisabled.value) return
+  emit('upscale')
+}
+</script>
+
+<template>
+  <div
+    v-if="flowPos"
+    class="selection-action-bar-layer pointer-events-none absolute inset-0 z-[46] overflow-visible"
+  >
+    <div class="origin-top-left" :style="transformStyle">
+      <div class="pointer-events-auto absolute" :style="barStyle">
+        <div
+          class="neo-chrome flex items-center justify-center gap-1 rounded-xl px-1.5 py-1"
+          @click.stop
+        >
+          <button
+            type="button"
+            class="toolbar-action accent"
+            :disabled="upscaleDisabled"
+            :title="upscaleTitle"
+            @click="onUpscale"
+          >
+            {{ loading ? '放大中…' : '放大' }}
+          </button>
+          <button
+            type="button"
+            class="toolbar-action"
+            title="编辑图像"
+            @click="emit('edit')"
+          >
+            编辑
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.toolbar-action {
+  border-radius: 0.5rem;
+  padding: 0.25rem 0.625rem;
+  font-size: 11px;
+  line-height: 1.25;
+  color: var(--neo-text);
+  transition: background 0.15s ease, opacity 0.15s ease;
+}
+.toolbar-action:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--neo-text) 8%, transparent);
+}
+.toolbar-action.accent {
+  color: var(--neo-accent, #5b8def);
+  font-weight: 600;
+}
+.toolbar-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+</style>

--- a/apps/web/src/composables/useCapabilities.ts
+++ b/apps/web/src/composables/useCapabilities.ts
@@ -8,6 +8,9 @@ const cache = ref<Record<GenerationType, AIModel[]>>({
   video: [...VIDEO_MODELS],
 })
 
+const imageUpscale = ref(false)
+const stsDirectUpload = ref(false)
+
 let loaded = false
 
 export function useCapabilities() {
@@ -23,6 +26,8 @@ export function useCapabilities() {
         image: data.data.image?.length ? data.data.image : IMAGE_MODELS,
         video: data.data.video?.length ? data.data.video : VIDEO_MODELS,
       }
+      imageUpscale.value = Boolean(data.data.imageUpscale)
+      stsDirectUpload.value = Boolean(data.data.stsDirectUpload)
       loaded = true
     } catch {
       // fallback to shared defaults
@@ -39,5 +44,5 @@ export function useCapabilities() {
     return cache.value[type]
   }
 
-  return { loading, modelsFor, reload: load }
+  return { loading, modelsFor, reload: load, imageUpscale, stsDirectUpload }
 }

--- a/apps/web/src/composables/useImageUpscale.test.ts
+++ b/apps/web/src/composables/useImageUpscale.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useImageUpscale } from './useImageUpscale'
+
+vi.mock('@/services/canvas-api', () => ({
+  canvasApi: {
+    upscaleImage: vi.fn(),
+  },
+}))
+
+import { canvasApi } from '@/services/canvas-api'
+
+describe('useImageUpscale', () => {
+  beforeEach(() => {
+    vi.mocked(canvasApi.upscaleImage).mockReset()
+  })
+
+  it('POSTs upscale-image and toggles loading around the request', async () => {
+    let resolveRequest!: (value: unknown) => void
+    const pending = new Promise((resolve) => {
+      resolveRequest = resolve
+    })
+    vi.mocked(canvasApi.upscaleImage).mockReturnValue(pending as never)
+
+    const onSuccess = vi.fn()
+    const { loading, error, runUpscale } = useImageUpscale()
+
+    expect(loading.value).toBe(false)
+
+    const runPromise = runUpscale({
+      sessionId: 's1',
+      nodeId: 'img-1',
+      imageUrl: 'https://cdn/src.png',
+      onSuccess,
+    })
+
+    expect(loading.value).toBe(true)
+    expect(canvasApi.upscaleImage).toHaveBeenCalledWith({
+      sessionId: 's1',
+      nodeId: 'img-1',
+      imageUrl: 'https://cdn/src.png',
+      scale: 2,
+    })
+
+    resolveRequest({
+      data: {
+        data: {
+          url: 'https://cdn/up.png',
+          scale: 2,
+          providerId: 'fal',
+        },
+      },
+    })
+    const result = await runPromise
+
+    expect(loading.value).toBe(false)
+    expect(error.value).toBeNull()
+    expect(result).toEqual({
+      url: 'https://cdn/up.png',
+      scale: 2,
+      providerId: 'fal',
+    })
+    expect(onSuccess).toHaveBeenCalledWith({ url: 'https://cdn/up.png' })
+  })
+
+  it('sets error and clears loading when API fails', async () => {
+    vi.mocked(canvasApi.upscaleImage).mockRejectedValue({
+      response: { data: { message: '积分不足' } },
+    })
+
+    const { loading, error, runUpscale } = useImageUpscale()
+
+    await expect(
+      runUpscale({
+        sessionId: 's1',
+        nodeId: 'img-1',
+        imageUrl: 'https://cdn/src.png',
+      }),
+    ).rejects.toBeTruthy()
+
+    expect(loading.value).toBe(false)
+    expect(error.value).toBe('积分不足')
+  })
+})

--- a/apps/web/src/composables/useImageUpscale.ts
+++ b/apps/web/src/composables/useImageUpscale.ts
@@ -1,0 +1,47 @@
+import { ref } from 'vue'
+import { canvasApi } from '@/services/canvas-api'
+import { apiErrorMessage } from '@/utils/apiError'
+
+export type UpscaleResult = {
+  url: string
+  scale: 2 | 4
+  providerId: string
+  recordId?: string
+}
+
+export type RunUpscaleInput = {
+  sessionId: string
+  nodeId?: string
+  imageUrl: string
+  /** UI 固定 2×；API 仍预留 4 */
+  scale?: 2 | 4
+  onSuccess?: (result: { url: string }) => void
+}
+
+export function useImageUpscale() {
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function runUpscale(input: RunUpscaleInput): Promise<UpscaleResult> {
+    loading.value = true
+    error.value = null
+    try {
+      const { data } = await canvasApi.upscaleImage({
+        sessionId: input.sessionId,
+        nodeId: input.nodeId,
+        imageUrl: input.imageUrl,
+        scale: input.scale ?? 2,
+      })
+      const result = data.data
+      input.onSuccess?.({ url: result.url })
+      return result
+    } catch (err) {
+      error.value = apiErrorMessage(err, '放大失败')
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return { loading, error, runUpscale }
+}

--- a/apps/web/src/pages/CanvasPage.vue
+++ b/apps/web/src/pages/CanvasPage.vue
@@ -126,6 +126,11 @@ import RefineWorkViewport from '@/components/canvas/refine/RefineWorkViewport.vu
 import MediaPreviewOverlay from '@/components/canvas/MediaPreviewOverlay.vue'
 import MediaInspectorDrawer from '@/components/media/MediaInspectorDrawer.vue'
 import CanvasContextMenu from '@/components/canvas/CanvasContextMenu.vue'
+import SelectionActionBar from '@/components/canvas/SelectionActionBar.vue'
+import { useImageUpscale } from '@/composables/useImageUpscale'
+import { useCapabilities } from '@/composables/useCapabilities'
+import { canUpscaleNode } from '@/utils/upscaleNode'
+import { apiErrorMessage } from '@/utils/apiError'
 import {
   duplicateSubgraph,
   resolveDuplicateSourceIds,
@@ -726,11 +731,34 @@ const editorNode = computed((): EditableFlowNode | null => {
   return null
 })
 
+const { imageUpscale: imageUpscaleCapability } = useCapabilities()
+const { loading: upscaleLoading, runUpscale } = useImageUpscale()
+
 const refinePanelNode = computed((): EditableFlowNode | null => {
   if (!CX_IMAGE_EDIT_ENABLED) return null
   const target = canvasEditor.imageTarget
   if (!target) return null
   return findNodeById(target.nodeId)
+})
+
+/** 单选 + 可放大图像节点时显示选中浮层（多选不出现） */
+const selectionUpscaleNode = computed((): EditableFlowNode | null => {
+  if (refinePanelNode.value) return null
+  if (multiSelectedIds.value.length !== 1) return null
+  const node = findNodeById(multiSelectedIds.value[0])
+  if (!node) return null
+  const data = (node.data ?? {}) as Record<string, unknown>
+  if (!String(data.url ?? '').trim()) return null
+  if (
+    !canUpscaleNode({
+      type: String(node.type ?? ''),
+      mediaKind: typeof data.mediaKind === 'string' ? data.mediaKind : null,
+      mimeType: typeof data.mimeType === 'string' ? data.mimeType : null,
+    })
+  ) {
+    return null
+  }
+  return node as EditableFlowNode
 })
 
 const refineBeforeUrl = computed(() => {
@@ -2456,6 +2484,56 @@ function openRefineForSelected() {
   openRefineForNode(editorNode.value)
 }
 
+async function handleUpscaleForNode(nodeId: string) {
+  if (!imageUpscaleCapability.value || upscaleLoading.value) return
+  const node = findNodeById(nodeId)
+  if (!node) return
+  const data = (node.data ?? {}) as Record<string, unknown>
+  const imageUrl = String(data.url ?? '').trim()
+  if (!imageUrl) return
+
+  try {
+    await runUpscale({
+      sessionId: sessionId.value,
+      nodeId: node.id,
+      imageUrl,
+      scale: 2,
+      onSuccess: ({ url }) => {
+        const { w } = getNodeSize(node as FlowNode)
+        const childId = addNode(
+          'image',
+          {
+            url,
+            status: 'completed',
+            title: '放大 2×',
+            prompt: '',
+            imageModel: getProviderConfig('image').model,
+          },
+          {
+            position: { x: node.position.x + w + 36, y: node.position.y },
+          },
+        )
+        addEdge({
+          id: `e-${node.id}-${childId}`,
+          source: node.id,
+          target: childId,
+        })
+        selectOnlyNode(childId)
+        void persistUserEditAsync()
+        void focusNodeById(childId)
+      },
+    })
+  } catch (err) {
+    ElMessage.error(apiErrorMessage(err, '放大失败'))
+  }
+}
+
+function handleSelectionUpscale() {
+  const node = selectionUpscaleNode.value
+  if (!node) return
+  void handleUpscaleForNode(node.id)
+}
+
 function closeRefineWorkbench() {
   canvasEditor.closeImageEditor()
 }
@@ -2752,6 +2830,11 @@ function handleContextAction(action: string) {
 
   if (action === 'edit-image' && menu.nodeId) {
     openRefineForNode(findNodeById(menu.nodeId))
+    return
+  }
+
+  if (action === 'upscale-image' && menu.nodeId) {
+    void handleUpscaleForNode(menu.nodeId)
     return
   }
 
@@ -3330,6 +3413,15 @@ onUnmounted(() => {
             @duplicate-upstream="handleToolbarDuplicateUpstream"
           />
 
+          <SelectionActionBar
+            v-if="selectionUpscaleNode"
+            :node="selectionUpscaleNode as FlowNode"
+            :image-upscale="imageUpscaleCapability"
+            :loading="upscaleLoading"
+            @upscale="handleSelectionUpscale"
+            @edit="openRefineForSelected"
+          />
+
           <MultiSelectConnectOverlay
             :selected-ids="multiSelectedIds"
             @connect-target="handleMultiConnectTarget"
@@ -3555,6 +3647,7 @@ onUnmounted(() => {
       :has-url="contextMenu.hasUrl"
       :media-kind="contextMenu.mediaKind"
       :mime-type="contextMenu.mimeType"
+      :image-upscale="imageUpscaleCapability"
       :multi-selected-count="
         contextMenu.nodeId &&
         multiSelectedIds.includes(contextMenu.nodeId) &&

--- a/apps/web/src/services/canvas-api.ts
+++ b/apps/web/src/services/canvas-api.ts
@@ -68,6 +68,16 @@ export const canvasApi = {
       mentionedKeys: settings?.mentionedKeys,
       referenceImageUrl: settings?.referenceImageUrl,
     }),
+  upscaleImage: (body: {
+    sessionId: string
+    nodeId?: string
+    imageUrl?: string
+    scale?: 2 | 4
+    provider?: string
+  }) =>
+    api.post<{
+      data: { url: string; scale: 2 | 4; providerId: string; recordId?: string }
+    }>('/agent/canvas/material/upscale-image', body, { timeout: 300_000 }),
   statusBatch: (ids: string[]) =>
     api.get('/agent/canvas/shot/status/batch', { params: { ids: ids.join(',') } }),
   optimizePrompt: (prompt: string, style?: string) =>

--- a/apps/web/src/services/capabilities-api.ts
+++ b/apps/web/src/services/capabilities-api.ts
@@ -5,6 +5,10 @@ export interface CapabilitiesData {
   text: AIModel[]
   image: AIModel[]
   video: AIModel[]
+  /** COS 预签名直传是否可用 */
+  stsDirectUpload?: boolean
+  /** 至少注册一个 UpscaleProvider 时为 true */
+  imageUpscale?: boolean
 }
 
 export const capabilitiesApi = {

--- a/apps/web/src/utils/upscaleNode.ts
+++ b/apps/web/src/utils/upscaleNode.ts
@@ -1,0 +1,4 @@
+import { canOpenRefineForNode } from '@/utils/refineSession'
+
+/** 可放大判定与 Refine 开图一致（image / mediaInput 图片） */
+export const canUpscaleNode = canOpenRefineForNode

--- a/docs/DOCK_STUDIO_E2E_TRACKING.md
+++ b/docs/DOCK_STUDIO_E2E_TRACKING.md
@@ -3,7 +3,7 @@
 > **对标参考**：[NeoWOW Workflow](https://neowow.cn/workflow?sessionId=2074796563114016768)  
 > **UI 调研**：[NEOWOW_CANVAS_UI_RESEARCH.md](./NEOWOW_CANVAS_UI_RESEARCH.md)（§4.2 BottomToolbarWrapper / NodePanel）  
 > **创建日期**：2026-07-13  
-> **最后更新**：2026-07-19（§十 BYOK 渠道；§C2.1 Canvas T*/I* refs 验收）
+> **最后更新**：2026-09-13（B-2 / I-7 image upscale ✅；§十 BYOK 渠道；§C2.1 Canvas T*/I* refs 验收）
 
 ---
 
@@ -14,13 +14,13 @@
 | 阶段 | 完成度 | 说明 |
 |------|--------|------|
 | **Phase 0** 基础架构 | **100%** | P0-1 ~ P0-6 全部完成 |
-| **Phase 1** 核心生成节点 | **~92%** | text/image/video/audio/shot 主链路完成；T-5/I-6/I-7/V-6 待补 |
+| **Phase 1** 核心生成节点 | **~94%** | text/image/video/audio/shot 主链路完成；T-5/I-6/V-6 待补；I-7 upscale ✅ |
 | **Phase 2** 输入与编排 | **~90%** | mediaInput ✅；sceneComposer D-1~D-4 ✅（API 手测）；videoComposition C-1~C-4 ✅（export 生产）；worldModel 未开始 |
 | **Phase 3** Dock UX | **~88%** | UX-1~UX-5 ✅；UX-6 Capabilities **部分**（`useCapabilities` + `UniversalModelSelector` 已接，未全量替换硬编码） |
-| **Phase 4** 后端补齐 | **~67%** | B-1/B-3/B-4/B-6 ✅；B-2 upscale、B-5 lip-sync 未开始 |
+| **Phase 4** 后端补齐 | **~83%** | B-1/B-2/B-3/B-4/B-6 ✅；B-5 lip-sync 未开始 |
 | **里程碑 M1/M2** | **已完成** | 代码落地；**真实 AI 生成**待生产 API Key |
 | **里程碑 M3** | **~90%** | 编排 + export 生产 API ✅；sceneComposer/shot **浏览器 UI** 待验 |
-| **里程碑 M4** | **未开始** | OSS STS + upscale/lip-sync + worldModel |
+| **里程碑 M4** | **进行中** | OSS STS + upscale ✅；lip-sync / worldModel 未开始 |
 | **浏览器 E2E 手测** | **🟡 部分** | 2026-07-14 Dock 壳层 ✅；2026-07-16 export/sceneComposer **API** ✅；UI 闭环 ☐（见 §0.5） |
 
 ### 0.4 生产环境 E2E 手测记录（2026-07-14）
@@ -97,7 +97,7 @@
 | 节点 | Dock | 生成 E2E | 状态 | 待办 |
 |------|------|----------|------|------|
 | text | ✅ | ✅ | **已完成** | T-5 txt 拖入验收 |
-| image | ✅ | ✅ | **已完成** | I-6 编辑器联动、I-7 upscale |
+| image | ✅ | ✅ | **已完成** | I-6 编辑器联动；I-7 upscale ✅ |
 | video | ✅ | ✅ | **已完成** | V-6 多选批量一致 |
 | audio | ✅ | ✅ | **已完成** | — |
 | shot | ✅ | ✅ | **代码完成** | 生产 UI 手测（§0.5 U3） |
@@ -200,7 +200,7 @@ completed → 写回 url / content / coverUrl
 | 节点 type | Dock 是否出现 | Dock 能力完整度 | 生成 E2E | 上游连线消费 | 主要缺口 | 状态 |
 |-----------|--------------|----------------|----------|-------------|---------|------|
 | **text** | ✅ | 🟢 85% | ✅ studio | ✅ 出边供下游消费 | TextDockPanel 已拆 | 已完成 |
-| **image** | ✅ | 🟢 85% | ✅ 统一 composable | ✅ 入边 text/image 预填 | upscale 未做；比例仅存 metadata | 已完成 |
+| **image** | ✅ | 🟢 90% | ✅ 统一 composable | ✅ 入边 text/image 预填 | upscale ✅（fal Real-ESRGAN）；比例仅存 metadata | 已完成 |
 | **video** | ✅ | 🟢 80% | ✅ 异步轮询 | ✅ I2V + 入边参考图 | crop 已 UI 未传 provider | 已完成 |
 | **audio** | ✅ | 🟢 80% | ✅ voice+settings | ✅ 入边 text 预填 | 情感/语速存 metadata | 已完成 |
 | **shot（分镜）** | ✅ | 🟢 85% | ✅ canvas | ✅ 入边 text + shotGenerateMode | ShotDockPanel 已拆 | 已完成 |
@@ -235,7 +235,7 @@ completed → 写回 url / content / coverUrl
 |-----|-----------|---------|------|
 | canvas CRUD + shot/material | ✅ | shot, image | 已完成 |
 | `optimize-prompt` | ✅ Dock 内 Text/Shot 已接 | shot, text | 已完成 |
-| `material/upscale` | ❌ | image | 未开始 |
+| `material/upscale` | ✅ `POST .../upscale-image`（fal Real-ESRGAN） | image | 已完成 |
 | `material/lip-sync` | ❌ | video（可选） | 未开始 |
 | OSS upload / STS | Presigned PUT 直传（COS 就绪时）+ 本地 `POST /api/upload` 兜底 | mediaInput | 直传 Presigned PUT 已做 / 本地兜底 |
 | `capabilities/list` → UniversalModelSelector | 🟡 部分对接（`useCapabilities` 已接，fallback 硬编码） | 全部生成节点 | 进行中 |
@@ -361,7 +361,7 @@ interface DockStudioEntry {
 | I-4 | 统一 generate 路径（去掉 shot/独立双轨分散） | P0-1 | 已完成 |
 | I-5 | 生成中 skeleton + 完成后节点预览 | P0-4 | 已完成 |
 | I-6 | 右键「编辑图像」→ AIImageEditor 与 Dock 数据同步 | — | 未开始 |
-| I-7 | 放大 `upscale`（可选） | 后端 B-2 | 未开始 |
+| I-7 | 放大 `upscale`（可选） | 后端 B-2 | 已完成（浮层/右键；fal；新节点落点） |
 
 **E2E 验收**：text→image 连线 → 选 image → Dock 有 prompt+比例 → 生成 → 预览图 → 保存画布。
 
@@ -371,7 +371,7 @@ interface DockStudioEntry {
 - [x] I-4 — 统一 generate 路径
 - [x] I-5 — skeleton + 预览
 - [ ] I-6 — AIImageEditor 联动
-- [ ] I-7 — upscale（可选）
+- [x] I-7 — upscale（可选）
 
 ---
 
@@ -528,14 +528,14 @@ interface DockStudioEntry {
 | ID | API | 服务节点 | 状态 |
 |----|-----|---------|------|
 | B-1 | `POST /agent/chat/optimize-prompt`（Dock 已接） | shot, text | 已完成 |
-| B-2 | `POST /agent/canvas/material/upscale-image` | image | 未开始 |
+| B-2 | `POST /agent/canvas/material/upscale-image` | image | 已完成（fal Real-ESRGAN；积分 image_upscale） |
 | B-3 | `POST /studio/audio/generate` 扩展 voice/emotion/speed/language | audio | 已完成 |
 | B-4 | OSS STS + `POST /upload` | mediaInput | 直传 Presigned PUT 已做 / 本地兜底 |
 | B-5 | `POST /agent/canvas/material/lip-sync` | video（可选） | 未开始 |
 | B-6 | video 异步 job status 查询 | video, shot | 已完成（`GET /studio/generations/:id`） |
 
 - [x] B-1 — optimize-prompt（经 chat API）
-- [ ] B-2 — upscale-image
+- [x] B-2 — upscale-image
 - [x] B-3 — audio voice/emotion/speed/language
 - [x] B-4 — 直传 Presigned PUT 已做 / 本地兜底
 - [ ] B-5 — lip-sync（可选）

--- a/docs/superpowers/specs/2026-09-12-wave-a-a1-sts-upscale-design.md
+++ b/docs/superpowers/specs/2026-09-12-wave-a-a1-sts-upscale-design.md
@@ -192,8 +192,8 @@ interface UpscaleProvider {
 
 | providerId | 状态 | 探测结论 | 备注 |
 |------------|------|----------|------|
-| `agnes` | 待探测 | PR2 实现前填写：满足 / 不满足 + 依据 | 优先 |
-| （其它） | 仅当 agnes 不满足时追加 | … | 列明 model / baseUrl 特征 |
+| `agnes` | 未接入 | **不满足**（2026-09-12）：官方文档仅有 `POST /v1/images/generations` 文生图 / 图生图（`extra_body.image` + prompt），无独立超分端点、无 upscale 模型名；用 prompt「放大」冒充超分被本规格禁止 | 优先探测；不注册 |
+| `fal` | **已接入** | Agnes 不满足后接线现有 `FAL_KEY` 通道：`POST https://fal.run/fal-ai/esrgan`，body `{ image_url, scale: 2\|4 }`，返回 `image.url`（Real-ESRGAN，非文生图） | `modelId`: `fal-ai/esrgan`；与 Segment SAM 同凭证栈；支持 2× 与 4× |
 
 合并 PR2 时本表必须与代码注册表一致；建议单测断言注册 id 列表 ⊆ 本表「已接入」行。
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2,7 +2,11 @@ export { applyCanvasActions } from './tools/executor'
 export { createImageProvider, PlaceholderImageProvider, OpenAIImageProvider } from './tools/image-provider'
 export { createImageEditProvider, ApimartImageEditProvider } from './tools/image-edit-provider'
 export { createSegmentProvider } from './tools/segment-provider'
-export { createUpscaleProviders, FalEsrganUpscaleProvider } from './tools/upscale-provider'
+export {
+  createUpscaleProviders,
+  FalEsrganUpscaleProvider,
+  SPEC_CONNECTED_UPSCALE_PROVIDERS,
+} from './tools/upscale-provider'
 export {
   createTextProvider,
   PlaceholderTextProvider,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2,6 +2,7 @@ export { applyCanvasActions } from './tools/executor'
 export { createImageProvider, PlaceholderImageProvider, OpenAIImageProvider } from './tools/image-provider'
 export { createImageEditProvider, ApimartImageEditProvider } from './tools/image-edit-provider'
 export { createSegmentProvider } from './tools/segment-provider'
+export { createUpscaleProviders, FalEsrganUpscaleProvider } from './tools/upscale-provider'
 export {
   createTextProvider,
   PlaceholderTextProvider,
@@ -15,6 +16,11 @@ export { createAudioProvider, PlaceholderAudioProvider, OpenAITTSProvider, Fallb
 export type { ImageProvider, ProviderCredentialOpts, ImageGenerateOptions } from './tools/image-provider'
 export type { ImageEditProvider, ImageEditInput } from './tools/image-edit-provider'
 export type { SegmentProvider, SegmentPointInput } from './tools/segment-provider'
+export type {
+  UpscaleProvider,
+  UpscaleInput,
+  UpscaleResult,
+} from './tools/upscale-provider'
 export type { TextProvider, TextGenerateOptions, TextThinkingEffort } from './tools/text-provider'
 export type { VideoProvider } from './tools/video-provider'
 export type { AudioProvider, AudioGenerateOptions } from './tools/audio-provider'

--- a/packages/agent/src/tools/upscale-provider.test.ts
+++ b/packages/agent/src/tools/upscale-provider.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { createUpscaleProviders } from './upscale-provider'
+
+describe('createUpscaleProviders', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('returns empty without credentials', () => {
+    expect(createUpscaleProviders({})).toEqual([])
+  })
+
+  it('returns empty when only Agnes credentials (probe: Agnes has no real upscale API)', () => {
+    expect(
+      createUpscaleProviders({
+        agnesApiKey: 'k',
+        agnesBaseUrl: 'https://apihub.agnes-ai.com/v1',
+      }),
+    ).toEqual([])
+  })
+
+  it('fal esrgan upscales 2x/4x via fal.run', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toBe('https://fal.run/fal-ai/esrgan')
+      expect(init?.method).toBe('POST')
+      expect(init?.headers).toMatchObject({
+        Authorization: 'Key fal-k',
+        'Content-Type': 'application/json',
+      })
+      const body = JSON.parse(String(init?.body))
+      expect(body.image_url).toBe('https://in/a.png')
+      expect(body.scale).toBe(2)
+      expect(body.output_format).toBe('png')
+      return new Response(
+        JSON.stringify({
+          image: { url: 'https://out/hi.png' },
+        }),
+        { status: 200 },
+      )
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const providers = createUpscaleProviders({ falApiKey: 'fal-k' })
+    expect(providers.map((p) => p.id)).toEqual(['fal'])
+    expect(providers[0].supportsScale(2)).toBe(true)
+    expect(providers[0].supportsScale(4)).toBe(true)
+
+    const out = await providers[0].upscale({
+      imageUrl: 'https://in/a.png',
+      scale: 2,
+    })
+    expect(out).toEqual({
+      url: 'https://out/hi.png',
+      providerId: 'fal',
+      modelId: expect.any(String),
+    })
+  })
+
+  it('fal esrgan posts scale 4', async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body))
+      expect(body.scale).toBe(4)
+      return new Response(JSON.stringify({ image: { url: 'https://out/4x.png' } }), { status: 200 })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const providers = createUpscaleProviders({ falApiKey: 'fal-k' })
+    const out = await providers[0].upscale({ imageUrl: 'https://in/a.png', scale: 4 })
+    expect(out.url).toBe('https://out/4x.png')
+  })
+
+  it('throws when fal response has no image url', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({}), { status: 200 })),
+    )
+    const providers = createUpscaleProviders({ falApiKey: 'fal-k' })
+    await expect(providers[0].upscale({ imageUrl: 'https://in/a.png', scale: 2 })).rejects.toThrow(
+      /url/i,
+    )
+  })
+})

--- a/packages/agent/src/tools/upscale-provider.test.ts
+++ b/packages/agent/src/tools/upscale-provider.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, it, vi, afterEach } from 'vitest'
-import { createUpscaleProviders } from './upscale-provider'
+import {
+  createUpscaleProviders,
+  SPEC_CONNECTED_UPSCALE_PROVIDERS,
+} from './upscale-provider'
+
+const testCreds = { falApiKey: 'fal-k' }
 
 describe('createUpscaleProviders', () => {
   afterEach(() => vi.unstubAllGlobals())
+
+  it('registered provider ids are listed as connected in spec checklist constant', () => {
+    const ids = createUpscaleProviders(testCreds).map((p) => p.id)
+    expect(SPEC_CONNECTED_UPSCALE_PROVIDERS).toEqual(expect.arrayContaining(ids))
+  })
 
   it('returns empty without credentials', () => {
     expect(createUpscaleProviders({})).toEqual([])

--- a/packages/agent/src/tools/upscale-provider.ts
+++ b/packages/agent/src/tools/upscale-provider.ts
@@ -1,3 +1,10 @@
+/**
+ * Spec §5.3 「已接入」provider ids — must stay in sync with
+ * docs/superpowers/specs/2026-09-12-wave-a-a1-sts-upscale-design.md §5.3.
+ * Changing the checklist requires updating this constant.
+ */
+export const SPEC_CONNECTED_UPSCALE_PROVIDERS = ['fal'] as const
+
 export interface UpscaleInput {
   imageUrl: string
   scale: 2 | 4

--- a/packages/agent/src/tools/upscale-provider.ts
+++ b/packages/agent/src/tools/upscale-provider.ts
@@ -1,0 +1,85 @@
+export interface UpscaleInput {
+  imageUrl: string
+  scale: 2 | 4
+}
+
+export interface UpscaleResult {
+  url: string
+  providerId: string
+  modelId?: string
+}
+
+export interface UpscaleProvider {
+  readonly id: string
+  /** 该实现是否支持给定 scale；不支持则 service 层返回 400/501 */
+  supportsScale(scale: 2 | 4): boolean
+  upscale(input: UpscaleInput): Promise<UpscaleResult>
+}
+
+const FAL_ESRGAN_MODEL = 'fal-ai/esrgan'
+
+function extractUpscaleUrl(json: unknown): string | undefined {
+  if (!json || typeof json !== 'object') return undefined
+  const image = (json as Record<string, unknown>).image
+  if (image && typeof image === 'object') {
+    const url = (image as Record<string, unknown>).url
+    if (typeof url === 'string' && url) return url
+  }
+  return undefined
+}
+
+/** Real-ESRGAN via fal (same FAL_KEY stack as SegmentProvider). */
+export class FalEsrganUpscaleProvider implements UpscaleProvider {
+  readonly id = 'fal'
+
+  constructor(private apiKey: string) {}
+
+  supportsScale(scale: 2 | 4): boolean {
+    return scale === 2 || scale === 4
+  }
+
+  async upscale(input: UpscaleInput): Promise<UpscaleResult> {
+    const res = await fetch(`https://fal.run/${FAL_ESRGAN_MODEL}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Key ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        image_url: input.imageUrl,
+        scale: input.scale,
+        model: input.scale === 2 ? 'RealESRGAN_x2plus' : 'RealESRGAN_x4plus',
+        output_format: 'png',
+      }),
+    })
+    if (!res.ok) throw new Error(`Upscale API ${res.status}: ${await res.text()}`)
+    const json = await res.json()
+    const url = extractUpscaleUrl(json)
+    if (!url) {
+      throw new Error(`Upscale API response missing image url: ${JSON.stringify(json)}`)
+    }
+    return {
+      url,
+      providerId: this.id,
+      modelId: FAL_ESRGAN_MODEL,
+    }
+  }
+}
+
+/**
+ * Agnes-first factory: Agnes has no documented native upscale endpoint
+ * (only generative img2img — forbidden as fake upscale). When Agnes is
+ * unavailable, register fal Real-ESRGAN if `falApiKey` is set.
+ *
+ * `agnesApiKey` / `agnesBaseUrl` are reserved for a future Agnes upscale
+ * wire-up; they currently never register a provider (see spec §5.3).
+ */
+export function createUpscaleProviders(opts: {
+  agnesApiKey?: string
+  agnesBaseUrl?: string
+  /** Present only when Agnes cannot provide real upscale */
+  falApiKey?: string
+}): UpscaleProvider[] {
+  const falKey = opts.falApiKey?.trim()
+  return falKey ? [new FalEsrganUpscaleProvider(falKey)] : []
+}


### PR DESCRIPTION
## Summary
- Implements Wave A **A1 image upscale** end-to-end (spec §5–§8): `UpscaleProvider` / `UpscaleService`, `POST .../upscale-image`, Agent tool, capabilities `imageUpscale`, selection-bar + context-menu「放大」, new image node placement, points `image_upscale`.
- **Provider choice:** Agnes probe failed (no native upscale API; generative img2img forbidden as fake upscale) → wired **fal** Real-ESRGAN (`fal-ai/esrgan`) via existing `FAL_KEY` stack; registry ids asserted ⊆ `SPEC_CONNECTED_UPSCALE_PROVIDERS` (spec §5.3).
- Tracking: `docs/DOCK_STUDIO_E2E_TRACKING.md` **B-2** / **I-7** marked done.

## Spec coverage (§5–§8)
| Spec | Delivered |
|------|-----------|
| §5.1–5.3 Provider + 清单 | Agnes-first factory; fal connected; checklist constant + test |
| §5.4 API | `upscale-image` canvas/agent paths |
| §5.5 计费 | points reason + refund on failure |
| §5.6 落点 | new node offset from source |
| §5.7 Agent | upscale tool |
| §5.8 capabilities | `imageUpscale` gate |
| §6 UI | 浮层 / 右键「放大」; disabled+tooltip when off |
| §7 错误 | no provider / upstream / points / URL |
| §8 测试 | provider, service, reason-map, composable, SelectionActionBar, CanvasContextMenu |

直传 STS 不在本 PR 范围。

## Test plan
- [ ] `pnpm --filter @lnkpi/server exec prisma generate`
- [ ] `pnpm --filter @lnkpi/agent exec vitest run src/tools/upscale-provider.test.ts`
- [ ] `pnpm --filter @lnkpi/server exec vitest run src/studio/upscale.service.test.ts src/points/reason-map.test.ts`
- [ ] `pnpm --filter @lnkpi/web exec vitest run src/composables/useImageUpscale.test.ts src/components/canvas/SelectionActionBar.test.ts src/components/canvas/CanvasContextMenu.test.ts`
- [ ] `pnpm build`
- [ ] 画布选中图片 → 浮层「放大」→ 出新节点（非原地替换）
- [ ] capabilities 无 provider 时「放大」disabled + tooltip
- [ ] 积分流水出现 `image_upscale`（失败退款）


Made with [Cursor](https://cursor.com)